### PR TITLE
zaki/update_smartcharts_betam

### DIFF
--- a/packages/bot-web-ui/package-lock.json
+++ b/packages/bot-web-ui/package-lock.json
@@ -4119,6 +4119,12 @@
         "wrap-ansi": "^2.0.0"
       }
     },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "dev": true
+    },
     "clone-deep": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -8868,6 +8874,12 @@
       "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
       "dev": true
     },
+    "image-size": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
+      "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
+      "dev": true
+    },
     "immutable": {
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
@@ -11428,6 +11440,15 @@
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
     },
+    "merge-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-1.0.1.tgz",
+      "integrity": "sha512-iuPV41VWKWBIOpBsjoxjDZw8/GbSfZ2mk7N1453bwMrfzdrIk7EzBd+8UVR6rkw67th7xnk9Dytl3J+lHPdxvg==",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "^1.1"
+      }
+    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -11631,6 +11652,12 @@
           }
         }
       }
+    },
+    "mitt": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.1.2.tgz",
+      "integrity": "sha1-OA5hSA1qYVtmDwertg1R4KTkvtY=",
+      "dev": true
     },
     "mixin-deep": {
       "version": "1.3.2",
@@ -12846,6 +12873,15 @@
         "postcss": "^7.0.6"
       }
     },
+    "postcss-prefix-selector": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/postcss-prefix-selector/-/postcss-prefix-selector-1.7.2.tgz",
+      "integrity": "sha512-ddmzjWNmGs7E/nyolJ021/Gk6oBLRQLyyXKGV4Mu+Y0gquo+XlXSDP0/Y2J8C/cad/GLyftf2H0XtuDFQZxN3w==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.0"
+      }
+    },
     "postcss-reporter": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-6.0.1.tgz",
@@ -12925,6 +12961,64 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
       "integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
       "dev": true
+    },
+    "posthtml": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.9.2.tgz",
+      "integrity": "sha1-9MBtufZ7Yf0XxOJW5+PZUVv3Jv0=",
+      "dev": true,
+      "requires": {
+        "posthtml-parser": "^0.2.0",
+        "posthtml-render": "^1.0.5"
+      }
+    },
+    "posthtml-parser": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.2.1.tgz",
+      "integrity": "sha1-NdUw3jhnQMK6JP8usvrznM3ycd0=",
+      "dev": true,
+      "requires": {
+        "htmlparser2": "^3.8.3",
+        "isobject": "^2.1.0"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "dev": true,
+          "requires": {
+            "isarray": "1.0.0"
+          }
+        }
+      }
+    },
+    "posthtml-rename-id": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/posthtml-rename-id/-/posthtml-rename-id-1.0.11.tgz",
+      "integrity": "sha512-8doF8+w+WJT4AZuLVC0feA8Yy7g00IUmZw3YDKn8CKx0uC8FLbCH7JaGMbDOE1ArjyZsJMt1vmyP+IZ8SnNmXw==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5"
+      }
+    },
+    "posthtml-render": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-1.2.0.tgz",
+      "integrity": "sha512-dQB+hoAKDtnI94RZm/wxBUH9My8OJcXd0uhWmGh2c7tVtQ85A+OS3yCN3LNbFtPz3bViwBJXAeoi+CBGMXM0DA==",
+      "dev": true
+    },
+    "posthtml-svg-mode": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/posthtml-svg-mode/-/posthtml-svg-mode-1.0.3.tgz",
+      "integrity": "sha512-hEqw9NHZ9YgJ2/0G7CECOeuLQKZi8HjWLkBaSVtOWjygQ9ZD8P7tqeowYs7WrFdKsWEKG7o+IlsPY8jrr0CJpQ==",
+      "dev": true,
+      "requires": {
+        "merge-options": "1.0.1",
+        "posthtml": "^0.9.2",
+        "posthtml-parser": "^0.2.1",
+        "posthtml-render": "^1.0.6"
+      }
     },
     "prefix-style": {
       "version": "2.0.1",
@@ -14786,9 +14880,9 @@
       }
     },
     "smartcharts-beta": {
-      "version": "0.8.0-betam.4",
-      "resolved": "https://registry.npmjs.org/smartcharts-beta/-/smartcharts-beta-0.8.0-betam.4.tgz",
-      "integrity": "sha512-klWethZMG4aD00h5NYR5qNIc+Z4FVigsa/+QYEeptpPtvRd/tSuOqMRVhY6b/nxPkSTXUjyTDjhiEyYYGir8Ew==",
+      "version": "0.8.0-betam.5",
+      "resolved": "https://registry.npmjs.org/smartcharts-beta/-/smartcharts-beta-0.8.0-betam.5.tgz",
+      "integrity": "sha512-Sz536c0tA5tgabKU2/qhgKzMDb4ugQpaCfZ7dak00Bxmw/4UIXCjkxk0IQWqeZ1UFFvtBbGdPIQq9oMI/leTNw==",
       "requires": {
         "@welldone-software/why-did-you-render": "^3.3.8",
         "event-emitter-es6": "^1.1.5",
@@ -15921,51 +16015,31 @@
         "has-flag": "^3.0.0"
       }
     },
