### PR TITLE
Maryia/Fix for non-Jersey postcode regex

### DIFF
--- a/packages/account/src/Configs/address-details-config.js
+++ b/packages/account/src/Configs/address-details-config.js
@@ -119,7 +119,7 @@ const address_details_config = ({ account_settings, is_svg }) => {
                         'regular',
                         localize('Our accounts and services are unavailable for the Jersey postal code.'),
                         {
-                            regex: regex_checks.address_details.jersey_postcode,
+                            regex: regex_checks.address_details.non_jersey_postcode,
                         },
                     ],
                 ],

--- a/packages/account/src/Sections/Profile/PersonalDetails/personal-details.jsx
+++ b/packages/account/src/Sections/Profile/PersonalDetails/personal-details.jsx
@@ -379,7 +379,7 @@ export const PersonalDetailsForm = ({
 
         // Not allowing Jersey postcodes with a UK residence.
         if (
-            !regex_checks.address_details.jersey_postcode.test(values.address_postcode) &&
+            !regex_checks.address_details.non_jersey_postcode.test(values.address_postcode) &&
             (is_uk || values.citizen === 'United Kingdom')
         ) {
             errors.address_postcode = localize('Our accounts and services are unavailable for the Jersey postal code');

--- a/packages/shared/src/utils/validation/regex-validation.js
+++ b/packages/shared/src/utils/validation/regex-validation.js
@@ -5,7 +5,6 @@ export const regex_checks = {
         address_line_2: /^[a-zA-Z0-9\s'.,:;()@#/-]{0,70}$/,
         address_postcode: /^[a-zA-Z0-9\s-]{0,20}$/,
         address_state: /^[\w\s\W'.;,-]{0,35}$/,
-        jersey_postcode:
-            /^(?!((je)\s*)|(\s*(je)\s*)|(((je)[0-9])\s([a-zA-Z0-9])*\s*))|(((je)[0-9])\s([a-zA-Z0-9])*\s*([a-zA-Z0-9]))$/i,
+        non_jersey_postcode: /^(?!\s*je.*)[a-zA-Z0-9\s-]*/i,
     },
 };


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-   Fix for non-Jersey postcode regex

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
