### PR TITLE
Bala/fix contract sold notification on mobile

### DIFF
--- a/packages/core/src/App/Containers/app-notification-messages.jsx
+++ b/packages/core/src/App/Containers/app-notification-messages.jsx
@@ -19,7 +19,7 @@ class AppNotificationMessages extends React.Component {
     };
 
     render() {
-        const allowed_on_mobile = ['mf_retail', 'unwelcome'];
+        const allowed_on_mobile = ['mf_retail', 'unwelcome', 'contract_sold'];
 
         const { marked_notifications, notification_messages, removeNotificationMessage } = this.props;
         const { bounds } = this.state;

--- a/packages/core/src/Stores/Helpers/client-notifications.js
+++ b/packages/core/src/Stores/Helpers/client-notifications.js
@@ -420,14 +420,16 @@ const checkAccountStatus = (account_status, client, addNotificationMessage, logi
     };
 };
 
-export const excluded_notifications = [
-    'you_are_offline',
-    'password_changed',
-    'switch_to_tick_chart',
-    'contract_sold',
-    'maintenance',
-    'bot_switch_account',
-];
+export const excluded_notifications = isMobile()
+    ? ['contract_sold']
+    : [
+          'you_are_offline',
+          'password_changed',
+          'switch_to_tick_chart',
+          'contract_sold',
+          'maintenance',
+          'bot_switch_account',
+      ];
 
 export const handleClientNotifications = (
     client,


### PR DESCRIPTION
### Changelog

- Added `contract_sold` to allowed notification toast on mobile
-  Notifications other than `contract_sold` which were only shown as toast on desktop will be shown on notification centre on mobile