-    "svg-sprite-loader": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/svg-sprite-loader/-/svg-sprite-loader-4.2.0.tgz",
-      "integrity": "sha512-OxRf8WhtPMYPueabbcQ3Ptaf5xMgCp4sgcUFId7GRbHaHalXYRKQIsfrGu4s/otAwGRHcN5XaS+Zt/WoGGe9dA==",
+    "svg-baker": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/svg-baker/-/svg-baker-1.5.0.tgz",
+      "integrity": "sha512-UMU4WQMfsmY1l8eqoxBoGTDht02RVu46cC0QoAVsJM6lUvbGCkPnAHHMG3mM8m/D1zAGg8Q0IZXnHokZ9umX0Q==",
       "dev": true,
       "requires": {
         "bluebird": "^3.5.0",
-        "deepmerge": "1.3.2",
-        "domready": "1.0.8",
-        "escape-string-regexp": "1.0.5",
-        "html-webpack-plugin": "^3.2.0",
+        "clone": "^2.1.1",
+        "he": "^1.1.1",
+        "image-size": "^0.5.1",
         "loader-utils": "^1.1.0",
-        "svg-baker": "^1.5.0",
-        "svg-baker-runtime": "^1.4.3",
-        "url-slug": "2.0.0"
+        "merge-options": "1.0.1",
+        "micromatch": "3.1.0",
+        "postcss": "^5.2.17",
+        "postcss-prefix-selector": "^1.6.0",
+        "posthtml-rename-id": "^1.0",
+        "posthtml-svg-mode": "^1.0.3",
+        "query-string": "^4.3.2",
+        "traverse": "^0.6.6"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "big.js": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
-          "integrity": "sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg=",
-          "dev": true
-        },
-        "bluebird": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
-          "dev": true
-        },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
           "dev": true
         },
         "chalk": {
@@ -15989,98 +16063,22 @@
             }
           }
         },
-        "clone": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-          "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-          "dev": true
-        },
-        "deepmerge": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.3.2.tgz",
-          "integrity": "sha1-FmNpFinU2/42T6EqKk8KqGqjoFA=",
-          "dev": true
-        },
-        "dom-serializer": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-          "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "domelementtype": "~1.1.1",
-            "entities": "~1.1.1"
-          },
-          "dependencies": {
-            "domelementtype": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-              "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
-              "dev": true
-            }
+            "is-descriptor": "^1.0.0"
           }
         },
-        "domelementtype": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-          "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
-          "dev": true
-        },
-        "domhandler": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
-          "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "domelementtype": "1"
-          }
-        },
-        "domready": {
-          "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/domready/-/domready-1.0.8.tgz",
-          "integrity": "sha1-kfJS5Ze2Wvd+dFriTdAYXV4m1Yw=",
-          "dev": true
-        },
-        "domutils": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.6.0.tgz",
-          "integrity": "sha1-hT3gfwEyh/l2t/4EYXQCIuoU7Ls=",
-          "dev": true,
-          "requires": {
-            "dom-serializer": "0",
-            "domelementtype": "1"
-          }
-        },
-        "emojis-list": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-          "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-          "dev": true
-        },
-        "entities": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-          "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
+            "is-extendable": "^0.1.0"
           }
         },
         "has-flag": {
@@ -16089,57 +16087,179 @@
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
           "dev": true
         },
-        "htmlparser2": {
-          "version": "3.9.2",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
-          "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
-          "dev": true,
-          "requires": {
-            "domelementtype": "^1.3.0",
-            "domhandler": "^2.3.0",
-            "domutils": "^1.5.1",
-            "entities": "^1.1.1",
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.2"
-          }
-        },
-        "image-size": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.1.tgz",
-          "integrity": "sha1-KO6oVIpLFENIDd3cHgg65UZSQ58=",
-          "dev": true
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
-        },
-        "is-plain-obj": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-          "dev": true
-        },
-        "isarray": {
+        "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "isarray": "1.0.0"
+            "kind-of": "^6.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "6.0.3",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+              "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+              "dev": true
+            }
           }
         },
-        "js-base64": {
-          "version": "2.1.9",
-          "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
-          "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4=",
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "6.0.3",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+              "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+              "dev": true
+            }
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "6.0.3",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+              "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+              "dev": true
+            }
+          }
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.0.tgz",
+          "integrity": "sha512-3StSelAE+hnRvMs8IdVW7Uhk8CVed5tp+kLLGlBP6WiRAXS21GPGu/Nat4WNPXj2Eoc24B02SaeoyozPMfj0/g==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.2.2",
+            "define-property": "^1.0.0",
+            "extend-shallow": "^2.0.1",
+            "extglob": "^2.0.2",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^5.0.2",
+            "nanomatch": "^1.2.1",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          }
+        },
+        "postcss": {
+          "version": "5.2.18",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
+          }
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        }
+      }
+    },
+    "svg-baker-runtime": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/svg-baker-runtime/-/svg-baker-runtime-1.4.3.tgz",
+      "integrity": "sha512-QY6RlJN3v6xPxVQboSrsGiLWaWay+uFstic6QEzoIUK2l6M/lqL/wiqFcoqroBsGpqpP0knXplltLZGTzncbNw==",
+      "dev": true,
+      "requires": {
+        "deepmerge": "1.3.2",
+        "mitt": "1.1.2",
+        "svg-baker": "^1.5.0"
+      },
+      "dependencies": {
+        "deepmerge": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.3.2.tgz",
+          "integrity": "sha1-FmNpFinU2/42T6EqKk8KqGqjoFA=",
+          "dev": true
+        }
+      }
+    },
+    "svg-sprite-loader": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/svg-sprite-loader/-/svg-sprite-loader-4.2.0.tgz",
+      "integrity": "sha512-OxRf8WhtPMYPueabbcQ3Ptaf5xMgCp4sgcUFId7GRbHaHalXYRKQIsfrGu4s/otAwGRHcN5XaS+Zt/WoGGe9dA==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.5.0",
+        "deepmerge": "1.3.2",
+        "domready": "1.0.8",
+        "escape-string-regexp": "1.0.5",
+        "html-webpack-plugin": "^3.2.0",
+        "loader-utils": "^1.1.0",
+        "svg-baker": "^1.5.0",
+        "svg-baker-runtime": "^1.4.3",
+        "url-slug": "2.0.0"
+      },
+      "dependencies": {
+        "big.js": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+          "integrity": "sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg=",
+          "dev": true
+        },
+        "bluebird": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
+          "dev": true
+        },
+        "deepmerge": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.3.2.tgz",
+          "integrity": "sha1-FmNpFinU2/42T6EqKk8KqGqjoFA=",
+          "dev": true
+        },
+        "domready": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/domready/-/domready-1.0.8.tgz",
+          "integrity": "sha1-kfJS5Ze2Wvd+dFriTdAYXV4m1Yw=",
+          "dev": true
+        },
+        "emojis-list": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+          "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "json5": {
@@ -16159,203 +16279,6 @@
             "json5": "^0.5.0"
           }
         },
