### PR TITLE
Ako/ increase test time to prevent ci failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,6 +273,7 @@ jobs:
       - build
       - run:
           name: "Run tests"
+          no_output_timeout: 30m
           command: npm test
 
 workflows:


### PR DESCRIPTION
## Changes:

circleci test time increased to 30 minutes to prevent circleci failure.
since we need the testCoverage for sonarcloud the test time has increased and in some cases it throws error when ci is running.
As you can see in [this](https://circleci.com/docs/2.0/configuration-reference/) documentation (search for `no_output_timeout` in it) with the added option we can increase task time. 

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [x] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
