### PR TITLE
trader/timepicker_value_reset

### DIFF
--- a/packages/trader/src/Stores/Modules/Trading/trade-store.js
+++ b/packages/trader/src/Stores/Modules/Trading/trade-store.js
@@ -73,6 +73,7 @@ export default class TradeStore extends BaseStore {
     @observable duration_min_max    = {};
     @observable expiry_date         = '';
     @observable expiry_time         = '';
+    @observable expiry_time_old     = '';
     @observable expiry_type         = 'duration';
 
     // Barrier
@@ -129,6 +130,7 @@ export default class TradeStore extends BaseStore {
             'duration',
             'duration_unit',
             'expiry_date',
+            'expiry_time_old',
             'expiry_type',
             'is_equal',
             'last_digit',


### PR DESCRIPTION
Time picker value reset on refresh and date change.

Change Log :

- New observable `expiry_date_time` that saves to local storage to store previous `expiry_time` values.