-        "merge-options": {
-          "version": "0.0.64",
-          "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-0.0.64.tgz",
-          "integrity": "sha1-y+BPWUppheryf3+PCyo6z2+dVi0=",
-          "dev": true,
-          "requires": {
-            "is-plain-obj": "^1.1.0"
-          }
-        },
-        "mitt": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.1.2.tgz",
-          "integrity": "sha1-OA5hSA1qYVtmDwertg1R4KTkvtY=",
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        },
-        "postcss": {
-          "version": "5.2.17",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
-          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
-          "dev": true,
-          "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
-          }
-        },
-        "postcss-prefix-selector": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/postcss-prefix-selector/-/postcss-prefix-selector-1.6.0.tgz",
-          "integrity": "sha1-tJWUnWOcYxRxRWSDJoUyFvPBCQA=",
-          "dev": true,
-          "requires": {
-            "postcss": "^5.0.8"
-          }
-        },
-        "posthtml": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.9.2.tgz",
-          "integrity": "sha1-9MBtufZ7Yf0XxOJW5+PZUVv3Jv0=",
-          "dev": true,
-          "requires": {
-            "posthtml-parser": "^0.2.0",
-            "posthtml-render": "^1.0.5"
-          }
-        },
-        "posthtml-parser": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.2.1.tgz",
-          "integrity": "sha1-NdUw3jhnQMK6JP8usvrznM3ycd0=",
-          "dev": true,
-          "requires": {
-            "htmlparser2": "^3.8.3",
-            "isobject": "^2.1.0"
-          }
-        },
-        "posthtml-rename-id": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/posthtml-rename-id/-/posthtml-rename-id-1.0.1.tgz",
-          "integrity": "sha1-BAjSrlMlM21vvqr40f3Dnk548cY=",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "1.0.5"
-          }
-        },
-        "posthtml-render": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-1.0.6.tgz",
-          "integrity": "sha1-G4i454YKjr3+LyoTEKRkKlXPW9o=",
-          "dev": true
-        },
-        "posthtml-svg-mode": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/posthtml-svg-mode/-/posthtml-svg-mode-1.0.0.tgz",
-          "integrity": "sha1-zdwE4cQYU9WYbAGfURs6qpRxDJU=",
-          "dev": true,
-          "requires": {
-            "merge-options": "0.0.64",
-            "posthtml": "^0.9.2",
-            "posthtml-parser": "^0.2.1",
-            "posthtml-render": "^1.0.6"
-          }
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "dev": true
-        },
-        "query-string": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-          "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.0",
-            "strict-uri-encode": "^1.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "2.2.9",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-          "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
-          "dev": true,
-          "requires": {
-            "buffer-shims": "~1.0.0",
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~1.0.0",
-            "util-deprecate": "~1.0.1"
-          },
-          "dependencies": {
-            "string_decoder": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
-              "integrity": "sha1-8G9BFXtmTYYGn4S9vcmw2KsoFmc=",
-              "dev": true,
-              "requires": {
-                "buffer-shims": "~1.0.0"
-              }
-            }
-          }
-        },
-        "source-map": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
-          "dev": true
-        },
-        "strict-uri-encode": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-          "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
-          "requires": {
-            "has-flag": "^1.0.0"
-          }
-        },
-        "svg-baker": {
-          "version": "1.2.6",
-          "resolved": "https://registry.npmjs.org/svg-baker/-/svg-baker-1.2.6.tgz",
-          "integrity": "sha1-rCSK9yKyDIkzFhxGOmXBtfiW754=",
-          "dev": true,
-          "requires": {
-            "bluebird": "^3.5.0",
-            "clone": "^2.1.1",
-            "image-size": "^0.5.1",
-            "loader-utils": "^1.1.0",
-            "merge-options": "0.0.64",
-            "postcss": "^5.2.17",
-            "postcss-prefix-selector": "^1.6.0",
-            "posthtml-rename-id": "^1.0",
-            "posthtml-svg-mode": "^1.0",
-            "query-string": "^4.3.2",
-            "traverse": "^0.6.6"
-          }
-        },
-        "svg-baker-runtime": {
-          "version": "1.2.92",
-          "resolved": "https://registry.npmjs.org/svg-baker-runtime/-/svg-baker-runtime-1.2.92.tgz",
-          "integrity": "sha1-zuz0EybNwQ/ZoBWrxVf+Ytar64U=",
-          "dev": true,
-          "requires": {
-            "deepmerge": "1.3.2",
-            "mitt": "1.1.2",
-            "svg-baker": "^1.2.0"
-          }
-        },
-        "traverse": {
-          "version": "0.6.6",
-          "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-          "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
-          "dev": true
-        },
         "unidecode": {
           "version": "0.1.8",
           "resolved": "https://registry.npmjs.org/unidecode/-/unidecode-0.1.8.tgz",
@@ -16370,12 +16293,6 @@
           "requires": {
             "unidecode": "0.1.8"
           }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-          "dev": true
         }
       }
     },
