### PR TITLE
oskar/remove_unused_method_call

### DIFF
--- a/packages/bot-web-ui/src/stores/main-content-store.js
+++ b/packages/bot-web-ui/src/stores/main-content-store.js
@@ -37,6 +37,5 @@ export default class MainContentStore {
     @action.bound
     onUnmount() {
         window.removeEventListener('resize', this.setContainerSize);
-        this.disposeIsDrawerOpenReaction();
     }
 }


### PR DESCRIPTION
There is no method `disposeIsDrawerOpenReaction` on the `MainContentStore` - calling it will cause an error