### PR TITLE
Bump @deriv/api-types from 1.0.24 to 1.0.35

### DIFF
--- a/packages/dashboard/package-lock.json
+++ b/packages/dashboard/package-lock.json
@@ -14,31 +14,30 @@
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.13.12",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.12.tgz",
-			"integrity": "sha512-3eJJ841uKxeV8dcN/2yGEUy+RfgQspPEgQat85umsE1rotuquQ2AbIub4S6j7c50a2d+4myc+zSlnXeIHrOnhQ==",
+			"version": "7.14.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.0.tgz",
+			"integrity": "sha512-vu9V3uMM/1o5Hl5OekMUowo3FqXLJSw+s+66nt0fSWVWTtmosdzn45JHOB3cPtZoe6CTBDzvSw0RdOY85Q37+Q==",
 			"dev": true
 		},
 		"@babel/core": {
-			"version": "7.13.10",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.10.tgz",
-			"integrity": "sha512-bfIYcT0BdKeAZrovpMqX2Mx5NrgAckGbwT982AkdS5GNfn3KMGiprlBAtmBcFZRUmpaufS6WZFP8trvx8ptFDw==",
+			"version": "7.14.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.0.tgz",
+			"integrity": "sha512-8YqpRig5NmIHlMLw09zMlPTvUVMILjqCOtVgu+TVNWEBvy9b5I3RRyhqnrV4hjgEK7n8P9OqvkWJAFmEL6Wwfw==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.12.13",
-				"@babel/generator": "^7.13.9",
-				"@babel/helper-compilation-targets": "^7.13.10",
-				"@babel/helper-module-transforms": "^7.13.0",
-				"@babel/helpers": "^7.13.10",
-				"@babel/parser": "^7.13.10",
+				"@babel/generator": "^7.14.0",
+				"@babel/helper-compilation-targets": "^7.13.16",
+				"@babel/helper-module-transforms": "^7.14.0",
+				"@babel/helpers": "^7.14.0",
+				"@babel/parser": "^7.14.0",
 				"@babel/template": "^7.12.13",
-				"@babel/traverse": "^7.13.0",
-				"@babel/types": "^7.13.0",
+				"@babel/traverse": "^7.14.0",
+				"@babel/types": "^7.14.0",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
 				"json5": "^2.1.2",
-				"lodash": "^4.17.19",
 				"semver": "^6.3.0",
 				"source-map": "^0.5.0"
 			},
@@ -55,12 +54,12 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.13.9",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
-			"integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
+			"version": "7.14.1",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.1.tgz",
+			"integrity": "sha512-TMGhsXMXCP/O1WtQmZjpEYDhCYC9vFhayWZPJSZCGkPJgUqX0rF0wwtrYvnzVxIjcF80tkUertXVk5cwqi5cAQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.13.0",
+				"@babel/types": "^7.14.1",
 				"jsesc": "^2.5.1",
 				"source-map": "^0.5.0"
 			}
@@ -85,27 +84,28 @@
 			}
 		},
 		"@babel/helper-compilation-targets": {
-			"version": "7.13.10",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.10.tgz",
-			"integrity": "sha512-/Xju7Qg1GQO4mHZ/Kcs6Au7gfafgZnwm+a7sy/ow/tV1sHeraRUHbjdat8/UvDor4Tez+siGKDk6zIKtCPKVJA==",
+			"version": "7.13.16",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.16.tgz",
+			"integrity": "sha512-3gmkYIrpqsLlieFwjkGgLaSHmhnvlAYzZLlYVjlW+QwI+1zE17kGxuJGmIqDQdYp56XdmGeD+Bswx0UTyG18xA==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.13.8",
+				"@babel/compat-data": "^7.13.15",
 				"@babel/helper-validator-option": "^7.12.17",
 				"browserslist": "^4.14.5",
 				"semver": "^6.3.0"
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.13.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.13.11.tgz",
-			"integrity": "sha512-ays0I7XYq9xbjCSvT+EvysLgfc3tOkwCULHjrnscGT3A9qD4sk3wXnJ3of0MAWsWGjdinFvajHU2smYuqXKMrw==",
+			"version": "7.14.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.14.1.tgz",
+			"integrity": "sha512-r8rsUahG4ywm0QpGcCrLaUSOuNAISR3IZCg4Fx05Ozq31aCUrQsTLH6KPxy0N5ULoQ4Sn9qjNdGNtbPWAC6hYg==",
 			"dev": true,
 			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.12.13",
 				"@babel/helper-function-name": "^7.12.13",
-				"@babel/helper-member-expression-to-functions": "^7.13.0",
+				"@babel/helper-member-expression-to-functions": "^7.13.12",
 				"@babel/helper-optimise-call-expression": "^7.12.13",
-				"@babel/helper-replace-supers": "^7.13.0",
+				"@babel/helper-replace-supers": "^7.13.12",
 				"@babel/helper-split-export-declaration": "^7.12.13"
 			}
 		},
@@ -120,9 +120,9 @@
 			}
 		},
 		"@babel/helper-define-polyfill-provider": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.1.5.tgz",
-			"integrity": "sha512-nXuzCSwlJ/WKr8qxzW816gwyT6VZgiJG17zR40fou70yfAcqjoNyTLl/DQ+FExw5Hx5KNqshmN8Ldl/r2N7cTg==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.0.tgz",
+			"integrity": "sha512-JT8tHuFjKBo8NnaUbblz7mIu1nnvUDiHVjXXkulZULyidvo/7P6TY7+YqpV37IfF+KUFxmlK04elKtGKXaiVgw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-compilation-targets": "^7.13.0",
@@ -165,13 +165,13 @@
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.13.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.13.0.tgz",
-			"integrity": "sha512-0kBzvXiIKfsCA0y6cFEIJf4OdzfpRuNk4+YTeHZpGGc666SATFKTz6sRncwFnQk7/ugJ4dSrCj6iJuvW4Qwr2g==",
+			"version": "7.13.16",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.13.16.tgz",
+			"integrity": "sha512-1eMtTrXtrwscjcAeO4BVK+vvkxaLJSPFz1w1KLawz6HLNi9bPFGBNwwDyVfiu1Tv/vRRFYfoGaKhmAQPGPn5Wg==",
 			"dev": true,
 			"requires": {
-				"@babel/traverse": "^7.13.0",
-				"@babel/types": "^7.13.0"
+				"@babel/traverse": "^7.13.15",
+				"@babel/types": "^7.13.16"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
@@ -193,19 +193,19 @@
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.13.12",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.12.tgz",
-			"integrity": "sha512-7zVQqMO3V+K4JOOj40kxiCrMf6xlQAkewBB0eu2b03OO/Q21ZutOzjpfD79A5gtE/2OWi1nv625MrDlGlkbknQ==",
+			"version": "7.14.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.0.tgz",
+			"integrity": "sha512-L40t9bxIuGOfpIGA3HNkJhU9qYrf4y5A5LUSw7rGMSn+pcG8dfJ0g6Zval6YJGd2nEjI7oP00fRdnhLKndx6bw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.13.12",
 				"@babel/helper-replace-supers": "^7.13.12",
 				"@babel/helper-simple-access": "^7.13.12",
 				"@babel/helper-split-export-declaration": "^7.12.13",
-				"@babel/helper-validator-identifier": "^7.12.11",
+				"@babel/helper-validator-identifier": "^7.14.0",
 				"@babel/template": "^7.12.13",
-				"@babel/traverse": "^7.13.0",
-				"@babel/types": "^7.13.12"
+				"@babel/traverse": "^7.14.0",
+				"@babel/types": "^7.14.0"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
@@ -274,9 +274,9 @@
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+			"version": "7.14.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
+			"integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
 			"dev": true
 		},
 		"@babel/helper-validator-option": {
@@ -298,31 +298,31 @@
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.13.10",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.10.tgz",
-			"integrity": "sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==",
+			"version": "7.14.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.0.tgz",
+			"integrity": "sha512-+ufuXprtQ1D1iZTO/K9+EBRn+qPWMJjZSw/S0KlFrxCw4tkrzv9grgpDHkY9MeQTjTY8i2sp7Jep8DfU6tN9Mg==",
 			"dev": true,
 			"requires": {
 				"@babel/template": "^7.12.13",
-				"@babel/traverse": "^7.13.0",
-				"@babel/types": "^7.13.0"
+				"@babel/traverse": "^7.14.0",
+				"@babel/types": "^7.14.0"
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.13.10",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-			"integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+			"version": "7.14.0",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
+			"integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.12.11",
+				"@babel/helper-validator-identifier": "^7.14.0",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			}
 		},
 		"@babel/parser": {
-			"version": "7.13.12",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.12.tgz",
-			"integrity": "sha512-4T7Pb244rxH24yR116LAuJ+adxXXnHhZaLJjegJVKSdoNCe4x1eDBaud5YIcQFcqzsaD5BHvJw5BQ0AZapdCRw==",
+			"version": "7.14.1",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.1.tgz",
+			"integrity": "sha512-muUGEKu8E/ftMTPlNp+mc6zL3E9zKWmF5sDHZ5MSsoTP9Wyz64AhEf9kD08xYJ7w6Hdcu8H550ircnPyWSIF0Q==",
 			"dev": true
 		},
 		"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
