### PR TITLE
Bump @deriv/api-types from 1.0.36 to 1.0.37

### DIFF
--- a/packages/dashboard/package-lock.json
+++ b/packages/dashboard/package-lock.json
@@ -1239,9 +1239,9 @@
 			"dev": true
 		},
 		"@deriv/api-types": {
-			"version": "1.0.36",
-			"resolved": "https://registry.npmjs.org/@deriv/api-types/-/api-types-1.0.36.tgz",
-			"integrity": "sha512-my7jMTvTgvwyTE7Qb7uGWs8403QLkUV3b0snhUTUhAJgTZVgRU2pPeOxstsWUvFdZGRj8iAYC1TZCpRRcKy7/w==",
+			"version": "1.0.38",
+			"resolved": "https://registry.npmjs.org/@deriv/api-types/-/api-types-1.0.38.tgz",
+			"integrity": "sha512-D93nvx5j2376EBKbToij8IofBRQUkTsChy+9zwMZ02Zsrlk06HI7UeCo1+VMdnZNtIGkVX3YM5MI1PVhWSNgxw==",
 			"dev": true
 		},
 		"@discoveryjs/json-ext": {
@@ -1901,24 +1901,24 @@
 			}
 		},
 		"@webpack-cli/configtest": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.0.2.tgz",
-			"integrity": "sha512-3OBzV2fBGZ5TBfdW50cha1lHDVf9vlvRXnjpVbJBa20pSZQaSkMJZiwA8V2vD9ogyeXn8nU5s5A6mHyf5jhMzA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.0.3.tgz",
+			"integrity": "sha512-WQs0ep98FXX2XBAfQpRbY0Ma6ADw8JR6xoIkaIiJIzClGOMqVRvPCWqndTxf28DgFopWan0EKtHtg/5W1h0Zkw==",
 			"dev": true
 		},
 		"@webpack-cli/info": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.2.3.tgz",
-			"integrity": "sha512-lLek3/T7u40lTqzCGpC6CAbY6+vXhdhmwFRxZLMnRm6/sIF/7qMpT8MocXCRQfz0JAh63wpbXLMnsQ5162WS7Q==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.2.4.tgz",
+			"integrity": "sha512-ogE2T4+pLhTTPS/8MM3IjHn0IYplKM4HbVNMCWA9N4NrdPzunwenpCsqKEXyejMfRu6K8mhauIPYf8ZxWG5O6g==",
 			"dev": true,
 			"requires": {
 				"envinfo": "^7.7.3"
 			}
 		},
 		"@webpack-cli/serve": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.3.1.tgz",
-			"integrity": "sha512-0qXvpeYO6vaNoRBI52/UsbcaBydJCggoBBnIo/ovQQdn6fug0BgwsjorV1hVS7fMqGVTZGcVxv8334gjmbj5hw==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.4.0.tgz",
+			"integrity": "sha512-xgT/HqJ+uLWGX+Mzufusl3cgjAcnqYYskaB7o0vRcwOEfuu6hMzSILQpnIzFMGsTaeaX4Nnekl+6fadLbl1/Vg==",
 			"dev": true
 		},
 		"@xtuc/ieee754": {
@@ -3264,9 +3264,9 @@
 			"dev": true
 		},
 		"core-js-compat": {
-			"version": "3.11.3",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.11.3.tgz",
-			"integrity": "sha512-oNjHN/qUHOA0dPv+v5prqHfeSvIEJrk3hYVoaUK4MNzL9U433uu0MN+pImcdntV8o9pDq0r1v+9lTfKPjjbX/A==",
+			"version": "3.12.0",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.12.0.tgz",
+			"integrity": "sha512-vvaN8EOvYBEjrr+MN3vCKrMNc/xdYZI+Rt/uPMROi4T5Hj8Fz6TiPQm2mrB9aZoQVW1lCFHYmMrv99aUct9mkg==",
 			"dev": true,
 			"requires": {
 				"browserslist": "^4.16.6",
@@ -4803,9 +4803,9 @@
 			}
 		},
 		"glob": {
-			"version": "7.1.6",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"version": "7.1.7",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+			"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
@@ -11928,18 +11928,17 @@
 			}
 		},
 		"webpack-cli": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.6.0.tgz",
-			"integrity": "sha512-9YV+qTcGMjQFiY7Nb1kmnupvb1x40lfpj8pwdO/bom+sQiP4OBMKjHq29YQrlDWDPZO9r/qWaRRywKaRDKqBTA==",
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.7.0.tgz",
+			"integrity": "sha512-7bKr9182/sGfjFm+xdZSwgQuFjgEcy0iCTIBxRUeteJ2Kr8/Wz0qNJX+jw60LU36jApt4nmMkep6+W5AKhok6g==",
 			"dev": true,
 			"requires": {
 				"@discoveryjs/json-ext": "^0.5.0",
-				"@webpack-cli/configtest": "^1.0.2",
-				"@webpack-cli/info": "^1.2.3",
-				"@webpack-cli/serve": "^1.3.1",
+				"@webpack-cli/configtest": "^1.0.3",
+				"@webpack-cli/info": "^1.2.4",
+				"@webpack-cli/serve": "^1.4.0",
 				"colorette": "^1.2.1",
 				"commander": "^7.0.0",
-				"enquirer": "^2.3.6",
 				"execa": "^5.0.0",
 				"fastest-levenshtein": "^1.0.12",
 				"import-local": "^3.0.2",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -55,7 +55,7 @@
         "@babel/preset-env": "^7.12.11",
         "@babel/preset-react": "^7.12.10",
         "@babel/preset-typescript": "^7.12.7",
-        "@deriv/api-types": "1.0.36",
+        "@deriv/api-types": "1.0.38",
         "@deriv/publisher": "^0.0.1-beta4",
         "@types/classnames": "^2.2.11",
         "@types/object.fromentries": "^2.0.0",


### PR DESCRIPTION
```diff <!DOCTYPE html>
<html lang="en">
<head>
<meta charset="utf-8">
<title>Error</title>
</head>
<body>
<pre>versions must be exact semver values</pre>
</body>
</html> ```