### PR TITLE
Bump @deriv/api-types from 1.0.36 to 1.0.38

### DIFF
--- a/packages/dashboard/package-lock.json
+++ b/packages/dashboard/package-lock.json
@@ -1239,9 +1239,9 @@
 			"dev": true
 		},
 		"@deriv/api-types": {
-			"version": "1.0.36",
-			"resolved": "https://registry.npmjs.org/@deriv/api-types/-/api-types-1.0.36.tgz",
-			"integrity": "sha512-my7jMTvTgvwyTE7Qb7uGWs8403QLkUV3b0snhUTUhAJgTZVgRU2pPeOxstsWUvFdZGRj8iAYC1TZCpRRcKy7/w==",
+			"version": "1.0.39",
+			"resolved": "https://registry.npmjs.org/@deriv/api-types/-/api-types-1.0.39.tgz",
+			"integrity": "sha512-Uyk+GnPbfOMsmqBv3ofqs22j0ahh/VGC64IEvx00mWHYk6EZtfOHok9ZZWYi7qzpahqZVizAX7197UgCkwMIEA==",
 			"dev": true
 		},
 		"@discoveryjs/json-ext": {
@@ -1901,24 +1901,24 @@
 			}
 		},
 		"@webpack-cli/configtest": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.0.2.tgz",
-			"integrity": "sha512-3OBzV2fBGZ5TBfdW50cha1lHDVf9vlvRXnjpVbJBa20pSZQaSkMJZiwA8V2vD9ogyeXn8nU5s5A6mHyf5jhMzA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.0.3.tgz",
+			"integrity": "sha512-WQs0ep98FXX2XBAfQpRbY0Ma6ADw8JR6xoIkaIiJIzClGOMqVRvPCWqndTxf28DgFopWan0EKtHtg/5W1h0Zkw==",
 			"dev": true
 		},
 		"@webpack-cli/info": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.2.3.tgz",
-			"integrity": "sha512-lLek3/T7u40lTqzCGpC6CAbY6+vXhdhmwFRxZLMnRm6/sIF/7qMpT8MocXCRQfz0JAh63wpbXLMnsQ5162WS7Q==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.2.4.tgz",
+			"integrity": "sha512-ogE2T4+pLhTTPS/8MM3IjHn0IYplKM4HbVNMCWA9N4NrdPzunwenpCsqKEXyejMfRu6K8mhauIPYf8ZxWG5O6g==",
 			"dev": true,
 			"requires": {
 				"envinfo": "^7.7.3"
 			}
 		},
 		"@webpack-cli/serve": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.3.1.tgz",
-			"integrity": "sha512-0qXvpeYO6vaNoRBI52/UsbcaBydJCggoBBnIo/ovQQdn6fug0BgwsjorV1hVS7fMqGVTZGcVxv8334gjmbj5hw==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.4.0.tgz",
+			"integrity": "sha512-xgT/HqJ+uLWGX+Mzufusl3cgjAcnqYYskaB7o0vRcwOEfuu6hMzSILQpnIzFMGsTaeaX4Nnekl+6fadLbl1/Vg==",
 			"dev": true
 		},
 		"@xtuc/ieee754": {
@@ -3264,9 +3264,9 @@
 			"dev": true
 		},
 		"core-js-compat": {
-			"version": "3.11.3",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.11.3.tgz",
-			"integrity": "sha512-oNjHN/qUHOA0dPv+v5prqHfeSvIEJrk3hYVoaUK4MNzL9U433uu0MN+pImcdntV8o9pDq0r1v+9lTfKPjjbX/A==",
+			"version": "3.12.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.12.1.tgz",
+			"integrity": "sha512-i6h5qODpw6EsHAoIdQhKoZdWn+dGBF3dSS8m5tif36RlWvW3A6+yu2S16QHUo3CrkzrnEskMAt9f8FxmY9fhWQ==",
 			"dev": true,
 			"requires": {
 				"browserslist": "^4.16.6",
@@ -3925,9 +3925,9 @@
 			}
 		},
 		"date-fns": {
-			"version": "2.21.2",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.21.2.tgz",
-			"integrity": "sha512-FMkG7pIPx64mGIpS2LOb3Wp3O606H/hatoiz7G0oiYWai1izdM4tF1dd7QABv2NogkIDI4wxsfLLFQSuVvDHgA==",
+			"version": "2.21.3",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.21.3.tgz",
+			"integrity": "sha512-HeYdzCaFflc1i4tGbj7JKMjM4cKGYoyxwcIIkHzNgCkX8xXDNJDZXgDDVchIWpN4eQc3lH37WarduXFZJOtxfw==",
 			"dev": true
 		},
 		"debug": {
@@ -4803,9 +4803,9 @@
 			}
 		},
 		"glob": {
-			"version": "7.1.6",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"version": "7.1.7",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+			"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
@@ -5198,11 +5198,11 @@
 			"integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA=="
 		},
 		"is-boolean-object": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