@@ -337,9 +337,9 @@
 			}
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
-			"version": "7.13.8",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.13.8.tgz",
-			"integrity": "sha512-rPBnhj+WgoSmgq+4gQUtXx/vOcU+UYtjy1AA/aeD61Hwj410fwYyqfUcRP3lR8ucgliVJL/G7sXcNUecC75IXA==",
+			"version": "7.13.15",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.13.15.tgz",
+			"integrity": "sha512-VapibkWzFeoa6ubXy/NgV5U2U4MVnUlvnx6wo1XhlsaTrLYWE0UFpDQsVrmn22q5CzeloqJ8gEMHSKxuee6ZdA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.13.0",
@@ -357,13 +357,23 @@
 				"@babel/helper-plugin-utils": "^7.13.0"
 			}
 		},
-		"@babel/plugin-proposal-decorators": {
-			"version": "7.13.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.13.5.tgz",
-			"integrity": "sha512-i0GDfVNuoapwiheevUOuSW67mInqJ8qw7uWfpjNVeHMn143kXblEy/bmL9AdZ/0yf/4BMQeWXezK0tQIvNPqag==",
+		"@babel/plugin-proposal-class-static-block": {
+			"version": "7.13.11",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.13.11.tgz",
+			"integrity": "sha512-fJTdFI4bfnMjvxJyNuaf8i9mVcZ0UhetaGEUHaHV9KEnibLugJkZAtXikR8KcYj+NYmI4DZMS8yQAyg+hvfSqg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.13.0",
+				"@babel/helper-plugin-utils": "^7.13.0",
+				"@babel/plugin-syntax-class-static-block": "^7.12.13"
+			}
+		},
+		"@babel/plugin-proposal-decorators": {
+			"version": "7.13.15",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.13.15.tgz",
+			"integrity": "sha512-ibAMAqUm97yzi+LPgdr5Nqb9CMkeieGHvwPg1ywSGjZrZHQEGqE01HmOio8kxRpA/+VtOHouIVy2FMpBbtltjA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-create-class-features-plugin": "^7.13.11",
 				"@babel/helper-plugin-utils": "^7.13.0",
 				"@babel/plugin-syntax-decorators": "^7.12.13"
 			}
@@ -482,6 +492,18 @@
 				"@babel/helper-plugin-utils": "^7.13.0"
 			}
 		},
+		"@babel/plugin-proposal-private-property-in-object": {
+			"version": "7.14.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.14.0.tgz",
+			"integrity": "sha512-59ANdmEwwRUkLjB7CRtwJxxwtjESw+X2IePItA+RGQh+oy5RmpCh/EvVVvh5XQc3yxsm5gtv0+i9oBZhaDNVTg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.12.13",
+				"@babel/helper-create-class-features-plugin": "^7.14.0",
+				"@babel/helper-plugin-utils": "^7.13.0",
+				"@babel/plugin-syntax-private-property-in-object": "^7.14.0"
+			}
+		},
 		"@babel/plugin-proposal-unicode-property-regex": {
 			"version": "7.12.13",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.12.13.tgz",
@@ -514,6 +536,15 @@
 			"version": "7.12.13",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
 			"integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.12.13"
+			}
+		},
+		"@babel/plugin-syntax-class-static-block": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.12.13.tgz",
+			"integrity": "sha512-ZmKQ0ZXR0nYpHZIIuj9zE7oIqCx2hw9TKi+lIo73NNrMPAZGHfS92/VRV0ZmPj6H2ffBgyFHXvJ5NYsNeEaP2A==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.12.13"
@@ -636,6 +667,15 @@
 				"@babel/helper-plugin-utils": "^7.8.0"
 			}
 		},
+		"@babel/plugin-syntax-private-property-in-object": {
+			"version": "7.14.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.0.tgz",
+			"integrity": "sha512-bda3xF8wGl5/5btF794utNOL0Jw+9jE5C1sLZcoK7c4uonE/y3iQiyG+KbkF3WBV/paX58VCpjhxLPkdj5Fe4w==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.13.0"
+			}
+		},
 		"@babel/plugin-syntax-top-level-await": {
 			"version": "7.12.13",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.13.tgz",
@@ -684,12 +724,12 @@
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.12.13",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.13.tgz",
-			"integrity": "sha512-Pxwe0iqWJX4fOOM2kEZeUuAxHMWb9nK+9oh5d11bsLoB0xMg+mkDpt0eYuDZB7ETrY9bbcVlKUGTOGWy7BHsMQ==",
+			"version": "7.14.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.14.1.tgz",
+			"integrity": "sha512-2mQXd0zBrwfp0O1moWIhPpEeTKDvxyHcnma3JATVP1l+CctWBuot6OJG8LQ4DnBj4ZZPSmlb/fm4mu47EOAnVA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.12.13"
+				"@babel/helper-plugin-utils": "^7.13.0"
 			}
 		},
 		"@babel/plugin-transform-classes": {
@@ -717,9 +757,9 @@
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.13.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.13.0.tgz",
-			"integrity": "sha512-zym5em7tePoNT9s964c0/KU3JPPnuq7VhIxPRefJ4/s82cD+q1mgKfuGRDMCPL0HTyKz4dISuQlCusfgCJ86HA==",
+			"version": "7.13.17",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.13.17.tgz",
+			"integrity": "sha512-UAUqiLv+uRLO+xuBKKMEpC+t7YRNVRqBsWWq1yKXbBZBje/t3IXCiSinZhjn/DC3qzBfICeYd2EFGEbHsh5RLA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.13.0"
@@ -792,25 +832,25 @@
 			}
 		},
 		"@babel/plugin-transform-modules-amd": {
-			"version": "7.13.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.13.0.tgz",
-			"integrity": "sha512-EKy/E2NHhY/6Vw5d1k3rgoobftcNUmp9fGjb9XZwQLtTctsRBOTRO7RHHxfIky1ogMN5BxN7p9uMA3SzPfotMQ==",
+			"version": "7.14.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.14.0.tgz",
+			"integrity": "sha512-CF4c5LX4LQ03LebQxJ5JZes2OYjzBuk1TdiF7cG7d5dK4lAdw9NZmaxq5K/mouUdNeqwz3TNjnW6v01UqUNgpQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.13.0",
+				"@babel/helper-module-transforms": "^7.14.0",
 				"@babel/helper-plugin-utils": "^7.13.0",
 				"babel-plugin-dynamic-import-node": "^2.3.3"
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.13.8",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.13.8.tgz",
-			"integrity": "sha512-9QiOx4MEGglfYZ4XOnU79OHr6vIWUakIj9b4mioN8eQIoEh+pf5p/zEB36JpDFWA12nNMiRf7bfoRvl9Rn79Bw==",
+			"version": "7.14.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.14.0.tgz",
+			"integrity": "sha512-EX4QePlsTaRZQmw9BsoPeyh5OCtRGIhwfLquhxGp5e32w+dyL8htOcDwamlitmNFK6xBZYlygjdye9dbd9rUlQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.13.0",
+				"@babel/helper-module-transforms": "^7.14.0",
 				"@babel/helper-plugin-utils": "^7.13.0",
-				"@babel/helper-simple-access": "^7.12.13",
+				"@babel/helper-simple-access": "^7.13.12",
 				"babel-plugin-dynamic-import-node": "^2.3.3"
 			}
 		},
@@ -828,12 +868,12 @@
 			}
 		},
 		"@babel/plugin-transform-modules-umd": {
-			"version": "7.13.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.13.0.tgz",
-			"integrity": "sha512-D/ILzAh6uyvkWjKKyFE/W0FzWwasv6vPTSqPcjxFqn6QpX3u8DjRVliq4F2BamO2Wee/om06Vyy+vPkNrd4wxw==",
+			"version": "7.14.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.14.0.tgz",
+			"integrity": "sha512-nPZdnWtXXeY7I87UZr9VlsWme3Y0cfFFE41Wbxz4bbaexAjNMInXPFUpRRUJ8NoMm0Cw+zxbqjdPmLhcjfazMw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.13.0",
+				"@babel/helper-module-transforms": "^7.14.0",
 				"@babel/helper-plugin-utils": "^7.13.0"
 			}
 		},
