### PR TITLE
Maryia/Added padding-bottom to timeline container

### DIFF
--- a/packages/components/src/components/timeline/timeline.scss
+++ b/packages/components/src/components/timeline/timeline.scss
@@ -11,6 +11,7 @@
     &__container {
         margin-top: 4px;
         margin-left: 20px;
+        padding-bottom: 11px;
     }
     &__title {
         max-width: 500px;


### PR DESCRIPTION
Added padding-bottom to the timeline container used to display content in each step on the 'API-token' page as well as on the 'Two-factor authentication' page.