### PR TITLE
Bala/fix storybook build

### DIFF
--- a/packages/components/.storybook/webpack.config.js
+++ b/packages/components/.storybook/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const CopyPlugin = require('copy-webpack-plugin');
+const CopyPlugin = require('copy-webpack-plugin-v6');
 
 // Export a function. Accept the base config as the only param.
 module.exports = async ({ config, mode }) => {
@@ -57,9 +57,7 @@ module.exports = async ({ config, mode }) => {
 
     config.plugins.push(
         new CopyPlugin({
-            patterns: [
-                { from: path.resolve(__dirname, '../lib/icon/sprites'), to: 'public/sprites', toType: 'dir' },
-            ],
+            patterns: [{ from: path.resolve(__dirname, '../lib/icon/sprites'), to: 'public/sprites', toType: 'dir' }],
         })
     );
     // Return the altered config

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -41,6 +41,7 @@
         "babel-eslint": "^10.1.0",
         "babel-loader": "^8.1.0",
         "copy-webpack-plugin": "^9.0.1",
+        "copy-webpack-plugin-v6": "npm:copy-webpack-plugin@6",
         "cross-env": "^5.2.0",
         "eslint-config-airbnb-base": "^14.2.1",
         "eslint-config-binary": "^1.0.2",


### PR DESCRIPTION
## Changes:

Below error is thrown when we try to start the storybook in the components package.
```ERR! TypeError: compilation.getCache is not a function```
This is because `storybook` uses `webpack4` and we use `webpack5` in `deriv-app`. The error above comes from `copy-webpack-plugin` which is compatible only with `>=webpack5`. 

In this PR, I've added `copy-webpack-plugin` package which is compatible with `webpack4`.

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