@@ -925,9 +965,9 @@
 			}
 		},
 		"@babel/plugin-transform-regenerator": {
-			"version": "7.12.13",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.12.13.tgz",
-			"integrity": "sha512-lxb2ZAvSLyJ2PEe47hoGWPmW22v7CtSl9jW8mingV4H2sEX/JOcrAj2nPuGWi56ERUm2bUpjKzONAuT6HCn2EA==",
+			"version": "7.13.15",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.13.15.tgz",
+			"integrity": "sha512-Bk9cOLSz8DiurcMETZ8E2YtIVJbFCPGW28DJWUakmyVWtQSm6Wsf0p4B4BfEr/eL2Nkhe/CICiUiMOCi1TPhuQ==",
 			"dev": true,
 			"requires": {
 				"regenerator-transform": "^0.14.2"
@@ -1019,18 +1059,19 @@
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.13.12",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.13.12.tgz",
-			"integrity": "sha512-JzElc6jk3Ko6zuZgBtjOd01pf9yYDEIH8BcqVuYIuOkzOwDesoa/Nz4gIo4lBG6K861KTV9TvIgmFuT6ytOaAA==",
+			"version": "7.14.1",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.14.1.tgz",
+			"integrity": "sha512-0M4yL1l7V4l+j/UHvxcdvNfLB9pPtIooHTbEhgD/6UGyh8Hy3Bm1Mj0buzjDXATCSz3JFibVdnoJZCrlUCanrQ==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.13.12",
-				"@babel/helper-compilation-targets": "^7.13.10",
+				"@babel/compat-data": "^7.14.0",
+				"@babel/helper-compilation-targets": "^7.13.16",
 				"@babel/helper-plugin-utils": "^7.13.0",
 				"@babel/helper-validator-option": "^7.12.17",
 				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.13.12",
-				"@babel/plugin-proposal-async-generator-functions": "^7.13.8",
+				"@babel/plugin-proposal-async-generator-functions": "^7.13.15",
 				"@babel/plugin-proposal-class-properties": "^7.13.0",
+				"@babel/plugin-proposal-class-static-block": "^7.13.11",
 				"@babel/plugin-proposal-dynamic-import": "^7.13.8",
 				"@babel/plugin-proposal-export-namespace-from": "^7.12.13",
 				"@babel/plugin-proposal-json-strings": "^7.13.8",
@@ -1041,9 +1082,11 @@
 				"@babel/plugin-proposal-optional-catch-binding": "^7.13.8",
 				"@babel/plugin-proposal-optional-chaining": "^7.13.12",
 				"@babel/plugin-proposal-private-methods": "^7.13.0",
+				"@babel/plugin-proposal-private-property-in-object": "^7.14.0",
 				"@babel/plugin-proposal-unicode-property-regex": "^7.12.13",
 				"@babel/plugin-syntax-async-generators": "^7.8.4",
 				"@babel/plugin-syntax-class-properties": "^7.12.13",
+				"@babel/plugin-syntax-class-static-block": "^7.12.13",
 				"@babel/plugin-syntax-dynamic-import": "^7.8.3",
 				"@babel/plugin-syntax-export-namespace-from": "^7.8.3",
 				"@babel/plugin-syntax-json-strings": "^7.8.3",
@@ -1053,14 +1096,15 @@
 				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
 				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
 				"@babel/plugin-syntax-optional-chaining": "^7.8.3",
+				"@babel/plugin-syntax-private-property-in-object": "^7.14.0",
 				"@babel/plugin-syntax-top-level-await": "^7.12.13",
 				"@babel/plugin-transform-arrow-functions": "^7.13.0",
 				"@babel/plugin-transform-async-to-generator": "^7.13.0",
 				"@babel/plugin-transform-block-scoped-functions": "^7.12.13",
-				"@babel/plugin-transform-block-scoping": "^7.12.13",
+				"@babel/plugin-transform-block-scoping": "^7.14.1",
 				"@babel/plugin-transform-classes": "^7.13.0",
 				"@babel/plugin-transform-computed-properties": "^7.13.0",
-				"@babel/plugin-transform-destructuring": "^7.13.0",
+				"@babel/plugin-transform-destructuring": "^7.13.17",
 				"@babel/plugin-transform-dotall-regex": "^7.12.13",
 				"@babel/plugin-transform-duplicate-keys": "^7.12.13",
 				"@babel/plugin-transform-exponentiation-operator": "^7.12.13",
@@ -1068,16 +1112,16 @@
 				"@babel/plugin-transform-function-name": "^7.12.13",
 				"@babel/plugin-transform-literals": "^7.12.13",
 				"@babel/plugin-transform-member-expression-literals": "^7.12.13",
-				"@babel/plugin-transform-modules-amd": "^7.13.0",
-				"@babel/plugin-transform-modules-commonjs": "^7.13.8",
+				"@babel/plugin-transform-modules-amd": "^7.14.0",
+				"@babel/plugin-transform-modules-commonjs": "^7.14.0",
 				"@babel/plugin-transform-modules-systemjs": "^7.13.8",
-				"@babel/plugin-transform-modules-umd": "^7.13.0",
+				"@babel/plugin-transform-modules-umd": "^7.14.0",
 				"@babel/plugin-transform-named-capturing-groups-regex": "^7.12.13",
 				"@babel/plugin-transform-new-target": "^7.12.13",
 				"@babel/plugin-transform-object-super": "^7.12.13",
 				"@babel/plugin-transform-parameters": "^7.13.0",
 				"@babel/plugin-transform-property-literals": "^7.12.13",
-				"@babel/plugin-transform-regenerator": "^7.12.13",
+				"@babel/plugin-transform-regenerator": "^7.13.15",
 				"@babel/plugin-transform-reserved-words": "^7.12.13",
 				"@babel/plugin-transform-shorthand-properties": "^7.12.13",
 				"@babel/plugin-transform-spread": "^7.13.0",
@@ -1087,10 +1131,10 @@
 				"@babel/plugin-transform-unicode-escapes": "^7.12.13",
 				"@babel/plugin-transform-unicode-regex": "^7.12.13",
 				"@babel/preset-modules": "^0.1.4",
-				"@babel/types": "^7.13.12",
-				"babel-plugin-polyfill-corejs2": "^0.1.4",
-				"babel-plugin-polyfill-corejs3": "^0.1.3",
-				"babel-plugin-polyfill-regenerator": "^0.1.2",
+				"@babel/types": "^7.14.1",
+				"babel-plugin-polyfill-corejs2": "^0.2.0",
+				"babel-plugin-polyfill-corejs3": "^0.2.0",
+				"babel-plugin-polyfill-regenerator": "^0.2.0",
 				"core-js-compat": "^3.9.0",
 				"semver": "^6.3.0"
 			}
@@ -1109,15 +1153,16 @@
 			}
 		},
 		"@babel/preset-react": {
-			"version": "7.12.13",
-			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.12.13.tgz",
-			"integrity": "sha512-TYM0V9z6Abb6dj1K7i5NrEhA13oS5ujUYQYDfqIBXYHOc2c2VkFgc+q9kyssIyUfy4/hEwqrgSlJ/Qgv8zJLsA==",
+			"version": "7.13.13",
+			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.13.13.tgz",
+			"integrity": "sha512-gx+tDLIE06sRjKJkVtpZ/t3mzCDOnPG+ggHZG9lffUbX8+wC739x20YQc9V35Do6ZAxaUc/HhVHIiOzz5MvDmA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.12.13",
+				"@babel/helper-plugin-utils": "^7.13.0",
+				"@babel/helper-validator-option": "^7.12.17",
 				"@babel/plugin-transform-react-display-name": "^7.12.13",
-				"@babel/plugin-transform-react-jsx": "^7.12.13",
-				"@babel/plugin-transform-react-jsx-development": "^7.12.12",
+				"@babel/plugin-transform-react-jsx": "^7.13.12",
+				"@babel/plugin-transform-react-jsx-development": "^7.12.17",
 				"@babel/plugin-transform-react-pure-annotations": "^7.12.1"
 			}
 		},
@@ -1133,9 +1178,9 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.13.10",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
-			"integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+			"version": "7.14.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
+			"integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			}
@@ -1152,30 +1197,28 @@
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.13.0",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.0.tgz",
-			"integrity": "sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==",
+			"version": "7.14.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.0.tgz",
+			"integrity": "sha512-dZ/a371EE5XNhTHomvtuLTUyx6UEoJmYX+DT5zBCQN3McHemsuIaKKYqsc/fs26BEkHs/lBZy0J571LP5z9kQA==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.12.13",
-				"@babel/generator": "^7.13.0",
+				"@babel/generator": "^7.14.0",
 				"@babel/helper-function-name": "^7.12.13",
 				"@babel/helper-split-export-declaration": "^7.12.13",
-				"@babel/parser": "^7.13.0",
-				"@babel/types": "^7.13.0",
+				"@babel/parser": "^7.14.0",
+				"@babel/types": "^7.14.0",
 				"debug": "^4.1.0",
-				"globals": "^11.1.0",
-				"lodash": "^4.17.19"
+				"globals": "^11.1.0"
 			}
 		},
 		"@babel/types": {
-			"version": "7.13.12",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.12.tgz",
-			"integrity": "sha512-K4nY2xFN4QMvQwkQ+zmBDp6ANMbVNw6BbxWmYA4qNjhR9W+Lj/8ky5MEY2Me5r+B2c6/v6F53oMndG+f9s3IiA==",
+			"version": "7.14.1",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.1.tgz",
+			"integrity": "sha512-S13Qe85fzLs3gYRUnrpyeIrBJIMYv33qSTg1qoBwiG6nPKwUWAD9odSzWhEedpwOIzSEI6gbdQIWEMiCI42iBA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.12.11",
-				"lodash": "^4.17.19",
+				"@babel/helper-validator-identifier": "^7.14.0",
 				"to-fast-properties": "^2.0.0"
 			}
 		},
