### PR TITLE
mahdi/fix_gsw_config

### DIFF
--- a/packages/trader/build/config.js
+++ b/packages/trader/build/config.js
@@ -25,7 +25,7 @@ const copyConfig = (base) => ([
 ]);
 
 const generateSWConfig = () => ({
-    importWorkboxFrom    : IS_RELEASE ? 'local' : 'disabled',
+    importWorkboxFrom    : 'local',
     cleanupOutdatedCaches: true,
     exclude              : [/CNAME$/, /index\.html$/, /404\.html$/],
     skipWaiting          : true,

--- a/packages/trader/build/constants.js
+++ b/packages/trader/build/constants.js
@@ -117,11 +117,12 @@ const plugins = (base, is_test_env, is_mocha_only) => ([
     new IgnorePlugin(/^\.\/locale$/, /moment$/),
     new MiniCssExtractPlugin(cssConfig()),
     new CircularDependencyPlugin({ exclude: /node_modules/, failOnError: true }),
-    ...(IS_RELEASE ? [] : [ new AssetsManifestPlugin({ fileName: 'asset-manifest.json', filter: (file) => file.name !== 'CNAME' }) ]),
+    ...(IS_RELEASE && !is_test_env ? [
+        new GenerateSW(generateSWConfig())
+    ] : [ new AssetsManifestPlugin({ fileName: 'asset-manifest.json', filter: (file) => file.name !== 'CNAME' }) ]),
     ...(is_test_env && !is_mocha_only ? [
         new StylelintPlugin(stylelintConfig()),
     ] : [
-        new GenerateSW(generateSWConfig())
         // ...(!IS_RELEASE ? [ new BundleAnalyzerPlugin({ analyzerMode: 'static' }) ] : []),
     ])
 ]);


### PR DESCRIPTION
Fixed issue with Workbox folder not generating on release builds

### Trader

+ Removed `new GenerateSW` from plugins list if `IS_RELEASE` is falsy
+ Removed `IS_RELEASE` condition from `generateSWConfig()` config obj