### PR TITLE
zaki / fix_step_rng_multiup|down_sell

### DIFF
--- a/packages/shared/src/utils/shortcode/shortcode.js
+++ b/packages/shared/src/utils/shortcode/shortcode.js
@@ -34,6 +34,7 @@ export const isMultiplier = ({ shortcode = '', shortcode_info = '' }) => {
 };
 
 export const isForwardStarting = (shortcode, purchase_time) => {
+    if (extractInfoFromShortcode(shortcode)?.multiplier) return false;
     const start_time = shortcode.split('_')[3].replace(/\D/g, '');
     return start_time && purchase_time && +start_time !== +purchase_time;
 };


### PR DESCRIPTION
**Changelog**
- fix: add checks for multiplier in `isForwardStarting` check as sell transaction returns `purchase_time` value causing false positive