### PR TITLE
zaki/remove_chartid_from_contract-replay

### DIFF
--- a/src/javascript/app/Modules/Contract/Containers/contract-replay.jsx
+++ b/src/javascript/app/Modules/Contract/Containers/contract-replay.jsx
@@ -29,9 +29,6 @@ class ContractReplay extends React.Component {
     }
 
     componentWillUnmount() {
-        // SmartCharts keeps saving layout for ContractReplay even if layouts prop is set to null
-        // As a result, we have to remove it manually for each SmartChart instance in ContractReplay
-        localStorage.removeItem('layout-contract-replay');
         this.props.hideBlur();
         this.props.onUnmount();
         document.removeEventListener('mousedown', this.handleClickOutside);
@@ -59,7 +56,6 @@ class ContractReplay extends React.Component {
         const {
             config,
             contract_info,
-            chart_id,
             is_chart_loading,
             is_dark_theme,
             is_sell_requested,
@@ -96,7 +92,6 @@ class ContractReplay extends React.Component {
                         <ChartLoader is_visible={is_chart_loading} />
                         {(!!(contract_info.underlying) && !isEmptyObject(config)) &&
                         <SmartChart
-                            chart_id={chart_id}
                             chartControlsWidgets={null}
                             Digits={<Digits />}
                             InfoBox={<InfoBox />}
@@ -115,7 +110,6 @@ class ContractReplay extends React.Component {
 }
 
 ContractReplay.propTypes = {
-    chart_id        : PropTypes.string,
     config          : PropTypes.object,
     contract_id     : PropTypes.number,
     contract_info   : PropTypes.object,
@@ -137,7 +131,6 @@ ContractReplay.propTypes = {
 
 export default withRouter(connect(
     ({ modules, ui }) => ({
-        chart_id         : modules.smart_chart.replay_id,
         config           : modules.contract.replay_config,
         is_sell_requested: modules.contract.is_sell_requested,
         is_static_chart  : modules.contract.is_replay_static_chart,

--- a/src/javascript/app/Stores/Modules/SmartChart/smart-chart-store.js
+++ b/src/javascript/app/Stores/Modules/SmartChart/smart-chart-store.js
@@ -33,7 +33,6 @@ export default class SmartChartStore extends BaseStore {
     @observable scroll_to_left_epoch_offset = 0;
 
     @observable chart_id             = 'trade';
-    @observable replay_id            = 'contract-replay';
     @observable is_chart_loading     = false;
     @observable is_chart_ready       = false;
     @observable should_import_layout = false;


### PR DESCRIPTION
Changelog
- Since `layouts` is unnecessary in `contract-replay` we should disable the saving of the `layout` to `localStorage` to prevent unnecessary overrides when opening contracts with `contract-replay`.
- SmartCharts checks for `chartId` before it saves the `layout` to `localstorage`, hence removing it fixes the issue with saved `layouts` overriding contract specific layouts.