### PR TITLE
zaki/open_positions_and_duration_label_fix

### DIFF
--- a/packages/trader/src/App/Components/Elements/TogglePositions/toggle-positions-mobile.jsx
+++ b/packages/trader/src/App/Components/Elements/TogglePositions/toggle-positions-mobile.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
-import { NavLink } from 'react-router-dom';
 import { Icon, Div100vhContainer, Modal } from '@deriv/components';
 import { localize } from '@deriv/translations';
 import routes from 'Constants/routes';
+import { BinaryLink } from 'App/Components/Routes';
 import EmptyPortfolioMessage from 'Modules/Reports/Components/empty-portfolio-message.jsx';
 import PositionsModalCard from 'App/Components/Elements/PositionsDrawer/positions-modal-card.jsx';
 import { connect } from 'Stores/connect';
@@ -96,12 +96,13 @@ class TogglePositionsMobile extends React.Component {
                             {is_empty || error ? <EmptyPortfolioMessage error={error} /> : body_content}
                         </div>
                         <div className='positions-modal__footer'>
-                            <NavLink
+                            <BinaryLink
+                                onClick={this.togglePositions}
                                 className='btn btn--secondary btn__large positions-modal__footer-btn'
                                 to={routes.reports}
                             >
                                 <span className='btn__text'>{localize('Go to Reports')}</span>
-                            </NavLink>
+                            </BinaryLink>
                         </div>
                     </Div100vhContainer>
                 </Modal>

--- a/packages/trader/src/App/Components/Elements/TogglePositions/toggle-positions-mobile.jsx
+++ b/packages/trader/src/App/Components/Elements/TogglePositions/toggle-positions-mobile.jsx
@@ -99,7 +99,7 @@ class TogglePositionsMobile extends React.Component {
                             <BinaryLink
                                 onClick={this.togglePositions}
                                 className='btn btn--secondary btn__large positions-modal__footer-btn'
-                                to={routes.reports}
+                                to={routes.positions}
                             >
                                 <span className='btn__text'>{localize('Go to Reports')}</span>
                             </BinaryLink>

--- a/packages/trader/src/App/Components/Elements/TogglePositions/toggle-positions-mobile.jsx
+++ b/packages/trader/src/App/Components/Elements/TogglePositions/toggle-positions-mobile.jsx
@@ -6,9 +6,10 @@ import { localize } from '@deriv/translations';
 import routes from 'Constants/routes';
 import EmptyPortfolioMessage from 'Modules/Reports/Components/empty-portfolio-message.jsx';
 import PositionsModalCard from 'App/Components/Elements/PositionsDrawer/positions-modal-card.jsx';
+import { connect } from 'Stores/connect';
 import TogglePositions from './toggle-positions.jsx';
 
-class TogglePositionsMobile extends React.PureComponent {
+class TogglePositionsMobile extends React.Component {
     constructor(props) {
         super(props);
 
@@ -108,5 +109,6 @@ class TogglePositionsMobile extends React.PureComponent {
         );
     }
 }
-
-export default TogglePositionsMobile;
+// TODO: Needs to be connected to store due to issue with trade-header-extensions not updating all_positions prop
+// Fixes issue with positions not updated in positions modal
+export default connect(() => ({}))(TogglePositionsMobile);

--- a/packages/trader/src/Modules/Reports/Helpers/market-underlying.js
+++ b/packages/trader/src/Modules/Reports/Helpers/market-underlying.js
@@ -26,11 +26,12 @@ export const getMarketName = underlying => (underlying ? getMarketNamesMap()[und
 export const getTradeTypeName = category => (category ? getContractConfig()[category.toUpperCase()].name : null);
 
 export const getContractDurationType = longcode => {
-    const duration_pattern = new RegExp('ticks|seconds|minutes|hours');
+    const duration_pattern = new RegExp('ticks|tick|seconds|minutes|minute|hour|hours');
     const extracted = duration_pattern.exec(longcode);
-    if (extracted != null) {
+    if (extracted !== null) {
         const duration_type = extracted[0];
-        return duration_type[0].toUpperCase() + duration_type.slice(1);
+        const duration_text = duration_type[0].toUpperCase() + duration_type.slice(1);
+        return duration_text.endsWith('s') ? duration_text : `${duration_text}s`;
     }
     return 'Days';
 };


### PR DESCRIPTION
### Changelog

**Trader**
- Fix issue with Recent Positions Modal not updating ongoing positions until sell.
- Fix wrong labels in Reports for Open Positions and Profit Table when duration is singular word.