@@ -16808,6 +16725,12 @@
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/trackjs/-/trackjs-2.13.0.tgz",
       "integrity": "sha512-O3x/Krn0iQhCacfazqiNrWakQbM6Nj1SDd9BvZeVGNFbkq8YkhblNnSp+VC7u+wXBh05dX3TDtDSl+WgAxwdlg==",
+      "dev": true
+    },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
       "dev": true
     },
     "tree-kill": {

--- a/packages/bot-web-ui/package-lock.json
+++ b/packages/bot-web-ui/package-lock.json
@@ -14880,9 +14880,9 @@
       }
     },
     "smartcharts-beta": {
-      "version": "0.8.0-betam.5",
-      "resolved": "https://registry.npmjs.org/smartcharts-beta/-/smartcharts-beta-0.8.0-betam.5.tgz",
-      "integrity": "sha512-Sz536c0tA5tgabKU2/qhgKzMDb4ugQpaCfZ7dak00Bxmw/4UIXCjkxk0IQWqeZ1UFFvtBbGdPIQq9oMI/leTNw==",
+      "version": "0.8.0-betam.6",
+      "resolved": "https://registry.npmjs.org/smartcharts-beta/-/smartcharts-beta-0.8.0-betam.6.tgz",
+      "integrity": "sha512-uFIdgO1s/YdRlDbPCwI7GYYqGML8Fms0miaKN2MCMSDlGY1iRFBQ/ypPRKLEsr262ShPWskRDOS1V1rZCnoOZA==",
       "requires": {
         "@welldone-software/why-did-you-render": "^3.3.8",
         "event-emitter-es6": "^1.1.5",

--- a/packages/bot-web-ui/package.json
+++ b/packages/bot-web-ui/package.json
@@ -117,6 +117,6 @@
     "react-dom": "~16.8.6",
     "react-render-html": "^0.6.0",
     "react-transition-group": "^4.0.1",
-    "smartcharts-beta": "^0.8.0-betam.5"
+    "smartcharts-beta": "^0.8.0-betam.6"
   }
 }

--- a/packages/bot-web-ui/package.json
+++ b/packages/bot-web-ui/package.json
@@ -117,6 +117,6 @@
     "react-dom": "~16.8.6",
     "react-render-html": "^0.6.0",
     "react-transition-group": "^4.0.1",
-    "smartcharts-beta": "^0.8.0-betam.4"
+    "smartcharts-beta": "^0.8.0-betam.5"
   }
 }

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -13255,9 +13255,9 @@
       }
     },
     "smartcharts-beta": {
-      "version": "0.8.0-betam.4",
-      "resolved": "https://registry.npmjs.org/smartcharts-beta/-/smartcharts-beta-0.8.0-betam.4.tgz",
-      "integrity": "sha512-klWethZMG4aD00h5NYR5qNIc+Z4FVigsa/+QYEeptpPtvRd/tSuOqMRVhY6b/nxPkSTXUjyTDjhiEyYYGir8Ew==",
+      "version": "0.8.0-betam.5",
+      "resolved": "https://registry.npmjs.org/smartcharts-beta/-/smartcharts-beta-0.8.0-betam.5.tgz",
+      "integrity": "sha512-Sz536c0tA5tgabKU2/qhgKzMDb4ugQpaCfZ7dak00Bxmw/4UIXCjkxk0IQWqeZ1UFFvtBbGdPIQq9oMI/leTNw==",
       "requires": {
         "@welldone-software/why-did-you-render": "^3.3.8",
         "event-emitter-es6": "^1.1.5",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -13255,9 +13255,9 @@
       }
     },
     "smartcharts-beta": {
-      "version": "0.8.0-betam.5",
-      "resolved": "https://registry.npmjs.org/smartcharts-beta/-/smartcharts-beta-0.8.0-betam.5.tgz",
-      "integrity": "sha512-Sz536c0tA5tgabKU2/qhgKzMDb4ugQpaCfZ7dak00Bxmw/4UIXCjkxk0IQWqeZ1UFFvtBbGdPIQq9oMI/leTNw==",
+      "version": "0.8.0-betam.6",
+      "resolved": "https://registry.npmjs.org/smartcharts-beta/-/smartcharts-beta-0.8.0-betam.6.tgz",
+      "integrity": "sha512-uFIdgO1s/YdRlDbPCwI7GYYqGML8Fms0miaKN2MCMSDlGY1iRFBQ/ypPRKLEsr262ShPWskRDOS1V1rZCnoOZA==",
       "requires": {
         "@welldone-software/why-did-you-render": "^3.3.8",
         "event-emitter-es6": "^1.1.5",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -140,7 +140,7 @@
     "react-tiny-popover": "^4.0.0",
     "react-transition-group": "^2.5.0",
     "react-window": "^1.8.4",
-    "smartcharts-beta": "^0.8.0-betam.4",
+    "smartcharts-beta": "^0.8.0-betam.5",
     "url-polyfill": "^1.1.5",
     "web-push-notifications": "^3.2.15"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -140,7 +140,7 @@
     "react-tiny-popover": "^4.0.0",
     "react-transition-group": "^2.5.0",
     "react-window": "^1.8.4",
-    "smartcharts-beta": "^0.8.0-betam.5",
+    "smartcharts-beta": "^0.8.0-betam.6",
     "url-polyfill": "^1.1.5",
     "web-push-notifications": "^3.2.15"
   }

--- a/packages/core/src/sass/app/_common/components/account-switcher.scss
+++ b/packages/core/src/sass/app/_common/components/account-switcher.scss
@@ -124,6 +124,9 @@
         &:not(:last-child) {
             margin-right: 1em;
         }
+        @include mobile {
+            height: 2.8rem !important;
+        }
     }
 }
 
