### PR TITLE
zaki/update_endtime_logic

### DIFF
--- a/src/javascript/app/Stores/Modules/Contract/Helpers/__tests__/logic.js
+++ b/src/javascript/app/Stores/Modules/Contract/Helpers/__tests__/logic.js
@@ -267,7 +267,7 @@ describe('logic', () => {
                 tick_count: 5,
                 exit_tick_time: 9999999,
                 sell_time: 1000000,
-                is_sold: 1,
+                is_expired: 1,
                 date_expiry: 8888888,
             };
             expect(Logic.getEndTime(contract_info)).to.eql(9999999);
@@ -276,7 +276,7 @@ describe('logic', () => {
             const contract_info = {
                 exit_tick_time: 9999999,
                 sell_time: 8888888,
-                is_sold: 1,
+                is_expired: 1,
                 date_expiry: 7777777,
             };
             expect(Logic.getEndTime(contract_info)).to.eql(7777777);
@@ -285,7 +285,7 @@ describe('logic', () => {
             const contract_info = {
                 exit_tick_time: 9999999,
                 sell_time: 7777777,
-                is_sold: 1,
+                is_expired: 1,
                 date_expiry: 8888888,
             };
             expect(Logic.getEndTime(contract_info)).to.eql(9999999);
@@ -294,7 +294,6 @@ describe('logic', () => {
             const contract_info = {
                 date_expiry: 8888888,
                 exit_tick_time: 8888887,
-                is_sold: 1,
                 sell_time: 8888889,
                 status: 'sold',
             };
@@ -304,7 +303,6 @@ describe('logic', () => {
             const contract_info = {
                 date_expiry: 8888889,
                 exit_tick_time: 8888887,
-                is_sold: 1,
                 sell_time: 8888888,
                 status: 'sold',
             };
@@ -314,7 +312,17 @@ describe('logic', () => {
             const contract_info = {
                 exit_tick_time: 9999999,
                 sell_time: 1000000,
-                is_sold: 0,
+                is_expired: 0,
+                date_expiry: 888888,
+            };
+            expect(Logic.getEndTime(contract_info)).to.eql(undefined);
+        });
+        it('Should return exit_tick_time if contract is_path_dependent', () => {
+            const contract_info = {
+                exit_tick_time: 9999999,
+                sell_time: 1000000,
+                is_expired: 0,
+                is_path_dependent: '1',
                 date_expiry: 888888,
             };
             expect(Logic.getEndTime(contract_info)).to.eql(undefined);

--- a/src/javascript/app/Stores/Modules/Contract/Helpers/logic.js
+++ b/src/javascript/app/Stores/Modules/Contract/Helpers/logic.js
@@ -87,9 +87,16 @@ export const isValidToSell = (contract_info) => (
 );
 
 export const getEndTime = (contract_info) => {
-    const { exit_tick_time, date_expiry, sell_time, tick_count : is_tick_contract, is_sold } = contract_info;
+    const {
+        exit_tick_time,
+        date_expiry,
+        is_expired,
+        is_path_dependent,
+        sell_time,
+        tick_count: is_tick_contract,
+    } = contract_info;
 
-    if (!is_sold) return undefined;
+    if (!is_expired && !isUserSold(contract_info)) return undefined;
 
     if (isUserSold(contract_info)) {
         return (sell_time > date_expiry) ?
@@ -98,5 +105,5 @@ export const getEndTime = (contract_info) => {
         return date_expiry;
     }
 
-    return exit_tick_time;
+    return (date_expiry > exit_tick_time && !(+is_path_dependent)) ? date_expiry : exit_tick_time;
 };


### PR DESCRIPTION
Changelog
- Update endtime logic for drawing exit_spot and end_time markers/lines in same response once the properties are available.
- Updated test file.