@@ -1196,9 +1239,9 @@
 			"dev": true
 		},
 		"@deriv/api-types": {
-			"version": "1.0.24",
-			"resolved": "https://registry.npmjs.org/@deriv/api-types/-/api-types-1.0.24.tgz",
-			"integrity": "sha512-QYhsYDTFE9Qro9TN9e3JYFyL4gvbIyNEMCrf8o9oRqm5x6xSbyHBsKEU0a4tAsO3iYg7vUifEMenDX+kBrhvmA==",
+			"version": "1.0.36",
+			"resolved": "https://registry.npmjs.org/@deriv/api-types/-/api-types-1.0.36.tgz",
+			"integrity": "sha512-my7jMTvTgvwyTE7Qb7uGWs8403QLkUV3b0snhUTUhAJgTZVgRU2pPeOxstsWUvFdZGRj8iAYC1TZCpRRcKy7/w==",
 			"dev": true
 		},
 		"@discoveryjs/json-ext": {
@@ -1259,9 +1302,9 @@
 					}
 				},
 				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+					"integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -1329,9 +1372,9 @@
 					}
 				},
 				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+					"integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -1397,9 +1440,9 @@
 			}
 		},
 		"@polka/url": {
-			"version": "1.0.0-next.11",
-			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.11.tgz",
-			"integrity": "sha512-3NsZsJIA/22P3QUyrEDNA2D133H4j224twJrdipXN38dpnIOzAbUDtOwkcJ5pXmn75w7LSQDjA4tO9dm1XlqlA==",
+			"version": "1.0.0-next.12",
+			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.12.tgz",
+			"integrity": "sha512-6RglhutqrGFMO1MNUXp95RBuYIuc8wTnMAV5MUhLmjTOy78ncwOw7RgeQ/HeymkKXRhZd0s2DNrM1rL7unk3MQ==",
 			"dev": true
 		},
 		"@types/babel__core": {
@@ -1444,15 +1487,18 @@
 			}
 		},
 		"@types/classnames": {
-			"version": "2.2.11",
-			"resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.2.11.tgz",
-			"integrity": "sha512-2koNhpWm3DgWRp5tpkiJ8JGc1xTn2q0l+jUNUE7oMKXUf5NpI9AIdC4kbjGNFBdHtcxBD18LAksoudAVhFKCjw==",
-			"dev": true
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.3.1.tgz",
+			"integrity": "sha512-zeOWb0JGBoVmlQoznvqXbE0tEC/HONsnoUNH19Hc96NFsTAwTXbTqb8FMYkru1F/iqp7a18Ws3nWJvtA1sHD1A==",
+			"dev": true,
+			"requires": {
+				"classnames": "*"
+			}
 		},
 		"@types/eslint": {
-			"version": "7.2.7",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.7.tgz",
-			"integrity": "sha512-EHXbc1z2GoQRqHaAT7+grxlTJ3WE2YNeD6jlpPoRc83cCoThRY+NUWjCUZaYmk51OICkPXn2hhphcWcWXgNW0Q==",
+			"version": "7.2.10",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.10.tgz",
+			"integrity": "sha512-kUEPnMKrqbtpCq/KTaGFFKAcz6Ethm2EjCoKIDaCmfRBWLbFuTcOJfTlorwbnboXBzahqWLgUp1BQeKHiJzPUQ==",
 			"dev": true,
 			"requires": {
 				"@types/estree": "*",
@@ -1470,9 +1516,9 @@
 			}
 		},
 		"@types/estree": {
-			"version": "0.0.46",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
-			"integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==",
+			"version": "0.0.47",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.47.tgz",
+			"integrity": "sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==",
 			"dev": true
 		},
 		"@types/graceful-fs": {
@@ -1521,9 +1567,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.14.35",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
-			"integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==",
+			"version": "15.0.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.2.tgz",
+			"integrity": "sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA==",
 			"dev": true
 		},
 		"@types/object.fromentries": {
@@ -1551,9 +1597,9 @@
 			"dev": true
 		},
 		"@types/react": {
-			"version": "17.0.3",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.3.tgz",
-			"integrity": "sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==",
+			"version": "17.0.5",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.5.tgz",
+			"integrity": "sha512-bj4biDB9ZJmGAYTWSKJly6bMr4BLUiBrx9ujiJEoP9XIDY9CTaPGxE5QWN/1WjpPLzYF7/jRNnV2nNxNe970sw==",
 			"dev": true,
 			"requires": {
 				"@types/prop-types": "*",
@@ -1562,9 +1608,9 @@
 			}
 		},
 		"@types/react-router": {
-			"version": "5.1.12",
-			"resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.12.tgz",
-			"integrity": "sha512-0bhXQwHYfMeJlCh7mGhc0VJTRm0Gk+Z8T00aiP4702mDUuLs9SMhnd2DitpjWFjdOecx2UXtICK14H9iMnziGA==",
+			"version": "5.1.14",
+			"resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.14.tgz",
+			"integrity": "sha512-LAJpqYUaCTMT2anZheoidiIymt8MuX286zoVFPM3DVb23aQBH0mAkFvzpd4LKqiolV8bBtZWT5Qp7hClCNDENw==",
 			"dev": true,
 			"requires": {
 				"@types/history": "*",
@@ -1604,13 +1650,13 @@
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "4.19.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.19.0.tgz",
-			"integrity": "sha512-CRQNQ0mC2Pa7VLwKFbrGVTArfdVDdefS+gTw0oC98vSI98IX5A8EVH4BzJ2FOB0YlCmm8Im36Elad/Jgtvveaw==",
+			"version": "4.22.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.22.1.tgz",
+			"integrity": "sha512-kVTAghWDDhsvQ602tHBc6WmQkdaYbkcTwZu+7l24jtJiYvm9l+/y/b2BZANEezxPDiX5MK2ZecE+9BFi/YJryw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/experimental-utils": "4.19.0",
-				"@typescript-eslint/scope-manager": "4.19.0",
+				"@typescript-eslint/experimental-utils": "4.22.1",
+				"@typescript-eslint/scope-manager": "4.22.1",
 				"debug": "^4.1.1",
 				"functional-red-black-tree": "^1.0.1",
 				"lodash": "^4.17.15",
@@ -1631,55 +1677,55 @@
 			}
 		},
 		"@typescript-eslint/experimental-utils": {
-			"version": "4.19.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.19.0.tgz",
-			"integrity": "sha512-9/23F1nnyzbHKuoTqFN1iXwN3bvOm/PRIXSBR3qFAYotK/0LveEOHr5JT1WZSzcD6BESl8kPOG3OoDRKO84bHA==",
+			"version": "4.22.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.22.1.tgz",
+			"integrity": "sha512-svYlHecSMCQGDO2qN1v477ax/IDQwWhc7PRBiwAdAMJE7GXk5stF4Z9R/8wbRkuX/5e9dHqbIWxjeOjckK3wLQ==",
 			"dev": true,
 			"requires": {
 				"@types/json-schema": "^7.0.3",
-				"@typescript-eslint/scope-manager": "4.19.0",
-				"@typescript-eslint/types": "4.19.0",
-				"@typescript-eslint/typescript-estree": "4.19.0",
+				"@typescript-eslint/scope-manager": "4.22.1",
+				"@typescript-eslint/types": "4.22.1",
+				"@typescript-eslint/typescript-estree": "4.22.1",
 				"eslint-scope": "^5.0.0",
 				"eslint-utils": "^2.0.0"
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "4.19.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.19.0.tgz",
-			"integrity": "sha512-/uabZjo2ZZhm66rdAu21HA8nQebl3lAIDcybUoOxoI7VbZBYavLIwtOOmykKCJy+Xq6Vw6ugkiwn8Js7D6wieA==",
+			"version": "4.22.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.22.1.tgz",
+			"integrity": "sha512-l+sUJFInWhuMxA6rtirzjooh8cM/AATAe3amvIkqKFeMzkn85V+eLzb1RyuXkHak4dLfYzOmF6DXPyflJvjQnw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "4.19.0",
-				"@typescript-eslint/types": "4.19.0",
-				"@typescript-eslint/typescript-estree": "4.19.0",
+				"@typescript-eslint/scope-manager": "4.22.1",
+				"@typescript-eslint/types": "4.22.1",
+				"@typescript-eslint/typescript-estree": "4.22.1",
 				"debug": "^4.1.1"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "4.19.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.19.0.tgz",
-			"integrity": "sha512-GGy4Ba/hLXwJXygkXqMzduqOMc+Na6LrJTZXJWVhRrSuZeXmu8TAnniQVKgj8uTRKe4igO2ysYzH+Np879G75g==",
+			"version": "4.22.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.22.1.tgz",
+			"integrity": "sha512-d5bAiPBiessSmNi8Amq/RuLslvcumxLmyhf1/Xa9IuaoFJ0YtshlJKxhlbY7l2JdEk3wS0EnmnfeJWSvADOe0g==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "4.19.0",
-				"@typescript-eslint/visitor-keys": "4.19.0"
+				"@typescript-eslint/types": "4.22.1",
+				"@typescript-eslint/visitor-keys": "4.22.1"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "4.19.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.19.0.tgz",
-			"integrity": "sha512-A4iAlexVvd4IBsSTNxdvdepW0D4uR/fwxDrKUa+iEY9UWvGREu2ZyB8ylTENM1SH8F7bVC9ac9+si3LWNxcBuA==",
+			"version": "4.22.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.22.1.tgz",
+			"integrity": "sha512-2HTkbkdAeI3OOcWbqA8hWf/7z9c6gkmnWNGz0dKSLYLWywUlkOAQ2XcjhlKLj5xBFDf8FgAOF5aQbnLRvgNbCw==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "4.19.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.19.0.tgz",
-			"integrity": "sha512-3xqArJ/A62smaQYRv2ZFyTA+XxGGWmlDYrsfZG68zJeNbeqRScnhf81rUVa6QG4UgzHnXw5VnMT5cg75dQGDkA==",
+			"version": "4.22.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.22.1.tgz",
+			"integrity": "sha512-p3We0pAPacT+onSGM+sPR+M9CblVqdA9F1JEdIqRVlxK5Qth4ochXQgIyb9daBomyQKAXbygxp1aXQRV0GC79A==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "4.19.0",
-				"@typescript-eslint/visitor-keys": "4.19.0",
+				"@typescript-eslint/types": "4.22.1",
+				"@typescript-eslint/visitor-keys": "4.22.1",
 				"debug": "^4.1.1",
 				"globby": "^11.0.1",
 				"is-glob": "^4.0.1",
@@ -1699,12 +1745,12 @@
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "4.19.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.19.0.tgz",
-			"integrity": "sha512-aGPS6kz//j7XLSlgpzU2SeTqHPsmRYxFztj2vPuMMFJXZudpRSehE3WCV+BaxwZFvfAqMoSd86TEuM0PQ59E/A==",
+			"version": "4.22.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.22.1.tgz",
+			"integrity": "sha512-WPkOrIRm+WCLZxXQHCi+WG8T2MMTUFR70rWjdWYddLT7cEfb2P4a3O/J2U1FBVsSFTocXLCoXWY6MZGejeStvQ==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "4.19.0",
+				"@typescript-eslint/types": "4.22.1",
 				"eslint-visitor-keys": "^2.0.0"
 			}
 		},
