### PR TITLE
zaki/remove_contract-replay_local_layout

### DIFF
--- a/src/javascript/app/Modules/Contract/Containers/contract-replay.jsx
+++ b/src/javascript/app/Modules/Contract/Containers/contract-replay.jsx
@@ -31,6 +31,9 @@ class ContractReplay extends React.Component {
     }
 
     componentWillUnmount() {
+        // SmartCharts keeps saving layout for ContractPlay even if layouts prop is set to null
+        // As a result, we have to remove it manually for each SmartChart instance in ContractReplay
+        localStorage.removeItem('layout-contract-replay');
         this.props.hideBlur();
         this.props.onUnmount();
         document.removeEventListener('mousedown', this.handleClickOutside);

--- a/src/javascript/app/Modules/Reports/Containers/reports.jsx
+++ b/src/javascript/app/Modules/Reports/Containers/reports.jsx
@@ -22,6 +22,10 @@ class Reports extends React.Component {
     };
 
     componentDidMount() {
+        // SmartCharts keeps saving layout for ContractPlay even if layouts prop is set to null
+        // As a result, we have to remove it manually for each SmartChart instance in ContractReplay
+        // TODO: Remove this once SmartCharts finds a way to stop ChartIQ from saving layouts to localStorage
+        localStorage.removeItem('layout-contract-replay');
         this.props.showBlur();
         document.addEventListener('mousedown', this.handleClickOutside);
         this.setState({ is_visible: true });


### PR DESCRIPTION
Changelog
- Temporary fix to remove `layout` from being saved into `localStorage` for layout of contracts loaded in `contract-replay`.