### PR TITLE
Arash/Duration datepicker

### DIFF
--- a/packages/components/src/components/relative-datepicker/relative-datepicker.jsx
+++ b/packages/components/src/components/relative-datepicker/relative-datepicker.jsx
@@ -2,7 +2,7 @@ import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import { toMoment, daysFromTodayTo } from '@deriv/shared/utils/date';
 
-const RelativeDatepicker = ({ onChange, min_date, max_date, title }) => {
+const RelativeDatepicker = ({ onChange, min, max, title }) => {
     const hidden_input_ref = useRef();
 
     const clickHandler = () => {
@@ -12,12 +12,14 @@ const RelativeDatepicker = ({ onChange, min_date, max_date, title }) => {
         onChange(daysFromTodayTo(e.target.value));
     };
 
-    const min_date_moment = toMoment()
-        .add(min_date || 1, 'd')
-        .format('YYYY-MM-DD');
-    const max_date_moment = max_date
+    const min_date = min
         ? toMoment()
-              .add(max_date, 'd')
+              .add(min, 'd')
+              .format('YYYY-MM-DD')
+        : null;
+    const max_date = max
+        ? toMoment()
+              .add(max, 'd')
               .format('YYYY-MM-DD')
         : null;
     return (
@@ -27,8 +29,8 @@ const RelativeDatepicker = ({ onChange, min_date, max_date, title }) => {
                 type='date'
                 ref={hidden_input_ref}
                 onChange={onChangeHandler}
-                min_date={min_date_moment}
-                max={max_date_moment}
+                min={min_date}
+                max={max_date}
                 className='dc-relative-datepicker__input'
             />
         </div>
@@ -36,8 +38,8 @@ const RelativeDatepicker = ({ onChange, min_date, max_date, title }) => {
 };
 
 RelativeDatepicker.propTypes = {
-    max_date: PropTypes.string,
-    min_date: PropTypes.string,
+    max: PropTypes.string,
+    min: PropTypes.string,
     onChange: PropTypes.func,
     title: PropTypes.string,
 };

--- a/packages/components/src/components/relative-datepicker/relative-datepicker.jsx
+++ b/packages/components/src/components/relative-datepicker/relative-datepicker.jsx
@@ -1,8 +1,8 @@
-import React, { useRef } from 'react';
+import React, { useRef, Children } from 'react';
 import PropTypes from 'prop-types';
 import { toMoment, daysFromTodayTo } from '@deriv/shared/utils/date';
 
-const RelativeDatepicker = ({ onChange, min, max, title }) => {
+const RelativeDatepicker = ({ onChange, min, max, children }) => {
     const hidden_input_ref = useRef();
 
     const clickHandler = () => {
@@ -12,8 +12,7 @@ const RelativeDatepicker = ({ onChange, min, max, title }) => {
         onChange(daysFromTodayTo(e.target.value));
     };
 
-    const InputDateFormat = date => {
-        console.log(date);
+    const inputDateFormat = date => {
         return date
             ? toMoment()
                   .add(date, 'd')
@@ -22,13 +21,13 @@ const RelativeDatepicker = ({ onChange, min, max, title }) => {
     };
     return (
         <div className='dc-relative-datepicker' onClick={clickHandler}>
-            <span className='dc-relative-datepicker__span'>{title}</span>
+            {children}
             <input
                 type='date'
                 ref={hidden_input_ref}
                 onChange={onChangeHandler}
-                min={InputDateFormat(min)}
-                max={InputDateFormat(max)}
+                min={inputDateFormat(min)}
+                max={inputDateFormat(max)}
                 className='dc-relative-datepicker__input'
             />
         </div>
@@ -39,7 +38,6 @@ RelativeDatepicker.propTypes = {
     max: PropTypes.number,
     min: PropTypes.number,
     onChange: PropTypes.func,
-    title: PropTypes.string,
 };
 
 export default RelativeDatepicker;

--- a/packages/components/src/components/relative-datepicker/relative-datepicker.jsx
+++ b/packages/components/src/components/relative-datepicker/relative-datepicker.jsx
@@ -12,16 +12,14 @@ const RelativeDatepicker = ({ onChange, min, max, title }) => {
         onChange(daysFromTodayTo(e.target.value));
     };
 
-    const min_date = min
-        ? toMoment()
-              .add(min, 'd')
-              .format('YYYY-MM-DD')
-        : null;
-    const max_date = max
-        ? toMoment()
-              .add(max, 'd')
-              .format('YYYY-MM-DD')
-        : null;
+    const InputDateFormat = date => {
+        console.log(date);
+        return date
+            ? toMoment()
+                  .add(date, 'd')
+                  .format('YYYY-MM-DD')
+            : null;
+    };
     return (
         <div className='dc-relative-datepicker' onClick={clickHandler}>
             <span className='dc-relative-datepicker__span'>{title}</span>
@@ -29,8 +27,8 @@ const RelativeDatepicker = ({ onChange, min, max, title }) => {
                 type='date'
                 ref={hidden_input_ref}
                 onChange={onChangeHandler}
-                min={min_date}
-                max={max_date}
+                min={InputDateFormat(min)}
+                max={InputDateFormat(max)}
                 className='dc-relative-datepicker__input'
             />
         </div>
@@ -38,8 +36,8 @@ const RelativeDatepicker = ({ onChange, min, max, title }) => {
 };
 
 RelativeDatepicker.propTypes = {
-    max: PropTypes.string,
-    min: PropTypes.string,
+    max: PropTypes.number,
+    min: PropTypes.number,
     onChange: PropTypes.func,
     title: PropTypes.string,
 };

--- a/packages/components/src/components/relative-datepicker/relative-datepicker.jsx
+++ b/packages/components/src/components/relative-datepicker/relative-datepicker.jsx
@@ -1,6 +1,6 @@
-import React, { useRef, Children } from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
-import { toMoment, daysFromTodayTo } from '@deriv/shared/utils/date';
+import { toMoment } from '@deriv/shared/utils/date';
 
 const RelativeDatepicker = ({ onChange, min, max, children }) => {
     const hidden_input_ref = useRef();
@@ -9,7 +9,7 @@ const RelativeDatepicker = ({ onChange, min, max, children }) => {
         hidden_input_ref.current.click();
     };
     const onChangeHandler = e => {
-        onChange(daysFromTodayTo(e.target.value));
+        onChange(toMoment(e.target.value));
     };
 
     const inputDateFormat = date => {

--- a/packages/components/src/components/relative-datepicker/relative-datepicker.scss
+++ b/packages/components/src/components/relative-datepicker/relative-datepicker.scss
@@ -1,17 +1,6 @@
 .dc-relative-datepicker {
     width: 100%;
     text-align: center;
-    padding-bottom: 16px;
-    position: relative;
-
-    &__span {
-        width: 100%;
-        font-size: 1.4em;
-        color: var(--purchase-main-2);
-        line-height: 1.43;
-        font-weight: bold;
-        cursor: pointer;
-    }
     // This css is for make date input field invisible
     &__input {
         opacity: 0;

--- a/packages/components/src/components/relative-datepicker/relative-datepicker.scss
+++ b/packages/components/src/components/relative-datepicker/relative-datepicker.scss
@@ -3,12 +3,7 @@
     text-align: center;
     // This css is for make date input field invisible
     &__input {
-        opacity: 0;
+        transform: scale(0);
         position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        z-index: 2;
     }
 }

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-mobile.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-mobile.jsx
@@ -3,6 +3,7 @@ import { Tabs, TickPicker, Numpad, RelativeDatepicker } from '@deriv/components'
 import ObjectUtils from '@deriv/shared/utils/object';
 import { localize } from '@deriv/translations';
 import { connect } from 'Stores/connect';
+import { daysFromTodayTo } from '@deriv/shared/utils/date';
 import { getDurationMinMaxValues } from 'Stores/Modules/Trading/Helpers/duration';
 
 const submit_label = localize('OK');
@@ -170,9 +171,7 @@ const Duration = ({
         ? duration_tab_idx
         : duration_units_list.findIndex(d => d.value === duration_unit);
     const [min, max] = getDurationMinMaxValues(duration_min_max, 'daily', 'd');
-    const handleRelativeChange = date => {
-        setSelectedDuration('d', date);
-    };
+    const handleRelativeChange = date => setSelectedDuration('d', daysFromTodayTo(date));
     const selected_basis_option = () => {
         if (amount_tab_idx === 0) {
             return 'stake';

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-mobile.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-mobile.jsx
@@ -181,7 +181,6 @@ const Duration = ({
         }
         return trade_basis;
     };
-
     return (
         <div>
             <Tabs
@@ -260,12 +259,19 @@ const Duration = ({
                                         stake_value={stake_value}
                                         payout_value={payout_value}
                                     />
-                                    <RelativeDatepicker
-                                        onChange={handleRelativeChange}
-                                        min={min}
-                                        max={max}
-                                        title='Pick an end date'
-                                    />
+                                    <RelativeDatepicker onChange={handleRelativeChange} min={min} max={max}>
+                                        <div
+                                            style={{
+                                                fontSize: '1.4em',
+                                                color: 'var(--purchase-main-2)',
+                                                lineHeight: '1.43',
+                                                fontWeight: 'bold',
+                                                paddingBottom: '16px',
+                                            }}
+                                        >
+                                            {localize('Pick a end time')}
+                                        </div>
+                                    </RelativeDatepicker>
                                 </div>
                             );
                         default:


### PR DESCRIPTION
Change relative datepicker workflow.
It would render children component and when you click on the child it'll open the native calendar on mobile after submitting a date it returns a Moment object then you can use the Moment object.