@@ -1855,24 +1901,24 @@
 			}
 		},
 		"@webpack-cli/configtest": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.0.1.tgz",
-			"integrity": "sha512-B+4uBUYhpzDXmwuo3V9yBH6cISwxEI4J+NO5ggDaGEEHb0osY/R7MzeKc0bHURXQuZjMM4qD+bSJCKIuI3eNBQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.0.2.tgz",
+			"integrity": "sha512-3OBzV2fBGZ5TBfdW50cha1lHDVf9vlvRXnjpVbJBa20pSZQaSkMJZiwA8V2vD9ogyeXn8nU5s5A6mHyf5jhMzA==",
 			"dev": true
 		},
 		"@webpack-cli/info": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.2.2.tgz",
-			"integrity": "sha512-5U9kUJHnwU+FhKH4PWGZuBC1hTEPYyxGSL5jjoBI96Gx8qcYJGOikpiIpFoTq8mmgX3im2zAo2wanv/alD74KQ==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.2.3.tgz",
+			"integrity": "sha512-lLek3/T7u40lTqzCGpC6CAbY6+vXhdhmwFRxZLMnRm6/sIF/7qMpT8MocXCRQfz0JAh63wpbXLMnsQ5162WS7Q==",
 			"dev": true,
 			"requires": {
 				"envinfo": "^7.7.3"
 			}
 		},
 		"@webpack-cli/serve": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.3.0.tgz",
-			"integrity": "sha512-k2p2VrONcYVX1wRRrf0f3X2VGltLWcv+JzXRBDmvCxGlCeESx4OXw91TsWeKOkp784uNoVQo313vxJFHXPPwfw==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.3.1.tgz",
+			"integrity": "sha512-0qXvpeYO6vaNoRBI52/UsbcaBydJCggoBBnIo/ovQQdn6fug0BgwsjorV1hVS7fMqGVTZGcVxv8334gjmbj5hw==",
 			"dev": true
 		},
 		"@xtuc/ieee754": {
@@ -1900,15 +1946,15 @@
 			"dev": true
 		},
 		"acorn": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.0.tgz",
-			"integrity": "sha512-LWCF/Wn0nfHOmJ9rzQApGnxnvgfROzGilS8936rqN/lfcYkY9MYZzdMqN+2NJ4SlTc+m5HiSa+kNfDtI64dwUA==",
+			"version": "8.2.4",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.2.4.tgz",
+			"integrity": "sha512-Ibt84YwBDDA890eDiDCEqcbwvHlBvzzDkU2cGBBDDI1QWT12jTiXIOn2CIw5KK4i6N5Z2HUxwYjzriDyqaqqZg==",
 			"dev": true
 		},
 		"acorn-walk": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.0.2.tgz",
-			"integrity": "sha512-+bpA9MJsHdZ4bgfDcpk0ozQyhhVct7rzOmO0s1IIr0AGGgKBljss8n2zp11rRP2wid5VGeh04CgeKzgat5/25A==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.1.0.tgz",
+			"integrity": "sha512-mjmzmv12YIG/G8JQdQuz2MUDShEJ6teYpT5bmWA4q7iwoGen8xtt3twF3OvzIUl+Q06aWIjvnwQUKvQ6TtMRjg==",
 			"dev": true
 		},
 		"adjust-sourcemap-loader": {
@@ -1990,12 +2036,12 @@
 			"dev": true
 		},
 		"ansi-escapes": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-			"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+			"integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
 			"dev": true,
 			"requires": {
-				"type-fest": "^0.11.0"
+				"type-fest": "^0.21.3"
 			}
 		},
 		"ansi-regex": {
@@ -2014,9 +2060,9 @@
 			}
 		},
 		"anymatch": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-			"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+			"integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
 			"dev": true,
 			"requires": {
 				"normalize-path": "^3.0.0",
@@ -2356,9 +2402,9 @@
 					}
 				},
 				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+					"integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -2453,33 +2499,33 @@
 			}
 		},
 		"babel-plugin-polyfill-corejs2": {
-			"version": "0.1.10",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.1.10.tgz",
-			"integrity": "sha512-DO95wD4g0A8KRaHKi0D51NdGXzvpqVLnLu5BTvDlpqUEpTmeEtypgC1xqesORaWmiUOQI14UHKlzNd9iZ2G3ZA==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.0.tgz",
+			"integrity": "sha512-9bNwiR0dS881c5SHnzCmmGlMkJLl0OUZvxrxHo9w/iNoRuqaPjqlvBf4HrovXtQs/au5yKkpcdgfT1cC5PAZwg==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.13.0",
-				"@babel/helper-define-polyfill-provider": "^0.1.5",
+				"@babel/compat-data": "^7.13.11",
+				"@babel/helper-define-polyfill-provider": "^0.2.0",
 				"semver": "^6.1.1"
 			}
 		},
 		"babel-plugin-polyfill-corejs3": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.1.7.tgz",
-			"integrity": "sha512-u+gbS9bbPhZWEeyy1oR/YaaSpod/KDT07arZHb80aTpl8H5ZBq+uN1nN9/xtX7jQyfLdPfoqI4Rue/MQSWJquw==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.0.tgz",
+			"integrity": "sha512-zZyi7p3BCUyzNxLx8KV61zTINkkV65zVkDAFNZmrTCRVhjo1jAS+YLvDJ9Jgd/w2tsAviCwFHReYfxO3Iql8Yg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-define-polyfill-provider": "^0.1.5",
-				"core-js-compat": "^3.8.1"
+				"@babel/helper-define-polyfill-provider": "^0.2.0",
+				"core-js-compat": "^3.9.1"
 			}
 		},
 		"babel-plugin-polyfill-regenerator": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.1.6.tgz",
-			"integrity": "sha512-OUrYG9iKPKz8NxswXbRAdSwF0GhRdIEMTloQATJi4bDuFqrXaXcCUT/VGNrr8pBcjMh1RxZ7Xt9cytVJTJfvMg==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.0.tgz",
+			"integrity": "sha512-J7vKbCuD2Xi/eEHxquHN14bXAW9CXtecwuLrOIDJtcZzTaPzV1VdEfoUf9AzcRBMolKUQKM9/GVojeh0hFiqMg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-define-polyfill-provider": "^0.1.5"
+				"@babel/helper-define-polyfill-provider": "^0.2.0"
 			}
 		},
 		"babel-preset-current-node-syntax": {
@@ -2625,9 +2671,9 @@
 			"dev": true
 		},
 		"balanced-match": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
 		"base": {
@@ -2735,16 +2781,16 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.16.3",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
-			"integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+			"version": "4.16.6",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+			"integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001181",
-				"colorette": "^1.2.1",
-				"electron-to-chromium": "^1.3.649",
+				"caniuse-lite": "^1.0.30001219",
+				"colorette": "^1.2.2",
+				"electron-to-chromium": "^1.3.723",
 				"escalade": "^3.1.1",
-				"node-releases": "^1.1.70"
+				"node-releases": "^1.1.71"
 			}
 		},
 		"bser": {
@@ -2857,9 +2903,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001204",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001204.tgz",
-			"integrity": "sha512-JUdjWpcxfJ9IPamy2f5JaRDCaqJOxDzOSKtbdx4rH9VivMd1vIzoPumsJa9LoMIi4Fx2BV2KZOxWhNkBjaYivQ==",
+			"version": "1.0.30001223",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001223.tgz",
+			"integrity": "sha512-k/RYs6zc/fjbxTjaWZemeSmOjO0JJV+KguOBA3NwPup8uzxM1cMhR2BD9XmO86GuqaqTCO8CgkgH9Rz//vdDiA==",
 			"dev": true
 		},
 		"capture-exit": {
@@ -2909,13 +2955,10 @@
 			"dev": true
 		},
 		"chrome-trace-event": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
