### PR TITLE
Bala/fix-data-list-desktop-scroll

### DIFF
--- a/packages/components/src/components/data-list/data-list.jsx
+++ b/packages/components/src/components/data-list/data-list.jsx
@@ -2,7 +2,6 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { NavLink } from 'react-router-dom';
-import { TransitionGroup } from 'react-transition-group';
 import { CellMeasurer, CellMeasurerCache } from 'react-virtualized/dist/es/CellMeasurer';
 import { AutoSizer } from 'react-virtualized/dist/es/AutoSizer';
 import { List } from 'react-virtualized/dist/es/List';

--- a/packages/components/src/components/data-list/data-list.jsx
+++ b/packages/components/src/components/data-list/data-list.jsx
@@ -122,17 +122,11 @@ class DataList extends React.PureComponent {
                     [`${className}__data-list`]: className,
                 })}
             >
-                <div className={classNames('data-list__body', { [`${className}__data-list-body`]: className })}>
-                    <AutoSizer>
-                        {({ width, height }) => (
-                            <div
-                                className='data-list__body-wrapper'
-                                style={{
-                                    height,
-                                    width,
-                                }}
-                            >
-                                <TransitionGroup>
+                <div className='data-list__body-wrapper'>
+                    <div className={classNames('data-list__body', { [`${className}__data-list-body`]: className })}>
+                        <AutoSizer>
+                            {({ width, height }) => (
+                                <div style={{ height, width }}>
                                     <ThemedScrollbars onScroll={this.handleScroll} autoHide is_bypassed={isMobile()}>
                                         <List
                                             ref={ref => (this.list_ref = ref)}
@@ -150,11 +144,11 @@ class DataList extends React.PureComponent {
                                                 : { onScroll: target => this.handleScroll({ target }) })}
                                         />
                                     </ThemedScrollbars>
-                                    {children}
-                                </TransitionGroup>
-                            </div>
-                        )}
-                    </AutoSizer>
+                                </div>
+                            )}
+                        </AutoSizer>
+                    </div>
+                    {children}
                 </div>
                 {footer && (
                     <div

--- a/packages/components/src/components/data-list/data-list.scss
+++ b/packages/components/src/components/data-list/data-list.scss
@@ -11,6 +11,7 @@
         &-wrapper {
             display: flex;
             flex-direction: column;
+            height: 100%;
         }
     }
     &__footer {


### PR DESCRIPTION
- Removed `TransitionGroup` because it only applies to immediate children