### PR TITLE
khalid/MS Edge range thumb 

### DIFF
--- a/src/sass/app/_common/components/range-slider.scss
+++ b/src/sass/app/_common/components/range-slider.scss
@@ -40,12 +40,12 @@
             }
         }
     }
-    &__track {
+    &__track[type=range] {
         position: relative;
         // removal of !important is pending refactor in main trading sass file that overrides rules for input els
         appearance: none !important;
         width: 100% !important;
-        height: 2px !important;
+        height: 2px;  // !important had to be removed to fix disappearing thumb on MS Edge
         border-radius: 5px;
         outline: none;
         padding: 0;
@@ -56,6 +56,12 @@
             border: none;
         }
 
+        // Handles Track - MS Edge and IE
+        @supports (-ms-ime-align:auto) {
+            height: 14px;
+            position: relative;
+            top: -6px;
+        }
         // Range Handle Thumb - Chrome / Webkit based browsers
         &::-webkit-slider-thumb {
             @include thumbStyle();
@@ -89,10 +95,31 @@
                 background: themed('container_color');
             }
         }
-        &::-ms-track {
+        &::-ms-tooltip {
+            display: none;
+        }
+        &[type=range]::-ms-track {
+            /*example */
+            width: 100%;
+            height: 2px;
+            border-width: 6px 0;
+            @include themify($themes) {
+                background: themed('container_color');
+                border-color: themed('background_container_color');
+                color: themed('background_container_color');
+            }
+        }
+        &[type=range]::-ms-fill-upper {
             @include themify($themes) {
                 background: themed('container_color');
             }
+            height: 2px;
+        }
+        &[type=range]::-ms-fill-lower {
+            @include themify($themes) {
+                background: themed('container_color');
+            }
+            height: 2px;
         }
     }
     &__ticks {

--- a/src/sass/app/_common/components/range-slider.scss
+++ b/src/sass/app/_common/components/range-slider.scss
@@ -110,16 +110,16 @@
             }
         }
         &[type=range]::-ms-fill-upper {
+            height: 2px;
             @include themify($themes) {
                 background: themed('container_color');
             }
-            height: 2px;
         }
         &[type=range]::-ms-fill-lower {
+            height: 2px;
             @include themify($themes) {
                 background: themed('container_color');
             }
-            height: 2px;
         }
     }
     &__ticks {


### PR DESCRIPTION
MS Edge's 'range' input has a known issue where the thumb's height is limited to the track's height, which makes the thumb partially disappear. A workaround was implemented here until the issue is fixed in the new Chromium-based Edge (according to [this](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/20882987/))