### PR TITLE
zaki/update_deriv_api

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1047,9 +1047,9 @@
       "dev": true
     },
     "@deriv/deriv-api": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@deriv/deriv-api/-/deriv-api-1.0.1.tgz",
-      "integrity": "sha512-U69LF+AHzI4D2PKo2ufJtK7hKigYDpO1aAq6AdV50j/MxpES5vJyMYEpu4+IPG7+jz9RgkVujAx4h7jK7Y2sdQ==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@deriv/deriv-api/-/deriv-api-1.0.5.tgz",
+      "integrity": "sha512-2RLQ/hrQjOL+PjH/UmFMIyDZahIAoXCn9s3OYq0iLo26dj4e1kd5W3AIyPVnHQ4c3LMeDeXNzksNyPUVh2SvIQ==",
       "requires": {
         "dayjs": "^1.8.15",
         "json-stable-stringify": "^1.0.1",
@@ -4056,9 +4056,9 @@
       "dev": true
     },
     "dayjs": {
-      "version": "1.8.16",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.16.tgz",
-      "integrity": "sha512-XPmqzWz/EJiaRHjBqSJ2s6hE/BUoCIHKgdS2QPtTQtKcS9E4/Qn0WomoH1lXanWCzri+g7zPcuNV4aTZ8PMORQ=="
+      "version": "1.8.27",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.27.tgz",
+      "integrity": "sha512-Jpa2acjWIeOkg8KURUHICk0EqnEFSSF5eMEscsOgyJ92ZukXwmpmRkPSUka7KHSfbj5eKH30ieosYip+ky9emQ=="
     },
     "debug": {
       "version": "4.1.1",
@@ -15597,11 +15597,6 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
-    },
-    "url-polyfill": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/url-polyfill/-/url-polyfill-1.1.7.tgz",
-      "integrity": "sha512-ZrAxYWCREjmMtL8gSbSiKKLZZticgihCvVBtrFbUVpyoETt8GQJeG2okMWA8XryDAaHMjJfhnc+rnhXRbI4DXA=="
     },
     "url-resolve-browser": {
       "version": "1.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -109,7 +109,7 @@
     "@binary-com/binary-document-uploader": "^2.4.4",
     "@deriv/bot-web-ui": "^1.0.0",
     "@deriv/components": "^1.0.0",
-    "@deriv/deriv-api": "^1.0.1",
+    "@deriv/deriv-api": "^1.0.5",
     "@deriv/p2p": "^0.6.0",
     "@deriv/shared": "^1.0.0",
     "@deriv/trader": "^3.8.0",

--- a/packages/trader/package-lock.json
+++ b/packages/trader/package-lock.json
@@ -1062,9 +1062,9 @@
       "dev": true
     },
     "@deriv/deriv-api": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@deriv/deriv-api/-/deriv-api-1.0.1.tgz",
-      "integrity": "sha512-U69LF+AHzI4D2PKo2ufJtK7hKigYDpO1aAq6AdV50j/MxpES5vJyMYEpu4+IPG7+jz9RgkVujAx4h7jK7Y2sdQ==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@deriv/deriv-api/-/deriv-api-1.0.5.tgz",
+      "integrity": "sha512-2RLQ/hrQjOL+PjH/UmFMIyDZahIAoXCn9s3OYq0iLo26dj4e1kd5W3AIyPVnHQ4c3LMeDeXNzksNyPUVh2SvIQ==",
       "requires": {
         "dayjs": "^1.8.15",
         "json-stable-stringify": "^1.0.1",
@@ -4083,9 +4083,9 @@
       "dev": true
     },
     "dayjs": {
-      "version": "1.8.16",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.16.tgz",
-      "integrity": "sha512-XPmqzWz/EJiaRHjBqSJ2s6hE/BUoCIHKgdS2QPtTQtKcS9E4/Qn0WomoH1lXanWCzri+g7zPcuNV4aTZ8PMORQ=="
+      "version": "1.8.27",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.27.tgz",
+      "integrity": "sha512-Jpa2acjWIeOkg8KURUHICk0EqnEFSSF5eMEscsOgyJ92ZukXwmpmRkPSUka7KHSfbj5eKH30ieosYip+ky9emQ=="
     },
     "debug": {
       "version": "4.1.1",
@@ -15447,11 +15447,6 @@
           "dev": true
         }
       }
-    },
-    "url-polyfill": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/url-polyfill/-/url-polyfill-1.1.7.tgz",
-      "integrity": "sha512-ZrAxYWCREjmMtL8gSbSiKKLZZticgihCvVBtrFbUVpyoETt8GQJeG2okMWA8XryDAaHMjJfhnc+rnhXRbI4DXA=="
     },
     "url-resolve-browser": {
       "version": "1.1.0",

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -106,7 +106,7 @@
     "@babel/polyfill": "^7.4.4",
     "@binary-com/binary-document-uploader": "^2.4.4",
     "@deriv/components": "^1.0.0",
-    "@deriv/deriv-api": "^1.0.1",
+    "@deriv/deriv-api": "^1.0.5",
     "@deriv/shared": "^1.0.0",
     "@deriv/translations": "^1.0.0",
     "acorn": "^6.1.1",


### PR DESCRIPTION
### Changelog
- chore: updated deriv-api to `1.0.5`.