### PR TITLE
Kseniya/DP2P - Back arrow icon on the order details page is not vertically centered

### DIFF
--- a/packages/p2p/src/components/page-return/page-return.scss
+++ b/packages/p2p/src/components/page-return/page-return.scss
@@ -9,6 +9,7 @@
     margin: 2.4rem 0;
 
     &__button {
+        line-height: 1rem;
         cursor: pointer;
         border-radius: $BORDER_RADIUS;
         padding-right: 0.8rem;


### PR DESCRIPTION
 - removed extra height from button which shifted it by making the line-height equal to the height of the inline svg element 