### PR TITLE
zaki/fix_reports_scrollbar

### DIFF
--- a/packages/trader/src/App/Components/Elements/DataTable/data-table.jsx
+++ b/packages/trader/src/App/Components/Elements/DataTable/data-table.jsx
@@ -4,13 +4,42 @@ import { PropTypes as MobxPropTypes } from 'mobx-react';
 import { FixedSizeList as List }      from 'react-window';
 import { ThemedScrollbars }           from 'deriv-components';
 import PropTypes                      from 'prop-types';
-import React                          from 'react';
+import React, { useCallback }         from 'react';
 import TableRow                       from './table-row.jsx';
 
 /* TODO:
       1. implement sorting by column (ASC/DESC)
       2. implement filtering per column
 */
+
+const ListScrollbar = React.forwardRef((props, ref) => (
+    <ExtendedScrollbars {...props} forwardedRef={ref} />
+));
+
+// Display name is required by Developer Tools to give a name to the components we use.
+// If a component doesn't have a displayName is will be shown as <Unknown />. Hence, name is set.
+ListScrollbar.displayName = 'ListScrollbar';
+
+const ExtendedScrollbars = ({ onScroll, forwardedRef, style, children }) => {
+    const refSetter = useCallback(scrollbarsRef => {
+        if (scrollbarsRef) {
+            forwardedRef(scrollbarsRef.view);
+        } else {
+            forwardedRef(null);
+        }
+    }, []);
+
+    return (
+        <ThemedScrollbars
+            ref={refSetter}
+            style={{ ...style, overflow: 'hidden' }}
+            onScroll={onScroll}
+            autoHide
+        >
+            {children}
+        </ThemedScrollbars>
+    );
+};
 
 class DataTable extends React.PureComponent {
     constructor(props) {
@@ -109,6 +138,7 @@ class DataTable extends React.PureComponent {
                     itemCount={data_source.length}
                     itemSize={item_size || 63}
                     width={this.state.width}
+                    outerElementType={is_empty ? null : ListScrollbar}
                 >
                     {this.rowRenderer.bind(this)}
                 </List>
@@ -127,20 +157,10 @@ class DataTable extends React.PureComponent {
                 </div>
                 <div
                     className='table__body'
-                    onScroll={onScroll}
                     ref={el => { this.el_table_body = el; }}
+                    onScroll={onScroll}
                 >
-                    {is_empty ?
-                        TableData
-                        :
-                        <ThemedScrollbars
-                            autoHeight
-                            autoHeightMax={this.state.height}
-                            autoHide
-                        >
-                            {TableData}
-                        </ThemedScrollbars>
-                    }
+                    {TableData}
                 </div>
 
                 {footer &&


### PR DESCRIPTION
### Changelog

**Trader**
- Fixes issue where `List` from `react-window` is not rendering `ThemedScrollbars` in Reports pages (Statement/Profit Table). 
- Used `outerElementType` to render `ThemedScrollbars` around `TableData` instead.