### PR TITLE
kelly/fix_radio_group_key

### DIFF
--- a/src/App/Components/Form/Radio/radio-group.jsx
+++ b/src/App/Components/Form/Radio/radio-group.jsx
@@ -7,9 +7,9 @@ class RadioGroup extends React.PureComponent {
         const { selected, items } = this.props;
         return (
             <div className='radio-group'>
-                {items.map(item => (
+                {items.map((item, idx) => (
                     <Radio
-                        key={item.label}
+                        key={idx}
                         value={item.value}
                         selected={selected === item.value}
                         onClick={this.props.onToggle}


### PR DESCRIPTION
- pass `index` as component's `key` instead of label