### PR TITLE
Abdalla/Fix: MT5 Account Creation error

### DIFF
--- a/packages/account/src/Configs/personal-details-config.js
+++ b/packages/account/src/Configs/personal-details-config.js
@@ -55,14 +55,14 @@ const personal_details_config = ({ residence_list, account_settings, is_dashboar
         place_of_birth: {
             supported_in: ['maltainvest', 'iom', 'malta'],
             default_value: account_settings.place_of_birth
-                ? residence_list.find(item => item.value === account_settings.place_of_birth).text
+                ? residence_list.find(item => item.value === account_settings.place_of_birth)?.text
                 : '',
             rules: [['req', localize('Place of birth is required')]],
         },
         citizen: {
             supported_in: ['iom', 'malta', 'maltainvest'],
             default_value: account_settings.citizen
-                ? residence_list.find(item => item.value === account_settings.citizen).text
+                ? residence_list.find(item => item.value === account_settings.citizen)?.text
                 : '',
             rules: [['req', localize('Citizenship is required')]],
         },

--- a/packages/components/src/components/dialog/dialog.jsx
+++ b/packages/components/src/components/dialog/dialog.jsx
@@ -54,6 +54,7 @@ const Dialog = ({
         'dc-dialog__content--centered': is_content_centered,
     });
 
+    const is_text = typeof children === 'string' || typeof children?.props?.i18n_default_text === 'string';
     const dialog = (
         <CSSTransition
             appear
@@ -85,7 +86,7 @@ const Dialog = ({
                             </div>
                         )}
                     </div>
-                    {typeof children === 'string' ? (
+                    {is_text ? (
                         <Text as='p' size='xs' line_height='s' className={content_classes}>
                             {children}
                         </Text>

--- a/packages/components/src/components/text/text.jsx
+++ b/packages/components/src/components/text/text.jsx
@@ -16,8 +16,9 @@ const Text = ({ children, size, color, align, weight, line_height, as, className
         if (!isEmptyObject(styles)) {
             const combined_style = { ...class_styles, ...styles };
             setStyle(combined_style);
+        } else {
+            setStyle(class_styles);
         }
-        setStyle(class_styles);
     }, [size, color, line_height, weight, align]);
 
     const class_names = classNames('dc-text', className);


### PR DESCRIPTION
This PR fixes MT5 account creation issues
#### 1st issue:
* When `<Localize />` is passed to `Dialog` component it gets wrapped up with `div` since `<Localize />` is of type `object` 

#### 2nd issue:
* Blank page appears due to an error of `Cannot read property 'text' of undefined` in `personal-details-config`

#### 3rd issue:
* style in `Text` component gets always overwritten since there is no an `else` block.