### PR TITLE
zaki/contract_chart_fixes

### DIFF
--- a/src/Modules/Contract/Containers/contract-replay.jsx
+++ b/src/Modules/Contract/Containers/contract-replay.jsx
@@ -79,7 +79,7 @@ class ContractReplay extends React.Component {
                             <Icon
                                 className='vertical-tab__action-bar--icon'
                                 key={localize('Close')}
-                                icon='DialogIconClose'
+                                icon='ModalIconClose'
                                 onClick={() => this.props.history.push(AppRoutes.trade)}
                             />
                         </div>

--- a/src/Modules/Contract/Containers/contract-replay.jsx
+++ b/src/Modules/Contract/Containers/contract-replay.jsx
@@ -46,14 +46,6 @@ class ContractReplay extends React.Component {
     };
 
     render() {
-        const action_bar_items = [
-            {
-                onClick: () => this.props.history.push(AppRoutes.trade),
-                icon   : 'DialogIconClose',
-                title  : localize('Close'),
-            },
-        ];
-
         const {
             config,
             contract_info,
@@ -84,16 +76,12 @@ class ContractReplay extends React.Component {
                 <React.Suspense fallback={<div />}>
                     <div className='replay-chart__container'>
                         <div className='vertical-tab__action-bar'>
-                            {
-                                action_bar_items.map(({ icon, onClick, title }) => (
-                                    <Icon
-                                        className='vertical-tab__action-bar--icon'
-                                        key={title}
-                                        icon={icon}
-                                        onClick={onClick}
-                                    />
-                                ))
-                            }
+                            <Icon
+                                className='vertical-tab__action-bar--icon'
+                                key={localize('Close')}
+                                icon='DialogIconClose'
+                                onClick={() => this.props.history.push(AppRoutes.trade)}
+                            />
                         </div>
                         <NotificationMessages />
                         <ChartLoader is_visible={is_chart_loading} />

--- a/src/Stores/Modules/SmartChart/smart-chart-store.js
+++ b/src/Stores/Modules/SmartChart/smart-chart-store.js
@@ -63,11 +63,13 @@ export default class SmartChartStore extends BaseStore {
     @action.bound
     updateChartType(type) {
         this.chart_type = type;
+        this.trade_chart_type = type;
     }
 
     @action.bound
     updateGranularity(granularity) {
         this.granularity = granularity;
+        this.trade_chart_granularity = granularity;
     }
 
     @action.bound

--- a/src/Stores/Modules/Trading/trade-store.js
+++ b/src/Stores/Modules/Trading/trade-store.js
@@ -263,6 +263,11 @@ export default class TradeStore extends BaseStore {
     onChange(e) {
         const { name, value } = e.target;
 
+        // save trade_chart_symbol upon user change
+        if (name === 'symbol' && value) {
+            this.root_store.modules.smart_chart.trade_chart_symbol = value;
+        }
+
         if (name === 'currency') {
             this.root_store.client.selectCurrency(value);
         } else if (name === 'expiry_date') {
@@ -617,10 +622,12 @@ export default class TradeStore extends BaseStore {
     @action.bound
     restoreTradeChart() {
         const smart_chart_store = this.root_store.modules.smart_chart;
-        if (smart_chart_store.trade_chart_symbol !== this.symbol) {
+        if (smart_chart_store.trade_chart_symbol &&
+            (smart_chart_store.trade_chart_symbol !== this.symbol)) {
             this.symbol = smart_chart_store.trade_chart_symbol;
         }
-        if (smart_chart_store.trade_chart_granularity !== smart_chart_store.granularity) {
+        if (smart_chart_store.trade_chart_granularity &&
+            (smart_chart_store.trade_chart_granularity !== smart_chart_store.granularity)) {
             smart_chart_store.granularity = smart_chart_store.trade_chart_granularity;
         }
         if (smart_chart_store.trade_chart_chart_type !== smart_chart_store.chart_type) {

--- a/src/sass/app/_common/layout/layouts.scss
+++ b/src/sass/app/_common/layout/layouts.scss
@@ -263,20 +263,6 @@
     .chartContainer {
         background: transparent;
         min-height: 100%;
-
-        &:before {
-            content: '';
-            position: absolute;
-            height: 100%;
-            width: 80px;
-            top: 0;
-            left: -2px;
-            pointer-events: none;
-            z-index: 2;
-            @include themify($themes) {
-                background-image: themed('chart_gradient_color');
-            }
-        }
     }
     @media (max-width: 768px) {
         height: 400px;


### PR DESCRIPTION
Changelog
- Make sure chart `props` exist before re-assigning `trade_chart` props upon unMount.
- Remove white shade on left side of chart for highest lowest clipping issue.
- Renamed icon to fix issue with missing close button on contract page.