### PR TITLE
Matin/Fix: display transfer amount hint on page load

### DIFF
--- a/packages/core/src/Modules/Cashier/Components/Form/account-transfer-form.jsx
+++ b/packages/core/src/Modules/Cashier/Components/Form/account-transfer-form.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -92,7 +93,6 @@ let accounts_to = [];
 let mt_accounts_to = [];
 
 const AccountTransferForm = ({
-    account_transfer_amount,
     onMount,
     transfer_limit,
     account_limits,
@@ -209,7 +209,7 @@ const AccountTransferForm = ({
             </h2>
             <Formik
                 initialValues={{
-                    amount: account_transfer_amount,
+                    amount: '',
                 }}
                 onSubmit={() => {
                     setIsTransferConfirm(true);
@@ -420,7 +420,6 @@ AccountTransferForm.propTypes = {
 export default connect(({ client, modules }) => ({
     account_limits: client.account_limits,
     onMount: client.getLimits,
-    account_transfer_amount: modules.cashier.config.account_transfer.account_transfer_amount,
     accounts_list: modules.cashier.config.account_transfer.accounts_list,
     minimum_fee: modules.cashier.config.account_transfer.minimum_fee,
     onChangeTransferFrom: modules.cashier.onChangeTransferFrom,

--- a/packages/core/src/Modules/Cashier/Components/Form/account-transfer-form.jsx
+++ b/packages/core/src/Modules/Cashier/Components/Form/account-transfer-form.jsx
@@ -93,6 +93,7 @@ let accounts_to = [];
 let mt_accounts_to = [];
 
 const AccountTransferForm = ({
+    account_transfer_amount,
     onMount,
     transfer_limit,
     account_limits,
@@ -209,7 +210,7 @@ const AccountTransferForm = ({
             </h2>
             <Formik
                 initialValues={{
-                    amount: '',
+                    amount: account_transfer_amount || '',
                 }}
                 onSubmit={() => {
                     setIsTransferConfirm(true);
@@ -419,6 +420,7 @@ AccountTransferForm.propTypes = {
 
 export default connect(({ client, modules }) => ({
     account_limits: client.account_limits,
+    account_transfer_amount: modules.cashier.config.account_transfer.account_transfer_amount,
     onMount: client.getLimits,
     accounts_list: modules.cashier.config.account_transfer.accounts_list,
     minimum_fee: modules.cashier.config.account_transfer.minimum_fee,

--- a/packages/core/src/Stores/Modules/Cashier/cashier-store.js
+++ b/packages/core/src/Stores/Modules/Cashier/cashier-store.js
@@ -935,7 +935,7 @@ export default class CashierStore extends BaseStore {
                 return;
             }
 
-            this.sortAccountsTransfer(transfer_between_accounts);
+            await this.sortAccountsTransfer(transfer_between_accounts);
             this.setTransferFee();
             this.setMinimumFee();
             this.setTransferLimit();


### PR DESCRIPTION
* Await to set `transfer from & to` values and proceed with setting `transfer limits`
* Set amount initial value to undefined instead of `account_transfer_amount ` to make it an uncontrollable value