### PR TITLE
Bala/fix forward starting logic

### DIFF
--- a/packages/shared/src/utils/shortcode/shortcode.js
+++ b/packages/shared/src/utils/shortcode/shortcode.js
@@ -35,6 +35,6 @@ export const isMultiplier = ({ shortcode = '', shortcode_info = '' }) => {
 
 export const isForwardStarting = (shortcode, purchase_time) => {
     if (extractInfoFromShortcode(shortcode)?.multiplier) return false;
-    const start_time = shortcode.split('_')[3].replace(/\D/g, '');
+    const start_time = shortcode.split('_').slice(-4)[0].replace(/\D/g, '');
     return start_time && purchase_time && +start_time !== +purchase_time;
 };


### PR DESCRIPTION
Determine `start_time` from the end of `shortcode` string.
Volatility contracts have underscore in their symbol(`R_10`), so splitting by `_` doesn't work as expected