### PR TITLE
yashim/fix: add fallback for undefined in client notifications

### DIFF
--- a/packages/core/src/Stores/Helpers/client-notifications.js
+++ b/packages/core/src/Stores/Helpers/client-notifications.js
@@ -658,7 +658,7 @@ export const handleClientNotifications = (client, client_store, ui_store, cashie
     const { current_language, selected_contract_type } = common_store;
     let has_missing_required_field, has_risk_assessment;
 
-    const { withdrawal_locked, deposit_locked } = getStatusValidations(account_status.status);
+    const { withdrawal_locked, deposit_locked } = getStatusValidations(account_status.status || []);
 
     if (loginid !== LocalStore.get('active_loginid')) return {};
 


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-   Add fallback if `account_status` is undefined when handling client notifications

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
