### PR TITLE
Maryia/Defining the country by the client's country of residence in showMxMltUnavailableError()

### DIFF
--- a/packages/trader/src/Stores/Modules/Trading/Helpers/active-symbols.js
+++ b/packages/trader/src/Stores/Modules/Trading/Helpers/active-symbols.js
@@ -27,10 +27,10 @@ export const showUnavailableLocationError = flow(function* (showError, is_logged
 });
 
 export const showMxMltUnavailableError = flow(function* (showError, can_have_mlt_account, can_have_mx_account) {
-    const website_status = yield WS.wait('website_status');
+    const get_settings = yield WS.wait('get_settings');
     const residence_list = yield WS.residenceList();
 
-    const clients_country_code = website_status.website_status.clients_country;
+    const clients_country_code = get_settings.get_settings.country_code;
     const clients_country_text = (
         residence_list.residence_list.find(obj_country => obj_country.value === clients_country_code) || {}
     ).text;


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-   Defining the country by the client's country of residence received in get_settings WS response in showMxMltUnavailableError()

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [x] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