-			"integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
-			"dev": true,
-			"requires": {
-				"tslib": "^1.9.0"
-			}
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
+			"dev": true
 		},
 		"ci-info": {
 			"version": "2.0.0",
@@ -2947,9 +2990,9 @@
 			}
 		},
 		"classnames": {
-			"version": "2.2.6",
-			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-			"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+			"integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
 		},
 		"clean-stack": {
 			"version": "2.2.0",
@@ -3221,12 +3264,12 @@
 			"dev": true
 		},
 		"core-js-compat": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.9.1.tgz",
-			"integrity": "sha512-jXAirMQxrkbiiLsCx9bQPJFA6llDadKMpYrBJQJ3/c4/vsPP/fAf29h24tviRlvwUL6AmY5CHLu2GvjuYviQqA==",
+			"version": "3.11.3",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.11.3.tgz",
+			"integrity": "sha512-oNjHN/qUHOA0dPv+v5prqHfeSvIEJrk3hYVoaUK4MNzL9U433uu0MN+pImcdntV8o9pDq0r1v+9lTfKPjjbX/A==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.16.3",
+				"browserslist": "^4.16.6",
 				"semver": "7.0.0"
 			},
 			"dependencies": {
@@ -3458,23 +3501,22 @@
 			}
 		},
 		"css-loader": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.1.3.tgz",
-			"integrity": "sha512-CoPZvyh8sLiGARK3gqczpfdedbM74klGWurF2CsNZ2lhNaXdLIUks+3Mfax3WBeRuHoglU+m7KG/+7gY6G4aag==",
+			"version": "5.2.4",
+			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.4.tgz",
+			"integrity": "sha512-OFYGyINCKkdQsTrSYxzGSFnGS4gNjcXkKkQgWxK138jgnPt+lepxdjSZNc8sHAl5vP3DhsJUxufWIjOwI8PMMw==",
 			"dev": true,
 			"requires": {
 				"camelcase": "^6.2.0",
-				"cssesc": "^3.0.0",
 				"icss-utils": "^5.1.0",
 				"loader-utils": "^2.0.0",
-				"postcss": "^8.2.8",
+				"postcss": "^8.2.10",
 				"postcss-modules-extract-imports": "^3.0.0",
 				"postcss-modules-local-by-default": "^4.0.0",
 				"postcss-modules-scope": "^3.0.0",
 				"postcss-modules-values": "^4.0.0",
 				"postcss-value-parser": "^4.1.0",
 				"schema-utils": "^3.0.0",
-				"semver": "^7.3.4"
+				"semver": "^7.3.5"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -3627,13 +3669,13 @@
 			"dev": true
 		},
 		"cssnano": {
-			"version": "4.1.10",
-			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.10.tgz",
-			"integrity": "sha512-5wny+F6H4/8RgNlaqab4ktc3e0/blKutmq8yNlBFXA//nSFFAqAngjNVRzUvCgYROULmZZUoosL/KSoZo5aUaQ==",
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.11.tgz",
+			"integrity": "sha512-6gZm2htn7xIPJOHY824ERgj8cNPgPxyCSnkXc4v7YvNW+TdVfzgngHcEhy/8D11kUWRUMbke+tC+AUcUsnMz2g==",
 			"dev": true,
 			"requires": {
 				"cosmiconfig": "^5.0.0",
-				"cssnano-preset-default": "^4.0.7",
+				"cssnano-preset-default": "^4.0.8",
 				"is-resolvable": "^1.0.0",
 				"postcss": "^7.0.0"
 			},
@@ -3695,9 +3737,9 @@
 			}
 		},
 		"cssnano-preset-default": {
-			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-4.0.7.tgz",
-			"integrity": "sha512-x0YHHx2h6p0fCl1zY9L9roD7rnlltugGu7zXSKQx6k2rYw0Hi3IqxcoAGF7u9Q5w1nt7vK0ulxV8Lo+EvllGsA==",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-4.0.8.tgz",
+			"integrity": "sha512-LdAyHuq+VRyeVREFmuxUZR1TXjQm8QQU/ktoo/x7bz+SdOge1YKc5eMN6pRW7YWBmyq59CqYba1dJ5cUukEjLQ==",
 			"dev": true,
 			"requires": {
 				"css-declaration-sorter": "^4.0.1",
@@ -3728,7 +3770,7 @@
 				"postcss-ordered-values": "^4.1.2",
 				"postcss-reduce-initial": "^4.0.3",
 				"postcss-reduce-transforms": "^4.0.2",
-				"postcss-svgo": "^4.0.2",
+				"postcss-svgo": "^4.0.3",
 				"postcss-unique-selectors": "^4.0.1"
 			},
 			"dependencies": {
@@ -3825,9 +3867,9 @@
 			},
 			"dependencies": {
 				"css-tree": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.2.tgz",
-					"integrity": "sha512-wCoWush5Aeo48GLhfHPbmvZs59Z+M7k5+B1xDnXbdWNcEF423DoFdqSWE0PM5aNk5nI5cp1q7ms36zGApY/sKQ==",
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+					"integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
 					"dev": true,
 					"requires": {
 						"mdn-data": "2.0.14",
@@ -3849,9 +3891,9 @@
 			}
 		},
 		"csstype": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.7.tgz",
-			"integrity": "sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
+			"integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==",
 			"dev": true
 		},
 		"currently-unhandled": {
@@ -3883,9 +3925,9 @@
 			}
 		},
 		"date-fns": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.19.0.tgz",
-			"integrity": "sha512-X3bf2iTPgCAQp9wvjOQytnf5vO5rESYRXlPIVcgSbtT5OTScPcsf9eZU+B/YIkKAtYr5WeCii58BgATrNitlWg==",
+			"version": "2.21.2",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.21.2.tgz",
+			"integrity": "sha512-FMkG7pIPx64mGIpS2LOb3Wp3O606H/hatoiz7G0oiYWai1izdM4tF1dd7QABv2NogkIDI4wxsfLLFQSuVvDHgA==",
 			"dev": true
 		},
 		"debug": {
@@ -4014,9 +4056,9 @@
 			},
 			"dependencies": {
 				"domelementtype": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
-					"integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==",
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+					"integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
 					"dev": true
 				}
 			}
@@ -4071,9 +4113,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.693",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.693.tgz",
-			"integrity": "sha512-vUdsE8yyeu30RecppQtI+XTz2++LWLVEIYmzeCaCRLSdtKZ2eXqdJcrs85KwLiPOPVc6PELgWyXBsfqIvzGZag==",
+			"version": "1.3.727",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.727.tgz",
+			"integrity": "sha512-Mfz4FIB4FSvEwBpDfdipRIrwd6uo8gUDoRDF4QEYb4h4tSuI3ov594OrjU6on042UlFHouIJpClDODGkPcBSbg==",
 			"dev": true
 		},
 		"emoji-regex": {
@@ -4098,9 +4140,9 @@
 			}
 		},
 		"enhanced-resolve": {
-			"version": "5.7.0",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.7.0.tgz",
-			"integrity": "sha512-6njwt/NsZFUKhM6j9U8hzVyD4E4r0x7NQzhTCbcWOJ0IQjNSAoalWmb0AE51Wn+fwan5qVESWi7t2ToBxs9vrw==",
+			"version": "5.8.0",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.0.tgz",
+			"integrity": "sha512-Sl3KRpJA8OpprrtaIswVki3cWPiPKxXuFxJXBp+zNb6s6VwNWwFRUdtmzd2ReUut8n+sCPx7QCtQ7w5wfJhSgQ==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.2.4",
@@ -4123,9 +4165,9 @@
 			"dev": true
 		},
 		"envinfo": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.7.4.tgz",
-			"integrity": "sha512-TQXTYFVVwwluWSFis6K2XKxgrD22jEv0FTuLCQI+OjH7rn93+iY0fSSFM5lrSxFY+H1+B0/cvvlamr3UsBivdQ==",
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz",
+			"integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
 			"dev": true
 		},
 		"error-ex": {
@@ -4248,9 +4290,9 @@
 			}
 		},
 		"eslint-visitor-keys": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
-			"integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+			"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
 			"dev": true
 		},
 		"esprima": {
@@ -4295,9 +4337,9 @@
 			"dev": true
 		},
 		"exec-sh": {
-			"version": "0.3.5",
-			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.5.tgz",
-			"integrity": "sha512-0hzpaUazv4mEccxdn3TXC+HWNeVXNKMCJRK6E7Xyg+LwGAYI3yFag6jTkd4injV+kChYDQS1ftqDhnDVWNhU8A==",
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.6.tgz",
+			"integrity": "sha512-nQn+hI3yp+oD0huYhKwvYI32+JFeq+XkNcD1GAo3Y/MjxsfVGmrrzrnzjWiNY6f+pUCP440fThsFh5gZrRAU/w==",
 			"dev": true
 		},
 		"execa": {
@@ -4980,9 +5022,9 @@
 			}
 		},
 		"hosted-git-info": {
-			"version": "2.8.8",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-			"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+			"version": "2.8.9",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
 			"dev": true
 		},
 		"hsl-regex": {
@@ -4995,12 +5037,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
 			"integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
-			"dev": true
-		},
-		"html-comment-regex": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
-			"integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ==",
 			"dev": true
 		},
 		"http-signature": {
@@ -5157,9 +5193,9 @@
 			"dev": true
 		},
 		"is-bigint": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
