### PR TITLE
zaki/fix_contract_running_after_account_switch

### DIFF
--- a/src/App/Containers/AccountSwitcher/account-switcher.jsx
+++ b/src/App/Containers/AccountSwitcher/account-switcher.jsx
@@ -26,6 +26,7 @@ class AccountSwitcher extends React.Component {
         if (this.props.is_positions_drawer_on) {
             this.props.togglePositionsDrawer(); // TODO: hide drawer inside logout, once it is a mobx action
         }
+        this.props.clearContract();
         requestLogout().then(this.props.cleanUp);
     };
 
@@ -144,6 +145,7 @@ AccountSwitcher.propTypes = {
     account_list          : PropTypes.array,
     account_loginid       : PropTypes.string,
     cleanUp               : PropTypes.func,
+    clearContract         : PropTypes.func,
     clearError            : PropTypes.func,
     has_error             : PropTypes.bool,
     is_logged_in          : PropTypes.bool,
@@ -168,6 +170,7 @@ const account_switcher = connect(
         upgrade_info          : client.upgrade_info,
         cleanUp               : client.cleanUp,
         virtual_loginid       : client.virtual_account_loginid,
+        clearContract         : modules.trade.clearContract,
         clearError            : modules.contract.clearError,
         has_error             : modules.contract.has_error,
         is_positions_drawer_on: ui.is_positions_drawer_on,

--- a/src/Modules/Trading/Containers/trade.jsx
+++ b/src/Modules/Trading/Containers/trade.jsx
@@ -76,7 +76,7 @@ class Trade extends React.Component {
                         is_mobile={this.props.is_mobile}
                         is_contract_visible={this.props.is_contract_mode}
                         is_trade_enabled={this.props.is_trade_enabled}
-                        is_blurred={this.props.is_market_closed || !this.props.is_chart_ready}
+                        is_blurred={this.props.is_market_closed}
                     />
                 </div>
             </div>

--- a/src/Stores/Modules/Contract/contract-store.js
+++ b/src/Stores/Modules/Contract/contract-store.js
@@ -138,6 +138,9 @@ export default class ContractStore extends BaseStore {
     onMountBuy(contract_id) {
         if (contract_id === this.contract_id) return;
         this.contract_id = contract_id;
+        // clear proposal and purchase info once contract is mounted
+        this.root_store.modules.trade.proposal_info = {};
+        this.root_store.modules.trade.purchase_info = {};
         BinarySocket.wait('authorize').then(() => {
             this.handleSubscribeProposalOpenContract(this.contract_id, this.updateProposal);
         });
@@ -152,6 +155,10 @@ export default class ContractStore extends BaseStore {
         this.error_message     = '';
         this.contract_id       = contract_id;
         this.is_from_positions = is_from_positions;
+
+        // clear proposal and purchase info once contract is mounted
+        this.root_store.modules.trade.proposal_info = {};
+        this.root_store.modules.trade.purchase_info = {};
 
         if (contract_id) {
             this.replay_info = {};
@@ -212,7 +219,6 @@ export default class ContractStore extends BaseStore {
         if (!this.smart_chart) this.smart_chart = this.root_store.modules.smart_chart;
         this.smart_chart.cleanupContractChartView();
         this.smart_chart.applySavedTradeChartLayout();
-        WS.forgetAll('proposal').then(this.root_store.modules.trade.requestProposal());
     }
 
     @action.bound
@@ -299,7 +305,7 @@ export default class ContractStore extends BaseStore {
 
         // Set contract symbol if trade_symbol and contract_symbol don't match
         if (this.root_store.modules.trade.symbol !== this.contract_info.underlying) {
-            this.root_store.modules.trade.updateSymbol(this.contract_info.underlying);
+            this.root_store.modules.trade.symbol = this.contract_info.underlying;
         }
 
         this.drawChart(this.contract_info);

--- a/src/Stores/Modules/Contract/contract-store.js
+++ b/src/Stores/Modules/Contract/contract-store.js
@@ -146,7 +146,6 @@ export default class ContractStore extends BaseStore {
     @action.bound
     onMount(contract_id, is_from_positions) {
         if (contract_id === this.contract_id) return;
-        this.onSwitchAccount(this.accountSwitcherListener.bind(null));
         this.smart_chart       = this.root_store.modules.smart_chart;
         if (this.smart_chart.is_contract_mode) this.onCloseContract();
         this.has_error         = false;
@@ -194,12 +193,6 @@ export default class ContractStore extends BaseStore {
         this.sell_info                = {};
         this.smart_chart.setContractMode(false);
         this.smart_chart.cleanupContractChartView();
-    }
-
-    @action.bound
-    accountSwitcherListener () {
-        this.smart_chart.setContractMode(false);
-        return new Promise((resolve) => resolve(this.onCloseContract()));
     }
 
     @action.bound

--- a/src/Stores/Modules/Portfolio/portfolio-store.js
+++ b/src/Stores/Modules/Portfolio/portfolio-store.js
@@ -213,9 +213,9 @@ export default class PortfolioStore extends BaseStore {
 
     @action.bound
     accountSwitcherListener () {
-        return new Promise((resolve) => {
-            this.clearTable();
-            WS.forgetAll('proposal_open_contract', 'transaction');
+        return new Promise(async (resolve) => {
+            await this.clearTable();
+            await WS.forgetAll('proposal_open_contract', 'transaction');
             return resolve(this.initializePortfolio());
         });
     }

--- a/src/Stores/Modules/SmartChart/smart-chart-store.js
+++ b/src/Stores/Modules/SmartChart/smart-chart-store.js
@@ -42,6 +42,8 @@ export default class SmartChartStore extends BaseStore {
     @observable trade_chart_layout   = null;
     @observable should_refresh_active_symbols = false;
     trade_chart_symbol               = null;
+    trade_chart_granularity          = null;
+    trade_chart_type                 = null;
 
     @action.bound
     switchToContractMode(is_from_positions = false, granularity = 0, chart_type = 'mountain') {
@@ -194,10 +196,12 @@ export default class SmartChartStore extends BaseStore {
 
     @action.bound
     saveAndClearTradeChartLayout(chart_id) {
-        this.should_export_layout = true;
-        this.should_import_layout = false;
-        this.trade_chart_symbol   = this.root_store.modules.trade.symbol;
-        this.chart_id             = chart_id;
+        this.should_export_layout    = true;
+        this.should_import_layout    = false;
+        this.trade_chart_symbol      = this.root_store.modules.trade.symbol;
+        this.trade_chart_granularity = this.root_store.modules.smart_chart.granularity;
+        this.trade_chart_type        = this.root_store.modules.smart_chart.chart_type;
+        this.chart_id                = chart_id;
     }
 
     @action.bound
@@ -216,8 +220,9 @@ export default class SmartChartStore extends BaseStore {
 
             // Reset back to symbol before loading contract if trade_symbol and contract_symbol don't match
             if (this.trade_chart_symbol !== this.root_store.modules.trade.symbol) {
-                this.root_store.modules.trade.updateSymbol(this.trade_chart_symbol);
+                this.root_store.modules.trade.symbol = this.trade_chart_symbol;
             }
+            WS.forgetAll('proposal').then(this.root_store.modules.trade.requestProposal());
 
             // Clear chart loading status once ChartListener returns ready
             if (this.is_chart_ready) {

--- a/src/Stores/Modules/Trading/trade-store.js
+++ b/src/Stores/Modules/Trading/trade-store.js
@@ -615,11 +615,26 @@ export default class TradeStore extends BaseStore {
     }
 
     @action.bound
+    restoreTradeChart() {
+        const smart_chart_store = this.root_store.modules.smart_chart;
+        if (smart_chart_store.trade_chart_symbol !== this.symbol) {
+            this.symbol = smart_chart_store.trade_chart_symbol;
+        }
+        if (smart_chart_store.trade_chart_granularity !== smart_chart_store.granularity) {
+            smart_chart_store.granularity = smart_chart_store.trade_chart_granularity;
+        }
+        if (smart_chart_store.trade_chart_chart_type !== smart_chart_store.chart_type) {
+            smart_chart_store.chart_type = smart_chart_store.trade_chart_type;
+        }
+    }
+
+    @action.bound
     onUnmount() {
         this.disposeSwitchAccount();
         this.proposal_info = {};
         this.purchase_info = {};
         WS.forgetAll('proposal');
+        this.restoreTradeChart();
         this.is_trade_component_mounted = false;
         // clear url query string
         window.history.pushState(null, null, window.location.pathname);

--- a/src/Stores/client-store.js
+++ b/src/Stores/client-store.js
@@ -354,6 +354,7 @@ export default class ClientStore extends BaseStore {
                 });
                 // request a logout
                 requestLogout();
+                this.root_store.modules.trade.clearContract();
                 return;
             }
 

--- a/src/Stores/client-store.js
+++ b/src/Stores/client-store.js
@@ -15,10 +15,10 @@ import { localize }                  from 'App/i18n';
 import {
     LocalStore,
     State }                          from '_common/storage';
+import BinarySocketGeneral           from 'Services/socket-general';
 import BaseStore                     from './base-store';
 import { buildCurrenciesList }       from './Modules/Trading/Helpers/currency';
 import { handleClientNotifications } from './Helpers/client-notifications';
-import BinarySocketGeneral           from 'Services/socket-general';
 
 const storage_key = 'client.accounts';
 export default class ClientStore extends BaseStore {


### PR DESCRIPTION
Changelog
- Fixed issue with `contract-store` `accountSwitcherListener` not firing after switching accounts in contract-mode by moving the clearContract function to `trade-store`.