### PR TITLE
zaki/fix_remaining_validation_popup_issues

### DIFF
--- a/packages/components/src/components/button/button.scss
+++ b/packages/components/src/components/button/button.scss
@@ -15,6 +15,9 @@
     outline: 0;
     position: relative;
     text-decoration: none;
+    user-select: none;
+    -webkit-touch-callout: none;
+    -webkit-tap-highlight-color: transparent;
     /*
      * Text will be transformed to sentence case in JS
      * text-transform is declared in .btn instead of .btn__text

--- a/packages/components/src/components/numpad/numpad.jsx
+++ b/packages/components/src/components/numpad/numpad.jsx
@@ -143,10 +143,11 @@ const Numpad = ({
                     className={classNames('dc-numpad__number', {
                         'dc-numpad__number--is-disabled':
                             !default_value.toString().length ||
+                            (min && formatNumber(default_value) < min) ||
                             (typeof onValidate === 'function' ? !onValidate(default_value) : false),
                     })}
                     onClick={() => {
-                        if (!default_value.toString().length) return;
+                        if (!default_value.toString().length || (min && formatNumber(default_value) < min)) return;
                         if (typeof onValidate === 'function') {
                             onValidate(formatNumber(default_value));
                             onSubmit(formatNumber(default_value));
@@ -154,7 +155,7 @@ const Numpad = ({
                             onSubmit(formatNumber(default_value));
                         }
                     }}
-                    is_disabled={!default_value.toString().length}
+                    is_disabled={!default_value.toString().length || (min && formatNumber(default_value) < min)}
                 >
                     {submit_label}
                 </Button>

--- a/packages/components/src/components/numpad/numpad.jsx
+++ b/packages/components/src/components/numpad/numpad.jsx
@@ -31,8 +31,9 @@ const Numpad = ({
     const [default_value, setValue] = React.useState(formatted_value);
 
     const onSelect = num => {
+        console.warn(num, default_value);
         if (typeof onValidate === 'function' && default_value !== '') {
-            const passes = onValidate(concatenate(num, default_value));
+            const passes = formatNumber(default_value) <= 0 ? true : onValidate(concatenate(num, default_value));
             if (!passes) return;
         }
 
@@ -130,7 +131,14 @@ const Numpad = ({
                     type='secondary'
                     has_effect
                     className='dc-numpad__number'
-                    onClick={() => onSelect(-1)}
+                    onClick={() => {
+                        if (typeof onValidate === 'function') {
+                            onSelect(-1);
+                            onValidate(formatNumber(default_value));
+                        } else {
+                            onSelect(-1);
+                        }
+                    }}
                     is_disabled={!default_value.toString().length}
                 >
                     ⌫
@@ -147,7 +155,9 @@ const Numpad = ({
                             (typeof onValidate === 'function' ? !onValidate(default_value) : false),
                     })}
                     onClick={() => {
-                        if (!default_value.toString().length || (min && formatNumber(default_value) < min)) return;
+                        if (!default_value.toString().length) return;
+                        if (min && formatNumber(default_value) < min) return;
+                        else if (!min && formatNumber(default_value) < 1) return;
                         if (typeof onValidate === 'function') {
                             onValidate(formatNumber(default_value));
                             onSubmit(formatNumber(default_value));

--- a/packages/components/src/components/numpad/numpad.jsx
+++ b/packages/components/src/components/numpad/numpad.jsx
@@ -12,6 +12,7 @@ const Numpad = ({
     currency,
     is_regular,
     is_currency,
+    is_submit_disabled,
     label,
     max = 9999999,
     min = 0,
@@ -32,14 +33,7 @@ const Numpad = ({
 
     const onSelect = num => {
         if (typeof onValidate === 'function' && default_value !== '') {
-            let passes = false;
-            const zero_decimal_strings = ['0.0000000', '0.000000', '0.00000', '0.0000', '0.000', '0.00', '0.0', '0.'];
-            const is_formatted_zero = zero_value => zero_decimal_strings.includes(zero_value.toString());
-            if (is_currency) {
-                passes = is_formatted_zero(default_value) || onValidate(concatenate(num, default_value));
-            } else {
-                passes = onValidate(concatenate(num, default_value));
-            }
+            const passes = onValidate(concatenate(num, default_value));
             if (!passes) return;
         }
 
@@ -107,6 +101,7 @@ const Numpad = ({
         if (onValueChange) onValueChange(default_value);
     }, [default_value]);
 
+    const has_error = !onValidate(default_value) || onValidate(default_value) === 'error';
     return (
         <div
             className={classNames('dc-numpad', className, {
@@ -115,6 +110,7 @@ const Numpad = ({
             })}
         >
             <StepInput
+                className={has_error ? 'dc-numpad__input-field--has-error' : null}
                 currency={currency}
                 pip_size={pip_size}
                 value={default_value}
@@ -164,6 +160,7 @@ const Numpad = ({
                     has_effect
                     className={classNames('dc-numpad__number', {
                         'dc-numpad__number--is-disabled':
+                            is_submit_disabled ||
                             !default_value.toString().length ||
                             (min && formatNumber(default_value) < min) ||
                             (typeof onValidate === 'function' ? !onValidate(default_value) : false),
@@ -178,7 +175,11 @@ const Numpad = ({
                             onSubmit(formatNumber(default_value));
                         }
                     }}
-                    is_disabled={!default_value.toString().length || (min && formatNumber(default_value) < min)}
+                    is_disabled={
+                        is_submit_disabled ||
+                        !default_value.toString().length ||
+                        (min && formatNumber(default_value) < min)
+                    }
                 >
                     {submit_label}
                 </Button>
@@ -192,6 +193,7 @@ Numpad.propTypes = {
     format: PropTypes.func,
     is_currency: PropTypes.bool,
     is_regular: PropTypes.bool,
+    is_submit_disabled: PropTypes.bool,
     max: PropTypes.number,
     min: PropTypes.number,
     onSubmit: PropTypes.func,

--- a/packages/components/src/components/numpad/numpad.jsx
+++ b/packages/components/src/components/numpad/numpad.jsx
@@ -7,8 +7,6 @@ import StepInput from './step-input.jsx';
 
 const concatenate = (number, default_value) => default_value.toString().concat(number);
 
-let buttonPressTimer;
-
 const Numpad = ({
     className,
     currency,

--- a/packages/components/src/components/numpad/numpad.scss
+++ b/packages/components/src/components/numpad/numpad.scss
@@ -78,6 +78,10 @@ $SQUARE_SIZE: 48px;
             padding: 0;
             max-height: $SQUARE_SIZE;
         }
+        &--has-error {
+            color: var(--status-danger);
+            font-weight: bold;
+        }
     }
     &__number {
         border-radius: 2.4rem;

--- a/packages/components/src/components/numpad/step-input.jsx
+++ b/packages/components/src/components/numpad/step-input.jsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import CurrencyUtils from '@deriv/shared/utils/currency';
@@ -9,7 +10,7 @@ const getDecimals = val => {
     return array_value && array_value.length > 1 ? array_value[1].length : 0;
 };
 
-const StepInput = ({ max, min, value, onChange, render, pip_size = 0, currency }) => {
+const StepInput = ({ className, max, min, value, onChange, render, pip_size = 0, currency }) => {
     const getSmallestScale = () => {
         const is_crypto = !!currency && CurrencyUtils.isCryptocurrency(currency);
         const decimal_places = Number.isFinite(+value) ? getDecimals(value) : 0;
@@ -76,7 +77,7 @@ const StepInput = ({ max, min, value, onChange, render, pip_size = 0, currency }
                 {render &&
                     render({
                         value,
-                        className: 'dc-numpad__input-field',
+                        className: classNames('dc-numpad__input-field', className),
                     })}
             </React.Fragment>
             {!render && <Input className='dc-numpad__input-field' name='amount' value={value} readOnly />}
@@ -86,6 +87,7 @@ const StepInput = ({ max, min, value, onChange, render, pip_size = 0, currency }
 };
 
 StepInput.propTypes = {
+    className: PropTypes.string,
     max: PropTypes.number,
     min: PropTypes.number,
     onChange: PropTypes.func,

--- a/packages/components/src/components/tick-picker/tick-picker.jsx
+++ b/packages/components/src/components/tick-picker/tick-picker.jsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import React, { useState } from 'react';
 import throttle from 'lodash.throttle';
 import { useSwipeable } from 'react-swipeable';
@@ -8,6 +9,7 @@ const THROTTLE_INTERVAL_TIME = 100;
 
 const TickPicker = ({
     default_value,
+    is_submit_disabled,
     min_value,
     max_value,
     onSubmit,
@@ -75,7 +77,11 @@ const TickPicker = ({
                     <Icon icon='IcAdd' custom_color='var(--text-prominent)' />
                 </Button>
             </div>
-            <div className='dc-tick-picker__submit-wrapper'>
+            <div
+                className={classNames('dc-tick-picker__submit-wrapper', {
+                    'dc-tick-picker__submit-wrapper--is-disabled': is_submit_disabled,
+                })}
+            >
                 <Button rounded onClick={handleClick}>
                     {submit_label}
                 </Button>

--- a/packages/components/src/components/tick-picker/tick-picker.scss
+++ b/packages/components/src/components/tick-picker/tick-picker.scss
@@ -36,7 +36,7 @@
             height: 48px;
 
             .btn__text {
-                transform: scale(1.5);
+                transform: scale(2);
             }
         }
     }
@@ -52,6 +52,17 @@
             span {
                 color: var(--text-prominent);
                 font-size: 1.6rem;
+            }
+        }
+        &--is-disabled {
+            pointer-events: none;
+
+            .btn {
+                background-color: var(--general-disabled);
+
+                .btn__text {
+                    color: var(--text-disabled);
+                }
             }
         }
     }

--- a/packages/components/src/components/toast-error/toast-error.jsx
+++ b/packages/components/src/components/toast-error/toast-error.jsx
@@ -1,8 +1,9 @@
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { CSSTransition } from 'react-transition-group';
 
-const ToastError = ({ children, is_open = true, onClose, onClick, timeout = 0 }) => {
+const ToastError = ({ children, className, is_open = true, onClose, onClick, timeout = 0 }) => {
     const [is_visible, setVisible] = React.useState(false);
 
     React.useEffect(() => {
@@ -34,7 +35,7 @@ const ToastError = ({ children, is_open = true, onClose, onClick, timeout = 0 })
                 exit: 'dc-toast-error--exit',
             }}
         >
-            <div className='dc-toast-error' onClick={onClick}>
+            <div className={classNames('dc-toast-error', className)} onClick={onClick}>
                 <div className='dc-toast-error__message'>{children}</div>
             </div>
         </CSSTransition>
@@ -42,6 +43,7 @@ const ToastError = ({ children, is_open = true, onClose, onClick, timeout = 0 })
 };
 
 ToastError.propTypes = {
+    className: PropTypes.string,
     is_open: PropTypes.bool,
     onClick: PropTypes.func,
     onClose: PropTypes.func,

--- a/packages/components/src/components/toast-error/toast-error.scss
+++ b/packages/components/src/components/toast-error/toast-error.scss
@@ -10,7 +10,7 @@
     align-items: center;
 
     &__message {
-        background-color: var(--brand-red-coral);
+        background-color: var(--status-danger);
         display: flex;
         align-items: center;
         justify-content: center;

--- a/packages/core/src/App/Containers/Layout/header.jsx
+++ b/packages/core/src/App/Containers/Layout/header.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { withRouter } from 'react-router-dom';
 import { DesktopWrapper, MobileWrapper } from '@deriv/components';
 import { isMobile } from '@deriv/shared/utils/screen';
+import { getDecimalPlaces } from '@deriv/shared/utils/currency';
 import { AccountActions, MenuLinks, PlatformSwitcher } from 'App/Components/Layout/Header';
 import platform_config from 'App/Constants/platform-config';
 import RealAccountSignup from 'App/Containers/RealAccountSignup';
@@ -95,6 +96,7 @@ class Header extends React.Component {
                             <div
                                 className={classNames('acc-info__preloader', {
                                     'acc-info__preloader--no-currency': !currency,
+                                    'acc-info__preloader--is-crypto': getDecimalPlaces(currency) > 2,
                                 })}
                             >
                                 <AccountsInfoLoader is_logged_in={is_logged_in} is_mobile={isMobile()} speed={3} />

--- a/packages/core/src/App/Containers/NotificationsDialog/notifications-dialog.jsx
+++ b/packages/core/src/App/Containers/NotificationsDialog/notifications-dialog.jsx
@@ -111,7 +111,7 @@ class NotificationsDialog extends React.Component {
             <React.Fragment>
                 <MobileWrapper>
                     <MobileDialog
-                        portal_element_id='deriv_app'
+                        portal_element_id='modal_root'
                         title={localize('Notifications')}
                         wrapper_classname='notifications-mobile-dialog'
                         visible={this.props.is_visible}

--- a/packages/core/src/Stores/Helpers/client-notifications.js
+++ b/packages/core/src/Stores/Helpers/client-notifications.js
@@ -1,7 +1,7 @@
 import React from 'react';
+import { Button } from '@deriv/components';
 import { WS } from 'Services';
 import { formatDate } from 'Utils/Date';
-import { Button } from '@deriv/components';
 import ObjectUtils from '@deriv/shared/utils/object';
 import { isMobile } from '@deriv/shared/utils/screen';
 import { getRiskAssessment, isAccountOfType, shouldAcceptTnc, shouldCompleteTax } from '_common/base/client_base';
@@ -110,7 +110,7 @@ export const clientNotifications = (ui = {}) => {
                                 target='_blank'
                                 href={urlFor('contact', undefined, undefined, true)}
                             >
-                                <Button secondary medium text={localize('Contact Us')}></Button>
+                                <Button secondary medium text={localize('Contact Us')} />
                             </a>
                         </React.Fragment>,
                     ]}
@@ -144,7 +144,7 @@ export const clientNotifications = (ui = {}) => {
                                 target='_blank'
                                 href={urlFor('contact', undefined, undefined, true)}
                             >
-                                <Button secondary medium text={localize('Contact Us')}></Button>
+                                <Button secondary medium text={localize('Contact Us')} />
                             </a>
                         </React.Fragment>,
                     ]}

--- a/packages/core/src/index.html
+++ b/packages/core/src/index.html
@@ -236,7 +236,6 @@
     </div>
 </div>
 <!-- End Temporary Mobile Landscape UI Blocker -->
-<div id="popup_root" class="popup-root"></div>
 <script>
     performance.mark('first-contentful-paint');
 </script>

--- a/packages/core/src/sass/app/_common/components/account-switcher.scss
+++ b/packages/core/src/sass/app/_common/components/account-switcher.scss
@@ -40,6 +40,9 @@
             &:before {
                 display: none;
             }
+            &--is-crypto {
+                width: 100%;
+            }
         }
     }
     &__container {
@@ -55,6 +58,9 @@
         justify-content: center;
         position: relative;
         margin-right: 0.8rem;
+        user-select: none;
+        -webkit-touch-callout: none;
+        -webkit-tap-highlight-color: transparent;
     }
     &__id {
         pointer-events: none;
@@ -86,13 +92,16 @@
             transform: rotate(180deg);
         }
     }
-    &:hover:not(.show):not(&--is-disabled) {
-        background: var(--state-hover);
+    @include desktop {
+        &:hover:not(.show):not(&--is-disabled) {
+            background: var(--state-hover);
 
-        .symbols {
-            background: transparent;
+            .symbols {
+                background: transparent;
+            }
         }
     }
+
     &--is-virtual {
         .acc-info__balance {
             color: var(--text-profit-success);

--- a/packages/core/src/sass/app/modules/notifications-dialog.scss
+++ b/packages/core/src/sass/app/modules/notifications-dialog.scss
@@ -11,6 +11,9 @@
 
             &-wrapper {
                 cursor: pointer;
+                user-select: none;
+                -webkit-touch-callout: none;
+                -webkit-tap-highlight-color: transparent;
 
                 &--active {
                     cursor: default;

--- a/packages/trader/src/App/Components/Elements/PositionsDrawer/positions-modal-card.jsx
+++ b/packages/trader/src/App/Components/Elements/PositionsDrawer/positions-modal-card.jsx
@@ -2,8 +2,9 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { CSSTransition } from 'react-transition-group';
-// import { NavLink } from 'react-router-dom'; // TODO: Change this after making decision of nav link on mobile
 import { Button, Icon, Money } from '@deriv/components';
+import { getContractPath } from 'App/Components/Routes/helpers';
+import { BinaryLink } from 'App/Components/Routes';
 import CurrencyUtils from '@deriv/shared/utils/currency';
 import Shortcode from 'Modules/Reports/Helpers/shortcode';
 import { localize } from '@deriv/translations';
@@ -29,6 +30,7 @@ const PositionsModalCard = ({
     result,
     sell_price,
     status,
+    togglePositions,
     toggleUnsupportedContractModal,
     type,
 }) => {
@@ -169,36 +171,22 @@ const PositionsModalCard = ({
 
     return (
         <div id={`dt_drawer_card_${id}`} className={classNames('positions-modal-card__wrapper', className)}>
-            {/* TODO: Discuss about this navlink on mobile */}
-            <div className={classNames('positions-modal-card')}>
-                {contract_info.underlying ? contract_el : loader_el}
-            </div>
-            {/* {is_unsupported ? (
+            {is_unsupported ? (
                 <div
-                    className={classNames('positions-modal-card', {
-                        // 'positions-modal-card--green': profit_loss > 0 && !result,
-                        // 'positions-modal-card--red': profit_loss < 0 && !result,
-                    })}
+                    className={classNames('positions-modal-card')}
                     onClick={() => toggleUnsupportedContractModal(true)}
                 >
                     {contract_info.underlying ? contract_el : loader_el}
                 </div>
             ) : (
-                <NavLink
-                    className={classNames('positions-modal-card', {
-                        // 'positions-modal-card--green': profit_loss > 0 && !result,
-                        // 'positions-modal-card--red': profit_loss < 0 && !result,
-                    })}
-                    to={{
-                        pathname: `/contract/${id}`,
-                        state: {
-                            // from_table_row: true,
-                        },
-                    }}
+                <BinaryLink
+                    onClick={togglePositions}
+                    className={classNames('positions-modal-card')}
+                    to={getContractPath(id)}
                 >
                     {contract_info.underlying ? contract_el : loader_el}
-                </NavLink>
-            )} */}
+                </BinaryLink>
+            )}
         </div>
     );
 };

