### PR TITLE
zaki / no_welcome_modal_if_no_mt5

### DIFF
--- a/packages/components/src/components/vertical-tab/vertical-tab.jsx
+++ b/packages/components/src/components/vertical-tab/vertical-tab.jsx
@@ -138,7 +138,7 @@ VerticalTab.propTypes = {
     list_groups: PropTypes.arrayOf(
         PropTypes.shape({
             icon: PropTypes.string,
-            label: PropTypes.string,
+            label: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
             subitems: PropTypes.arrayOf(PropTypes.number),
         })
     ),

--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -981,7 +981,7 @@ export default class ClientStore extends BaseStore {
 
         this.setLoginId(LocalStore.get('active_loginid'));
         this.setAccounts(LocalStore.getObject(storage_key));
-        if (this.is_logged_in && !this.switched && !this.has_any_real_account) {
+        if (this.is_logged_in && !this.switched && !this.has_any_real_account && this.is_mt5_allowed) {
             this.root_store.ui.toggleWelcomeModal({ is_visible: true });
         }
         this.setSwitched('');
@@ -1617,7 +1617,9 @@ export default class ClientStore extends BaseStore {
                     this.root_store.ui.showAccountTypesModalForEuropean();
                 }
 
-                this.root_store.ui.toggleWelcomeModal({ is_visible: true, should_persist: true });
+                if (this.is_mt5_allowed) {
+                    this.root_store.ui.toggleWelcomeModal({ is_visible: true, should_persist: true });
+                }
             }
         });
     }


### PR DESCRIPTION
**Changelog**
- fix: `VerticalTabl` `PropType` warning for `label`
- fix: hide welcome modal if **MT5** is not allowed