### PR TITLE
Maryia/Added name of wallet for withdrawal to 'About Tether' note title

### DIFF
--- a/packages/cashier/src/Components/usdt-side-note.jsx
+++ b/packages/cashier/src/Components/usdt-side-note.jsx
@@ -12,7 +12,7 @@ const USDTSideNote = ({ type }) => {
     return (
         <div className='cashier__usdt-side-note'>
             <Text as='h2' weight='bold' color='prominent'>
-                <Localize i18n_default_text='About Tether' />
+                <Localize i18n_default_text={`About Tether (${type === 'eusdt' ? 'Ethereum' : 'Omni'})`} />
             </Text>
             {type === 'eusdt' && (
                 <Text as='p' size='xxs'>

--- a/packages/cashier/src/Components/usdt-side-note.jsx
+++ b/packages/cashier/src/Components/usdt-side-note.jsx
@@ -12,7 +12,8 @@ const USDTSideNote = ({ type }) => {
     return (
         <div className='cashier__usdt-side-note'>
             <Text as='h2' weight='bold' color='prominent'>
-                <Localize i18n_default_text={`About Tether (${type === 'eusdt' ? 'Ethereum' : 'Omni'})`} />
+                {type === 'eusdt' && <Localize i18n_default_text='About Tether (Ethereum)' />}
+                {type === 'usdt' && <Localize i18n_default_text='About Tether (Omni)' />}
             </Text>
             {type === 'eusdt' && (
                 <Text as='p' size='xxs'>


### PR DESCRIPTION
Added the name of a specific wallet that is available for withdrawal into the round brackets at the end of the side note title: changed ’About Tether’ to ‘About Tether (Ethereum)’ for Tether eUSDT and to ‘About Tether (Omni)’ for Tether USDT.