-			"integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg=="
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+			"integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA=="
 		},
 		"is-boolean-object": {
 			"version": "1.1.0",
@@ -5204,9 +5240,9 @@
 			}
 		},
 		"is-core-module": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-			"integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.3.0.tgz",
+			"integrity": "sha512-xSphU2KG9867tsYdLD4RWQ1VqdFl4HTO9Thf3I/3dLEfr0dbPTWKsuCKrgqMljg4nPE+Gq0VCnzT3gr0CyBmsw==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
@@ -5233,9 +5269,9 @@
 			}
 		},
 		"is-date-object": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.3.tgz",
+			"integrity": "sha512-tDpEUInNcy2Yw3lNSepK3Wdw1RnXLcIVienz6Ou631Acl15cJyRWK4dgA1vCmOEgIbtOV0W7MHg+AR2Gdg1NXQ=="
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
@@ -5357,15 +5393,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
 			"integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
-		},
-		"is-svg": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-svg/-/is-svg-3.0.0.tgz",
-			"integrity": "sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==",
-			"dev": true,
-			"requires": {
-				"html-comment-regex": "^1.1.0"
-			}
 		},
 		"is-symbol": {
 			"version": "1.0.3",
@@ -5502,9 +5529,9 @@
 					}
 				},
 				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+					"integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -5728,9 +5755,9 @@
 					}
 				},
 				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+					"integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -5852,18 +5879,18 @@
 			}
 		},
 		"listr2": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/listr2/-/listr2-3.4.3.tgz",
-			"integrity": "sha512-wZmkzNiuinOfwrGqAwTCcPw6aKQGTAMGXwG5xeU1WpDjJNeBA35jGBeWxR3OF+R6Yl5Y3dRG+3vE8t6PDcSNHA==",
+			"version": "3.8.2",
+			"resolved": "https://registry.npmjs.org/listr2/-/listr2-3.8.2.tgz",
+			"integrity": "sha512-E28Fw7Zd3HQlCJKzb9a8C8M0HtFWQeucE+S8YrSrqZObuCLPRHMRrR8gNmYt65cU9orXYHwvN5agXC36lYt7VQ==",
 			"dev": true,
 			"requires": {
-				"chalk": "^4.1.0",
+				"chalk": "^4.1.1",
 				"cli-truncate": "^2.1.0",
 				"figures": "^3.2.0",
 				"indent-string": "^4.0.0",
 				"log-update": "^4.0.0",
 				"p-map": "^4.0.0",
-				"rxjs": "^6.6.6",
+				"rxjs": "^6.6.7",
 				"through": "^2.3.8",
 				"wrap-ansi": "^7.0.0"
 			},
@@ -5884,9 +5911,9 @@
 					}
 				},
 				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+					"integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -6041,12 +6068,6 @@
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 			"dev": true
 		},
-		"lodash._reinterpolate": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-			"dev": true
-		},
 		"lodash.debounce": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -6058,25 +6079,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
 			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
 			"dev": true
-		},
-		"lodash.template": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
-			"integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
-			"dev": true,
-			"requires": {
-				"lodash._reinterpolate": "^3.0.0",
-				"lodash.templatesettings": "^4.0.0"
-			}
-		},
-		"lodash.templatesettings": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
-			"integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
-			"dev": true,
-			"requires": {
-				"lodash._reinterpolate": "^3.0.0"
-			}
 		},
 		"lodash.uniq": {
 			"version": "4.5.0",
@@ -6104,9 +6106,9 @@
 					}
 				},
 				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+					"integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -6346,13 +6348,13 @@
 			"dev": true
 		},
 		"micromatch": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-			"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+			"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
 			"dev": true,
 			"requires": {
 				"braces": "^3.0.1",
-				"picomatch": "^2.0.5"
+				"picomatch": "^2.2.3"
 			}
 		},
 		"mime": {
@@ -6362,18 +6364,18 @@
 			"dev": true
 		},
 		"mime-db": {
-			"version": "1.46.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
-			"integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==",
+			"version": "1.47.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
+			"integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==",
 			"dev": true
 		},
 		"mime-types": {
-			"version": "2.1.29",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
-			"integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
+			"version": "2.1.30",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
+			"integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
 			"dev": true,
 			"requires": {
-				"mime-db": "1.46.0"
+				"mime-db": "1.47.0"
 			}
 		},
 		"mimic-fn": {
@@ -6392,9 +6394,9 @@
 			}
 		},
 		"mini-css-extract-plugin": {
-			"version": "1.3.9",
-			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.3.9.tgz",
-			"integrity": "sha512-Ac4s+xhVbqlyhXS5J/Vh/QXUz3ycXlCqoCPpg0vdfhsIBH9eg/It/9L1r1XhSCH737M1lqcWnMuWL13zcygn5A==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.6.0.tgz",
+			"integrity": "sha512-nPFKI7NSy6uONUo9yn2hIfb9vyYvkFu95qki0e21DQ9uaqNKDP15DGpK0KnV6wDroWxPHtExrdEwx/yDQ8nVRw==",
 			"dev": true,
 			"requires": {
 				"loader-utils": "^2.0.0",
@@ -6801,9 +6803,9 @@
 			}
 		},
 		"object-inspect": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-			"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
+			"integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA=="
 		},
 		"object-keys": {
 			"version": "1.1.1",
@@ -7044,9 +7046,9 @@
 			"dev": true
 		},
 		"picomatch": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
+			"integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
 			"dev": true
 		},
 		"pify": {
@@ -7104,13 +7106,13 @@
 			"dev": true
 		},
 		"postcss": {
-			"version": "8.2.8",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.8.tgz",
-			"integrity": "sha512-1F0Xb2T21xET7oQV9eKuctbM9S7BC0fetoHCc4H13z0PT6haiRLP4T0ZY4XWh7iLP0usgqykT6p9B2RtOf4FPw==",
+			"version": "8.2.14",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.14.tgz",
+			"integrity": "sha512-+jD0ZijcvyCqPQo/m/CW0UcARpdFylq04of+Q7RKX6f/Tu+dvpUI/9Sp81+i6/vJThnOBX09Quw0ZLOVwpzX3w==",
 			"dev": true,
 			"requires": {
 				"colorette": "^1.2.2",
-				"nanoid": "^3.1.20",
+				"nanoid": "^3.1.22",
 				"source-map": "^0.6.1"
 			},
 			"dependencies": {
@@ -8078,12 +8080,11 @@
 			}
 		},
 		"postcss-initial": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-3.0.2.tgz",
-			"integrity": "sha512-ugA2wKonC0xeNHgirR4D3VWHs2JcU08WAi1KFLVcnb7IN89phID6Qtg2RIctWbnvp1TM2BOmDtX8GGLCKdR8YA==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-3.0.4.tgz",
+			"integrity": "sha512-3RLn6DIpMsK1l5UUy9jxQvoDeUN4gP939tDcKUHD/kM8SGSKbFAnvkpFpj3Bhtz3HGk1jWY5ZNWX6mPta5M9fg==",
 			"dev": true,
 			"requires": {
-				"lodash.template": "^4.5.0",
 				"postcss": "^7.0.2"
 			},
 			"dependencies": {
@@ -9536,24 +9537,21 @@
 			}
 		},
 		"postcss-selector-parser": {
-			"version": "6.0.4",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",
-			"integrity": "sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==",
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.5.tgz",
+			"integrity": "sha512-aFYPoYmXbZ1V6HZaSvat08M97A8HqO6Pjz+PiNpw/DhuRrC72XWAdp3hL6wusDCN31sSmcZyMGa2hZEuX+Xfhg==",
 			"dev": true,
 			"requires": {
 				"cssesc": "^3.0.0",
-				"indexes-of": "^1.0.1",
-				"uniq": "^1.0.1",
 				"util-deprecate": "^1.0.2"
 			}
 		},
 		"postcss-svgo": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-4.0.2.tgz",
