### PR TITLE
zaki/disable_unsupported_trade_types

### DIFF
--- a/packages/components/src/components/mobile-dialog/mobile-dialog.scss
+++ b/packages/components/src/components/mobile-dialog/mobile-dialog.scss
@@ -40,7 +40,6 @@
         box-sizing: border-box;
         position: relative;
         padding-top: 3.6rem;
-        padding-bottom: 7rem; // ios bottom bar fix
         z-index: 1;
         background: var(--general-section-2);
         transition: all 0.2s ease-out;

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-mobile.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-mobile.jsx
@@ -58,11 +58,12 @@ const Ticks = ({
     };
 
     const onTickChange = tick => setSelectedDuration('t', tick);
-
+    const should_reset_tick_value = trade_duration_unit === 't' && trade_duration >= min_tick;
+    const tick_duration = trade_duration < min_tick && selected_duration < min_tick ? min_tick : selected_duration;
     return (
         <div className='trade-params__duration-tickpicker'>
             <TickPicker
-                default_value={trade_duration_unit === 't' ? trade_duration : selected_duration}
+                default_value={should_reset_tick_value ? trade_duration : tick_duration}
                 submit_label={submit_label}
                 max_value={max_tick}
                 min_value={min_tick}

--- a/packages/trader/src/Modules/Trading/Helpers/contract-type.js
+++ b/packages/trader/src/Modules/Trading/Helpers/contract-type.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { localize } from '@deriv/translations';
+import { isMobile } from '@deriv/shared/utils/screen';
 import { flatten } from 'Modules/Account/Helpers/flatten';
 
 export const unsupported_contract_types_list = [
@@ -15,6 +16,9 @@ export const unsupported_contract_types_list = [
     'lb_put',
     'lb_high_low',
     'multiplier',
+    // TODO: Remove the conditional values below once barrier and path dependent contracts are ready for mobile
+    isMobile() ? 'high_low' : null,
+    isMobile() ? 'touch' : null,
 ];
 
 export const contract_category_icon = {

--- a/packages/trader/src/sass/app/_common/components/composite-calendar.scss
+++ b/packages/trader/src/sass/app/_common/components/composite-calendar.scss
@@ -36,6 +36,7 @@
                 height: 32px;
                 background-color: var(--fill-normal);
                 border: 1px solid var(--border-normal);
+                appearance: none;
 
                 &:hover {
                     border-color: var(--border-hover);
@@ -98,7 +99,6 @@
             }
             &-today {
                 width: 100%;
-                margin-top: 40px;
             }
         }
         &__radio-group {

--- a/packages/trader/src/sass/app/modules/trading-mobile.scss
+++ b/packages/trader/src/sass/app/modules/trading-mobile.scss
@@ -1,3 +1,12 @@
+/** @define dc-swipeable; weak */
+.dc-swipeable {
+    &__item {
+        .chartContainer {
+            pointer-events: none;
+        }
+    }
+}
+
 /** @define dc-modal; weak */
 .dc-modal {
     &__container_trade-params {


### PR DESCRIPTION
### Changelog

**Trader**
- Filter contract types not yet supported for mobile.
- Fix for default selected values for tick duration when value is less than minimum.

**Components**
- Removed unnecessary `padding-bottom` rule from `MobileDialog`.