### PR TITLE
Matin/Fix: Date field in self exclusion is not hidden on small screens

### DIFF
--- a/packages/account/src/Sections/Security/SelfExclusion/self-exclusion.jsx
+++ b/packages/account/src/Sections/Security/SelfExclusion/self-exclusion.jsx
@@ -336,7 +336,7 @@ class SelfExclusion extends React.Component {
             show_article,
             submit_error_message,
         } = this.state;
-        const { is_virtual, is_switching, currency, is_eu } = this.props;
+        const { is_virtual, is_switching, currency, is_eu, is_tablet } = this.props;
 
         if (is_virtual) return <DemoMessage />;
 
@@ -382,7 +382,7 @@ class SelfExclusion extends React.Component {
                                         </ThemedScrollbars>
                                     </Modal>
                                     {is_confirm_page ? (
-                                        <>
+                                        <React.Fragment>
                                             <Modal
                                                 className='self_exclusion__modal'
                                                 is_open={show_confirm}
@@ -526,9 +526,9 @@ class SelfExclusion extends React.Component {
                                                     />
                                                 )}
                                             </div>
-                                        </>
+                                        </React.Fragment>
                                     ) : (
-                                        <>
+                                        <React.Fragment>
                                             <h2 className='self-exclusion__header'>
                                                 {localize('Your stake and loss limits')}
                                             </h2>
@@ -734,7 +734,7 @@ class SelfExclusion extends React.Component {
                                                         {({ field }) => (
                                                             <DatePicker
                                                                 {...field}
-                                                                alignment='left'
+                                                                alignment={is_tablet ? 'bottom' : 'left'}
                                                                 className='self-exclusion__input'
                                                                 label={localize('Date')}
                                                                 value={values.exclude_until}
@@ -961,7 +961,7 @@ class SelfExclusion extends React.Component {
                                                     {localize('Save')}
                                                 </Button>
                                             </div>
-                                        </>
+                                        </React.Fragment>
                                     )}
                                 </Form>
                             )}
@@ -976,7 +976,8 @@ class SelfExclusion extends React.Component {
     }
 }
 
-export default connect(({ client }) => ({
+export default connect(({ client, ui }) => ({
+    is_tablet: ui.is_tablet,
     currency: client.currency,
     is_virtual: client.is_virtual,
     is_switching: client.is_switching,

--- a/packages/account/src/Styles/account.scss
+++ b/packages/account/src/Styles/account.scss
@@ -764,6 +764,12 @@ $MIN_HEIGHT_FLOATING: calc(
             width: 100%;
             height: 100%;
 
+            @media (min-width: 1025px) and (max-width: 1199px) {
+                .account__article {
+                    width: 19rem; // Need to decrease width for better user experience and wider Fields
+                }
+            }
+
             @include mobile {
                 flex-direction: column;
                 overflow-y: auto;
@@ -851,8 +857,8 @@ $MIN_HEIGHT_FLOATING: calc(
                 grid-template-columns: 1fr 1fr 1fr;
                 grid-gap: 1.6rem;
 
-                @media (max-width: 1200px) {
-                    grid-template-columns: 1fr 1fr;
+                @media (max-width: 1024px) {
+                    grid-template-columns: 1fr;
                 }
                 @include mobile {
                     grid-template-columns: 1fr;


### PR DESCRIPTION
* Datepicker bottom alignment on tablet and mobile
* 1 column to display fields on tablet and mobile