### PR TITLE
Maryia/Removed transition effect from an active step of adding a real money account

### DIFF
--- a/packages/components/src/components/form-progress/form-progress.scss
+++ b/packages/components/src/components/form-progress/form-progress.scss
@@ -32,7 +32,6 @@
             &--active {
                 background-color: var(--brand-red-coral) !important;
                 border: 1px solid var(--brand-red-coral) !important;
-                transition: all 0.3s ease;
             }
         }
     }


### PR DESCRIPTION
Removed the transition effect from an active step number displayed when a user is adding a real money account.