### PR TITLE
Bala/Change default contract type 2

### DIFF
--- a/packages/trader/src/Modules/Trading/Components/Form/ContractType/contract-type-item.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/ContractType/contract-type-item.jsx
@@ -5,15 +5,13 @@ import React from 'react';
 import { Icon, DesktopWrapper, Text } from '@deriv/components';
 import IconTradeCategory from 'Assets/Trading/Categories/icon-trade-categories.jsx';
 
-const Item = ({ contract_types, handleInfoClick, handleSelect, is_equal, name, value }) =>
+const Item = ({ contract_types, handleInfoClick, handleSelect, name, value }) =>
     contract_types.map((type, idx) => (
         <div
             id={`dt_contract_${type.value}_item`}
             key={idx}
             className={classNames('contract-type-item', {
                 'contract-type-item--selected': value === type.value,
-                'contract-type-item--invisible':
-                    (type.value === 'rise_fall' && is_equal) || (type.value === 'rise_fall_equal' && !is_equal),
             })}
             name={name}
             value={type.value}
@@ -35,7 +33,6 @@ Item.propTypes = {
     contract_types: MobxPropTypes.arrayOrObservableArray,
     handleInfoClick: PropTypes.func,
     handleSelect: PropTypes.func,
-    is_equal: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     name: PropTypes.string,
     value: PropTypes.string,
 };

--- a/packages/trader/src/Modules/Trading/Components/Form/ContractType/contract-type-list.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/ContractType/contract-type-list.jsx
@@ -2,29 +2,39 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Item from './contract-type-item.jsx';
 
-const List = ({ handleInfoClick, handleSelect, is_equal, list, name, value }) =>
-    list.map((contract_category, key) => (
-        <div key={key} className='contract-type-list'>
-            <div className='contract-type-list__label'>
-                <span>{contract_category.label}</span>
+const List = ({ handleInfoClick, handleSelect, list, name, value }) =>
+    list.map((contract_category, key) => {
+        const contract_types = contract_category.contract_types.filter(contract_type => {
+            const base_contract_type = /^(.*)_equal$/.exec(contract_type.value)?.[1];
+
+            if (base_contract_type) {
+                return !contract_category.contract_types.some(c => c.value === base_contract_type);
+            }
+
+            return true;
+        });
+
+        return (
+            <div key={key} className='contract-type-list'>
+                <div className='contract-type-list__label'>
+                    <span>{contract_category.label}</span>
+                </div>
+                <div className='contract-type-list__wrapper'>
+                    <Item
+                        contract_types={contract_types}
+                        handleSelect={handleSelect}
+                        handleInfoClick={handleInfoClick}
+                        name={name}
+                        value={value}
+                    />
+                </div>
             </div>
-            <div className='contract-type-list__wrapper'>
-                <Item
-                    contract_types={contract_category.contract_types}
-                    handleSelect={handleSelect}
-                    handleInfoClick={handleInfoClick}
-                    is_equal={is_equal}
-                    name={name}
-                    value={value}
-                />
-            </div>
-        </div>
-    ));
+        );
+    });
 
 List.propTypes = {
     handleInfoClick: PropTypes.func,
     handleSelect: PropTypes.func,
-    is_equal: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     list: PropTypes.array,
     name: PropTypes.string,
     value: PropTypes.string,

--- a/packages/trader/src/Modules/Trading/Components/Form/ContractType/contract-type-list.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/ContractType/contract-type-list.jsx
@@ -4,7 +4,7 @@ import Item from './contract-type-item.jsx';
 
 const List = ({ handleInfoClick, handleSelect, list, name, value }) =>
     list.map((contract_category, key) => {
-        const contract_types = contract_category.contract_types.filter(contract_type => {
+        const contract_types = contract_category.contract_types?.filter(contract_type => {
             const base_contract_type = /^(.*)_equal$/.exec(contract_type.value)?.[1];
 
             if (base_contract_type) {

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/allow-equals.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/allow-equals.jsx
@@ -16,6 +16,7 @@ const AllowEquals = ({
     expiry_type,
     onChange,
     value,
+    has_equals_only,
 }) => {
     const has_callputequal_duration = hasDurationForCallPutEqual(
         contract_types_list,
@@ -44,6 +45,7 @@ const AllowEquals = ({
                     name='is_equal'
                     label={localize('Allow equals')}
                     classNameLabel='allow-equals__label'
+                    disabled={has_equals_only}
                 />
                 <Popover
                     alignment='left'
@@ -65,6 +67,7 @@ AllowEquals.propTypes = {
     contract_types_list: PropTypes.object,
     duration_unit: PropTypes.string,
     expiry_type: PropTypes.string,
+    has_equals_only: PropTypes.bool,
     onChange: PropTypes.func,
     value: PropTypes.number,
 };

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/amount.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/amount.jsx
@@ -63,6 +63,7 @@ const Amount = ({
     is_multiplier,
     is_nativepicker,
     is_single_currency,
+    has_equals_only,
     onChange,
     setCurrentFocus,
     stop_out,
@@ -160,6 +161,7 @@ const Amount = ({
                 expiry_type={expiry_type}
                 onChange={onChange}
                 value={parseInt(is_equal)}
+                has_equals_only={has_equals_only}
             />
             {is_multiplier && (
                 <MultipliersInfo
@@ -189,6 +191,7 @@ Amount.propTypes = {
     is_multiplier: PropTypes.bool,
     is_nativepicker: PropTypes.bool,
     is_single_currency: PropTypes.bool,
+    has_equals_only: PropTypes.bool,
     setCurrentFocus: PropTypes.func,
     onChange: PropTypes.func,
     validation_errors: PropTypes.object,
@@ -209,6 +212,7 @@ export default connect(({ modules, client, ui }) => ({
     is_equal: modules.trade.is_equal,
     is_single_currency: client.is_single_currency,
     is_multiplier: modules.trade.is_multiplier,
+    has_equals_only: modules.trade.has_equals_only,
     stop_out: modules.trade.stop_out,
     onChange: modules.trade.onChange,
     setCurrentFocus: ui.setCurrentFocus,

--- a/packages/trader/src/Modules/Trading/Containers/allow-equals.jsx
+++ b/packages/trader/src/Modules/Trading/Containers/allow-equals.jsx
@@ -5,7 +5,7 @@ import { Checkbox, Text } from '@deriv/components';
 import { Localize, localize } from '@deriv/translations';
 import { connect } from 'Stores/connect';
 
-const AllowEquals = ({ onChange, is_allow_equal, className }) => {
+const AllowEquals = ({ onChange, is_allow_equal, has_equals_only, className }) => {
     const handleOnChange = e => {
         e.persist();
         const { name, checked } = e.target;
@@ -14,7 +14,13 @@ const AllowEquals = ({ onChange, is_allow_equal, className }) => {
 
     return (
         <div className={classNames('allow-equals', 'mobile-widget', className)}>
-            <Checkbox label={localize('Equals')} value={is_allow_equal} name='is_equal' onChange={handleOnChange} />
+            <Checkbox
+                label={localize('Equals')}
+                value={is_allow_equal}
+                name='is_equal'
+                onChange={handleOnChange}
+                disabled={has_equals_only}
+            />
             <Text as='p' size='xxxs'>
                 <Localize i18n_default_text='Win payout if exit spot is also equal to entry spot.' />
             </Text>
@@ -24,10 +30,12 @@ const AllowEquals = ({ onChange, is_allow_equal, className }) => {
 
 AllowEquals.propTypes = {
     is_allow_equal: PropTypes.bool,
+    has_equals_only: PropTypes.bool,
     onChange: PropTypes.func,
 };
 
 export default connect(({ modules }) => ({
     is_allow_equal: !!modules.trade.is_equal,
+    has_equals_only: modules.trade.has_equals_only,
     onChange: modules.trade.onChange,
 }))(AllowEquals);

--- a/packages/trader/src/Stores/Modules/Trading/Helpers/contract-type.js
+++ b/packages/trader/src/Stores/Modules/Trading/Helpers/contract-type.js
@@ -187,7 +187,9 @@ const ContractType = (() => {
     const getContractType = (list, contract_type) => {
         const arr_list = Object.keys(list || {})
             .reduce((k, l) => [...k, ...list[l].map(ct => ct.value)], [])
-            .filter(type => unsupported_contract_types_list.indexOf(type) === -1);
+            .filter(type => unsupported_contract_types_list.indexOf(type) === -1)
+            .sort((a, b) => (a === 'multiplier' || b === 'multiplier' ? -1 : 0));
+
         return {
             contract_type: getArrayDefaultValue(arr_list, contract_type),
         };

--- a/packages/trader/src/Stores/Modules/Trading/Helpers/contract-type.js
+++ b/packages/trader/src/Stores/Modules/Trading/Helpers/contract-type.js
@@ -167,6 +167,7 @@ const ContractType = (() => {
         const obj_multiplier_range_list = getMultiplierRange(contract_type, multiplier);
         const obj_cancellation = getCancellation(contract_type, cancellation_duration, symbol);
         const obj_expiry_type = getExpiryType(obj_duration_units_list, expiry_type);
+        const obj_equal = getEqualProps(contract_type);
 
         return {
             ...form_components,
@@ -181,6 +182,7 @@ const ContractType = (() => {
             ...obj_expiry_type,
             ...obj_multiplier_range_list,
             ...obj_cancellation,
+            ...obj_equal,
         };
     };
 
@@ -549,6 +551,18 @@ const ContractType = (() => {
             cancellation_range_list: arr_cancellation_range.map(d => ({ text: `${getText(d)}`, value: d })),
             ...(should_show_cancellation ? {} : { has_cancellation: false }),
         };
+    };
+
+    const getEqualProps = contract_type => {
+        const base_contract_type = /^(.*)_equal$/.exec(contract_type)?.[1];
+
+        if (base_contract_type && !available_contract_types[base_contract_type]) {
+            return {
+                is_equal: 1,
+                has_equals_only: true,
+            };
+        }
+        return {};
     };
 
     return {

--- a/packages/trader/src/Stores/Modules/Trading/trade-store.js
+++ b/packages/trader/src/Stores/Modules/Trading/trade-store.js
@@ -39,6 +39,7 @@ export default class TradeStore extends BaseStore {
     @observable is_purchase_enabled = false;
     @observable is_trade_enabled = false;
     @observable is_equal = 0;
+    @observable has_equals_only = false;
 
     // Underlying
     @observable symbol;

--- a/packages/trader/src/sass/app/_common/components/contract-type-list.scss
+++ b/packages/trader/src/sass/app/_common/components/contract-type-list.scss
@@ -57,9 +57,6 @@
             }
         }
     }
-    &--invisible {
-        display: none;
-    }
     &--selected {
         background: var(--state-active);
         color: var(--text-prominent);


### PR DESCRIPTION
### Changelog

- Low priority to select `Multipliers` as default contract.
- When `rise_fall_equals` is available and when `rise_fall` is suspended, `rise_fall_equals` is selected by default, and `Allow equals` checkbox will be checked and it will be disabled
