### PR TITLE
zaki/fix_acc_opening_reason

### DIFF
--- a/packages/trader/src/Modules/MT5/Containers/mt5-financial-stp-real-account-signup.jsx
+++ b/packages/trader/src/Modules/MT5/Containers/mt5-financial-stp-real-account-signup.jsx
@@ -17,11 +17,8 @@ const index_lookup = {
     MT5PendingVerification: 3,
 };
 
-const MT5_PERSONAL_DETAILS_CACHE_KEY = 'mt5_financial_stp_signup_personal_details';
-
 class MT5FinancialStpRealAccountSignup extends React.Component {
     state = {};
-    should_retain_cache = true;
 
     constructor(props) {
         super(props);
@@ -107,8 +104,6 @@ class MT5FinancialStpRealAccountSignup extends React.Component {
 
     finishWizard = setSubmitting => {
         setSubmitting(false);
-        sessionStorage.removeItem(MT5_PERSONAL_DETAILS_CACHE_KEY);
-        this.should_retain_cache = false;
         this.props.openPendingDialog();
         this.props.toggleModal();
     };
@@ -188,7 +183,6 @@ class MT5FinancialStpRealAccountSignup extends React.Component {
     };
 
     componentDidMount() {
-        this.populateFromSessionStorage();
         if (this.state_index === index_lookup.MT5PersonalDetailsForm) {
             this.setState({
                 is_loading: true,
@@ -198,28 +192,6 @@ class MT5FinancialStpRealAccountSignup extends React.Component {
                     is_loading: false,
                 });
             });
-        }
-    }
-
-    populateFromSessionStorage = () => {
-        const cached_form_fills = sessionStorage.getItem(MT5_PERSONAL_DETAILS_CACHE_KEY);
-        if (cached_form_fills) {
-            const cached_values = JSON.parse(cached_form_fills);
-            this.setState(({ items }) => {
-                const form_values = items[index_lookup.MT5PersonalDetailsForm].form_value;
-                Object.keys(form_values).forEach(key => (form_values[key] = cached_values[key]));
-
-                return items;
-            });
-        }
-    };
-
-    componentWillUnmount() {
-        if (this.should_retain_cache) {
-            sessionStorage.setItem(
-                MT5_PERSONAL_DETAILS_CACHE_KEY,
-                JSON.stringify(this.state.items[index_lookup.MT5PersonalDetailsForm].form_value)
-            );
         }
     }
 

--- a/packages/trader/src/Modules/MT5/Containers/mt5-financial-stp-real-account-signup.jsx
+++ b/packages/trader/src/Modules/MT5/Containers/mt5-financial-stp-real-account-signup.jsx
@@ -164,6 +164,10 @@ class MT5FinancialStpRealAccountSignup extends React.Component {
             cloned[index_lookup.MT5PersonalDetailsForm].form_value.tax_identification_number =
                 response.get_settings.tax_identification_number;
         }
+        if (response.get_settings.account_opening_reason) {
+            cloned[index_lookup.MT5PersonalDetailsForm].form_value.account_opening_reason =
+                response.get_settings.account_opening_reason;
+        }
         this.setState(
             {
                 items: cloned,


### PR DESCRIPTION
**Changelog**
- fix: pre-populate value for `account_opening_reason` from `get_settings` for MT5 STP Financial.