### PR TITLE
zaki/fix_close_on_buy

### DIFF
--- a/src/javascript/app/Stores/Modules/Contract/contract-store.js
+++ b/src/javascript/app/Stores/Modules/Contract/contract-store.js
@@ -216,6 +216,7 @@ export default class ContractStore extends BaseStore {
         this.is_ongoing_contract = false;
         this.sell_info           = {};
 
+        if (!this.smart_chart) this.smart_chart = this.root_store.modules.smart_chart;
         this.smart_chart.cleanupContractChartView();
         this.smart_chart.applySavedTradeChartLayout();
         WS.forgetAll('proposal').then(this.root_store.modules.trade.requestProposal());


### PR DESCRIPTION
Changelog
- Fix error for undefined `smartchart` instance when `proposal_open_contract` response has yet to be received and mounted after `contract_mode` is initialized from `buy`.