### PR TITLE
Bala/fix-mf-console-error

### DIFF
--- a/packages/trader/src/Modules/Trading/Containers/trade.jsx
+++ b/packages/trader/src/Modules/Trading/Containers/trade.jsx
@@ -228,12 +228,14 @@ class ChartTradeClass extends React.Component {
     }
 
     render() {
-        const { show_digits_stats, main_barrier, should_refresh, extra_barriers = [] } = this.props;
+        const { show_digits_stats, main_barrier, should_refresh, extra_barriers = [], active_symbols } = this.props;
 
         const barriers = main_barrier ? [main_barrier, ...extra_barriers] : extra_barriers;
 
         // max ticks to display for mobile view for tick chart
         const max_ticks = this.props.granularity === 0 ? 8 : 24;
+
+        if (active_symbols.length === 0) return null;
 
         return (
             <SmartChart

--- a/packages/trader/src/Modules/Trading/Containers/trade.jsx
+++ b/packages/trader/src/Modules/Trading/Containers/trade.jsx
@@ -228,14 +228,21 @@ class ChartTradeClass extends React.Component {
     }
 
     render() {
-        const { show_digits_stats, main_barrier, should_refresh, extra_barriers = [], active_symbols } = this.props;
+        const {
+            show_digits_stats,
+            main_barrier,
+            should_refresh,
+            extra_barriers = [],
+            symbol,
+            active_symbols,
+        } = this.props;
 
         const barriers = main_barrier ? [main_barrier, ...extra_barriers] : extra_barriers;
 
         // max ticks to display for mobile view for tick chart
         const max_ticks = this.props.granularity === 0 ? 8 : 24;
 
-        if (active_symbols.length === 0) return null;
+        if (!symbol || active_symbols.length === 0) return null;
 
         return (
             <SmartChart


### PR DESCRIPTION
Smartcharts throws the below error when there are no symbols available. This PR is to prevent smartcharts from rendering where there are no symbols available.

> Uncaught (in promise) TypeError: Cannot read property 'submarket_display_name' of undefined