### PR TITLE
Mikita / changed color for Text which is not visible when highlighted in Dark mode

### DIFF
--- a/packages/components/src/components/dropdown/dropdown.jsx
+++ b/packages/components/src/components/dropdown/dropdown.jsx
@@ -435,7 +435,7 @@ const Dropdown = ({
                     />
                 </div>
                 {!error && hint && (
-                    <Text as='p' color='less-prominent' size='xxs' className='dc-dropdown__hint'>
+                    <Text as='p' color='general' size='xxs' className='dc-dropdown__hint'>
                         {hint}
                     </Text>
                 )}

--- a/packages/components/src/components/input/input.jsx
+++ b/packages/components/src/components/input/input.jsx
@@ -98,7 +98,7 @@ const Input = React.forwardRef(
                             {warn && <Field className={classNameWarn} message={warn} type='warn' />}
                             {!error && hint && !is_relative_hint && (
                                 <div className='dc-input__hint'>
-                                    <Text as='p' color='less-prominent' size='xxs'>
+                                    <Text as='p' color='general' size='xxs'>
                                         {hint}
                                     </Text>
                                 </div>


### PR DESCRIPTION
Short description: Text is not visible in Dark mode in Cashier page-->Transfer section.
Even when highlighted, the text should be visible