### PR TITLE
zaki/fixed_smartcharts_version

### DIFF
--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -126,7 +126,7 @@
     "react-router-dom": "^5.0.1",
     "react-transition-group": "^2.5.0",
     "react-window": "^1.8.4",
-    "smartcharts-beta": "^0.5.1",
+    "smartcharts-beta": "~0.5.1",
     "tt-react-custom-scrollbars": "^4.2.1-tt2",
     "url-polyfill": "^1.1.5",
     "web-push-notifications": "^3.2.15"


### PR DESCRIPTION
Changelog
- Keep `smartcharts-beta` at `0.5.1` as latest published version requires API changes.