-			"integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+			"integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
 			"requires": {
-				"call-bind": "^1.0.0"
+				"call-bind": "^1.0.2"
 			}
 		},
 		"is-buffer": {
@@ -5240,9 +5240,9 @@
 			}
 		},
 		"is-core-module": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.3.0.tgz",
-			"integrity": "sha512-xSphU2KG9867tsYdLD4RWQ1VqdFl4HTO9Thf3I/3dLEfr0dbPTWKsuCKrgqMljg4nPE+Gq0VCnzT3gr0CyBmsw==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
+			"integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
@@ -5269,9 +5269,9 @@
 			}
 		},
 		"is-date-object": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.3.tgz",
-			"integrity": "sha512-tDpEUInNcy2Yw3lNSepK3Wdw1RnXLcIVienz6Ou631Acl15cJyRWK4dgA1vCmOEgIbtOV0W7MHg+AR2Gdg1NXQ=="
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
+			"integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A=="
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
@@ -5343,9 +5343,9 @@
 			"dev": true
 		},
 		"is-number-object": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
-			"integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw=="
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
+			"integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw=="
 		},
 		"is-obj": {
 			"version": "1.0.1",
@@ -5363,12 +5363,12 @@
 			}
 		},
 		"is-regex": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-			"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+			"integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
 			"requires": {
 				"call-bind": "^1.0.2",
-				"has-symbols": "^1.0.1"
+				"has-symbols": "^1.0.2"
 			}
 		},
 		"is-regexp": {
@@ -5390,16 +5390,16 @@
 			"dev": true
 		},
 		"is-string": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-			"integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+			"integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w=="
 		},
 		"is-symbol": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-			"integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+			"integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
 			"requires": {
-				"has-symbols": "^1.0.1"
+				"has-symbols": "^1.0.2"
 			}
 		},
 		"is-typedarray": {
@@ -6803,9 +6803,9 @@
 			}
 		},
 		"object-inspect": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
-			"integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA=="
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+			"integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw=="
 		},
 		"object-keys": {
 			"version": "1.1.1",
@@ -11928,18 +11928,17 @@
 			}
 		},
 		"webpack-cli": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.6.0.tgz",
-			"integrity": "sha512-9YV+qTcGMjQFiY7Nb1kmnupvb1x40lfpj8pwdO/bom+sQiP4OBMKjHq29YQrlDWDPZO9r/qWaRRywKaRDKqBTA==",
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.7.0.tgz",
+			"integrity": "sha512-7bKr9182/sGfjFm+xdZSwgQuFjgEcy0iCTIBxRUeteJ2Kr8/Wz0qNJX+jw60LU36jApt4nmMkep6+W5AKhok6g==",
 			"dev": true,
 			"requires": {
 				"@discoveryjs/json-ext": "^0.5.0",
-				"@webpack-cli/configtest": "^1.0.2",
-				"@webpack-cli/info": "^1.2.3",
-				"@webpack-cli/serve": "^1.3.1",
+				"@webpack-cli/configtest": "^1.0.3",
+				"@webpack-cli/info": "^1.2.4",
+				"@webpack-cli/serve": "^1.4.0",
 				"colorette": "^1.2.1",
 				"commander": "^7.0.0",
-				"enquirer": "^2.3.6",
 				"execa": "^5.0.0",
 				"fastest-levenshtein": "^1.0.12",
 				"import-local": "^3.0.2",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -55,7 +55,7 @@
         "@babel/preset-env": "^7.12.11",
         "@babel/preset-react": "^7.12.10",
         "@babel/preset-typescript": "^7.12.7",
-        "@deriv/api-types": "1.0.36",
+        "@deriv/api-types": "1.0.39",
         "@deriv/publisher": "^0.0.1-beta4",
         "@types/classnames": "^2.2.11",
         "@types/object.fromentries": "^2.0.0",


### PR DESCRIPTION
```diff <!DOCTYPE html>
<html lang="en">
<head>
<meta charset="utf-8">
<title>Error</title>
</head>
<body>
<pre>versions must be exact semver values</pre>
</body>
</html> ```