### PR TITLE
zaki / fix_account_types_box_mobile_spacing

### DIFF
--- a/packages/core/src/sass/app/modules/account-types.scss
+++ b/packages/core/src/sass/app/modules/account-types.scss
@@ -34,10 +34,10 @@
         }
         @include mobile {
             width: 100%;
-            grid-auto-rows: minmax(23rem, auto);
             grid-auto-flow: row;
             grid-gap: 1rem;
             box-shadow: none;
+            margin-bottom: 0;
         }
         @include tablet {
             max-width: 90vw;


### PR DESCRIPTION
**Changelog**
- fix: remove whitespace for account types in mobile