### PR TITLE
zaki/trade_type_explanation_theme_fix

### DIFF
--- a/src/javascript/app/Assets/Trading/Categories/trade-categories-gif.jsx
+++ b/src/javascript/app/Assets/Trading/Categories/trade-categories-gif.jsx
@@ -15,48 +15,48 @@ import ImageTouchDark        from 'Images/app/trade_explanations/img-touch-no-to
 import ImageTouchLight       from 'Images/app/trade_explanations/img-touch-no-touch-light.svg';
 
 // TODO: Replace static image svgs with themed GIFs or animated SVGs
-const TradeCategoriesGIF = ({ category, className, is_dark }) => {
+const TradeCategoriesGIF = ({ category, className, is_dark_theme }) => {
     let TradeTypeGIF;
     const themed_classes = classNames(className,
         {
-            [`${className}--dark`] : is_dark,
-            [`${className}--light`]: !is_dark,
+            [`${className}--dark`] : is_dark_theme,
+            [`${className}--light`]: !is_dark_theme,
         }
     );
     if (category) {
         switch (category) {
             case ('rise_fall' || 'rise_fall_equal'):
-                TradeTypeGIF = is_dark ?
+                TradeTypeGIF = is_dark_theme ?
                     (<ImageRiseFallDark className={themed_classes} />)
                     :
                     (<ImageRiseFallLight className={themed_classes} />);
                 break;
             case 'high_low':
-                TradeTypeGIF = is_dark ?
+                TradeTypeGIF = is_dark_theme ?
                     (<ImageHigherLowerDark className={themed_classes} />)
                     :
                     (<ImageHigherLowerLight className={themed_classes} />);
                 break;
             case 'match_diff':
-                TradeTypeGIF = is_dark ?
+                TradeTypeGIF = is_dark_theme ?
                     (<ImageMatchesDark className={themed_classes} />)
                     :
                     (<ImageMatchesLight className={themed_classes} />);
                 break;
             case 'even_odd':
-                TradeTypeGIF = is_dark ?
+                TradeTypeGIF = is_dark_theme ?
                     (<ImageEvenOddDark className={themed_classes} />)
                     :
                     (<ImageEvenOddLight className={themed_classes} />);
                 break;
             case 'over_under':
-                TradeTypeGIF = is_dark ?
+                TradeTypeGIF = is_dark_theme ?
                     (<ImageOverUnderDark className={themed_classes} />)
                     :
                     (<ImageOverUnderLight className={themed_classes} />);
                 break;
             case 'touch':
-                TradeTypeGIF = is_dark ?
+                TradeTypeGIF = is_dark_theme ?
                     (<ImageTouchDark className={themed_classes} />)
                     :
                     (<ImageTouchLight className={themed_classes} />);
@@ -74,9 +74,9 @@ const TradeCategoriesGIF = ({ category, className, is_dark }) => {
 };
 
 TradeCategoriesGIF.propTypes = {
-    category : PropTypes.string,
-    className: PropTypes.string,
-    is_dark  : PropTypes.bool,
+    category     : PropTypes.string,
+    className    : PropTypes.string,
+    is_dark_theme: PropTypes.bool,
 };
 
 export default TradeCategoriesGIF;

--- a/src/javascript/app/Assets/icon.jsx
+++ b/src/javascript/app/Assets/icon.jsx
@@ -36,7 +36,7 @@ class Icon extends React.PureComponent {
             IconWarning           : React.lazy(() => import('./Common/icon-warning.jsx')),
             IconWip               : React.lazy(() => import('./Common/icon-wip.jsx')),
             IconWithdrawal        : React.lazy(() => import('./Common/icon-withdrawal.jsx')),
-            
+
             // Contract
             ContractIconClose: React.lazy(() => import('./Contract/icon-close.jsx')),
             IconEndTime      : React.lazy(() => import('./Contract/icon-end-time.jsx')),
@@ -96,6 +96,7 @@ class Icon extends React.PureComponent {
             className    : this.props.className,
             classNamePath: this.props.classNamePath,
             classNameRect: this.props.classNameRect,
+            is_dark_theme: this.props.is_dark_theme,
             is_disabled  : this.props.is_disabled,
             onClick      : this.props.onClick,
             onMouseEnter : this.props.onMouseEnter,
@@ -105,7 +106,7 @@ class Icon extends React.PureComponent {
 
         const IconLazy = this.icons[this.props.icon];
         if (!IconLazy) return <div />;
-        
+
         return (
             <React.Suspense fallback={<div />}>
                 <IconLazy {...options} />
@@ -120,6 +121,7 @@ Icon.propTypes = {
     classNamePath: PropTypes.string,
     classNameRect: PropTypes.string,
     icon         : PropTypes.string,
+    is_dark_theme: PropTypes.bool,
     is_disabled  : PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
     onClick      : PropTypes.func,
     type         : PropTypes.string,

--- a/src/javascript/app/Modules/Trading/Components/Form/TradeTypeInfo/trade-type-info-item.jsx
+++ b/src/javascript/app/Modules/Trading/Components/Form/TradeTypeInfo/trade-type-info-item.jsx
@@ -41,7 +41,7 @@ const TradeTypeInfoItem = ({
                                     icon='TradeCategoriesGIF'
                                     category={type.value}
                                     className='trade-type-info-dialog__gif-image'
-                                    is_dark={is_dark_theme}
+                                    is_dark_theme={is_dark_theme}
                                 />
                             </div>
                             <div className='trade-type-info-dialog__content'>


### PR DESCRIPTION
Changelog
- Fixed incorrect asset used for dark theme when viewing trade type explanation image/gif.