### PR TITLE
salar / Fix PA radio to be auto selected

### DIFF
--- a/packages/cashier/src/Components/Form/payment-agent-withdraw-form.jsx
+++ b/packages/cashier/src/Components/Form/payment-agent-withdraw-form.jsx
@@ -91,6 +91,7 @@ const RadioDropDown = ({ field, values, ...props }) => (
                             value={values.payment_agents}
                             onChange={e => {
                                 params.form.setFieldValue('payment_agents', e.target.value);
+                                params.form.setFieldValue('payment_method', props.id);
                             }}
                         />
                     </DesktopWrapper>
@@ -101,7 +102,11 @@ const RadioDropDown = ({ field, values, ...props }) => (
                             list_items={props.payment_agent_list}
                             value={values.payment_agents}
                             label={localize('Choose agent')}
-                            onChange={e => params.form.setFieldValue('payment_agents', e.target.value)}
+                            should_show_empty_option={false}
+                            onChange={e => {
+                                params.form.setFieldValue('payment_agents', e.target.value);
+                                params.form.setFieldValue('payment_method', props.id);
+                            }}
                             use_text={false}
                         />
                     </MobileWrapper>


### PR DESCRIPTION
- PA radios should be automatically selected by choosing values from dropdown or filling the input field.
- Mobile version should not show `empty option` on dropdown just like desktop version. It also leads to a console error.

Note. Desktop works since Radio and dropdown sit on the same line hence propagating the click from dropdown to Radio. I've added the correct logic for both.