### PR TITLE
hubert/ wrongly declared prop in api-token-table

### DIFF
--- a/packages/account/src/Components/api-token/api-token-table.jsx
+++ b/packages/account/src/Components/api-token/api-token-table.jsx
@@ -64,7 +64,7 @@ const ApiTokenTable = () => {
                                 <Clipboard
                                     className='da-api-token__clipboard'
                                     popover_props={{ relative_render: false, zIndex: 9999 }}
-                                    token={token.token}
+                                    text_copy={token.token}
                                 />
                             </div>
                         </div>


### PR DESCRIPTION
Changing the prop name "token" to "text_copy" resolved the issue.