### PR TITLE
mamali/Initialize language with the default when not available

### DIFF
--- a/packages/translations/src/i18next/i18next.js
+++ b/packages/translations/src/i18next/i18next.js
@@ -144,6 +144,9 @@ export const useOnLoadTranslation = () => {
     const [is_loaded, setLoaded] = React.useState(false);
 
     React.useEffect(() => {
+        if (!i18n.language) {
+            i18n.language = getInitialLanguage();
+        }
         const is_english = i18n.language === 'EN';
 
         if (is_english) {


### PR DESCRIPTION
In firefox, default language will never be loaded and causes a blank screen. 