@@ -425,6 +428,10 @@
     & .btn {
         display: flex;
         align-items: center;
+
+        @include mobile {
+            height: 2.8rem !important;
+        }
     }
 }
 

--- a/packages/trader/package-lock.json
+++ b/packages/trader/package-lock.json
@@ -13087,9 +13087,9 @@
       }
     },
     "smartcharts-beta": {
-      "version": "0.8.0-betam.4",
-      "resolved": "https://registry.npmjs.org/smartcharts-beta/-/smartcharts-beta-0.8.0-betam.4.tgz",
-      "integrity": "sha512-klWethZMG4aD00h5NYR5qNIc+Z4FVigsa/+QYEeptpPtvRd/tSuOqMRVhY6b/nxPkSTXUjyTDjhiEyYYGir8Ew==",
+      "version": "0.8.0-betam.5",
+      "resolved": "https://registry.npmjs.org/smartcharts-beta/-/smartcharts-beta-0.8.0-betam.5.tgz",
+      "integrity": "sha512-Sz536c0tA5tgabKU2/qhgKzMDb4ugQpaCfZ7dak00Bxmw/4UIXCjkxk0IQWqeZ1UFFvtBbGdPIQq9oMI/leTNw==",
       "requires": {
         "@welldone-software/why-did-you-render": "^3.3.8",
         "event-emitter-es6": "^1.1.5",

--- a/packages/trader/package-lock.json
+++ b/packages/trader/package-lock.json
@@ -13087,9 +13087,9 @@
       }
     },
     "smartcharts-beta": {
-      "version": "0.8.0-betam.5",
-      "resolved": "https://registry.npmjs.org/smartcharts-beta/-/smartcharts-beta-0.8.0-betam.5.tgz",
-      "integrity": "sha512-Sz536c0tA5tgabKU2/qhgKzMDb4ugQpaCfZ7dak00Bxmw/4UIXCjkxk0IQWqeZ1UFFvtBbGdPIQq9oMI/leTNw==",
+      "version": "0.8.0-betam.6",
+      "resolved": "https://registry.npmjs.org/smartcharts-beta/-/smartcharts-beta-0.8.0-betam.6.tgz",
+      "integrity": "sha512-uFIdgO1s/YdRlDbPCwI7GYYqGML8Fms0miaKN2MCMSDlGY1iRFBQ/ypPRKLEsr262ShPWskRDOS1V1rZCnoOZA==",
       "requires": {
         "@welldone-software/why-did-you-render": "^3.3.8",
         "event-emitter-es6": "^1.1.5",

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -136,7 +136,7 @@
     "react-router-dom": "^5.0.1",
     "react-transition-group": "^2.5.0",
     "react-window": "^1.8.4",
-    "smartcharts-beta": "^0.8.0-betam.4",
+    "smartcharts-beta": "^0.8.0-betam.5",
     "url-polyfill": "^1.1.5",
     "web-push-notifications": "^3.2.15",
     "workbox-webpack-plugin": "^4.3.1"

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -136,7 +136,7 @@
     "react-router-dom": "^5.0.1",
     "react-transition-group": "^2.5.0",
     "react-window": "^1.8.4",
-    "smartcharts-beta": "^0.8.0-betam.5",
+    "smartcharts-beta": "^0.8.0-betam.6",
     "url-polyfill": "^1.1.5",
     "web-push-notifications": "^3.2.15",
     "workbox-webpack-plugin": "^4.3.1"

--- a/packages/trader/src/Modules/SmartChart/Components/toolbar-widgets.jsx
+++ b/packages/trader/src/Modules/SmartChart/Components/toolbar-widgets.jsx
@@ -1,0 +1,18 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { isMobile } from '@deriv/shared/utils/screen';
+import { ChartMode, ToolbarWidget } from 'Modules/SmartChart';
+
+const ToolbarWidgets = ({ position, updateChartType, updateGranularity }) => (
+    <ToolbarWidget position={position || isMobile() ? 'bottom' : null}>
+        <ChartMode portalNodeId='modal_root' onChartType={updateChartType} onGranularity={updateGranularity} />
+    </ToolbarWidget>
+);
+
+ToolbarWidgets.propTypes = {
+    position: PropTypes.string,
+    updateChartType: PropTypes.func,
+    updateGranularity: PropTypes.func,
+};
+
+export default ToolbarWidgets;

--- a/packages/trader/src/Modules/SmartChart/index.js
+++ b/packages/trader/src/Modules/SmartChart/index.js
@@ -25,6 +25,7 @@ export const DrawTools = React.lazy(load('DrawTools'));
 export const Share = React.lazy(load('Share'));
 export const StudyLegend = React.lazy(load('StudyLegend'));
 export const Views = React.lazy(load('Views'));
+export const ToolbarWidget = React.lazy(load('ToolbarWidget'));
 
 export const FastMarker = React.lazy(load('FastMarker'));
 export const RawMarker = React.lazy(load('RawMarker'));

--- a/packages/trader/src/Modules/Trading/Containers/chart-widgets.jsx
+++ b/packages/trader/src/Modules/Trading/Containers/chart-widgets.jsx
@@ -4,6 +4,7 @@ import Digits from 'Modules/Contract/Components/Digits';
 import { connect } from 'Stores/connect';
 import BottomWidgets from '../../SmartChart/Components/bottom-widgets.jsx';
 import ControlWidgets from '../../SmartChart/Components/control-widgets.jsx';
+import ToolbarWidgets from '../../SmartChart/Components/toolbar-widgets.jsx';
 import TopWidgets from '../../SmartChart/Components/top-widgets.jsx';
 import { symbolChange } from '../../SmartChart/Helpers/symbol';
 
@@ -46,6 +47,13 @@ export const ChartTopWidgets = connect(({ modules, ui }) => ({
         />
     );
 });
+
+export const ChartToolbarWidgets = connect(({ modules }) => ({
+    updateChartType: modules.contract_trade.updateChartType,
+    updateGranularity: modules.contract_trade.updateGranularity,
+}))(({ updateChartType, updateGranularity }) => (
+    <ToolbarWidgets updateChartType={updateChartType} updateGranularity={updateGranularity} />
+));
 
 export const ChartBottomWidgets = ({ digits, tick }) => (
     <BottomWidgets Digits={<DigitsWidget digits={digits} tick={tick} />} />

--- a/packages/trader/src/Modules/Trading/Containers/trade.jsx
+++ b/packages/trader/src/Modules/Trading/Containers/trade.jsx
@@ -6,7 +6,13 @@ import { connect } from 'Stores/connect';
 import PositionsDrawer from 'App/Components/Elements/PositionsDrawer';
 import MarketIsClosedOverlay from 'App/Components/Elements/market-is-closed-overlay.jsx';
 import Test from './test.jsx';
-import { ChartBottomWidgets, ChartControlWidgets, ChartTopWidgets, DigitsWidget } from './chart-widgets.jsx';
+import {
+    ChartBottomWidgets,
+    ChartControlWidgets,
+    ChartToolbarWidgets,
+    ChartTopWidgets,
+    DigitsWidget,
+} from './chart-widgets.jsx';
 import FormLayout from '../Components/Form/form-layout.jsx';
 import AllMarkers from '../../SmartChart/Components/all-markers.jsx';
 
@@ -169,6 +175,7 @@ class ChartTradeClass extends React.Component {
                 topWidgets={this.props.is_trade_enabled ? this.topWidgets : null}
                 isConnectionOpened={this.props.is_socket_opened}
                 clearChart={false}
+                toolbarWidget={isMobile() ? ChartToolbarWidgets : null}
                 importedLayout={this.props.chart_layout}
                 onExportLayout={this.props.exportLayout}
                 shouldFetchTradingTimes={!this.props.end_epoch}

--- a/packages/trader/src/Modules/Trading/Containers/trade.jsx
+++ b/packages/trader/src/Modules/Trading/Containers/trade.jsx
@@ -151,6 +151,9 @@ class ChartTradeClass extends React.Component {
         // smartcharts only way to refresh active-symbols is to reset the connection.
         // const is_socket_opened = this.props.is_socket_opened && !should_refresh;
 
+        // max ticks to display for mobile view for tick chart
+        const max_ticks = this.props.granularity === 0 ? 8 : 24;
+
         return (
             <SmartChart
                 ref={ref => (this.charts_ref = ref)}
@@ -164,7 +167,7 @@ class ChartTradeClass extends React.Component {
                 enabledNavigationWidget={isDesktop()}
                 id='trade'
                 isMobile={isMobile()}
-                maxTick={isMobile() ? 8 : undefined}
+                maxTick={isMobile() ? max_ticks : undefined}
                 granularity={this.props.granularity}
                 requestAPI={this.props.wsSendRequest}
                 requestForget={this.props.wsForget}

--- a/packages/trader/src/sass/app/_common/layout/layouts.scss
+++ b/packages/trader/src/sass/app/_common/layout/layouts.scss
@@ -370,6 +370,33 @@ $FLOATING_HEADER_HEIGHT: 41px;
         .ciq-navigation-widget {
             transform: translate3d(0, 0, 0);
         }
+        .ciq-toolbar-widget {
+            @include mobile {
+                background: transparent;
+                border-width: 0;
+                bottom: 2.8rem;
+
+                .ciq-chart-mode {
+                    background: var(--general-section-1);
+                    padding: 0.4rem 0.2rem;
+                    width: 4rem;
+                    height: 4rem;
+                    display: flex;
+                    border-radius: 50%;
+                    justify-content: center;
+                    align-items: center;
+                    margin: 0.8rem;
+
+                    &__menu__timeperiod {
+                        top: 0.8rem;
+                        left: 0.8rem;
+                    }
+                    &__menu > .ic-icon {
+                        top: 0.2rem;
+                    }
+                }
+            }
+        }
     }
     .chartContainer {
         background: transparent;

--- a/packages/trader/src/sass/app/_common/layout/layouts.scss
+++ b/packages/trader/src/sass/app/_common/layout/layouts.scss
@@ -376,6 +376,7 @@ $FLOATING_HEADER_HEIGHT: 41px;
                 border-width: 0;
                 bottom: 2.8rem;
 
+                /* postcss-bem-linter: ignore */
                 .ciq-chart-mode {
                     background: var(--general-section-1);
                     padding: 0.4rem 0.2rem;
@@ -392,7 +393,7 @@ $FLOATING_HEADER_HEIGHT: 41px;
                         left: 0.8rem;
                     }
                     &__menu > .ic-icon {
-                        top: 0.2rem;
+                        top: 0.6rem;
                     }
                 }
             }
@@ -468,6 +469,40 @@ $FLOATING_HEADER_HEIGHT: 41px;
                 /* postcss-bem-linter: ignore */
                 .cq-dialog {
                     max-width: calc(100% - 36px);
+                }
+            }
+            /** @define ciq-chart-mode; weak */
+            .ciq-chart-mode {
+                /* postcss-bem-linter: ignore */
+                &__section__item {
+                    /* postcss-bem-linter: ignore */
+                    .cq-interval {
+                        display: grid;
+                        padding: 1.6rem;
+                        grid-template-columns: 1fr;
+
+                        /* postcss-bem-linter: ignore */
+                        &__content {
+                            display: grid;
+                            grid-template-columns: 1fr 1fr 1fr;
+                            padding-top: 16px;
+                        }
+                        /* postcss-bem-linter: ignore */
+                        &__item {
+                            width: 100% !important;
+                            margin: 0;
+
+                            /* postcss-bem-linter: ignore */
+                            .tooltip {
+                                display: none;
+                            }
+                        }
+                        /* postcss-bem-linter: ignore */
+                        &__info {
+                            margin-top: 0.4rem;
+                            padding-left: 0.2rem;
+                        }
+                    }
                 }
             }
         }

--- a/packages/trader/src/sass/app/modules/trading-mobile.scss
+++ b/packages/trader/src/sass/app/modules/trading-mobile.scss
@@ -1,163 +1,165 @@
-/** @define allow-equals; weak */
-.allow-equals {
-    &__subtitle {
-        font-size: 1rem;
-        font-weight: normal;
-    }
-    .dc-checkbox__label {
-        font-weight: bold;
-        color: var(--text-prominent);
-        margin-right: 0.8rem;
-    }
-}
-
-/** @define dc-modal; weak */
-.dc-modal {
-    &__container_trade-params {
-        border-radius: 2px;
-        box-shadow: 0 16px 16px 0 var(--shadow-menu-2), 0 0 16px 0 var(--shadow-menu-2);
-
-        /* postcss-bem-linter: ignore */
-        .dc-relative-datepicker {
-            margin-top: -0.8rem;
-            max-width: 110px;
-            margin-left: auto;
-            margin-right: auto;
-
-            /* iPhone SE screen height fixes due to UI space restrictions */
-            @media only screen and (max-height: 480px) {
-                margin-top: -4.3rem;
-            }
+@include mobile {
+    /** @define allow-equals; weak */
+    .allow-equals {
+        &__subtitle {
+            font-size: 1rem;
+            font-weight: normal;
         }
-        /* iPhone SE screen height fixes due to UI space restrictions */
-        @media only screen and (max-height: 480px) {
-            top: 0.4rem;
+        .dc-checkbox__label {
+            font-weight: bold;
+            color: var(--text-prominent);
+            margin-right: 0.8rem;
         }
     }
-    &-header {
-        /* postcss-bem-linter: ignore */
-        &--trade-params {
-            line-height: 1.4;
-            border-bottom-width: 1px;
+    /** @define dc-modal; weak */
+    .dc-modal {
+        &__container_trade-params {
+            border-radius: 2px;
+            box-shadow: 0 16px 16px 0 var(--shadow-menu-2), 0 0 16px 0 var(--shadow-menu-2);
 
             /* postcss-bem-linter: ignore */
-            .dc-modal-header__close {
-                padding: 0.8rem 0.8rem 0;
-                margin: 0.4rem 0.4rem 0.2rem;
+            .dc-relative-datepicker {
+                margin-top: -0.8rem;
+                max-width: 110px;
+                margin-left: auto;
+                margin-right: auto;
+
+                /* iPhone SE screen height fixes due to UI space restrictions */
+                @media only screen and (max-height: 480px) {
+                    margin-top: -4.3rem;
+                }
+            }
+            /* iPhone SE screen height fixes due to UI space restrictions */
+            @media only screen and (max-height: 480px) {
+                top: 0.4rem;
+            }
+        }
+        &-header {
+            /* postcss-bem-linter: ignore */
+            &--trade-params {
+                line-height: 1.4;
+                border-bottom-width: 1px;
+
+                /* postcss-bem-linter: ignore */
+                .dc-modal-header__close {
+                    padding: 0.8rem 0.8rem 0;
+                    margin: 0.4rem 0.4rem 0.2rem;
+                }
             }
         }
     }
-}
+    /** @define trade-params; weak */
+    .trade-params {
+        &__error-popup {
+            top: 12rem !important;
+            opacity: 0.8;
+            z-index: 2 !important;
 
-/** @define trade-params; weak */
-.trade-params {
-    &__error-popup {
-        top: 12rem !important;
-        opacity: 0.8;
-        z-index: 2 !important;
-
-        &--has-numpad {
-            z-index: 9999 !important;
-            top: 0.8rem !important;
+            &--has-numpad {
+                z-index: 9999 !important;
+                top: 0.8rem !important;
+            }
         }
-    }
-    &__duration {
-        &-tickpicker {
-            height: 328px;
+        &__duration {
+            &-tickpicker {
+                height: 328px;
 
-            .dc-tick-picker {
-                max-width: 100%;
-                height: 100%;
+                .dc-tick-picker {
+                    max-width: 100%;
+                    height: 100%;
+                    align-items: center;
+                    justify-content: center;
+                }
+            }
+        }
+        &__amount {
+            &-keypad {
+                width: 100%;
+                padding: 1.6rem;
+                height: auto;
+                margin-top: 0.8rem;
+                margin-bottom: 0.8rem;
+                display: flex;
                 align-items: center;
                 justify-content: center;
-            }
-        }
-    }
-    &__amount {
-        &-keypad {
-            width: 100%;
-            padding: 1.6rem;
-            height: auto;
-            margin-top: 0.8rem;
-            margin-bottom: 0.8rem;
-            display: flex;
-            align-items: center;
-            justify-content: center;
 
-            .dc-numpad--is-currency,
-            .dc-numpad--is-regular {
-                max-width: 100%;
-                grid-template-columns: repeat(4, 1fr);
-                grid-gap: 16px;
-            }
-            .dc-numpad__increment,
-            .dc-numpad__decrement {
-                .btn__text {
-                    font-size: 3rem;
-                    font-weight: normal;
+                .dc-numpad--is-currency,
+                .dc-numpad--is-regular {
+                    max-width: 100%;
+                    grid-template-columns: repeat(4, 1fr);
+                    grid-gap: 16px;
                 }
-                &[disabled] {
+                .dc-numpad__increment,
+                .dc-numpad__decrement {
+                    height: 48px !important;
+
                     .btn__text {
-                        color: var(--text-disabled);
+                        font-size: 3rem;
+                        font-weight: normal;
                     }
-                }
-            }
-            .dc-numpad__number {
-                border-radius: 2.4rem;
-                background-color: var(--general-section-2);
-                width: 48px;
-                height: 48px;
-                font-weight: 700;
-                text-transform: none;
-                line-height: 1.75;
-                color: var(--text-prominent);
-                text-align: left !important;
-
-                .btn__text {
-                    font-size: 1.8rem;
-                }
-                &--is-left-aligned {
-                    padding: 0 0 0 0.2rem;
-                }
-            }
-            .dc-numpad__bkspace,
-            .dc-numpad__ok {
-                .dc-numpad__number {
-                    height: 100%;
-                }
-            }
-            .dc-numpad__bkspace {
-                .dc-numpad__number {
                     &[disabled] {
-                        background-color: var(--general-disabled);
-
                         .btn__text {
                             color: var(--text-disabled);
                         }
                     }
                 }
-            }
-            /* iPhone SE screen height fixes due to UI space restrictions */
-            @media only screen and (max-height: 480px) {
-                transform: scale(0.92);
-                transform-origin: top;
+                .dc-numpad__number {
+                    border-radius: 2.4rem;
+                    background-color: var(--general-section-2);
+                    width: 48px;
+                    height: 48px !important;
+                    font-weight: 700;
+                    text-transform: none;
+                    line-height: 1.75;
+                    color: var(--text-prominent);
+                    text-align: left !important;
+
+                    .btn__text {
+                        font-size: 1.8rem;
+                    }
+                    &--is-left-aligned {
+                        padding: 0 0 0 0.2rem;
+                    }
+                }
+                .dc-numpad__bkspace,
+                .dc-numpad__ok {
+                    .dc-numpad__number {
+                        height: 100% !important;
+                    }
+                }
+                .dc-numpad__bkspace {
+                    .dc-numpad__number {
+                        &[disabled] {
+                            background-color: var(--general-disabled);
+
+                            .btn__text {
+                                color: var(--text-disabled);
+                            }
+                        }
+                    }
+                }
+                /* iPhone SE screen height fixes due to UI space restrictions */
+                @media only screen and (max-height: 480px) {
+                    transform: scale(0.92);
+                    transform-origin: top;
+                }
             }
         }
-    }
-    &__header {
-        @include mobile {
-            padding: 0.5rem 0;
+        &__header {
+            @include mobile {
+                padding: 0.5rem 0;
 
-            &-label {
-                line-height: 2rem;
-            }
-            &-value {
-                line-height: 1.8rem;
-                font-size: 1.2rem;
+                &-label {
+                    line-height: 2rem;
+                }
+                &-value {
+                    line-height: 1.8rem;
+                    font-size: 1.2rem;
 
-                &--has-error {
-                    color: var(--status-danger);
-                    font-weight: bold;
+                    &--has-error {
+                        color: var(--status-danger);
+                        font-weight: bold;
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Changelog

**Trader**
- Updated smartcharts-beta to `smartcharts-beta@0.8.0-betam.6`.
- Updated styles for `ChartMode` widget.
- Added temporary fixes for `smartcharts` button stylesheet overriding `deriv` `Button` components in production builds.
- Set `maxTicks` props based on `granularity`.

**Core** 
- Updated smartcharts-beta to `smartcharts-beta@0.8.0-betam.6`.

**Bot**
- Updated smartcharts-beta to `smartcharts-beta@0.8.0-betam.6`.