### PR TITLE
Nijil/Handle NaN notification in DBot journal

### DIFF
--- a/packages/bot-web-ui/src/utils/journal-notifications.js
+++ b/packages/bot-web-ui/src/utils/journal-notifications.js
@@ -34,6 +34,22 @@ export const isCustomJournalMessage = (
         );
         return true;
     }
+    // notify null variable block
+    if (message === null) {
+        pushMessage('NULL');
+        return true;
+    }
+    // notify NaN variable block
+    if (Object.is(message, NaN)) {
+        showErrorMessageWithButton(
+            localize('Tried to perform an invalid operation.'),
+            block_id,
+            showErrorMessage,
+            centerAndHighlightBlock
+        );
+        // pushMessage(message.toString());
+        return true;
+    }
     // notify list block
     if (Array.isArray(message)) {
         const message_length = message.length;

--- a/packages/bot-web-ui/src/utils/journal-notifications.js
+++ b/packages/bot-web-ui/src/utils/journal-notifications.js
@@ -47,7 +47,6 @@ export const isCustomJournalMessage = (
             showErrorMessage,
             centerAndHighlightBlock
         );
-        // pushMessage(message.toString());
         return true;
     }
     // notify list block


### PR DESCRIPTION
For example, In case of a division by zero operation inside `Notify` block, check for NaN and show `Tried to perform an invalid operation` error in Journal with a `Go to block` button which takes you to the block that caused the error.