### PR TITLE
zaki/end_line_fix

### DIFF
--- a/src/javascript/app/App/Components/Elements/ContractDrawer/contract-drawer.jsx
+++ b/src/javascript/app/App/Components/Elements/ContractDrawer/contract-drawer.jsx
@@ -80,6 +80,7 @@ class ContractDrawer extends Component {
                     <ContractAudit
                         contract_info={contract_info}
                         contract_end_time={getEndTime(contract_info)}
+                        is_open={true}
                         is_shade_visible={this.handleShade}
                         duration={getDurationTime(contract_info)}
                         duration_unit={getDurationUnitText(getDurationPeriod(contract_info))}

--- a/src/javascript/app/App/Components/Elements/PositionsDrawer/result-details.jsx
+++ b/src/javascript/app/App/Components/Elements/PositionsDrawer/result-details.jsx
@@ -14,7 +14,7 @@ import ResultDetailsItem from './result-details-item.jsx';
 
 class ResultDetails extends React.PureComponent {
     state = {
-        is_open: false,
+        is_open: this.props.is_open || false,
     };
 
     toggleDetails = () => {
@@ -108,6 +108,7 @@ ResultDetails.propTypes = {
     duration_unit: PropTypes.string,
     exit_spot    : PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     has_result   : PropTypes.bool,
+    is_open      : PropTypes.bool,
 };
 
 export default ResultDetails;

--- a/src/javascript/app/App/Components/Form/ButtonToggleMenu/button-highlight-wrapper.jsx
+++ b/src/javascript/app/App/Components/Form/ButtonToggleMenu/button-highlight-wrapper.jsx
@@ -13,7 +13,6 @@ class HighlightWrapper extends React.PureComponent {
         const active_button_el = [...this.node.getElementsByClassName('button-menu__button--active')][0];
         if (!this.node) return;
         this.updateHighlightPosition(active_button_el);
-        // window.addEventListener('resize', this.updateHighlightPosition);
     }
 
     componentDidUpdate() {
@@ -26,7 +25,6 @@ class HighlightWrapper extends React.PureComponent {
     }
 
     componentWillUnMount() {
-        // window.removeEventListener('resize', this.updateHighlightPosition);
         this.resetHighlight();
     }
 

--- a/src/javascript/app/App/Components/Form/ButtonToggleMenu/button-highlight-wrapper.jsx
+++ b/src/javascript/app/App/Components/Form/ButtonToggleMenu/button-highlight-wrapper.jsx
@@ -12,10 +12,8 @@ class HighlightWrapper extends React.PureComponent {
     componentDidMount() {
         const active_button_el = [...this.node.getElementsByClassName('button-menu__button--active')][0];
         if (!this.node) return;
-        // Timeout needed here for bug where the el is returning wrong width and offset after mount
-        setTimeout(() => {
-            this.updateHighlightPosition(active_button_el);
-        }, 250);
+        this.updateHighlightPosition(active_button_el);
+        // window.addEventListener('resize', this.updateHighlightPosition);
     }
 
     componentDidUpdate() {
@@ -28,7 +26,7 @@ class HighlightWrapper extends React.PureComponent {
     }
 
     componentWillUnMount() {
-        window.removeEventListener('resize', this.updateHighlightPosition);
+        // window.removeEventListener('resize', this.updateHighlightPosition);
         this.resetHighlight();
     }
 

--- a/src/javascript/app/App/Components/Form/ButtonToggleMenu/button-highlight.jsx
+++ b/src/javascript/app/App/Components/Form/ButtonToggleMenu/button-highlight.jsx
@@ -3,14 +3,16 @@ import React     from 'react';
 
 const Highlight = ({ left, width }) => {
     const border_radius_size = '4px';
+    const left_offset        = (left < 110) ? 0 : left;
+    const width_offset       = (width < 110) ? 111 : width;
     const highlight_style = {
-        width,
+        width                    : width_offset,
         left                     : 0,
-        transform                : `translate3d(${left}px, 0, 0)`,
-        'borderTopLeftRadius'    : (left === 0) ? border_radius_size : 0,
-        'borderTopRightRadius'   : (left === 0) ? 0 : border_radius_size ,
-        'borderBottomLeftRadius' : (left === 0) ? border_radius_size  : 0,
-        'borderBottomRightRadius': (left === 0) ? 0 : border_radius_size ,
+        transform                : `translate3d(${left_offset}px, 0, 0)`,
+        'borderTopLeftRadius'    : (left_offset === 0) ? border_radius_size : 0,
+        'borderTopRightRadius'   : (left_offset === 0) ? 0 : border_radius_size ,
+        'borderBottomLeftRadius' : (left_offset === 0) ? border_radius_size  : 0,
+        'borderBottomRightRadius': (left_offset === 0) ? 0 : border_radius_size ,
     };
 
     return (

--- a/src/javascript/app/Modules/Contract/Containers/contract-replay.jsx
+++ b/src/javascript/app/Modules/Contract/Containers/contract-replay.jsx
@@ -18,6 +18,7 @@ class ContractReplay extends React.Component {
     };
 
     componentDidMount() {
+        this.props.hidePositions();
         this.props.setChartLoader(true);
         this.props.showBlur();
         const url_contract_id = /[^/]*$/.exec(location.pathname)[0];
@@ -105,6 +106,7 @@ ContractReplay.propTypes = {
     contract_id     : PropTypes.string,
     contract_info   : PropTypes.object,
     hideBlur        : PropTypes.func,
+    hidePositions   : PropTypes.func,
     history         : PropTypes.object,
     is_chart_loading: PropTypes.bool,
     location        : PropTypes.object,
@@ -124,6 +126,7 @@ export default withRouter(connect(
         contract_info   : modules.contract.replay_info,
         setChartLoader  : modules.smart_chart.setIsChartLoading,
         is_chart_loading: modules.smart_chart.is_chart_loading,
+        hidePositions   : ui.hidePositionsFooterToggle,
         hideBlur        : ui.hideRouteBlur,
         showBlur        : ui.showRouteBlur,
 

--- a/src/javascript/app/Modules/Contract/Containers/contract-replay.jsx
+++ b/src/javascript/app/Modules/Contract/Containers/contract-replay.jsx
@@ -81,7 +81,8 @@ class ContractReplay extends React.Component {
                                 ))
                             }
                         </div>
-                        <ChartLoader is_visible={is_chart_loading} />
+                        <ChartLoader is_visible={is_chart_loading && !!(config)} />
+                        {(config && config.symbol) &&
                         <SmartChart
                             chart_id={chart_id}
                             chartControlsWidgets={null}
@@ -90,6 +91,7 @@ class ContractReplay extends React.Component {
                             should_show_last_digit_stats={false}
                             {...config}
                         />
+                        }
                     </div>
                 </React.Suspense>
             </div>

--- a/src/javascript/app/Modules/SmartChart/Components/Markers/marker-line.jsx
+++ b/src/javascript/app/Modules/SmartChart/Components/Markers/marker-line.jsx
@@ -11,28 +11,32 @@ const MarkerLine = ({
     line_style,
     marker_config,
     status,
-}) => (
-    <div className={classNames('chart-marker-line__wrapper', `chart-marker-line--${line_style}`)}>
-        { label === marker_config.LINE_END.content_config.label &&
-            <Icon
-                icon={IconEndTimeSVG}
-                className={classNames('chart-marker-line__icon', {
-                    'chart-marker-line__icon--won' : status === 'won',
-                    'chart-marker-line__icon--lost': status === 'lost',
-                })}
-            />
-        }
-        { label === marker_config.LINE_START.content_config.label &&
-            <Icon
-                icon={IconStartTimeSVG}
-                className={classNames(
-                    'chart-marker-line__icon',
-                    'chart-marker-line__icon--time',
-                )}
-            />
-        }
-    </div>
-);
+}) => {
+    // TODO: Find a more elegant solution
+    if (!marker_config) return <div />;
+    return (
+        <div className={classNames('chart-marker-line__wrapper', `chart-marker-line--${line_style}`)}>
+            { label === marker_config.LINE_END.content_config.label &&
+                <Icon
+                    icon={IconEndTimeSVG}
+                    className={classNames('chart-marker-line__icon', {
+                        'chart-marker-line__icon--won' : status === 'won',
+                        'chart-marker-line__icon--lost': status === 'lost',
+                    })}
+                />
+            }
+            { label === marker_config.LINE_START.content_config.label &&
+                <Icon
+                    icon={IconStartTimeSVG}
+                    className={classNames(
+                        'chart-marker-line__icon',
+                        'chart-marker-line__icon--time',
+                    )}
+                />
+            }
+        </div>
+    );
+};
 
 MarkerLine.propTypes = {
     label        : PropTypes.string,

--- a/src/javascript/app/Modules/Trading/Components/Form/TimePicker/trading-time-picker.jsx
+++ b/src/javascript/app/Modules/Trading/Components/Form/TimePicker/trading-time-picker.jsx
@@ -22,7 +22,7 @@ const TradingTimePicker = ({
     const market_close_datetime = setTime(moment_expiry_date.clone(), market_close_times.slice(-1)[0]);
     const expiry_datetime = setTime(moment_expiry_date.clone(), expiry_time);
     const server_datetime = toMoment(server_time);
-    
+
     const boundaries = getBoundaries(
         server_datetime.clone(),
         market_open_datetime.clone(),

--- a/src/javascript/app/Modules/Trading/Components/Form/TimePicker/trading-time-picker.jsx
+++ b/src/javascript/app/Modules/Trading/Components/Form/TimePicker/trading-time-picker.jsx
@@ -18,7 +18,7 @@ const TradingTimePicker = ({
     server_time,
 }) => {
     const moment_expiry_date = toMoment(expiry_date);
-    const market_open_datetime  = setTime(moment_expiry_date.clone(), market_open_times[0]);
+    const market_open_datetime = setTime(moment_expiry_date.clone(), market_open_times[0]);
     const market_close_datetime = setTime(moment_expiry_date.clone(), market_close_times.slice(-1)[0]);
     const expiry_datetime = setTime(moment_expiry_date.clone(), expiry_time);
     const server_datetime = toMoment(server_time);

--- a/src/javascript/app/Stores/Modules/Contract/Helpers/logic.js
+++ b/src/javascript/app/Stores/Modules/Contract/Helpers/logic.js
@@ -29,7 +29,7 @@ const hour_to_granularity_map = [
     [30 * 24, 14400],
 ];
 
-const getExpiryTime = (time) =>  time || ServerTime.get().unix();
+const getExpiryTime = (time) => time || ServerTime.get().unix();
 
 export const getChartType = (start_time, expiry_time) => {
     const duration = moment.duration(moment.unix(getExpiryTime(expiry_time)).diff(moment.unix(start_time))).asHours();

--- a/src/javascript/app/Stores/Modules/Portfolio/Helpers/details.js
+++ b/src/javascript/app/Stores/Modules/Portfolio/Helpers/details.js
@@ -36,11 +36,11 @@ export const getDurationUnitText = (obj_duration) => {
     const duration_ms = obj_duration.asMilliseconds() / 1000;
     if (duration_ms) {
         if (duration_ms >= 86400000) {
-            return (duration_ms === 8640000) ? unit_map.d.name_singular : unit_map.d.name_plural;
+            return (duration_ms >= 8640000) ? unit_map.d.name_singular : unit_map.d.name_plural;
         } else if (duration_ms >= 3600000 && duration_ms < 86400000) {
-            return (duration_ms === 360000) ? unit_map.h.name_singular : unit_map.h.name_plural;
+            return (duration_ms >= 360000) ? unit_map.h.name_singular : unit_map.h.name_plural;
         } else if (duration_ms >= 60000 && duration_ms < 3600000) {
-            return (duration_ms === 60000) ? unit_map.m.name_singular : unit_map.m.name_plural;
+            return (duration_ms >= 60000) ? unit_map.m.name_singular : unit_map.m.name_plural;
         } else if (duration_ms >= 1000 && duration_ms < 60000) {
             return unit_map.s.name;
         }

--- a/src/javascript/app/Stores/Modules/Portfolio/Helpers/details.js
+++ b/src/javascript/app/Stores/Modules/Portfolio/Helpers/details.js
@@ -36,11 +36,12 @@ export const getDurationUnitText = (obj_duration) => {
     const duration_ms = obj_duration.asMilliseconds() / 1000;
     if (duration_ms) {
         if (duration_ms >= 86400000) {
-            return (duration_ms >= 8640000) ? unit_map.d.name_singular : unit_map.d.name_plural;
+            const days_value = duration_ms / 86400000;
+            return (days_value <= 2) ? unit_map.d.name_singular : unit_map.d.name_plural;
         } else if (duration_ms >= 3600000 && duration_ms < 86400000) {
-            return (duration_ms >= 360000) ? unit_map.h.name_singular : unit_map.h.name_plural;
+            return (duration_ms === 3600000) ? unit_map.h.name_singular : unit_map.h.name_plural;
         } else if (duration_ms >= 60000 && duration_ms < 3600000) {
-            return (duration_ms >= 60000) ? unit_map.m.name_singular : unit_map.m.name_plural;
+            return (duration_ms === 60000) ? unit_map.m.name_singular : unit_map.m.name_plural;
         } else if (duration_ms >= 1000 && duration_ms < 60000) {
             return unit_map.s.name;
         }

--- a/src/sass/app/_common/components/date-picker.scss
+++ b/src/sass/app/_common/components/date-picker.scss
@@ -83,13 +83,13 @@
         position: absolute;
         top: 7px;
         z-index: 2;
-        transform-origin: left;
-        transform: scale(1, 0) translate3d(20px, 0, 0);
+        transform: translate3d(-275px, 0, 0);
+        opacity: 0;
         transition: transform 0.25s ease, opacity 0.25s linear;
 
         &--left {
             &-enter, &-exit {
-                transform: scale(1, 1) translate3d(-275px, 0, 0);
+                transform: translate3d(-275px, 0, 0);
                 opacity: 0;
             }
             &-enter-done {

--- a/src/sass/app/_common/drawer/contract-drawer.scss
+++ b/src/sass/app/_common/drawer/contract-drawer.scss
@@ -92,6 +92,9 @@ $header-height: 4em;
                 background: themed('hover_color');
             }
         }
+        &-underlying-trade {
+            width: 100%;
+        }
     }
     .purchase-price {
         font-weight: bold;
@@ -117,6 +120,12 @@ $header-height: 4em;
                     fill: themed('icon_color');
                 }
             }
+            .color2-fill {
+                fill: $COLOR_ORANGE !important;
+            }
+        }
+        .contract-type {
+            margin-left: 0.5em;
         }
     }
     &__symbol {
@@ -124,6 +133,7 @@ $header-height: 4em;
         font-size: 1em;
         line-height: 1.5;
         max-width: 60px;
+        word-break: break-word;
     }
     &__header {
         display: flex;

--- a/src/sass/app/_common/form/button-toggle-menu.scss
+++ b/src/sass/app/_common/form/button-toggle-menu.scss
@@ -21,7 +21,7 @@
             background-color: themed('container_color');
 
             &:hover:not(.button-menu__button--active) {
-                background-color: rgba(themed('tab_hover_color'), 0.08);
+                background-color: themed('tab_hover_color');
             }
         }
 
@@ -55,6 +55,7 @@
 
         .button-menu {
             &__button, &__button--active {
+                background-color: rgba(0, 0, 0, 0) !important;
                 z-index: 1;
             }
             &__button:nth-last-child(2) {


### PR DESCRIPTION
Changelog
- Fix for `END_LINE` undefined bug for certain contract that were causing contract container to unmount.
- Fix animation transition for `button-highlight` not working properly (reverted some breaking changes from #76 ). 
- Fix `singular` and `plural` duration unit text in contract-drawer and positions-drawer for `minutes`.
- Make `datepicker` dialog transition consistent with Timepicker (less jerky animation).