### PR TITLE
zaki/update_mobile_notifications

### DIFF
--- a/packages/components/src/components/collapsible/collapsible.scss
+++ b/packages/components/src/components/collapsible/collapsible.scss
@@ -31,7 +31,7 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        height: 40px;
+        height: 32px;
     }
     &__icon {
         transition: transform 0.3s ease-in-out;

--- a/packages/components/src/components/mobile-dialog/mobile-dialog.jsx
+++ b/packages/components/src/components/mobile-dialog/mobile-dialog.jsx
@@ -65,7 +65,10 @@ const MobileDialog = (props) => {
                         className='icons btn-close dc-mobile-dialog__close-btn'
                         onClick={props.onClose}
                     >
-                        <Icon icon='IcCross' className='dc-mobile-dialog__close-btn-icon' />
+                        <Icon
+                            icon='IcCross'
+                            className='dc-mobile-dialog__close-btn-icon'
+                        />
                     </div>
                 </div>
                 <div className='dc-mobile-dialog__content'>

--- a/packages/components/src/components/mobile-dialog/mobile-dialog.scss
+++ b/packages/components/src/components/mobile-dialog/mobile-dialog.scss
@@ -9,7 +9,7 @@
     z-index: 999;
     overflow: auto;
     transition: opacity 0.2s;
-    background: var(--general-section-1);
+    background: var(--general-section-2);
     // transform here would break fixed header
 
     &--enter, &--exit {
@@ -42,7 +42,7 @@
         padding-top: 3.6rem;
         padding-bottom: 7rem; // ios bottom bar fix
         z-index: 1;
-        background: var(--general-section-1);
+        background: var(--general-section-2);
         transition: all 0.2s ease-out;
     }
     &__header {
@@ -57,10 +57,10 @@
         padding: 1rem;
         height: $MOBILE_HEADER_HEIGHT;
         z-index: 4;
-        background: var(--general-section-1);
+        background: var(--general-section-2);
         transition: all 0.2s ease-out;
         transition-delay: 0.2s;
-        border-bottom: 1px solid var(--general-section-2);
+        border-bottom: 1px solid var(--border-disabled);
     }
     &__title {
         padding: 1.2rem 1.2rem 1.2rem 0.4rem;

--- a/packages/components/src/components/numpad/numpad.scss
+++ b/packages/components/src/components/numpad/numpad.scss
@@ -19,19 +19,19 @@ $SQUARE_SIZE: 48px;
 
     &--is-regular {
         grid-template-areas: 'np np np np'
-        'n n n b'
-        'n n n b'
-        'n n n o'
-        'z z z o';
+            'n n n b'
+            'n n n b'
+            'n n n o'
+            'z z z o';
         grid-template-columns: min-content min-content min-content minmax($SQUARE_SIZE, 1fr);
         max-width: min-content;
     }
     &--is-currency {
         grid-template-areas: 'np np np np'
-        'n n n b'
-        'n n n b'
-        'n n n o'
-        'z z p o';
+            'n n n b'
+            'n n n b'
+            'n n n o'
+            'z z p o';
         grid-template-columns: min-content min-content min-content minmax($SQUARE_SIZE, 1fr);
         max-width: min-content;
     }
@@ -49,14 +49,11 @@ $SQUARE_SIZE: 48px;
         grid-area: nc;
         @include append-button(left);
     }
-    &__increment,
-    &__decrement {
+    &__increment, &__decrement {
         width: $SQUARE_SIZE;
         height: $SQUARE_SIZE;
     }
-    &__input-field,
-    &__increment,
-    &__decrement {
+    &__input-field, &__increment, &__decrement {
         background-color: var(--general-section-1);
         color: var(--text-prominent);
     }

--- a/packages/core/src/App/Components/Layout/Header/account-actions.jsx
+++ b/packages/core/src/App/Components/Layout/Header/account-actions.jsx
@@ -55,6 +55,7 @@ export class AccountActions extends Component {
                 <React.Fragment>
                     <MobileWrapper>
                         <ToggleNotifications
+                            is_mobile
                             count={notifications_count}
                             is_visible={is_notifications_visible}
                             toggleDialog={toggleNotifications}

--- a/packages/core/src/App/Components/Layout/Header/account-actions.jsx
+++ b/packages/core/src/App/Components/Layout/Header/account-actions.jsx
@@ -55,7 +55,6 @@ export class AccountActions extends Component {
                 <React.Fragment>
                     <MobileWrapper>
                         <ToggleNotifications
-                            is_mobile
                             count={notifications_count}
                             is_visible={is_notifications_visible}
                             toggleDialog={toggleNotifications}

--- a/packages/core/src/App/Components/Layout/Header/toggle-notifications.jsx
+++ b/packages/core/src/App/Components/Layout/Header/toggle-notifications.jsx
@@ -2,44 +2,66 @@ import classNames          from 'classnames';
 import React               from 'react';
 import {
     Counter,
+    DesktopWrapper,
     Icon,
+    MobileWrapper,
     Popover }              from '@deriv/components';
 import NotificationsDialog from 'App/Containers/NotificationsDialog';
 import                          'Sass/app/modules/notifications-dialog.scss';
 
-const ToggleNotificationsDrawer = ({ count, is_visible, toggleDialog, tooltip_message }) =>  (
-    <div className={classNames('notifications-toggle', {
-        'notifications-toggle--active': is_visible,
-    })}
-    >
-        <Popover
-            classNameBubble='notifications-toggle__tooltip'
-            alignment='bottom'
-            message={tooltip_message}
+const ToggleNotificationsDrawer = ({
+    count,
+    is_visible,
+    toggleDialog,
+    tooltip_message }) => {
+
+    const notifications_toggler_el = (
+        <div
+            className={classNames('notifications-toggle__icon-wrapper', {
+                'notifications-toggle__icon-wrapper--active': is_visible,
+            })}
+            onClick={toggleDialog}
         >
-            <div
-                className={classNames('notifications-toggle__icon-wrapper', {
-                    'notifications-toggle__icon-wrapper--active': is_visible,
-                })}
-                onClick={toggleDialog}
-            >
-                <Icon
-                    className='notifications-toggle__icon'
-                    icon='IcBell'
+            <Icon
+                className='notifications-toggle__icon'
+                icon='IcBell'
+            />
+            {!!count &&
+                <Counter
+                    count={count}
+                    className='notifications-toggle__step'
                 />
-                {!!count &&
-                    <Counter
-                        count={count}
-                        className='notifications-toggle__step'
-                    />
-                }
-            </div>
-        </Popover>
-        <NotificationsDialog
-            is_visible={is_visible}
-            toggleDialog={toggleDialog}
-        />
-    </div>
-);
+            }
+        </div>
+    );
+
+    return (
+        <div className={classNames('notifications-toggle', {
+            'notifications-toggle--active': is_visible,
+        })}
+        >
+            <DesktopWrapper>
+                <Popover
+                    classNameBubble='notifications-toggle__tooltip'
+                    alignment='bottom'
+                    message={tooltip_message}
+                >
+                    {notifications_toggler_el}
+                </Popover>
+                <NotificationsDialog
+                    is_visible={is_visible}
+                    toggleDialog={toggleDialog}
+                />
+            </DesktopWrapper>
+            <MobileWrapper>
+                {notifications_toggler_el}
+                <NotificationsDialog
+                    is_visible={is_visible}
+                    toggleDialog={toggleDialog}
+                />
+            </MobileWrapper>
+        </div>
+    );
+};
 
 export default ToggleNotificationsDrawer;

--- a/packages/core/src/App/Containers/Layout/app-contents.jsx
+++ b/packages/core/src/App/Containers/Layout/app-contents.jsx
@@ -1,9 +1,13 @@
-import classNames           from 'classnames';
-import PropTypes            from 'prop-types';
-import React                from 'react';
-import { withRouter }       from 'react-router';
-import { ThemedScrollbars } from '@deriv/components';
-import { connect }          from 'Stores/connect';
+import classNames      from 'classnames';
+import PropTypes       from 'prop-types';
+import React           from 'react';
+import { withRouter }  from 'react-router';
+import {
+    DesktopWrapper,
+    MobileWrapper,
+    ThemedScrollbars } from '@deriv/components';
+import { isMobile }    from '@deriv/shared/utils/screen';
+import { connect }     from 'Stores/connect';
 // import InstallPWA    from './install-pwa.jsx';
 
 const AppContents = ({
@@ -13,7 +17,6 @@ const AppContents = ({
     is_app_disabled,
     is_positions_drawer_on,
     is_route_modal_on,
-    is_mobile,
     pageView,
     // setPWAPromptEvent,
 }) => {
@@ -42,22 +45,22 @@ const AppContents = ({
             className={classNames('app-contents', {
                 'app-contents--show-positions-drawer': is_positions_drawer_on,
                 'app-contents--is-disabled'          : is_app_disabled,
-                'app-contents--is-mobile'            : is_mobile,
+                'app-contents--is-mobile'            : isMobile(),
                 'app-contents--is-route-modal'       : is_route_modal_on,
             })}
         >
-            {/* Calculate height of user screen and offset height of header and footer */}
-            {is_mobile ?
-
-                children
-                :
+            <MobileWrapper>
+                {children}
+            </MobileWrapper>
+            <DesktopWrapper>
+                {/* Calculate height of user screen and offset height of header and footer */}
                 <ThemedScrollbars
                     autoHide
                     style={{ height: 'calc(100vh - 83px)' }}
                 >
                     {children}
                 </ThemedScrollbars>
-            }
+            </DesktopWrapper>
         </div>
     );
 };
@@ -67,7 +70,6 @@ AppContents.propTypes = {
     children              : PropTypes.any,
     is_app_disabled       : PropTypes.bool,
     is_logged_in          : PropTypes.bool,
-    is_mobile             : PropTypes.bool,
     is_positions_drawer_on: PropTypes.bool,
     is_route_modal_on     : PropTypes.bool,
     pwa_prompt_event      : PropTypes.object,
@@ -80,7 +82,6 @@ export default withRouter(connect(
         // addNotificationBar    : ui.addNotificationBar,
         identifyEvent         : segment.identifyEvent,
         is_app_disabled       : ui.is_app_disabled,
-        is_mobile             : ui.is_mobile,
         is_positions_drawer_on: ui.is_positions_drawer_on,
         is_route_modal_on     : ui.is_route_modal_on,
         pageView              : segment.pageView,

--- a/packages/core/src/App/Containers/Layout/header.jsx
+++ b/packages/core/src/App/Containers/Layout/header.jsx
@@ -2,7 +2,10 @@ import classNames              from 'classnames';
 import PropTypes               from 'prop-types';
 import React                   from 'react';
 import { withRouter }          from 'react-router-dom';
-import { isDesktop, isMobile } from '@deriv/shared/utils/screen';
+import {
+    DesktopWrapper,
+    MobileWrapper }            from '@deriv/components';
+import { isMobile }            from '@deriv/shared/utils/screen';
 import {
     AccountActions,
     MenuLinks,
@@ -65,31 +68,29 @@ class Header extends React.Component {
             >
                 <div className='header__menu-items'>
                     <div className='header__menu-left'>
-
-                        {isDesktop() ?
+                        <DesktopWrapper>
                             <PlatformSwitcher platform_config={filterPlatformsForClients(platform_config)} />
-                            :
-                            <>
-                                <ToggleMenuDrawer
-                                    enableApp={enableApp}
-                                    disableApp={disableApp}
-                                    logoutClient={logoutClient}
-                                    is_dark_mode={is_dark_mode}
-                                    is_logged_in={is_logged_in}
-                                    toggleTheme={setDarkMode}
-                                    platform_switcher={
-                                        <PlatformSwitcher
-                                            is_mobile={isMobile()}
-                                            platform_config={filterPlatformsForClients(platform_config)}
-                                        />}
-                                />
-                                {(header_extension && is_logged_in) &&
-                                    <div className='header__menu-left-extensions'>
-                                        { header_extension }
-                                    </div>
-                                }
-                            </>
-                        }
+                        </DesktopWrapper>
+                        <MobileWrapper>
+                            <ToggleMenuDrawer
+                                enableApp={enableApp}
+                                disableApp={disableApp}
+                                logoutClient={logoutClient}
+                                is_dark_mode={is_dark_mode}
+                                is_logged_in={is_logged_in}
+                                toggleTheme={setDarkMode}
+                                platform_switcher={
+                                    <PlatformSwitcher
+                                        is_mobile
+                                        platform_config={filterPlatformsForClients(platform_config)}
+                                    />}
+                            />
+                            {(header_extension && is_logged_in) &&
+                                <div className='header__menu-left-extensions'>
+                                    {header_extension}
+                                </div>
+                            }
+                        </MobileWrapper>
                         <MenuLinks
                             is_logged_in={is_logged_in}
                             items={header_links}
@@ -102,7 +103,6 @@ class Header extends React.Component {
                         {is_logging_in &&
                         <div className={classNames('acc-info__preloader', {
                             'acc-info__preloader--no-currency': !currency,
-                            'acc-info__preloader--is-mobile'  : isMobile(),
                         })}
                         >
                             <AccountsInfoLoader
@@ -121,7 +121,6 @@ class Header extends React.Component {
                                 disableApp={disableApp}
                                 enableApp={enableApp}
                                 is_acc_switcher_on={is_acc_switcher_on}
-                                is_mobile={isMobile()}
                                 is_notifications_visible={is_notifications_visible}
                                 is_logged_in={is_logged_in}
                                 is_virtual={is_virtual}

--- a/packages/core/src/App/Containers/Layout/header.jsx
+++ b/packages/core/src/App/Containers/Layout/header.jsx
@@ -2,6 +2,7 @@ import classNames              from 'classnames';
 import PropTypes               from 'prop-types';
 import React                   from 'react';
 import { withRouter }          from 'react-router-dom';
+import { isDesktop, isMobile } from '@deriv/shared/utils/screen';
 import {
     AccountActions,
     MenuLinks,
@@ -33,7 +34,6 @@ class Header extends React.Component {
             is_dark_mode,
             is_logged_in,
             is_logging_in,
-            is_mobile,
             is_mt5_allowed,
             is_notifications_visible,
             is_route_modal_on,
@@ -59,14 +59,14 @@ class Header extends React.Component {
 
         return (
             <header className={classNames('header', {
-                'header--is-mobile'  : is_mobile,
+                'header--is-mobile'  : isMobile(),
                 'header--is-disabled': (is_app_disabled || is_route_modal_on),
             })}
             >
                 <div className='header__menu-items'>
                     <div className='header__menu-left'>
 
-                        {!this.props.is_mobile ?
+                        {isDesktop() ?
                             <PlatformSwitcher platform_config={filterPlatformsForClients(platform_config)} />
                             :
                             <>
@@ -79,7 +79,7 @@ class Header extends React.Component {
                                     toggleTheme={setDarkMode}
                                     platform_switcher={
                                         <PlatformSwitcher
-                                            is_mobile={is_mobile}
+                                            is_mobile={isMobile()}
                                             platform_config={filterPlatformsForClients(platform_config)}
                                         />}
                                 />
@@ -96,18 +96,18 @@ class Header extends React.Component {
                         />
                     </div>
                     <div className={classNames('header__menu-right', {
-                        'header__menu-right--mobile': is_mobile,
+                        'header__menu-right--mobile': isMobile(),
                     })}
                     >
                         {is_logging_in &&
                         <div className={classNames('acc-info__preloader', {
                             'acc-info__preloader--no-currency': !currency,
-                            'acc-info__preloader--is-mobile'  : is_mobile,
+                            'acc-info__preloader--is-mobile'  : isMobile(),
                         })}
                         >
                             <AccountsInfoLoader
                                 is_logged_in={is_logged_in}
-                                is_mobile={is_mobile}
+                                is_mobile={isMobile()}
                                 speed={3}
                             />
                         </div>
@@ -121,7 +121,7 @@ class Header extends React.Component {
                                 disableApp={disableApp}
                                 enableApp={enableApp}
                                 is_acc_switcher_on={is_acc_switcher_on}
-                                is_mobile={is_mobile}
+                                is_mobile={isMobile()}
                                 is_notifications_visible={is_notifications_visible}
                                 is_logged_in={is_logged_in}
                                 is_virtual={is_virtual}
@@ -153,7 +153,6 @@ Header.propTypes = {
     is_dark_mode            : PropTypes.bool,
     is_logged_in            : PropTypes.bool,
     is_logging_in           : PropTypes.bool,
-    is_mobile               : PropTypes.bool,
     is_notifications_visible: PropTypes.bool,
     is_route_modal_on       : PropTypes.bool,
     is_virtual              : PropTypes.bool,
@@ -184,7 +183,6 @@ export default connect(
         notifications_count     : ui.notifications.length,
         is_notifications_visible: ui.is_notifications_visible,
         is_route_modal_on       : ui.is_route_modal_on,
-        is_mobile               : ui.is_mobile,
         openRealAccountSignup   : ui.openRealAccountSignup,
         disableApp              : ui.disableApp,
         toggleAccountsDialog    : ui.toggleAccountsDialog,

--- a/packages/core/src/App/Containers/NotificationsDialog/notifications-dialog.jsx
+++ b/packages/core/src/App/Containers/NotificationsDialog/notifications-dialog.jsx
@@ -4,8 +4,12 @@ import React                 from 'react';
 import { CSSTransition }     from 'react-transition-group';
 import {
     Button,
+    DesktopWrapper,
     Icon,
+    MobileDialog,
+    MobileWrapper,
     ThemedScrollbars }       from '@deriv/components';
+// import { isMobile }          from '@deriv/shared/utils/screen';
 import { BinaryLink }        from 'App/Components/Routes';
 import { connect }           from 'Stores/connect';
 import { localize }          from '@deriv/translations';
@@ -41,82 +45,101 @@ class NotificationsDialog extends React.Component {
     }
 
     render() {
-        return (
-            <CSSTransition
-                in={this.props.is_visible}
-                classNames={{
-                    enter    : 'notifications-dialog--enter',
-                    enterDone: 'notifications-dialog--enter-done',
-                    exit     : 'notifications-dialog--exit',
-                }}
-                timeout={150}
-                unmountOnExit
-            >
-                <div className='notifications-dialog' ref={this.setWrapperRef}>
-                    <div className='notifications-dialog__header'>
-                        <h2 className='notifications-dialog__header-text'>
-                            {localize('Notifications')}
-                        </h2>
-                    </div>
-                    <div className={classNames('notifications-dialog__content', {
-                        'notifications-dialog__content--empty': !(this.props.notifications && this.props.notifications.length),
-                    })}
-                    >
-                        {
-                            this.props.notifications && this.props.notifications.length ?
-                                <ThemedScrollbars
-                                    style={{ width: '100%', height: '100%' }}
-                                    autoHide
-                                >
-                                    {
-                                        this.props.notifications.map((item, idx) => (
-                                            <div className='notifications-item' key={idx}>
-                                                <h2 className='notifications-item__title'>
-                                                    {item.type &&
-                                                        <Icon
-                                                            icon={(item.type === 'info' || item.type === 'contract_sold') ?
-                                                                'IcAlertInfo'
-                                                                :
-                                                                `IcAlert${toTitleCase(item.type)}`
-                                                            }
-                                                            className={classNames('notifications-item__title-icon', {
-                                                                [`notifications-item__title-icon--${item.type}`]: item.type,
-                                                            })}
+        const notifications_dialog_el = (
+            <div className='notifications-dialog' ref={this.setWrapperRef}>
+                <div className='notifications-dialog__header'>
+                    <h2 className='notifications-dialog__header-text'>
+                        {localize('Notifications')}
+                    </h2>
+                </div>
+                <div className={classNames('notifications-dialog__content', {
+                    'notifications-dialog__content--empty': !(this.props.notifications && this.props.notifications.length),
+                })}
+                >
+                    {
+                        this.props.notifications && this.props.notifications.length ?
+                            <ThemedScrollbars
+                                style={{ width: '100%', height: '100%' }}
+                                autoHide
+                            >
+                                {
+                                    this.props.notifications.map((item, idx) => (
+                                        <div className='notifications-item' key={idx}>
+                                            <h2 className='notifications-item__title'>
+                                                {item.type &&
+                                                    <Icon
+                                                        icon={(item.type === 'info' || item.type === 'contract_sold') ?
+                                                            'IcAlertInfo'
+                                                            :
+                                                            `IcAlert${toTitleCase(item.type)}`
+                                                        }
+                                                        className={classNames('notifications-item__title-icon', {
+                                                            [`notifications-item__title-icon--${item.type}`]: item.type,
+                                                        })}
+                                                    />
+                                                }
+                                                {item.header}
+                                            </h2>
+                                            <div className='notifications-item__message'>
+                                                {item.message}
+                                            </div>
+                                            {!ObjectUtils.isEmptyObject(item.action) &&
+                                                <React.Fragment>
+                                                    { item.action.route ?
+                                                        <BinaryLink
+                                                            className={classNames('btn', 'btn--secondary', 'notifications-item__cta-button')}
+                                                            to={item.action.route}
+                                                        >
+                                                            <span className='btn__text'>{item.action.text}</span>
+                                                        </BinaryLink>
+                                                        :
+                                                        <Button
+                                                            className={classNames('btn--secondary', 'notifications-item__cta-button')}
+                                                            onClick={item.action.onClick}
+                                                            text={item.action.text}
                                                         />
                                                     }
-                                                    {item.header}
-                                                </h2>
-                                                <div className='notifications-item__message'>
-                                                    {item.message}
-                                                </div>
-                                                {!ObjectUtils.isEmptyObject(item.action) &&
-                                                    <React.Fragment>
-                                                        { item.action.route ?
-                                                            <BinaryLink
-                                                                className={classNames('btn', 'btn--secondary', 'notifications-item__cta-button')}
-                                                                to={item.action.route}
-                                                            >
-                                                                <span className='btn__text'>{item.action.text}</span>
-                                                            </BinaryLink>
-                                                            :
-                                                            <Button
-                                                                className={classNames('btn--secondary', 'notifications-item__cta-button')}
-                                                                onClick={item.action.onClick}
-                                                                text={item.action.text}
-                                                            />
-                                                        }
-                                                    </React.Fragment>
-                                                }
-                                            </div>
-                                        ))
-                                    }
-                                </ThemedScrollbars>
-                                :
-                                <EmptyNotification />
-                        }
-                    </div>
+                                                </React.Fragment>
+                                            }
+                                        </div>
+                                    ))
+                                }
+                            </ThemedScrollbars>
+                            :
+                            <EmptyNotification />
+                    }
                 </div>
-            </CSSTransition>
+            </div>
+        );
+
+        return (
+            <React.Fragment>
+                <MobileWrapper>
+                    <MobileDialog
+                        container_el='deriv_app'
+                        title={localize('Notifications')}
+                        wrapper_classname='notifications-mobile-dialog'
+                        visible={this.props.is_visible}
+                        onClose={this.props.toggleDialog}
+                    >
+                        {notifications_dialog_el}
+                    </MobileDialog>
+                </MobileWrapper>
+                <DesktopWrapper>
+                    <CSSTransition
+                        in={this.props.is_visible}
+                        classNames={{
+                            enter    : 'notifications-dialog--enter',
+                            enterDone: 'notifications-dialog--enter-done',
+                            exit     : 'notifications-dialog--exit',
+                        }}
+                        timeout={150}
+                        unmountOnExit
+                    >
+                        {notifications_dialog_el}
+                    </CSSTransition>
+                </DesktopWrapper>
+            </React.Fragment>
         );
     }
 }

--- a/packages/core/src/sass/app/_common/components/account-switcher.scss
+++ b/packages/core/src/sass/app/_common/components/account-switcher.scss
@@ -28,7 +28,7 @@
             top: 0;
             background: var(--general-main-1);
         }
-        &--is-mobile {
+        @include mobile {
             width: 216px;
             height: 40px;
             top: -3px;
@@ -143,7 +143,7 @@
         background-color: var(--general-main-2);
 
 
-        &--is-mobile {
+        @include mobile {
             position: relative;
             top: unset;
             left: unset;

--- a/packages/core/src/sass/app/_common/layout/header.scss
+++ b/packages/core/src/sass/app/_common/layout/header.scss
@@ -23,7 +23,7 @@
         content: '';
         background-color: var(--overlay-outside-dialog);
     }
-    &--is-mobile {
+    @include mobile {
         height: $MOBILE_HEADER_HEIGHT;
 
         .header__menu-left, .header__menu-right {
@@ -126,7 +126,7 @@
         height: #{$HEADER_HEIGHT - 1px};
         position: relative;
 
-        &--mobile {
+        @include mobile {
             .acc-info__separator {
                 display: none;
             }

--- a/packages/core/src/sass/app/_common/layout/layouts.scss
+++ b/packages/core/src/sass/app/_common/layout/layouts.scss
@@ -25,7 +25,7 @@
     &--is-route-modal {
         background-color: var(--overlay-outside-dialog);
     }
-    &--is-mobile {
+    @include mobile {
         margin: $MOBILE_HEADER_HEIGHT 0 $FOOTER_HEIGHT;
         height: calc(100vh - #{$MOBILE_HEADER_HEIGHT} - #{$FOOTER_HEIGHT});
     }

--- a/packages/core/src/sass/app/modules/notifications-dialog.scss
+++ b/packages/core/src/sass/app/modules/notifications-dialog.scss
@@ -62,6 +62,7 @@
             left: unset;
             box-shadow: none;
             width: 100%;
+            background: var(--general-section-2);
         }
         &__header {
             display: flex;

--- a/packages/core/src/sass/app/modules/notifications-dialog.scss
+++ b/packages/core/src/sass/app/modules/notifications-dialog.scss
@@ -54,6 +54,15 @@
         opacity: 0;
         transform: translate3d(0, -20px, 0);
 
+        @include mobile {
+            opacity: unset;
+            transform: none;
+            position: relative;
+            top: unset;
+            left: unset;
+            box-shadow: none;
+            width: 100%;
+        }
         &__header {
             display: flex;
             align-items: center;
@@ -66,12 +75,18 @@
                 margin: 1rem 0;
                 color: var(--text-prominent);
             }
+            @include mobile {
+                display: none;
+            }
         }
         &__content {
             padding: 8px 0;
             height: calc(100% - 37px);
             border-radius: $BORDER_RADIUS;
 
+            @include mobile {
+                height: calc(100vh - 40px);
+            }
             &--empty {
                 display: flex;
                 height: 100%;
@@ -146,6 +161,9 @@
             .btn__text {
                 font-size: 1.2rem;
             }
+            @include mobile {
+                margin: 8px 0 16px auto;
+            }
         }
         &__title {
             font-size: 1.4rem;
@@ -174,6 +192,16 @@
                 text-decoration: none;
                 font-weight: bold;
                 color: var(--text-prominent);
+            }
+        }
+        @include mobile {
+            display: flex;
+            flex-direction: column;
+
+            &:after {
+                left: -1.8rem;
+                width: calc(100% + 1.4em);
+                height: 2px;
             }
         }
     }

--- a/packages/shared/src/utils/screen/responsive.js
+++ b/packages/shared/src/utils/screen/responsive.js
@@ -1,5 +1,6 @@
 export const MAX_MOBILE_WIDTH = 767;
 export const MAX_TABLET_WIDTH = 1023;
-export const isMobile = () => window.innerWidth <= MAX_MOBILE_WIDTH;
+export const isTouchDevice = () => 'ontouchstart' in document.documentElement;
+export const isMobile = () => (window.innerWidth <= MAX_MOBILE_WIDTH);
 export const isDesktop = () => window.innerWidth > MAX_TABLET_WIDTH;
 export const isTablet = () => MAX_MOBILE_WIDTH < window.innerWidth && window.innerWidth <= MAX_TABLET_WIDTH;

--- a/packages/trader/src/Modules/SmartChart/Components/control-widgets.jsx
+++ b/packages/trader/src/Modules/SmartChart/Components/control-widgets.jsx
@@ -1,5 +1,6 @@
-import PropTypes      from 'prop-types';
-import React          from 'react';
+import PropTypes          from 'prop-types';
+import React              from 'react';
+import { DesktopWrapper } from '@deriv/components';
 import {
     ChartSize,
     ChartTypes,
@@ -9,24 +10,23 @@ import {
     Share,
     StudyLegend,
     Timeperiod,
-    Views }           from 'Modules/SmartChart';
+    Views }               from 'Modules/SmartChart';
 
 const ControlWidgets = ({
-    is_mobile,
     updateChartType,
     updateGranularity,
 }) => (
     <React.Fragment>
-        <CrosshairToggle enabled={!is_mobile} />
+        <DesktopWrapper>
+            <CrosshairToggle enabled />
+        </DesktopWrapper>
         <ChartTypes onChange={updateChartType} />
-        {!is_mobile &&
-            <>
-                <StudyLegend searchInputClassName='data-hj-whitelist' />
-                <Comparison searchInputClassName='data-hj-whitelist' />
-                <DrawTools />
-                <Views searchInputClassName='data-hj-whitelist' />
-            </>
-        }
+        <DesktopWrapper>
+            <StudyLegend searchInputClassName='data-hj-whitelist' />
+            <Comparison searchInputClassName='data-hj-whitelist' />
+            <DrawTools />
+            <Views searchInputClassName='data-hj-whitelist' />
+        </DesktopWrapper>
         <Share />
         <Timeperiod onChange={updateGranularity} />
         <ChartSize />
@@ -34,7 +34,6 @@ const ControlWidgets = ({
 );
 
 ControlWidgets.propTypes = {
-    is_mobile        : PropTypes.bool,
     updateChartType  : PropTypes.func,
     updateGranularity: PropTypes.func,
 };

--- a/packages/trader/src/Modules/Trading/Components/Form/ContractType/contract-type-dialog.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/ContractType/contract-type-dialog.jsx
@@ -1,17 +1,19 @@
 import PropTypes         from 'prop-types';
 import React             from 'react';
 import { CSSTransition } from 'react-transition-group';
-import { MobileDialog }  from '@deriv/components';
+import {
+    DesktopWrapper,
+    MobileDialog,
+    MobileWrapper }      from '@deriv/components';
 import { localize }      from '@deriv/translations';
 
 const ContractTypeDialog = ({
     children,
-    is_mobile,
     open,
     onClose,
 }) => (
-    is_mobile ?
-        <React.Fragment>
+    <React.Fragment>
+        <MobileWrapper>
             <span className='contract-type-widget__select-arrow' />
             <MobileDialog
                 container_el='deriv_app'
@@ -22,31 +24,32 @@ const ContractTypeDialog = ({
             >
                 {children}
             </MobileDialog>
-        </React.Fragment>
-        :
-        <CSSTransition
-            in={open}
-            timeout={100}
-            classNames={{
-                enter    : 'contracts-type-dialog--enter',
-                enterDone: 'contracts-type-dialog--enterDone',
-                exit     : 'contracts-type-dialog--exit',
-            }}
-            unmountOnExit
-        >
-            <div className='contracts-type-dialog'>
-                <div className='contracts-type-dialog__list-wrapper'>
-                    {children}
+        </MobileWrapper>
+        <DesktopWrapper>
+            <CSSTransition
+                in={open}
+                timeout={100}
+                classNames={{
+                    enter    : 'contracts-type-dialog--enter',
+                    enterDone: 'contracts-type-dialog--enterDone',
+                    exit     : 'contracts-type-dialog--exit',
+                }}
+                unmountOnExit
+            >
+                <div className='contracts-type-dialog'>
+                    <div className='contracts-type-dialog__list-wrapper'>
+                        {children}
+                    </div>
                 </div>
-            </div>
-        </CSSTransition>
+            </CSSTransition>
+        </DesktopWrapper>
+    </React.Fragment>
 );
 
 ContractTypeDialog.propTypes = {
-    children : PropTypes.element,
-    is_mobile: PropTypes.bool,
-    onClose  : PropTypes.func,
-    open     : PropTypes.bool,
+    children: PropTypes.element,
+    onClose : PropTypes.func,
+    open    : PropTypes.bool,
 };
 
 export default ContractTypeDialog;

--- a/packages/trader/src/Modules/Trading/Components/Form/ContractType/contract-type-item.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/ContractType/contract-type-item.jsx
@@ -2,7 +2,7 @@ import { PropTypes as MobxPropTypes } from 'mobx-react';
 import classNames                     from 'classnames';
 import PropTypes                      from 'prop-types';
 import React                          from 'react';
-import { Icon }                       from '@deriv/components';
+import { Icon, DesktopWrapper }       from '@deriv/components';
 import IconTradeCategory              from 'Assets/Trading/Categories/icon-trade-categories.jsx';
 
 const ContractTypeItem = ({
@@ -10,7 +10,6 @@ const ContractTypeItem = ({
     name,
     value,
     is_equal,
-    is_mobile,
     handleInfoClick,
     handleSelect,
 }) => (
@@ -30,11 +29,11 @@ const ContractTypeItem = ({
             <span className='contract-type-item__title'>
                 {contract.text}
             </span>
-            {!is_mobile &&
-            <div id='info-icon' className='contract-type-item__icon' onClick={() => handleInfoClick(contract)}>
-                <Icon icon='IcInfoOutline' />
-            </div>
-            }
+            <DesktopWrapper>
+                <div id='info-icon' className='contract-type-item__icon' onClick={() => handleInfoClick(contract)}>
+                    <Icon icon='IcInfoOutline' />
+                </div>
+            </DesktopWrapper>
         </div>
     ))
 );
@@ -47,9 +46,8 @@ ContractTypeItem.propTypes = {
         PropTypes.number,
         PropTypes.string,
     ]),
-    is_mobile: PropTypes.bool,
-    name     : PropTypes.string,
-    value    : PropTypes.string,
+    name : PropTypes.string,
+    value: PropTypes.string,
 };
 
 export default ContractTypeItem;

--- a/packages/trader/src/Modules/Trading/Components/Form/ContractType/contract-type-list.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/ContractType/contract-type-list.jsx
@@ -7,7 +7,6 @@ const ContractTypeList = ({
     handleInfoClick,
     handleSelect,
     is_equal,
-    is_mobile,
     list,
     name,
     value,
@@ -27,7 +26,6 @@ const ContractTypeList = ({
                             handleSelect={handleSelect}
                             handleInfoClick={handleInfoClick}
                             is_equal={is_equal}
-                            is_mobile={is_mobile}
                         />
                     </div>
                 </div>
@@ -42,10 +40,9 @@ ContractTypeList.propTypes = {
         PropTypes.number,
         PropTypes.string,
     ]),
-    is_mobile: PropTypes.bool,
-    list     : MobxPropTypes.objectOrObservableObject,
-    name     : PropTypes.string,
-    value    : PropTypes.string,
+    list : MobxPropTypes.objectOrObservableObject,
+    name : PropTypes.string,
+    value: PropTypes.string,
 };
 
 export default ContractTypeList;

--- a/packages/trader/src/Modules/Trading/Components/Form/ContractType/contract-type-widget.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/ContractType/contract-type-widget.jsx
@@ -4,6 +4,7 @@ import React               from 'react';
 import {
     Icon,
     DesktopWrapper }       from '@deriv/components';
+import { isMobile }        from '@deriv/shared/utils/screen';
 import IconTradeCategory   from 'Assets/Trading/Categories/icon-trade-categories.jsx';
 import ContractTypeDialog  from './contract-type-dialog.jsx';
 import ContractTypeList    from './contract-type-list.jsx';
@@ -78,7 +79,7 @@ class ContractTypeWidget extends React.PureComponent {
     };
 
     handleClickOutside = (event) => {
-        if (this.props.is_mobile) return;
+        if (isMobile()) return;
         if (this.wrapper_ref && !this.wrapper_ref.contains(event.target) && this.state.is_dialog_open) {
             this.setState({ is_dialog_open: false });
         } else if (this.wrapper_ref && !this.wrapper_ref.contains(event.target) && this.state.is_info_dialog_open) {
@@ -136,7 +137,7 @@ class ContractTypeWidget extends React.PureComponent {
     };
 
     render() {
-        const { is_dark_theme, is_equal, is_mobile, list, name, value } = this.props;
+        const { is_dark_theme, is_equal, list, name, value } = this.props;
         const { is_dialog_open, is_info_dialog_open, item }             = this.state;
         const item_list        = this.getItemList();
         const item_index       = this.getItemIndex(item, item_list);
@@ -144,9 +145,7 @@ class ContractTypeWidget extends React.PureComponent {
         return (
             <div
                 id='dt_contract_dropdown'
-                className={classNames('contract-type-widget', 'dropdown--left', {
-                    'contract-type-widget--mobile': is_mobile,
-                })}
+                className={classNames('contract-type-widget', 'dropdown--left')}
                 ref={this.setWrapperRef}
                 tabIndex='0'
             >
@@ -174,7 +173,6 @@ class ContractTypeWidget extends React.PureComponent {
                 </div>
 
                 <ContractTypeDialog
-                    is_mobile={is_mobile}
                     onClose={this.handleVisibility}
                     open={is_dialog_open}
                 >
@@ -182,14 +180,12 @@ class ContractTypeWidget extends React.PureComponent {
                         handleInfoClick={this.handleInfoClick}
                         handleSelect={this.handleSelect}
                         is_equal={is_equal}
-                        is_mobile={is_mobile}
                         list={list}
                         name={name}
                         value={value}
                     />
                 </ContractTypeDialog>
                 <TradeTypeInfoDialog
-                    is_mobile={is_mobile}
                     onClose={this.handleInfoClick}
                     open={is_info_dialog_open}
                     title={item.text}
@@ -199,7 +195,6 @@ class ContractTypeWidget extends React.PureComponent {
                         handleNextClick={this.handleNextClick}
                         handlePrevClick={this.handlePrevClick}
                         is_dark_theme={is_dark_theme}
-                        is_mobile={is_mobile}
                         item={item}
                         item_index={item_index < 0 ? undefined : item_index}
                         itemList={item_list}
@@ -219,7 +214,6 @@ ContractTypeWidget.propTypes = {
         PropTypes.number,
         PropTypes.string,
     ]),
-    is_mobile: PropTypes.bool,
     list     : PropTypes.object,
     name     : PropTypes.string,
     onChange : PropTypes.func,

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeTypeInfo/trade-type-info-dialog.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeTypeInfo/trade-type-info-dialog.jsx
@@ -1,50 +1,55 @@
 import PropTypes         from 'prop-types';
 import React             from 'react';
-import { MobileDialog }  from '@deriv/components';
+import {
+    DesktopWrapper,
+    MobileDialog,
+    MobileWrapper }      from '@deriv/components';
 import { CSSTransition } from 'react-transition-group';
 
 const TradeTypeInfoDialog = ({
     children,
-    is_mobile,
     open,
     onClose,
     title,
 }) => (
-    is_mobile ?
-        <MobileDialog
-            container_el='deriv_app'
-            visible={open}
-            onClose={onClose}
-            title={title}
-            wrapper_classname='trade-type-info-modal'
-        >
-            {children}
-        </MobileDialog>
-        :
-        <CSSTransition
-            classNames={{
-                enter    : 'trade-type-info-dialog--enter',
-                enterDone: 'trade-type-info-dialog--enterDone',
-                exit     : 'trade-type-info-dialog--exit',
-            }}
-            in={open}
-            timeout={100}
-            unmountOnExit
-        >
-            <div className='trade-type-info-dialog'>
-                <div className='trade-type-info-dialog__info-wrapper'>
-                    {children}
+    <React.Fragment>
+        <MobileWrapper>
+            <MobileDialog
+                container_el='deriv_app'
+                visible={open}
+                onClose={onClose}
+                title={title}
+                wrapper_classname='trade-type-info-modal'
+            >
+                {children}
+            </MobileDialog>
+        </MobileWrapper>
+        <DesktopWrapper>
+            <CSSTransition
+                classNames={{
+                    enter    : 'trade-type-info-dialog--enter',
+                    enterDone: 'trade-type-info-dialog--enterDone',
+                    exit     : 'trade-type-info-dialog--exit',
+                }}
+                in={open}
+                timeout={100}
+                unmountOnExit
+            >
+                <div className='trade-type-info-dialog'>
+                    <div className='trade-type-info-dialog__info-wrapper'>
+                        {children}
+                    </div>
                 </div>
-            </div>
-        </CSSTransition>
+            </CSSTransition>
+        </DesktopWrapper>
+    </React.Fragment>
 );
 
 TradeTypeInfoDialog.propTypes = {
-    children : PropTypes.element,
-    is_mobile: PropTypes.bool,
-    onClose  : PropTypes.func,
-    open     : PropTypes.bool,
-    title    : PropTypes.string,
+    children: PropTypes.element,
+    onClose : PropTypes.func,
+    open    : PropTypes.bool,
+    title   : PropTypes.string,
 };
 
 export default TradeTypeInfoDialog;

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeTypeInfo/trade-type-info-item.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeTypeInfo/trade-type-info-item.jsx
@@ -3,6 +3,7 @@ import PropTypes       from 'prop-types';
 import React           from 'react';
 import {
     Button,
+    DesktopWrapper,
     Icon,
     ThemedScrollbars }    from '@deriv/components';
 import TradeCategoriesGIF from 'Assets/Trading/Categories/trade-categories-gif.jsx';
@@ -14,7 +15,6 @@ const TradeTypeInfoItem = ({
     handleNextClick,
     handlePrevClick,
     is_dark_theme,
-    is_mobile,
     item,
     item_index,
     itemList,
@@ -23,14 +23,14 @@ const TradeTypeInfoItem = ({
     onSubmitButtonClick,
 }) => (
     <div id={`dt_contract_info_${item.value}`}>
-        {!is_mobile &&
-        <div className='trade-type-info-dialog__header'>
-            <span id='dt_contract_info_back_nav' onClick={() => onBackButtonClick()}>
-                <Icon icon='IcArrowLeftBold' />
-            </span>
-            <span className='title'>{item.text}</span>
-        </div>
-        }
+        <DesktopWrapper>
+            <div className='trade-type-info-dialog__header'>
+                <span id='dt_contract_info_back_nav' onClick={() => onBackButtonClick()}>
+                    <Icon icon='IcArrowLeftBold' />
+                </span>
+                <span className='title'>{item.text}</span>
+            </div>
+        </DesktopWrapper>
         <div className='trade-type-info-dialog__body'>
             <div
                 className='trade-type-info-dialog__card-wrapper'
@@ -108,7 +108,6 @@ TradeTypeInfoItem.propTypes = {
     handleNextClick      : PropTypes.func,
     handlePrevClick      : PropTypes.func,
     is_dark_theme        : PropTypes.bool,
-    is_mobile            : PropTypes.bool,
     item                 : PropTypes.object,
     item_index           : PropTypes.number,
     itemList             : PropTypes.array,

--- a/packages/trader/src/Modules/Trading/Components/Form/form-layout.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/form-layout.jsx
@@ -1,39 +1,35 @@
-import PropTypes   from 'prop-types';
-import React       from 'react';
-import Lazy        from 'App/Containers/Lazy';
-import ScreenLarge from './screen-large.jsx';
-
-// Check if device is touch capable
-const isTouchDevice = 'ontouchstart' in document.documentElement;
+import PropTypes    from 'prop-types';
+import React        from 'react';
+import {
+    DesktopWrapper,
+    MobileWrapper } from '@deriv/components';
+import Lazy         from 'App/Containers/Lazy';
+import ScreenLarge  from './screen-large.jsx';
 
 const FormLayout = ({
-    is_dark_theme,
     is_market_closed,
-    is_mobile,
-    is_tablet,
     is_trade_enabled,
 }) => (
-    (is_mobile || (is_tablet && isTouchDevice)) ?
-        <Lazy
-            ctor={() => import(/* webpackChunkName: "screen-small" */'./screen-small.jsx')}
-            should_load={is_mobile}
-            is_trade_enabled={is_trade_enabled}
-            is_dark_theme={is_dark_theme}
-            
-        />
-        :
-        <ScreenLarge
-            is_dark_theme={is_dark_theme}
-            is_trade_enabled={is_trade_enabled}
-            is_market_closed={is_market_closed}
-        />
+    <React.Fragment>
+        <MobileWrapper>
+            <Lazy
+                ctor={() => import(/* webpackChunkName: "screen-small" */'./screen-small.jsx')}
+                should_load={true}
+                is_trade_enabled={is_trade_enabled}
+
+            />
+        </MobileWrapper>
+        <DesktopWrapper>
+            <ScreenLarge
+                is_trade_enabled={is_trade_enabled}
+                is_market_closed={is_market_closed}
+            />
+        </DesktopWrapper>
+    </React.Fragment>
 );
 
 FormLayout.propTypes = {
-    is_dark_theme   : PropTypes.bool,
     is_market_closed: PropTypes.bool,
-    is_mobile       : PropTypes.bool,
-    is_tablet       : PropTypes.bool,
     is_trade_enabled: PropTypes.bool,
 };
 

--- a/packages/trader/src/Modules/Trading/Components/Form/screen-large.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/screen-large.jsx
@@ -7,14 +7,13 @@ import ContractType          from '../../Containers/contract-type.jsx';
 import Purchase              from '../../Containers/purchase.jsx';
 import TradeParams           from '../../Containers/trade-params.jsx';
 
-const ScreenLarge = ({ is_dark_theme, is_market_closed, is_trade_enabled }) => (
+const ScreenLarge = ({ is_market_closed, is_trade_enabled }) => (
     <div className={classNames('sidebar__items', {
         'sidebar__items--market-closed': is_market_closed,
     })}
     >
         {!is_trade_enabled ?
             <TradeParamsLoader
-                is_dark_theme={is_dark_theme}
                 speed={2}
             />
             :
@@ -32,7 +31,6 @@ const ScreenLarge = ({ is_dark_theme, is_market_closed, is_trade_enabled }) => (
 );
 
 ScreenLarge.propTypes = {
-    is_dark_theme   : PropTypes.bool,
     is_market_closed: PropTypes.bool,
     is_trade_enabled: PropTypes.bool,
 };

--- a/packages/trader/src/Modules/Trading/Components/Form/screen-small.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/screen-small.jsx
@@ -8,12 +8,9 @@ import ContractType          from '../../Containers/contract-type.jsx';
 import Purchase              from '../../Containers/purchase.jsx';
 import                            'Sass/app/_common/mobile-widget.scss';
 
-const ScreenSmall = ({ is_dark_theme, is_trade_enabled }) => (
+const ScreenSmall = ({ is_trade_enabled }) => (
     !is_trade_enabled ?
-        <TradeParamsLoader
-            is_dark_theme={is_dark_theme}
-            speed={2}
-        />
+        <TradeParamsLoader speed={2} />
         :
         <Collapsible
             position='top'
@@ -29,7 +26,6 @@ const ScreenSmall = ({ is_dark_theme, is_trade_enabled }) => (
 );
 
 ScreenSmall.propTypes = {
-    is_dark_theme   : PropTypes.bool,
     is_trade_enabled: PropTypes.bool,
 };
 

--- a/packages/trader/src/Modules/Trading/Containers/contract-type.jsx
+++ b/packages/trader/src/Modules/Trading/Containers/contract-type.jsx
@@ -8,13 +8,11 @@ const Contract = ({
     contract_types_list,
     is_dark_theme,
     is_equal,
-    is_mobile,
     onChange,
 }) => (
     <ContractTypeWidget
         is_dark_theme={is_dark_theme}
         is_equal={is_equal}
-        is_mobile={is_mobile}
         list={contract_types_list}
         name='contract_type'
         onChange={onChange}
@@ -40,6 +38,5 @@ export default connect(
         is_equal           : modules.trade.is_equal,
         onChange           : modules.trade.onChange,
         is_dark_theme      : ui.is_dark_mode_on,
-        is_mobile          : ui.is_mobile,
     })
 )(Contract);

--- a/packages/trader/src/Modules/Trading/Containers/trade.jsx
+++ b/packages/trader/src/Modules/Trading/Containers/trade.jsx
@@ -1,5 +1,9 @@
 import React                 from 'react';
 import Div100vh              from 'react-div-100vh';
+import { DesktopWrapper }    from '@deriv/components';
+import {
+    isDesktop,
+    isMobile }               from '@deriv/shared/utils/screen';
 import ChartLoader           from 'App/Components/Elements/chart-loader.jsx';
 import { connect }           from 'Stores/connect';
 import PositionsDrawer       from 'App/Components/Elements/PositionsDrawer';
@@ -22,16 +26,20 @@ class Trade extends React.Component {
 
     render() {
         const { NotificationMessages } = this.props;
-        const form_wrapper_class = this.props.is_mobile ? 'mobile-wrapper' : 'sidebar__container desktop-only';
+        const form_wrapper_class = isMobile() ? 'mobile-wrapper' : 'sidebar__container desktop-only';
         const is_trade_enabled = (this.props.form_components.length > 0) && this.props.is_trade_enabled;
-        const chart_height = this.props.is_mobile ? 'calc(100rvh - 270px)' : 'unset';
+        const chart_height = isMobile() ? 'calc(100rvh - 270px)' : 'unset';
         return (
             <div id='trade_container' className='trade-container'>
-                {!this.props.is_mobile && <PositionsDrawer />}
+                <DesktopWrapper>
+                    <PositionsDrawer />
+                </DesktopWrapper>
                 {/* Div100vh is workaround for iPhone without bezels,
                     using css vh is not returning correct screen height */}
                 <Div100vh className='chart-container' style={{ height: chart_height }}>
-                    <NotificationMessages />
+                    <DesktopWrapper>
+                        <NotificationMessages />
+                    </DesktopWrapper>
                     <React.Suspense
                         fallback={
                             <ChartLoader
@@ -48,12 +56,9 @@ class Trade extends React.Component {
                     <Test />
                 </Div100vh>
                 <div className={form_wrapper_class}>
-                    { this.props.is_market_closed && <MarketIsClosedOverlay />}
+                    {this.props.is_market_closed && <MarketIsClosedOverlay />}
                     <FormLayout
-                        is_dark_theme={this.props.is_dark_theme}
                         is_market_closed={this.props.is_market_closed}
-                        is_mobile={this.props.is_mobile}
-                        is_tablet={this.props.is_tablet}
                         is_trade_enabled={is_trade_enabled}
                     />
                 </div>
@@ -71,9 +76,6 @@ export default connect(
         onMount             : modules.trade.onMount,
         onUnmount           : modules.trade.onUnmount,
         purchase_info       : modules.trade.purchase_info,
-        is_dark_theme       : ui.is_dark_mode_on,
-        is_mobile           : ui.is_mobile,
-        is_tablet           : ui.is_tablet,
         NotificationMessages: ui.notification_messages_ui,
     })
 )(Trade);
@@ -81,7 +83,7 @@ export default connect(
 // CHART (ChartTrade)--------------------------------------------------------
 
 /* eslint-disable */
-import ControlWidgets          from '../../SmartChart/Components/control-widgets.jsx';
+import ControlWidgets from '../../SmartChart/Components/control-widgets.jsx';
 import { SmartChart } from 'Modules/SmartChart';
 
 // --- BottomWidgets for chart
@@ -171,7 +173,6 @@ class ChartTradeClass extends React.Component {
 
     chartControlsWidgets = () => (
         <ControlWidgets
-            is_mobile={this.props.is_mobile}
             updateChartType={this.props.updateChartType}
             updateGranularity={this.props.updateGranularity}
         />
@@ -202,13 +203,13 @@ class ChartTradeClass extends React.Component {
         return (
             <SmartChart
                 barriers={barriers}
-                bottomWidgets={(show_digits_stats && !this.props.is_mobile) ? this.bottomWidgets : null}
-                showLastDigitStats={!this.props.is_mobile ? show_digits_stats : false}
+                bottomWidgets={(show_digits_stats && isDesktop()) ? this.bottomWidgets : null}
+                showLastDigitStats={isDesktop() ? show_digits_stats : false}
                 chartControlsWidgets={this.chartControlsWidgets}
                 chartStatusListener={(v) => this.props.setChartStatus(!v)}
                 chartType={this.props.chart_type}
                 id='trade'
-                isMobile={this.props.is_mobile}
+                isMobile={isMobile()}
                 granularity={this.props.granularity}
                 requestAPI={this.props.wsSendRequest}
                 requestForget={this.props.wsForget}
@@ -232,7 +233,6 @@ class ChartTradeClass extends React.Component {
 
 const ChartTrade = connect(
     ({ modules, ui, common }) => ({
-        is_mobile        : ui.is_mobile,
         is_socket_opened : common.is_socket_opened,
         updateChartType  : modules.contract_trade.updateChartType,
         updateGranularity: modules.contract_trade.updateGranularity,

--- a/packages/trader/src/sass/app/_common/components/contract-type-list.scss
+++ b/packages/trader/src/sass/app/_common/components/contract-type-list.scss
@@ -3,6 +3,9 @@
     padding: 1.6em 1.6em 0em;
     border-bottom: 4px solid var(--general-section-2);
 
+    @include mobile {
+        border-bottom: 4px solid var(--border-disabled)
+    }
     &__label {
         @include typeface(--paragraph-left-bold-black);
         color: var(--text-prominent);

--- a/packages/trader/src/sass/app/_common/components/contract-type-widget.scss
+++ b/packages/trader/src/sass/app/_common/components/contract-type-widget.scss
@@ -7,14 +7,10 @@
     color: var(--text-prominent);
     background: var(--fill-normal);
     border: 1px solid var(--fill-normal);
+
     @include mobile {
         margin-bottom: 0.8rem;
         height: 4rem;
-    }
-
-    &--mobile {
-        border: 1px solid var(--border-normal);
-        margin-bottom: 8px;
 
         .contract-type-widget__display {
             padding: 0.8rem;

--- a/packages/trader/src/sass/app/_common/layout/layouts.scss
+++ b/packages/trader/src/sass/app/_common/layout/layouts.scss
@@ -34,11 +34,6 @@
             }
         }
     }
-    @media screen and (max-width: 768px) {
-        // no footer:
-        margin-bottom: 0;
-        height: calc(100vh - #{$HEADER_HEIGHT});
-    }
 }
 
 /** @define trade-container; weak */
@@ -133,7 +128,7 @@
             }
         }
     }
-    @media (max-width: 768px) {
+    @include mobile {
         flex-direction: column;
         min-height: calc(100vh - 48px);
         padding: 0;
@@ -269,11 +264,13 @@
         background: transparent;
         min-height: 100%;
     }
-    @media (max-width: 768px) {
+    @include mobile {
         // smartchart library style fixes
         .cq-context {
             div.cq-chart-controls {
                 border: 1px solid $COLOR_LIGHT_BLACK_4;
+                width: calc(100% - 16px);
+                margin-left: 8px;
             }
         }
         .cq-modal-dropdown {
@@ -367,114 +364,5 @@
         transform: translate3d(calc(100% + 1.6em), 0, 0);
         opacity: 0;
         pointer-events: none;
-    }
-}
-
-/** @define advanced-simple-toggle */
-.advanced-simple-toggle {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: calc(100% + 18px);
-    /* margin shorthand for values below does not work */
-    margin-top: 8px;
-    margin-left: -9px;
-    margin-bottom: -9px;
-    margin-right: 0;
-    padding: 8px 0;
-    border-bottom-right-radius: $BORDER_RADIUS;
-    border-bottom-left-radius: $BORDER_RADIUS;
-    border: 0;
-    background: none;
-    transition: background-color 0.25s linear;
-
-    &__icon {
-        transition: transform 0.2s ease;
-        @extend %inline-icon;
-
-        &--active {
-            transform: rotate(180deg);
-        }
-    }
-    &:hover {
-        cursor: pointer;
-        background-color: var(--general-hover);
-    }
-    &:focus {
-        outline: none;
-    }
-}
-
-@mixin contract_type_icon_wrapper {
-    width: 2.4em;
-    height: 2.4em;
-    border-radius: 3px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: var(--general-main-2);
-}
-
-/** @define category-wrapper */
-.category-wrapper {
-    @include contract_type_icon_wrapper;
-}
-
-/** @define type-wrapper */
-.type-wrapper {
-    @include contract_type_icon_wrapper;
-
-    /* postcss-bem-linter: ignore */
-    .color1-fill {
-        fill: var(--brand-red-coral);
-    }
-    /* postcss-bem-linter: ignore */
-    .color2-fill {
-        fill: var(--brand-secondary);
-    }
-}
-
-// Helpers
-/** @define no-scroll */
-.no-scroll {
-    overflow: hidden;
-    max-height: 100vh;
-}
-
-/** @define desktop-only */
-.desktop-only {
-    @media (max-width: 768px) {
-        display: none !important;
-    }
-}
-
-/** @define mobile-only */
-.mobile-only {
-    @media (min-width: 769px) {
-        display: none !important;
-    }
-}
-
-/** @define error */
-.error {
-    &__container {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        height: calc(100vh - 9em); // TODO: replace with 100vh - header height - footer height
-    }
-    &__message {
-        @include interpolate(font-size, 320px, 1440px, 14px, 20px);
-        color: var(--text-general);
-    }
-}
-
-@keyframes fadeIn {
-    from {
-        opacity: 0;
-    }
-    to {
-        opacity: 1;
     }
 }


### PR DESCRIPTION
### Changelog

**Trader**
- Removed `is_mobile` and replace with `MobileWrapper` and also `isMobile` from `components` and `shared`.
- Removed redundant styles in layouts.

**Core**
- Removed `is_mobile` and replace use-cases with `MobileWrapper` and `isMobile` from `components` and `shared` respectively.
- Update `NotificationsDialog` to use `MobileDialog` and mobile-only styles in responsive mobile design.

Components
- Update `MobileDialog` colors.
- Update `Collapsible` height.