--- a/packages/trader/src/App/Components/Elements/PositionsDrawer/result-mobile.jsx
+++ b/packages/trader/src/App/Components/Elements/PositionsDrawer/result-mobile.jsx
@@ -2,9 +2,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { CSSTransition } from 'react-transition-group';
-import { NavLink } from 'react-router-dom';
 import { Icon } from '@deriv/components';
-import { getContractPath } from 'App/Components/Routes/helpers';
 import { localize } from '@deriv/translations';
 
 class ResultMobile extends React.PureComponent {
@@ -16,7 +14,7 @@ class ResultMobile extends React.PureComponent {
     };
 
     render() {
-        const { contract_id, is_visible, result } = this.props;
+        const { is_visible, result } = this.props;
         const is_contract_won = result === 'won';
         return (
             <React.Fragment>
@@ -30,11 +28,7 @@ class ResultMobile extends React.PureComponent {
                     }}
                     unmountOnExit
                 >
-                    <NavLink
-                        className='positions-modal-card__caption-wrapper'
-                        to={getContractPath(contract_id)}
-                        onClick={this.handleClick}
-                    >
+                    <div className='positions-modal-card__caption-wrapper'>
                         <span
                             className={classNames('positions-modal-card__caption', {
                                 'positions-modal-card__caption--won': is_contract_won,
@@ -57,7 +51,7 @@ class ResultMobile extends React.PureComponent {
                                 </React.Fragment>
                             )}
                         </span>
-                    </NavLink>
+                    </div>
                 </CSSTransition>
             </React.Fragment>
         );
@@ -65,7 +59,6 @@ class ResultMobile extends React.PureComponent {
 }
 
 ResultMobile.propTypes = {
-    contract_id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     is_unsupported: PropTypes.bool,
     is_visible: PropTypes.bool,
     onClick: PropTypes.func,

--- a/packages/trader/src/App/Components/Elements/TogglePositions/toggle-positions-mobile.jsx
+++ b/packages/trader/src/App/Components/Elements/TogglePositions/toggle-positions-mobile.jsx
@@ -78,7 +78,7 @@ class TogglePositionsMobile extends React.Component {
                     toggleModal={this.togglePositions}
                     id='dt_mobile_positions'
                     is_vertical_top
-                    has_close_icon={false}
+                    has_close_icon
                     enableApp={this.props.enableApp}
                     disableApp={this.props.disableApp}
                     width='calc(100vw - 32px)'
@@ -102,7 +102,7 @@ class TogglePositionsMobile extends React.Component {
                                 className='btn btn--secondary btn__large positions-modal__footer-btn'
                                 to={routes.positions}
                             >
-                                <span className='btn__text'>{localize('Go to Reports')}</span>
+                                <span className='btn__text'>{localize('View more')}</span>
                             </BinaryLink>
                         </div>
                     </Div100vhContainer>

--- a/packages/trader/src/App/Components/Elements/TogglePositions/toggle-positions-mobile.jsx
+++ b/packages/trader/src/App/Components/Elements/TogglePositions/toggle-positions-mobile.jsx
@@ -57,6 +57,7 @@ class TogglePositionsMobile extends React.Component {
                                 key={portfolio_position.id}
                                 currency={currency}
                                 toggleUnsupportedContractModal={toggleUnsupportedContractModal}
+                                togglePositions={this.togglePositions}
                                 {...portfolio_position}
                             />
                         </CSSTransition>

--- a/packages/trader/src/App/Components/Form/CompositeCalendar/composite-calendar-mobile.jsx
+++ b/packages/trader/src/App/Components/Form/CompositeCalendar/composite-calendar-mobile.jsx
@@ -178,7 +178,7 @@ class CompositeCalendarMobile extends React.PureComponent {
                     />
                 </div>
                 <MobileDialog
-                    portal_element_id='deriv_app'
+                    portal_element_id='modal_root'
                     title={localize('Please select duration')}
                     visible={open}
                     onClose={() => this.setState({ open: false })}

--- a/packages/trader/src/Modules/Trading/Components/Elements/purchase-fieldset.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Elements/purchase-fieldset.jsx
@@ -117,7 +117,10 @@ class PurchaseFieldset extends React.PureComponent {
                         </div>
                     </div>
                 </DesktopWrapper>
-                <MobileWrapper>{purchase_button}</MobileWrapper>
+                <MobileWrapper>
+                    {is_proposal_error && <div className='btn-purchase__error'>{info.message}</div>}
+                    {purchase_button}
+                </MobileWrapper>
             </Fieldset>
         );
     }

--- a/packages/trader/src/Modules/Trading/Components/Form/ContractType/contract-type-dialog.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/ContractType/contract-type-dialog.jsx
@@ -18,7 +18,7 @@ const ContractTypeDialog = ({
         <MobileWrapper>
             <span className='contract-type-widget__select-arrow' />
             <MobileDialog
-                portal_element_id='deriv_app'
+                portal_element_id='modal_root'
                 title={localize('Trade type')}
                 wrapper_classname='contracts-modal-list'
                 visible={is_open}

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-mobile.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-mobile.jsx
@@ -134,6 +134,10 @@ const Numbers = ({
             setToastErrorVisibility(true);
             setDurationError(true);
             return 'error';
+        } else if (parseInt(value) > max) {
+            setToastErrorMessage(localized_message, 2000);
+            setToastErrorVisibility(true);
+            return 'error';
         } else if (value.toString().length < 1) {
             setToastErrorMessage(localized_message, 2000);
             setToastErrorVisibility(true);

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-mobile.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-mobile.jsx
@@ -129,7 +129,7 @@ const Numbers = ({
                 }}
             />
         );
-        if (parseInt(value) < min || parseInt(value) > max) {
+        if (parseInt(value) < min || parseInt(selected_duration) > max) {
             setToastErrorMessage(localized_message, 2000);
             setToastErrorVisibility(true);
             setDurationError(true);

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-mobile.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-mobile.jsx
@@ -108,7 +108,7 @@ const Numbers = ({
     const [min, max] = getDurationMinMaxValues(duration_min_max, contract_expiry, duration_unit);
 
     const validateDuration = value => {
-        if (value < min || value > max) {
+        if (value.toString().length < 1 || parseInt(value) < min || parseInt(value) > max) {
             setToastErrorMessage(
                 <Localize
                     i18n_default_text='Should be between {{min}} and {{max}}'

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-mobile.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-mobile.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Tabs, TickPicker, Numpad, RelativeDatepicker } from '@deriv/components';
 import ObjectUtils from '@deriv/shared/utils/object';
 import { Localize, localize } from '@deriv/translations';
+import { addComma } from '@deriv/shared/utils/currency';
 import { connect } from 'Stores/connect';
 import { getDurationMinMaxValues } from 'Stores/Modules/Trading/Helpers/duration';
 
@@ -113,7 +114,7 @@ const Numbers = ({
                     i18n_default_text='Should be between {{min}} and {{max}}'
                     values={{
                         min,
-                        max,
+                        max: addComma(max, 0, false),
                     }}
                 />
             );

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-mobile.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-mobile.jsx
@@ -141,7 +141,10 @@ const Numbers = ({
         toggleModal();
     };
 
-    const onNumberChange = num => setSelectedDuration(duration_unit, num);
+    const onNumberChange = num => {
+        setSelectedDuration(duration_unit, num);
+        validateDuration(num);
+    };
 
     return (
         <div className='trade-params__amount-keypad'>

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-mobile.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-mobile.jsx
@@ -26,58 +26,66 @@ const updateAmountChanges = (obj, stake_value, payout_value, basis, trade_basis,
     }
 };
 
-const Ticks = ({
-    basis_option,
-    toggleModal,
-    onChangeMultiple,
-    duration_min_max,
-    has_amount_error,
-    trade_duration,
-    trade_basis,
-    trade_amount,
-    trade_duration_unit,
-    payout_value,
-    stake_value,
-    selected_duration,
-    setSelectedDuration,
-}) => {
-    const [min_tick, max_tick] = getDurationMinMaxValues(duration_min_max, 'tick', 't');
+class Ticks extends React.Component {
+    componentDidMount() {
+        this.props.setDurationError(false);
+    }
 
-    const setTickDuration = value => {
-        const { value: duration } = value.target;
-        const on_change_obj = {};
+    render() {
+        const {
+            basis_option,
+            toggleModal,
+            onChangeMultiple,
+            duration_min_max,
+            has_amount_error,
+            trade_duration,
+            trade_basis,
+            trade_amount,
+            trade_duration_unit,
+            payout_value,
+            stake_value,
+            selected_duration,
+            setSelectedDuration,
+        } = this.props;
 
-        // check for any amount changes from Amount trade params tab before submitting onChange object
-        if (!has_amount_error)
-            updateAmountChanges(on_change_obj, stake_value, payout_value, basis_option, trade_basis, trade_amount);
+        const [min_tick, max_tick] = getDurationMinMaxValues(duration_min_max, 'tick', 't');
 
-        if (trade_duration !== duration || trade_duration_unit !== 't') {
-            on_change_obj.duration_unit = 't';
-            on_change_obj.duration = duration;
-        }
+        const setTickDuration = value => {
+            const { value: duration } = value.target;
+            const on_change_obj = {};
 
-        if (!ObjectUtils.isEmptyObject(on_change_obj)) onChangeMultiple(on_change_obj);
-        toggleModal();
-    };
+            // check for any amount changes from Amount trade params tab before submitting onChange object
+            if (!has_amount_error)
+                updateAmountChanges(on_change_obj, stake_value, payout_value, basis_option, trade_basis, trade_amount);
 
-    const onTickChange = tick => setSelectedDuration('t', tick);
-    const should_reset_tick_value = trade_duration_unit === 't' && trade_duration >= min_tick;
-    const tick_duration = trade_duration < min_tick && selected_duration < min_tick ? min_tick : selected_duration;
-    return (
-        <div className='trade-params__duration-tickpicker'>
-            <TickPicker
-                default_value={should_reset_tick_value ? trade_duration : tick_duration}
-                submit_label={submit_label}
-                max_value={max_tick}
-                min_value={min_tick}
-                onSubmit={setTickDuration}
-                onValueChange={onTickChange}
-                singular_label={localize('Tick')}
-                plural_label={localize('Ticks')}
-            />
-        </div>
-    );
-};
+            if (trade_duration !== duration || trade_duration_unit !== 't') {
+                on_change_obj.duration_unit = 't';
+                on_change_obj.duration = duration;
+            }
+
+            if (!ObjectUtils.isEmptyObject(on_change_obj)) onChangeMultiple(on_change_obj);
+            toggleModal();
+        };
+
+        const onTickChange = tick => setSelectedDuration('t', tick);
+        const should_reset_tick_value = trade_duration_unit === 't' && trade_duration >= min_tick;
+        const tick_duration = trade_duration < min_tick && selected_duration < min_tick ? min_tick : selected_duration;
+        return (
+            <div className='trade-params__duration-tickpicker'>
+                <TickPicker
+                    default_value={should_reset_tick_value ? trade_duration : tick_duration}
+                    submit_label={submit_label}
+                    max_value={max_tick}
+                    min_value={min_tick}
+                    onSubmit={setTickDuration}
+                    onValueChange={onTickChange}
+                    singular_label={localize('Tick')}
+                    plural_label={localize('Ticks')}
+                />
+            </div>
+        );
+    }
+}
 
 const TicksWrapper = connect(({ modules }) => ({
     duration_min_max: modules.trade.duration_min_max,
@@ -121,12 +129,12 @@ const Numbers = ({
                 }}
             />
         );
-        if (parseInt(value) < min) {
+        if (parseInt(value) < min || parseInt(value) > max) {
             setToastErrorMessage(localized_message, 2000);
             setToastErrorVisibility(true);
             setDurationError(true);
             return 'error';
-        } else if (value.toString().length < 1 || parseInt(value) > max) {
+        } else if (value.toString().length < 1) {
             setToastErrorMessage(localized_message, 2000);
             setToastErrorVisibility(true);
             setDurationError(true);
@@ -244,6 +252,7 @@ const Duration = ({
                                         has_amount_error={has_amount_error}
                                         toggleModal={toggleModal}
                                         selected_duration={t_duration}
+                                        setDurationError={setDurationError}
                                         setSelectedDuration={setSelectedDuration}
                                         stake_value={stake_value}
                                         payout_value={payout_value}

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-mobile.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-mobile.jsx
@@ -31,6 +31,7 @@ const Ticks = ({
     toggleModal,
     onChangeMultiple,
     duration_min_max,
+    has_amount_error,
     trade_duration,
     trade_basis,
     trade_amount,
@@ -47,7 +48,8 @@ const Ticks = ({
         const on_change_obj = {};
 
         // check for any amount changes from Amount trade params tab before submitting onChange object
-        updateAmountChanges(on_change_obj, stake_value, payout_value, basis_option, trade_basis, trade_amount);
+        if (!has_amount_error)
+            updateAmountChanges(on_change_obj, stake_value, payout_value, basis_option, trade_basis, trade_amount);
 
         if (trade_duration !== duration || trade_duration_unit !== 't') {
             on_change_obj.duration_unit = 't';
@@ -87,11 +89,13 @@ const TicksWrapper = connect(({ modules }) => ({
 }))(Ticks);
 
 const Numbers = ({
+    setDurationError,
     basis_option,
     toggleModal,
     onChangeMultiple,
     duration_min_max,
     duration_unit_option,
+    has_amount_error,
     contract_expiry = 'intraday',
     payout_value,
     stake_value,
@@ -108,21 +112,29 @@ const Numbers = ({
     const [min, max] = getDurationMinMaxValues(duration_min_max, contract_expiry, duration_unit);
 
     const validateDuration = value => {
-        if (value.toString().length < 1 || parseInt(value) < min || parseInt(value) > max) {
-            setToastErrorMessage(
-                <Localize
-                    i18n_default_text='Should be between {{min}} and {{max}}'
-                    values={{
-                        min,
-                        max: addComma(max, 0, false),
-                    }}
-                />
-            );
+        const localized_message = (
+            <Localize
+                i18n_default_text='Should be between {{min}} and {{max}}'
+                values={{
+                    min,
+                    max: addComma(max, 0, false),
+                }}
+            />
+        );
+        if (parseInt(value) < min) {
+            setToastErrorMessage(localized_message, 2000);
             setToastErrorVisibility(true);
+            setDurationError(true);
+            return 'error';
+        } else if (value.toString().length < 1 || parseInt(value) > max) {
+            setToastErrorMessage(localized_message, 2000);
+            setToastErrorVisibility(true);
+            setDurationError(true);
             return false;
         }
 
         setToastErrorVisibility(false);
+        setDurationError(false);
         return true;
     };
 
@@ -130,7 +142,8 @@ const Numbers = ({
         const on_change_obj = {};
 
         // check for any amount changes from Amount trade params tab before submitting onChange object
-        updateAmountChanges(on_change_obj, stake_value, payout_value, basis_option, trade_basis, trade_amount);
+        if (!has_amount_error)
+            updateAmountChanges(on_change_obj, stake_value, payout_value, basis_option, trade_basis, trade_amount);
 
         if (trade_duration !== duration || trade_duration_unit !== duration_unit) {
             on_change_obj.duration_unit = duration_unit;
@@ -183,7 +196,9 @@ const Duration = ({
     duration_unit,
     duration_tab_idx,
     duration_min_max,
+    has_amount_error,
     setDurationTabIdx,
+    setDurationError,
     t_duration,
     s_duration,
     m_duration,
@@ -226,6 +241,7 @@ const Duration = ({
                                 <div label={duration_unit_option.text} key={duration_unit_option.value}>
                                     <TicksWrapper
                                         basis_option={selected_basis_option()}
+                                        has_amount_error={has_amount_error}
                                         toggleModal={toggleModal}
                                         selected_duration={t_duration}
                                         setSelectedDuration={setSelectedDuration}
@@ -239,9 +255,11 @@ const Duration = ({
                                 <div label={duration_unit_option.text} key={duration_unit_option.value}>
                                     <NumpadWrapper
                                         basis_option={selected_basis_option()}
+                                        has_amount_error={has_amount_error}
                                         toggleModal={toggleModal}
                                         duration_unit_option={duration_unit_option}
                                         selected_duration={s_duration}
+                                        setDurationError={setDurationError}
                                         setSelectedDuration={setSelectedDuration}
                                         stake_value={stake_value}
                                         payout_value={payout_value}
@@ -253,9 +271,11 @@ const Duration = ({
                                 <div label={duration_unit_option.text} key={duration_unit_option.value}>
                                     <NumpadWrapper
                                         basis_option={selected_basis_option()}
+                                        has_amount_error={has_amount_error}
                                         toggleModal={toggleModal}
                                         duration_unit_option={duration_unit_option}
                                         selected_duration={m_duration}
+                                        setDurationError={setDurationError}
                                         setSelectedDuration={setSelectedDuration}
                                         stake_value={stake_value}
                                         payout_value={payout_value}
@@ -267,9 +287,11 @@ const Duration = ({
                                 <div label={duration_unit_option.text} key={duration_unit_option.value}>
                                     <NumpadWrapper
                                         basis_option={selected_basis_option()}
+                                        has_amount_error={has_amount_error}
                                         toggleModal={toggleModal}
                                         duration_unit_option={duration_unit_option}
                                         selected_duration={h_duration}
+                                        setDurationError={setDurationError}
                                         setSelectedDuration={setSelectedDuration}
                                         stake_value={stake_value}
                                         payout_value={payout_value}
@@ -281,10 +303,12 @@ const Duration = ({
                                 <div label={duration_unit_option.text} key={duration_unit_option.value}>
                                     <NumpadWrapper
                                         basis_option={selected_basis_option()}
+                                        has_amount_error={has_amount_error}
                                         toggleModal={toggleModal}
                                         duration_unit_option={duration_unit_option}
                                         contract_expiry='daily'
                                         selected_duration={d_duration}
+                                        setDurationError={setDurationError}
                                         setSelectedDuration={setSelectedDuration}
                                         stake_value={stake_value}
                                         payout_value={payout_value}

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/amount-mobile.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/amount-mobile.jsx
@@ -5,92 +5,97 @@ import { Localize, localize } from '@deriv/translations';
 import CurrencyUtils from '@deriv/shared/utils/currency';
 import { connect } from 'Stores/connect';
 
-const Basis = ({
-    setAmountError,
-    duration_unit,
-    duration_value,
-    toggleModal,
-    basis,
-    has_duration_error,
-    selected_basis,
-    setSelectedAmount,
-    onChangeMultiple,
-    currency,
-    trade_amount,
-    trade_basis,
-    trade_duration,
-    trade_duration_unit,
-    setToastErrorMessage,
-    setToastErrorVisibility,
-}) => {
-    const user_currency_decimal_places = CurrencyUtils.getDecimalPlaces(currency);
-    const onNumberChange = num => {
-        setSelectedAmount(basis, num);
-        validateAmount(num);
-    };
-    const formatAmount = value => (!isNaN(value) ? Number(value).toFixed(user_currency_decimal_places) : value);
-    const setBasisAndAmount = amount => {
-        const on_change_obj = {};
+class Basis extends React.Component {
+    setAmountErrorState = state => this.props.setAmountError(state);
 
-        // Check for any duration changes in Duration trade params Tab before sending onChange object
-        if (duration_unit !== trade_duration_unit && !has_duration_error) on_change_obj.duration_unit = duration_unit;
-        if (duration_value !== trade_duration && !has_duration_error) on_change_obj.duration = duration_value;
+    render() {
+        const {
+            duration_unit,
+            duration_value,
+            toggleModal,
+            basis,
+            has_duration_error,
+            selected_basis,
+            setSelectedAmount,
+            onChangeMultiple,
+            currency,
+            trade_amount,
+            trade_basis,
+            trade_duration,
+            trade_duration_unit,
+            setToastErrorMessage,
+            setToastErrorVisibility,
+        } = this.props;
+        const user_currency_decimal_places = CurrencyUtils.getDecimalPlaces(currency);
+        const onNumberChange = num => {
+            setSelectedAmount(basis, num);
+            validateAmount(num);
+        };
+        const formatAmount = value => (!isNaN(value) ? Number(value).toFixed(user_currency_decimal_places) : value);
+        const setBasisAndAmount = amount => {
+            const on_change_obj = {};
 
-        if (amount !== trade_amount || basis !== trade_basis) {
-            on_change_obj.basis = basis;
-            on_change_obj.amount = amount;
-        }
+            // Check for any duration changes in Duration trade params Tab before sending onChange object
+            if (duration_unit !== trade_duration_unit && !has_duration_error)
+                on_change_obj.duration_unit = duration_unit;
+            if (duration_value !== trade_duration && !has_duration_error) on_change_obj.duration = duration_value;
 
-        if (!ObjectUtils.isEmptyObject(on_change_obj)) onChangeMultiple(on_change_obj);
-        toggleModal();
-    };
-    const zero_decimals = Number('0').toFixed(CurrencyUtils.getDecimalPlaces(currency));
-    const min_amount = parseFloat(zero_decimals.toString().replace(/.$/, '1'));
+            if (amount !== trade_amount || basis !== trade_basis) {
+                on_change_obj.basis = basis;
+                on_change_obj.amount = amount;
+            }
 
-    const validateAmount = value => {
-        const localized_message = <Localize i18n_default_text='Should not be 0 or empty' />;
-        const selected_value = parseFloat(value.toString());
+            if (!ObjectUtils.isEmptyObject(on_change_obj)) onChangeMultiple(on_change_obj);
+            toggleModal();
+        };
+        const zero_decimals = Number('0').toFixed(CurrencyUtils.getDecimalPlaces(currency));
+        const min_amount = parseFloat(zero_decimals.toString().replace(/.$/, '1'));
 
-        if (value.toString() === '0.' || selected_value === 0) {
-            setToastErrorMessage(localized_message, 2000);
-            setToastErrorVisibility(true);
-            setAmountError(true);
-            return 'error';
-        } else if (selected_value < min_amount || value.toString().length < 1) {
-            setToastErrorMessage(localized_message, 2000);
-            setToastErrorVisibility(true);
-            setAmountError(true);
-            return false;
-        }
-        setToastErrorVisibility(false);
-        setAmountError(false);
-        return true;
-    };
+        const validateAmount = value => {
+            const localized_message = <Localize i18n_default_text='Should not be 0 or empty' />;
+            const selected_value = parseFloat(value.toString());
 
-    return (
-        <div className='trade-params__amount-keypad'>
-            <Numpad
-                value={selected_basis}
-                format={formatAmount}
-                onSubmit={setBasisAndAmount}
-                currency={currency}
-                min={min_amount}
-                is_currency
-                render={({ value: v, className }) => {
-                    return (
-                        <div className={className}>
-                            {!!v && (v > 0 ? <Money currency={currency} amount={v} should_format={false} /> : v)}
-                        </div>
-                    );
-                }}
-                pip_size={user_currency_decimal_places}
-                onValidate={validateAmount}
-                submit_label={localize('OK')}
-                onValueChange={onNumberChange}
-            />
-        </div>
-    );
-};
+            if (value.toString() === '0.' || selected_value === 0) {
+                setToastErrorMessage(localized_message, 2000);
+                setToastErrorVisibility(true);
+                this.setAmountErrorState(true);
+                return 'error';
+            } else if (selected_value < min_amount || value.toString().length < 1) {
+                setToastErrorMessage(localized_message, 2000);
+                setToastErrorVisibility(true);
+                this.setAmountErrorState(true);
+                return false;
+            }
+            setToastErrorVisibility(false);
+            this.setAmountErrorState(false);
+            return true;
+        };
+
+        return (
+            <div className='trade-params__amount-keypad'>
+                <Numpad
+                    value={selected_basis}
+                    format={formatAmount}
+                    onSubmit={setBasisAndAmount}
+                    currency={currency}
+                    min={min_amount}
+                    is_currency
+                    render={({ value: v, className }) => {
+                        return (
+                            <div className={className}>
+                                {!!v && (v > 0 ? <Money currency={currency} amount={v} should_format={false} /> : v)}
+                            </div>
+                        );
+                    }}
+                    pip_size={user_currency_decimal_places}
+                    onValidate={validateAmount}
+                    submit_label={localize('OK')}
+                    onValueChange={onNumberChange}
+                />
+            </div>
+        );
+    }
+}
 
 const AmountWrapper = connect(({ modules, client, ui }) => ({
     onChangeMultiple: modules.trade.onChangeMultiple,

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/amount-mobile.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/amount-mobile.jsx
@@ -22,7 +22,10 @@ const Basis = ({
     setToastErrorVisibility,
 }) => {
     const user_currency_decimal_places = CurrencyUtils.getDecimalPlaces(currency);
-    const onNumberChange = num => setSelectedAmount(basis, num);
+    const onNumberChange = num => {
+        setSelectedAmount(basis, num);
+        validateAmount(num);
+    };
     const formatAmount = value => (!isNaN(value) ? Number(value).toFixed(user_currency_decimal_places) : value);
     const setBasisAndAmount = amount => {
         const on_change_obj = {};
@@ -45,12 +48,10 @@ const Basis = ({
     const validateAmount = value => {
         const selected_value = parseFloat(value.toString());
         if (value.toString() === '0.') {
-            console.warn(selected_value);
             setToastErrorMessage(<Localize i18n_default_text='Should not be 0 or empty' />);
             setToastErrorVisibility(true);
             return true;
         } else if (selected_value < min_amount || value.toString().length < 1) {
-            console.warn(selected_value, min_amount);
             setToastErrorMessage(<Localize i18n_default_text='Should not be 0 or empty' />);
             setToastErrorVisibility(true);
             return false;

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/amount-mobile.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/amount-mobile.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Tabs, Numpad } from '@deriv/components';
 import ObjectUtils from '@deriv/shared/utils/object';
 import { Localize, localize } from '@deriv/translations';
-import CurrencyUtils, { addComma } from '@deriv/shared/utils/currency';
+import CurrencyUtils from '@deriv/shared/utils/currency';
 import { connect } from 'Stores/connect';
 
 const Basis = ({
@@ -39,24 +39,10 @@ const Basis = ({
         if (!ObjectUtils.isEmptyObject(on_change_obj)) onChangeMultiple(on_change_obj);
         toggleModal();
     };
-    const min = basis === 'payout' ? CurrencyUtils.getMinPayout(currency) : CurrencyUtils.getMinWithdrawal(currency);
-    const max = Math.pow(10, CurrencyUtils.AMOUNT_MAX_LENGTH) - 1;
-    const validateDuration = value => {
+    const validateAmount = value => {
         const selected_value = parseFloat(value.toString());
-        if (isNaN(selected_value) || selected_value < min || selected_value > max) {
-            setToastErrorMessage(
-                <Localize
-                    i18n_default_text='Should be between {{min}} and {{max}}'
-                    values={{
-                        min,
-                        max: addComma(
-                            max,
-                            CurrencyUtils.getDecimalPlaces(currency),
-                            CurrencyUtils.isCryptocurrency(currency)
-                        ),
-                    }}
-                />
-            );
+        if (isNaN(selected_value) || selected_value < 1 || value.toString().length < 1) {
+            setToastErrorMessage(<Localize i18n_default_text='Should not be 0 or empty' />);
             setToastErrorVisibility(true);
             return false;
         }
@@ -77,9 +63,7 @@ const Basis = ({
                     return <div className={className}>{v}</div>;
                 }}
                 pip_size={user_currency_decimal_places}
-                min={min}
-                max={max}
-                onValidate={validateDuration}
+                onValidate={validateAmount}
                 submit_label={localize('OK')}
                 onValueChange={onNumberChange}
             />

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/amount-mobile.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/amount-mobile.jsx
@@ -39,14 +39,22 @@ const Basis = ({
         if (!ObjectUtils.isEmptyObject(on_change_obj)) onChangeMultiple(on_change_obj);
         toggleModal();
     };
+    const zero_decimals = Number('0').toFixed(CurrencyUtils.getDecimalPlaces(currency));
+    const min_amount = parseFloat(zero_decimals.toString().replace(/.$/, '1'));
+
     const validateAmount = value => {
         const selected_value = parseFloat(value.toString());
-        if (isNaN(selected_value) || selected_value < 1 || value.toString().length < 1) {
+        if (value.toString() === '0.') {
+            console.warn(selected_value);
+            setToastErrorMessage(<Localize i18n_default_text='Should not be 0 or empty' />);
+            setToastErrorVisibility(true);
+            return true;
+        } else if (selected_value < min_amount || value.toString().length < 1) {
+            console.warn(selected_value, min_amount);
             setToastErrorMessage(<Localize i18n_default_text='Should not be 0 or empty' />);
             setToastErrorVisibility(true);
             return false;
         }
-
         setToastErrorVisibility(false);
         return true;
     };
@@ -58,6 +66,7 @@ const Basis = ({
                 format={formatAmount}
                 onSubmit={setBasisAndAmount}
                 currency={currency}
+                min={min_amount}
                 is_currency
                 render={({ value: v, className }) => {
                     return <div className={className}>{v}</div>;

--- a/packages/trader/src/Modules/Trading/Containers/toast-error-popup.jsx
+++ b/packages/trader/src/Modules/Trading/Containers/toast-error-popup.jsx
@@ -3,36 +3,27 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { connect } from 'Stores/connect';
 
-class ToastErrorPopup extends React.Component {
-    constructor(props) {
-        super(props);
-        this.el = document.createElement('div');
-        this.state = {
-            popup_root: document.getElementById('popup_root'),
-        };
-    }
-
-    componentDidMount() {
-        this.state.popup_root.appendChild(this.el);
-    }
-
-    componentWillUnmount() {
-        this.state.popup_root.removeChild(this.el);
-    }
-
-    render() {
-        return ReactDOM.createPortal(
-            <ToastError
-                is_open={this.props.should_show_toast_error}
-                onClose={() => this.props.setToastErrorVisibility(false)}
-                timeout={this.props.mobile_toast_timeout}
-            >
-                {this.props.mobile_toast_error}
-            </ToastError>,
-            this.el
-        );
-    }
-}
+const ToastErrorPopup = ({
+    className,
+    portal_id,
+    should_show_toast_error,
+    setToastErrorVisibility,
+    mobile_toast_error,
+    mobile_toast_timeout,
+}) => {
+    if (!document.getElementById(portal_id)) return null;
+    return ReactDOM.createPortal(
+        <ToastError
+            className={className}
+            is_open={should_show_toast_error}
+            onClose={() => setToastErrorVisibility(false)}
+            timeout={mobile_toast_timeout}
+        >
+            {mobile_toast_error}
+        </ToastError>,
+        document.getElementById(portal_id)
+    );
+};
 
 export default connect(({ ui }) => ({
     should_show_toast_error: ui.should_show_toast_error,

--- a/packages/trader/src/Modules/Trading/Containers/trade-params-mobile.jsx
+++ b/packages/trader/src/Modules/Trading/Containers/trade-params-mobile.jsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import React from 'react';
 import { Tabs, Modal, Money } from '@deriv/components';
 import { connect } from 'Stores/connect';
@@ -83,7 +84,12 @@ class TradeParamsModal extends React.Component {
         const { currency, duration_units_list } = this.props;
         return (
             <React.Fragment>
-                <ToastErrorPopup />
+                <ToastErrorPopup
+                    portal_id={this.props.is_open ? 'modal_root' : 'deriv_app'}
+                    className={classNames('trade-params__error-popup', {
+                        'trade-params__error-popup--has-numpad': this.props.is_open,
+                    })}
+                />
                 <Modal
                     id='dt_trade_parameters_mobile'
                     className='trade-params'

--- a/packages/trader/src/Modules/Trading/Containers/trade-params-mobile.jsx
+++ b/packages/trader/src/Modules/Trading/Containers/trade-params-mobile.jsx
@@ -90,7 +90,7 @@ class TradeParamsModal extends React.Component {
         return (
             <React.Fragment>
                 <ToastErrorPopup
-                    portal_id={this.props.is_open ? 'modal_root' : 'deriv_app'}
+                    portal_id={this.props.is_open ? 'modal_root' : null}
                     className={classNames('trade-params__error-popup', {
                         'trade-params__error-popup--has-numpad': this.props.is_open,
                     })}

--- a/packages/trader/src/Modules/Trading/Containers/trade-params-mobile.jsx
+++ b/packages/trader/src/Modules/Trading/Containers/trade-params-mobile.jsx
@@ -32,6 +32,8 @@ class TradeParamsModal extends React.Component {
             trade_param_tab_idx: 0,
             duration_tab_idx: undefined,
             amount_tab_idx: undefined,
+            has_amount_error: false,
+            has_duration_error: false,
             // duration unit values
             curr_duration_unit: undefined,
             curr_duration_value: undefined,
@@ -78,6 +80,9 @@ class TradeParamsModal extends React.Component {
         });
     };
 
+    setAmountError = has_error => this.setState({ has_amount_error: has_error });
+    setDurationError = has_error => this.setState({ has_duration_error: has_error });
+
     isVisible = component_key => this.props.form_components.includes(component_key);
 
     render() {
@@ -120,8 +125,12 @@ class TradeParamsModal extends React.Component {
                             duration_unit={this.state.curr_duration_unit}
                             duration_value={this.state.curr_duration_value}
                             duration_units_list={duration_units_list}
+                            has_amount_error={this.state.has_amount_error}
+                            setAmountError={this.setAmountError}
                             // duration
                             setSelectedDuration={this.setSelectedDuration}
+                            has_duration_error={this.state.has_duration_error}
+                            setDurationError={this.setDurationError}
                             t_duration={this.state.t_duration}
                             s_duration={this.state.s_duration}
                             m_duration={this.state.m_duration}
@@ -160,11 +169,15 @@ const TradeParamsMobile = ({
     duration_units_list,
     duration_value,
     duration_tab_idx,
+    has_amount_error,
+    has_duration_error,
     // amount
+    setAmountError,
     setSelectedAmount,
     stake_value,
     payout_value,
     // duration
+    setDurationError,
     setSelectedDuration,
     t_duration,
     s_duration,
@@ -174,7 +187,8 @@ const TradeParamsMobile = ({
 }) => {
     const getDurationText = () => {
         const duration = duration_units_list.find(d => d.value === duration_unit);
-        return `${duration_value} ${duration && duration.text}`;
+        return `${duration_value} ${duration &&
+            (duration_value > 1 ? localize(duration.text) : localize(duration.text.slice(0, -1)))}`;
     };
 
     const getAmountText = () => {
@@ -187,14 +201,26 @@ const TradeParamsMobile = ({
                 return (
                     <div className='trade-params__header'>
                         <div className='trade-params__header-label'>{localize('Duration')}</div>
-                        <div className='trade-params__header-value'>{getDurationText()}</div>
+                        <div
+                            className={classNames('trade-params__header-value', {
+                                'trade-params__header-value--has-error': has_duration_error,
+                            })}
+                        >
+                            {has_duration_error ? localize('Error') : getDurationText()}
+                        </div>
                     </div>
                 );
             case 'amount':
                 return (
                     <div className='trade-params__header'>
                         <div className='trade-params__header-label'>{localize('Amount')}</div>
-                        <div className='trade-params__header-value'>{getAmountText()}</div>
+                        <div
+                            className={classNames('trade-params__header-value', {
+                                'trade-params__header-value--has-error': has_amount_error,
+                            })}
+                        >
+                            {has_amount_error ? localize('Error') : getAmountText()}
+                        </div>
                     </div>
                 );
             default:
@@ -216,6 +242,8 @@ const TradeParamsMobile = ({
                         duration_tab_idx={duration_tab_idx}
                         setDurationTabIdx={setDurationTabIdx}
                         setSelectedDuration={setSelectedDuration}
+                        setDurationError={setDurationError}
+                        has_amount_error={has_amount_error}
                         t_duration={t_duration}
                         s_duration={s_duration}
                         m_duration={m_duration}
@@ -234,7 +262,9 @@ const TradeParamsMobile = ({
                         toggleModal={toggleModal}
                         amount_tab_idx={amount_tab_idx}
                         setAmountTabIdx={setAmountTabIdx}
+                        has_duration_error={has_duration_error}
                         setSelectedAmount={setSelectedAmount}
+                        setAmountError={setAmountError}
                         stake_value={stake_value}
                         payout_value={payout_value}
                     />

--- a/packages/trader/src/Modules/Trading/Containers/trade.jsx
+++ b/packages/trader/src/Modules/Trading/Containers/trade.jsx
@@ -45,7 +45,7 @@ class Trade extends React.Component {
                 {/* Div100vhContainer is workaround for browsers on devices
                     with toolbars covering screen height,
                     using css vh is not returning correct screen height */}
-                <Div100vhContainer className='chart-container' is_disabled={isDesktop()} height_offset='260px'>
+                <Div100vhContainer className='chart-container' is_disabled={isDesktop()} height_offset='249px'>
                     <DesktopWrapper>
                         <NotificationMessages />
                     </DesktopWrapper>

--- a/packages/trader/src/Stores/Modules/Trading/trade-store.js
+++ b/packages/trader/src/Stores/Modules/Trading/trade-store.js
@@ -690,13 +690,7 @@ export default class TradeStore extends BaseStore {
             if (error_id) {
                 this.setValidationErrorMessages(error_id, [response.error.message]);
             }
-            // TODO remove this once there is a proper API call for getting min/max stake/payout
-            if (this.root_store.ui.is_mobile) {
-                this.root_store.ui.setToastErrorMessage(response.error.message, 0);
-                this.root_store.ui.setToastErrorVisibility(true);
-            }
         } else {
-            this.root_store.ui.setToastErrorVisibility(false);
             this.validateAllProperties();
         }
 

--- a/packages/trader/src/sass/app/_common/components/purchase-button.scss
+++ b/packages/trader/src/sass/app/_common/components/purchase-button.scss
@@ -51,6 +51,22 @@
         &--swoosh {
             transform: none !important;
         }
+        &__error {
+            position: absolute;
+            padding: 0.8rem;
+            width: 100%;
+            height: 100%;
+            color: var(--text-colored-background);
+            background-color: var(--status-danger);
+            justify-content: center;
+            align-items: center;
+            line-height: 1.4;
+            z-index: 2;
+            border-radius: $BORDER_RADIUS;
+            max-height: 70px;
+            overflow: hidden;
+            font-weight: bold;
+        }
     }
 
     &__icon_wrapper {

--- a/packages/trader/src/sass/app/_common/drawer/positions-drawer-card-overlay.scss
+++ b/packages/trader/src/sass/app/_common/drawer/positions-drawer-card-overlay.scss
@@ -25,6 +25,9 @@
             height: calc(100% - 36px);
             text-decoration: none;
         }
+        @include mobile {
+            pointer-events: none;
+        }
     }
     &__close-btn {
         position: absolute;

--- a/packages/trader/src/sass/app/_common/drawer/positions-modal-card.scss
+++ b/packages/trader/src/sass/app/_common/drawer/positions-modal-card.scss
@@ -7,6 +7,9 @@
     text-decoration: none;
     position: relative;
     color: var(--text-general);
+    user-select: none;
+    -webkit-touch-callout: none;
+    -webkit-tap-highlight-color: transparent;
 
     &__result {
         &--enter,

--- a/packages/trader/src/sass/app/_common/layout/layouts.scss
+++ b/packages/trader/src/sass/app/_common/layout/layouts.scss
@@ -169,7 +169,7 @@ $FLOATING_HEADER_HEIGHT: 41px;
     padding: 0 0.8rem;
     display: flex;
     flex-direction: column;
-    height: 214px;
+    height: 202px;
     position: relative;
 
     &__content-loader {
@@ -177,7 +177,7 @@ $FLOATING_HEADER_HEIGHT: 41px;
         height: 100%;
         width: 100%;
         left: 0;
-        bottom: 0.4rem;
+        bottom: -0.8rem;
 
         svg {
             height: 100%;

--- a/packages/trader/src/sass/app/_common/layout/layouts.scss
+++ b/packages/trader/src/sass/app/_common/layout/layouts.scss
@@ -436,6 +436,7 @@ $FLOATING_HEADER_HEIGHT: 41px;
     &-dark,
     &-light {
         @include mobile {
+            /* postcss-bem-linter: ignore */
             .cq-dialog-portal {
                 .cq-dialog {
                     max-width: calc(100% - 36px);

--- a/packages/trader/src/sass/app/_common/layout/layouts.scss
+++ b/packages/trader/src/sass/app/_common/layout/layouts.scss
@@ -432,12 +432,13 @@ $FLOATING_HEADER_HEIGHT: 41px;
 }
 
 /** @define smartcharts; weak */
+/* postcss-bem-linter: ignore */
 .smartcharts {
     &-dark,
     &-light {
         @include mobile {
-            /* postcss-bem-linter: ignore */
             .cq-dialog-portal {
+                /* postcss-bem-linter: ignore */
                 .cq-dialog {
                     max-width: calc(100% - 36px);
                 }

--- a/packages/trader/src/sass/app/modules/trading-mobile.scss
+++ b/packages/trader/src/sass/app/modules/trading-mobile.scss
@@ -38,6 +38,16 @@
 
 /** @define trade-params; weak */
 .trade-params {
+    &__error-popup {
+        top: 12rem !important;
+        opacity: 0.8;
+        z-index: 2 !important;
+
+        &--has-numpad {
+            z-index: 9999 !important;
+            top: 0.8rem !important;
+        }
+    }
     &__duration {
         &-tickpicker {
             height: 328px;

--- a/packages/trader/src/sass/app/modules/trading-mobile.scss
+++ b/packages/trader/src/sass/app/modules/trading-mobile.scss
@@ -1,3 +1,15 @@
+/** @define allow-equals; weak */
+.allow-equals {
+    &__subtitle {
+        font-size: 1rem;
+        font-weight: normal;
+    }
+    .dc-checkbox__label {
+        font-weight: bold;
+        color: var(--text-prominent);
+    }
+}
+
 /** @define dc-modal; weak */
 .dc-modal {
     &__container_trade-params {
@@ -141,6 +153,11 @@
             &-value {
                 line-height: 1.8rem;
                 font-size: 1.2rem;
+
+                &--has-error {
+                    color: var(--status-danger);
+                    font-weight: bold;
+                }
             }
         }
     }

--- a/packages/trader/src/sass/app/modules/trading-mobile.scss
+++ b/packages/trader/src/sass/app/modules/trading-mobile.scss
@@ -83,6 +83,11 @@
                     font-size: 3rem;
                     font-weight: normal;
                 }
+                &[disabled] {
+                    .btn__text {
+                        color: var(--text-disabled);
+                    }
+                }
             }
             .dc-numpad__number {
                 border-radius: 2.4rem;
@@ -94,9 +99,6 @@
                 line-height: 1.75;
                 color: var(--text-prominent);
                 text-align: left !important;
-                user-select: none;
-                -webkit-touch-callout: none;
-                -webkit-tap-highlight-color: transparent;
 
                 .btn__text {
                     font-size: 1.8rem;
@@ -109,6 +111,17 @@
             .dc-numpad__ok {
                 .dc-numpad__number {
                     height: 100%;
+                }
+            }
+            .dc-numpad__bkspace {
+                .dc-numpad__number {
+                    &[disabled] {
+                        background-color: var(--general-disabled);
+
+                        .btn__text {
+                            color: var(--text-disabled);
+                        }
+                    }
                 }
             }
             /* iPhone SE screen height fixes due to UI space restrictions */

--- a/packages/trader/src/sass/app/modules/trading-mobile.scss
+++ b/packages/trader/src/sass/app/modules/trading-mobile.scss
@@ -7,6 +7,7 @@
     .dc-checkbox__label {
         font-weight: bold;
         color: var(--text-prominent);
+        margin-right: 0.8rem;
     }
 }
 

--- a/packages/trader/src/sass/app/modules/trading.scss
+++ b/packages/trader/src/sass/app/modules/trading.scss
@@ -341,6 +341,7 @@
         }
         @include mobile {
             padding: initial;
+            position: relative;
         }
     }
     &__loading {


### PR DESCRIPTION
### Changelog

**Trader**
- Added validation to Amount Tab.
- Use `modal_root` instead of `deriv_app` for higher z-index for MobileDialogs.
- Fix layout bugs in trade page.
- Update validation flow for `min_max`, allow user entries but not submission, but in case of validation errors, display toast message on keypad inputs.
- Add currency symbol to `StepInput` if currency exists.
- Add error states to TradeParams Labels.
- Moved `proposal` errors to `PurchaseButton`.
- Make Recent Positions Card clickable to Contract Details.
- Change text from `Go to Reports` to `View More` in Recent Positions footer.

**Core**
- Remove `popup_root` from `index.html`.
- Layout bug fixes with `AccountsInfo` preloader.

**Components**
- Update `ToastMessage` background colors.
- Remove blue glow bug on touch in mobile for all button based components.