-			"integrity": "sha512-C6wyjo3VwFm0QgBy+Fu7gCYOkCmgmClghO+pjcxvrcBKtiKt0uCF+hvbMO1fyv5BMImRK90SMb+dwUnfbGd+jw==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-4.0.3.tgz",
+			"integrity": "sha512-NoRbrcMWTtUghzuKSoIm6XV+sJdvZ7GZSc3wdBN0W19FTtp2ko8NqLsgoh/m9CzNhU3KLPvQmjIwtaNFkaFTvw==",
 			"dev": true,
 			"requires": {
-				"is-svg": "^3.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0",
 				"svgo": "^1.0.0"
@@ -9957,9 +9955,9 @@
 			"dev": true
 		},
 		"regjsparser": {
-			"version": "0.6.8",
-			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.8.tgz",
-			"integrity": "sha512-3weFrFQREJhJ2PW+iCGaG6TenyzNSZgsBKZ/oEf6Trme31COSeIWhHw9O6FPkuXktfx+b6Hf/5e6dKPHaROq2g==",
+			"version": "0.6.9",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.9.tgz",
+			"integrity": "sha512-ZqbNRz1SNjLAiYuwY0zoXW8Ne675IX5q+YHioAGbCw4X96Mjl2+dcX9B2ciaeyYjViDAfvIjFpQjJgLttTEERQ==",
 			"dev": true,
 			"requires": {
 				"jsesc": "~0.5.0"
@@ -9980,9 +9978,9 @@
 			"dev": true
 		},
 		"repeat-element": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
+			"integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==",
 			"dev": true
 		},
 		"repeat-string": {
@@ -10077,9 +10075,9 @@
 			"dev": true
 		},
 		"resolve-url-loader": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-3.1.2.tgz",
-			"integrity": "sha512-QEb4A76c8Mi7I3xNKXlRKQSlLBwjUV/ULFMP+G7n3/7tJZ8MG5wsZ3ucxP1Jz8Vevn6fnJsxDx9cIls+utGzPQ==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-3.1.3.tgz",
+			"integrity": "sha512-WbDSNFiKPPLem1ln+EVTE+bFUBdTTytfQZWbmghroaFNFaAVmGq0Saqw6F/306CwgPXsGwXVxbODE+3xAo/YbA==",
 			"dev": true,
 			"requires": {
 				"adjust-sourcemap-loader": "3.0.0",
@@ -10231,9 +10229,9 @@
 			}
 		},
 		"rxjs": {
-			"version": "6.6.6",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.6.tgz",
-			"integrity": "sha512-/oTwee4N4iWzAMAL9xdGKjkEHmIwupR3oXbQjCKywF1BeFohswF3vZdogbmEF6pZkOsXTzWkrZszrWpQTByYVg==",
+			"version": "6.6.7",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+			"integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
@@ -10469,9 +10467,9 @@
 			}
 		},
 		"sass-resources-loader": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/sass-resources-loader/-/sass-resources-loader-2.1.1.tgz",
-			"integrity": "sha512-/KrD5mEBTj3ZQ49thKSThhpv1OFhc82JbWA0bmv9yANRuPIlQrydNpZG82jdy4pEWY0QcQTGyd5OmCb3xVeZsw==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/sass-resources-loader/-/sass-resources-loader-2.2.1.tgz",
+			"integrity": "sha512-WlofxbWOVnxad874IHZdWbP9eW1pbyqsTJKBsMbeB+YELvLSrZQNDTpH70s6F19BwtanR3NEFnyGwJ9WyotJTQ==",
 			"dev": true,
 			"requires": {
 				"async": "^3.2.0",
@@ -10490,9 +10488,9 @@
 					}
 				},
 				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+					"integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -11308,9 +11306,9 @@
 			}
 		},
 		"terser": {
-			"version": "5.6.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.6.1.tgz",
-			"integrity": "sha512-yv9YLFQQ+3ZqgWCUk+pvNJwgUTdlIxUk1WTN+RnaFJe2L7ipG2csPT0ra2XRm7Cs8cxN7QXmK1rFzEwYEQkzXw==",
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.7.0.tgz",
+			"integrity": "sha512-HP5/9hp2UaZt5fYkuhNBR8YyRcT8juw8+uFbAme53iN9hblvKnLUTKkmwJG6ocWpIKf8UK4DoeWG4ty0J6S6/g==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.20.0",
@@ -11564,9 +11562,9 @@
 			"dev": true
 		},
 		"type-fest": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-			"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+			"version": "0.21.3",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
 			"dev": true
 		},
 		"typedarray-to-buffer": {
@@ -11579,20 +11577,20 @@
 			}
 		},
 		"typescript": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
-			"integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==",
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+			"integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
 			"dev": true
 		},
 		"unbox-primitive": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.0.tgz",
-			"integrity": "sha512-P/51NX+JXyxK/aigg1/ZgyccdAxm5K1+n8+tvqSntjOivPt19gvm1VC49RWYetsiub8WViUchdxl/KWHHB0kzA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+			"integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
 			"requires": {
 				"function-bind": "^1.1.1",
-				"has-bigints": "^1.0.0",
-				"has-symbols": "^1.0.0",
-				"which-boxed-primitive": "^1.0.1"
+				"has-bigints": "^1.0.1",
+				"has-symbols": "^1.0.2",
+				"which-boxed-primitive": "^1.0.2"
 			}
 		},
 		"unicode-canonical-property-names-ecmascript": {
@@ -11802,20 +11800,20 @@
 			}
 		},
 		"webpack": {
-			"version": "5.27.2",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.27.2.tgz",
-			"integrity": "sha512-brNF3N/EdvMzkaZ/Xzb8sqPn5Si3iw6meqCnmNFtcnkorZsFZCBFMa2ElpIMjx6sKWYsnUpBO2dnX+7xgj+mjg==",
+			"version": "5.36.2",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.36.2.tgz",
+			"integrity": "sha512-XJumVnnGoH2dV+Pk1VwgY4YT6AiMKpVoudUFCNOXMIVrEKPUgEwdIfWPjIuGLESAiS8EdIHX5+TiJz/5JccmRg==",
 			"dev": true,
 			"requires": {
 				"@types/eslint-scope": "^3.7.0",
-				"@types/estree": "^0.0.46",
+				"@types/estree": "^0.0.47",
 				"@webassemblyjs/ast": "1.11.0",
 				"@webassemblyjs/wasm-edit": "1.11.0",
 				"@webassemblyjs/wasm-parser": "1.11.0",
-				"acorn": "^8.0.4",
+				"acorn": "^8.2.1",
 				"browserslist": "^4.14.5",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.7.0",
+				"enhanced-resolve": "^5.8.0",
 				"es-module-lexer": "^0.4.0",
 				"eslint-scope": "^5.1.1",
 				"events": "^3.2.0",
@@ -11862,9 +11860,9 @@
 			}
 		},
 		"webpack-bundle-analyzer": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.4.0.tgz",
-			"integrity": "sha512-9DhNa+aXpqdHk8LkLPTBU/dMfl84Y+WE2+KnfI6rSpNRNVKa0VGLjPd2pjFubDeqnWmulFggxmWBxhfJXZnR0g==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.4.1.tgz",
+			"integrity": "sha512-j5m7WgytCkiVBoOGavzNokBOqxe6Mma13X1asfVYtKWM3wxBiRRu1u1iG0Iol5+qp9WgyhkMmBAcvjEfJ2bdDw==",
 			"dev": true,
 			"requires": {
 				"acorn": "^8.0.4",
@@ -11888,9 +11886,9 @@
 					}
 				},
 				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+					"integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -11930,15 +11928,15 @@
 			}
 		},
 		"webpack-cli": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.5.0.tgz",
-			"integrity": "sha512-wXg/ef6Ibstl2f50mnkcHblRPN/P9J4Nlod5Hg9HGFgSeF8rsqDGHJeVe4aR26q9l62TUJi6vmvC2Qz96YJw1Q==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.6.0.tgz",
+			"integrity": "sha512-9YV+qTcGMjQFiY7Nb1kmnupvb1x40lfpj8pwdO/bom+sQiP4OBMKjHq29YQrlDWDPZO9r/qWaRRywKaRDKqBTA==",
 			"dev": true,
 			"requires": {
 				"@discoveryjs/json-ext": "^0.5.0",
-				"@webpack-cli/configtest": "^1.0.1",
-				"@webpack-cli/info": "^1.2.2",
-				"@webpack-cli/serve": "^1.3.0",
+				"@webpack-cli/configtest": "^1.0.2",
+				"@webpack-cli/info": "^1.2.3",
+				"@webpack-cli/serve": "^1.3.1",
 				"colorette": "^1.2.1",
 				"commander": "^7.0.0",
 				"enquirer": "^2.3.6",
@@ -11986,9 +11984,9 @@
 					}
 				},
 				"get-stream": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
-					"integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==",
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+					"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
 					"dev": true
 				},
 				"human-signals": {
@@ -12194,15 +12192,15 @@
 			}
 		},
 		"ws": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
-			"integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==",
+			"version": "7.4.5",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
+			"integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==",
 			"dev": true
 		},
 		"y18n": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-			"integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
 			"dev": true
 		},
 		"yallist": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -55,7 +55,7 @@
         "@babel/preset-env": "^7.12.11",
         "@babel/preset-react": "^7.12.10",
         "@babel/preset-typescript": "^7.12.7",
-        "@deriv/api-types": "1.0.24",
+        "@deriv/api-types": "1.0.36",
         "@deriv/publisher": "^0.0.1-beta4",
         "@types/classnames": "^2.2.11",
         "@types/object.fromentries": "^2.0.0",


### PR DESCRIPTION
```diff <!DOCTYPE html>
<html lang="en">
<head>
<meta charset="utf-8">
<title>Error</title>
</head>
<body>
<pre>versions must be exact semver values</pre>
</body>
</html> ```