### PR TITLE
mahdi/add_missing_release_env_var

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,8 @@ jobs:
       - build
       - docker
       - k8s_deploy_staging
+    environment:
+      NODE_ENV: staging
 
   release_production:
     docker:
@@ -101,6 +103,8 @@ jobs:
       - build
       - docker
       - k8s_deploy_production
+    environment:
+      NODE_ENV: production
 
 workflows:
   release_staging:


### PR DESCRIPTION
Added `NODE_ENV` value to CircleCI release builds