### PR TITLE
zaki / fix_constant_welcome_modal

### DIFF
--- a/packages/core/src/App/Containers/WelcomeModal/welcome-modal.jsx
+++ b/packages/core/src/App/Containers/WelcomeModal/welcome-modal.jsx
@@ -71,7 +71,7 @@ const WelcomeModal = ({ toggleWelcomeModal, history }) => {
 
     const switchPlatform = React.useCallback(
         route => {
-            toggleWelcomeModal(false);
+            toggleWelcomeModal(false, true);
             history.push(route);
         },
         [toggleWelcomeModal, history]

--- a/packages/core/src/App/Containers/WelcomeModal/welcome-modal.jsx
+++ b/packages/core/src/App/Containers/WelcomeModal/welcome-modal.jsx
@@ -102,7 +102,7 @@ const WelcomeModal = ({ toggleWelcomeModal, history }) => {
                     })}
                 >
                     <Icon icon='IcArrowLeftCurly' size={43} />
-                    <p className='welcome__message__text'>{localize('Not sure? try this')}</p>
+                    <p className='welcome__message__text'>{localize('Not sure? Try this')}</p>
                 </div>
                 <div className='welcome__body'>
                     <WelcomeColumn

--- a/packages/core/src/App/Containers/WelcomeModal/welcome-modal.jsx
+++ b/packages/core/src/App/Containers/WelcomeModal/welcome-modal.jsx
@@ -71,7 +71,7 @@ const WelcomeModal = ({ toggleWelcomeModal, history }) => {
 
     const switchPlatform = React.useCallback(
         route => {
-            toggleWelcomeModal(false, true);
+            toggleWelcomeModal({ is_visible: false, should_persist: true });
             history.push(route);
         },
         [toggleWelcomeModal, history]

--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -982,7 +982,7 @@ export default class ClientStore extends BaseStore {
         this.setLoginId(LocalStore.get('active_loginid'));
         this.setAccounts(LocalStore.getObject(storage_key));
         if (this.is_logged_in && !this.switched && !this.has_any_real_account) {
-            this.root_store.ui.toggleWelcomeModal(true, false);
+            this.root_store.ui.toggleWelcomeModal({ is_visible: true });
         }
         this.setSwitched('');
         let client = this.accounts[this.loginid];
@@ -1617,7 +1617,7 @@ export default class ClientStore extends BaseStore {
                     this.root_store.ui.showAccountTypesModalForEuropean();
                 }
 
-                this.root_store.ui.toggleWelcomeModal(true, true);
+                this.root_store.ui.toggleWelcomeModal({ is_visible: true, should_persist: true });
             }
         });
     }

--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -982,7 +982,10 @@ export default class ClientStore extends BaseStore {
         this.setLoginId(LocalStore.get('active_loginid'));
         this.setAccounts(LocalStore.getObject(storage_key));
         if (this.is_logged_in && !this.switched && !this.has_any_real_account) {
-            this.root_store.ui.toggleWelcomeModal(true);
+            if (!LocalStore.get('has_viewed_welcome_screen')) {
+                this.root_store.ui.toggleWelcomeModal(true);
+            }
+            LocalStore.set('has_viewed_welcome_screen', true);
         }
         this.setSwitched('');
         let client = this.accounts[this.loginid];

--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -982,10 +982,7 @@ export default class ClientStore extends BaseStore {
         this.setLoginId(LocalStore.get('active_loginid'));
         this.setAccounts(LocalStore.getObject(storage_key));
         if (this.is_logged_in && !this.switched && !this.has_any_real_account) {
-            if (!LocalStore.get('has_viewed_welcome_screen')) {
-                this.root_store.ui.toggleWelcomeModal(true);
-            }
-            LocalStore.set('has_viewed_welcome_screen', true);
+            this.root_store.ui.toggleWelcomeModal(true, false);
         }
         this.setSwitched('');
         let client = this.accounts[this.loginid];
@@ -1620,7 +1617,7 @@ export default class ClientStore extends BaseStore {
                     this.root_store.ui.showAccountTypesModalForEuropean();
                 }
 
-                this.root_store.ui.toggleWelcomeModal(true);
+                this.root_store.ui.toggleWelcomeModal(true, true);
             }
         });
     }

--- a/packages/core/src/Stores/ui-store.js
+++ b/packages/core/src/Stores/ui-store.js
@@ -668,7 +668,7 @@ export default class UIStore extends BaseStore {
     }
 
     @action.bound
-    toggleWelcomeModal(is_visible = !this.is_welcome_modal_visible, should_persist) {
+    toggleWelcomeModal({ is_visible = !this.is_welcome_modal_visible, should_persist = false }) {
         if (LocalStore.get('has_viewed_welcome_screen') && !should_persist) return;
         this.is_welcome_modal_visible = is_visible;
         LocalStore.set('has_viewed_welcome_screen', true);

--- a/packages/core/src/Stores/ui-store.js
+++ b/packages/core/src/Stores/ui-store.js
@@ -668,8 +668,10 @@ export default class UIStore extends BaseStore {
     }
 
     @action.bound
-    toggleWelcomeModal(is_visible = !this.is_welcome_modal_visible) {
+    toggleWelcomeModal(is_visible = !this.is_welcome_modal_visible, should_persist) {
+        if (LocalStore.get('has_viewed_welcome_screen') && !should_persist) return;
         this.is_welcome_modal_visible = is_visible;
+        LocalStore.set('has_viewed_welcome_screen', true);
     }
 
     @action.bound


### PR DESCRIPTION
**Changelog**
- fix: view welcome modal only once upon login or refresh by setting viewed `boolean` in `localStorage`.