### PR TITLE
amam/use_github_token

### DIFF
--- a/.github/workflows/push_and_pull_crowdin_translations.yml
+++ b/.github/workflows/push_and_pull_crowdin_translations.yml
@@ -128,7 +128,7 @@ jobs:
             git push --set-upstream origin "$branch_name" -f
 
             sudo apt install gh
-            gh auth login --with-token <<< ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+            gh auth login --with-token <<< ${{ github.token }}
             gh pr close "$branch_name" || true
             gh pr create --fill --base "master" --head "binary-com:$branch_name"
           fi


### PR DESCRIPTION
- github authentication is not allowed using PAC in github action, changing it to github.token