### PR TITLE
Maryia/Loading favicons based on size & excluded them from service worker

### DIFF
--- a/packages/core/build/config.js
+++ b/packages/core/build/config.js
@@ -87,7 +87,7 @@ const copyConfig = base => {
             to: 'favicon.ico',
             toType: 'file',
         },
-        { from: path.resolve(__dirname, '../src/public/images/favicons/'), to: 'public/images/favicons' },
+        { from: path.resolve(__dirname, '../src/public/images/favicons/'), to: 'public/images/favicons/' },
         {
             from: path.resolve(__dirname, '../src/public/images/common/static_images/'),
             to: 'public/images/common',
@@ -132,6 +132,7 @@ const generateSWConfig = is_release => ({
         /sitemap\.xml$/,
         /robots\.txt$/,
         /manifest\.json$/,
+        /^public\/images\/favicons\//,
         /^apple-app-site-association/,
         /^assetlinks.json/,
         /^.well-known\//,
@@ -180,11 +181,107 @@ const htmlInjectConfig = () => ({
             },
         },
         {
-            path: 'public/images/favicons',
-            glob: '*',
-            globPath: path.resolve(__dirname, '../src/public/images/favicons'),
+            path: 'favicon.ico',
             attributes: {
                 rel: 'icon',
+            },
+        },
+        {
+            path: 'public/images/favicons/favicon-16.png',
+            attributes: {
+                rel: 'icon',
+                sizes: '16x16',
+            },
+        },
+        {
+            path: 'public/images/favicons/favicon-32.png',
+            attributes: {
+                rel: 'icon',
+                sizes: '32x32',
+            },
+        },
+        {
+            path: 'public/images/favicons/favicon-96.png',
+            attributes: {
+                rel: 'icon',
+                sizes: '96x96',
+            },
+        },
+        {
+            path: 'public/images/favicons/favicon-160.png',
+            attributes: {
+                rel: 'icon',
+                sizes: '160x160',
+            },
+        },
+        {
+            path: 'public/images/favicons/favicon-192.png',
+            attributes: {
+                rel: 'icon',
+                sizes: '192x192',
+            },
+        },
+        {
+            path: 'public/images/favicons/apple-touch-icon-57.png',
+            attributes: {
+                rel: 'apple-touch-icon',
+                sizes: '57x57',
+            },
+        },
+        {
+            path: 'public/images/favicons/apple-touch-icon-60.png',
+            attributes: {
+                rel: 'apple-touch-icon',
+                sizes: '60x60',
+            },
+        },
+        {
+            path: 'public/images/favicons/apple-touch-icon-72.png',
+            attributes: {
+                rel: 'apple-touch-icon',
+                sizes: '72x72',
+            },
+        },
+        {
+            path: 'public/images/favicons/apple-touch-icon-76.png',
+            attributes: {
+                rel: 'apple-touch-icon',
+                sizes: '76x76',
+            },
+        },
+        {
+            path: 'public/images/favicons/apple-touch-icon-114.png',
+            attributes: {
+                rel: 'apple-touch-icon',
+                sizes: '114x114',
+            },
+        },
+        {
+            path: 'public/images/favicons/apple-touch-icon-120.png',
+            attributes: {
+                rel: 'apple-touch-icon',
+                sizes: '120x120',
+            },
+        },
+        {
+            path: 'public/images/favicons/apple-touch-icon-144.png',
+            attributes: {
+                rel: 'apple-touch-icon',
+                sizes: '144x144',
+            },
+        },
+        {
+            path: 'public/images/favicons/apple-touch-icon-152.png',
+            attributes: {
+                rel: 'apple-touch-icon',
+                sizes: '152x152',
+            },
+        },
+        {
+            path: 'public/images/favicons/apple-touch-icon-180.png',
+            attributes: {
+                rel: 'apple-touch-icon',
+                sizes: '180x180',
             },
         },
     ],

--- a/packages/core/build/config.js
+++ b/packages/core/build/config.js
@@ -187,104 +187,28 @@ const htmlInjectConfig = () => ({
                 rel: 'icon',
             },
         },
-        {
-            path: 'public/images/favicons/favicon-16.png',
+        ...[
+            { name: 'favicon', rel: 'icon', size: '16' },
+            { name: 'favicon', rel: 'icon', size: '32' },
+            { name: 'favicon', rel: 'icon', size: '96' },
+            { name: 'favicon', rel: 'icon', size: '160' },
+            { name: 'favicon', rel: 'icon', size: '192' },
+            { name: 'apple-touch-icon', size: '57' },
+            { name: 'apple-touch-icon', size: '60' },
+            { name: 'apple-touch-icon', size: '72' },
+            { name: 'apple-touch-icon', size: '76' },
+            { name: 'apple-touch-icon', size: '114' },
+            { name: 'apple-touch-icon', size: '120' },
+            { name: 'apple-touch-icon', size: '144' },
+            { name: 'apple-touch-icon', size: '152' },
+            { name: 'apple-touch-icon', size: '180' },
+        ].map(({ name, rel, size }) => ({
+            path: `public/images/favicons/${name}-${size}.png`,
             attributes: {
-                rel: 'icon',
-                sizes: '16x16',
+                rel: rel || name,
+                sizes: `${size}x${size}`,
             },
-        },
-        {
-            path: 'public/images/favicons/favicon-32.png',
-            attributes: {
-                rel: 'icon',
-                sizes: '32x32',
-            },
-        },
-        {
-            path: 'public/images/favicons/favicon-96.png',
-            attributes: {
-                rel: 'icon',
-                sizes: '96x96',
-            },
-        },
-        {
-            path: 'public/images/favicons/favicon-160.png',
-            attributes: {
-                rel: 'icon',
-                sizes: '160x160',
-            },
-        },
-        {
-            path: 'public/images/favicons/favicon-192.png',
-            attributes: {
-                rel: 'icon',
-                sizes: '192x192',
-            },
-        },
-        {
-            path: 'public/images/favicons/apple-touch-icon-57.png',
-            attributes: {
-                rel: 'apple-touch-icon',
-                sizes: '57x57',
-            },
-        },
-        {
-            path: 'public/images/favicons/apple-touch-icon-60.png',
-            attributes: {
-                rel: 'apple-touch-icon',
-                sizes: '60x60',
-            },
-        },
-        {
-            path: 'public/images/favicons/apple-touch-icon-72.png',
-            attributes: {
-                rel: 'apple-touch-icon',
-                sizes: '72x72',
-            },
-        },
-        {
-            path: 'public/images/favicons/apple-touch-icon-76.png',
-            attributes: {
-                rel: 'apple-touch-icon',
-                sizes: '76x76',
-            },
-        },
-        {
-            path: 'public/images/favicons/apple-touch-icon-114.png',
-            attributes: {
-                rel: 'apple-touch-icon',
-                sizes: '114x114',
-            },
-        },
-        {
-            path: 'public/images/favicons/apple-touch-icon-120.png',
-            attributes: {
-                rel: 'apple-touch-icon',
-                sizes: '120x120',
-            },
-        },
-        {
-            path: 'public/images/favicons/apple-touch-icon-144.png',
-            attributes: {
-                rel: 'apple-touch-icon',
-                sizes: '144x144',
-            },
-        },
-        {
-            path: 'public/images/favicons/apple-touch-icon-152.png',
-            attributes: {
-                rel: 'apple-touch-icon',
-                sizes: '152x152',
-            },
-        },
-        {
-            path: 'public/images/favicons/apple-touch-icon-180.png',
-            attributes: {
-                rel: 'apple-touch-icon',
-                sizes: '180x180',
-            },
-        },
+        })),
     ],
     append: false,
 });

--- a/packages/core/build/config.js
+++ b/packages/core/build/config.js
@@ -133,6 +133,7 @@ const generateSWConfig = is_release => ({
         /robots\.txt$/,
         /manifest\.json$/,
         /^public\/images\/favicons\//,
+        /^favicon\.ico$/,
         /^apple-app-site-association/,
         /^assetlinks.json/,
         /^.well-known\//,

--- a/packages/trader/build/config.js
+++ b/packages/trader/build/config.js
@@ -27,13 +27,33 @@ const htmlOutputConfig = () => ({
 const htmlInjectConfig = () => ({
     links: [
         {
-            path: 'public/images/favicons',
-            glob: '*',
-            globPath: path.resolve(__dirname, '../src/public/images/favicons'),
+            path: 'favicon.ico',
             attributes: {
                 rel: 'icon',
             },
         },
+        ...[
+            { name: 'favicon', rel: 'icon', size: '16' },
+            { name: 'favicon', rel: 'icon', size: '32' },
+            { name: 'favicon', rel: 'icon', size: '96' },
+            { name: 'favicon', rel: 'icon', size: '160' },
+            { name: 'favicon', rel: 'icon', size: '192' },
+            { name: 'apple-touch-icon', size: '57' },
+            { name: 'apple-touch-icon', size: '60' },
+            { name: 'apple-touch-icon', size: '72' },
+            { name: 'apple-touch-icon', size: '76' },
+            { name: 'apple-touch-icon', size: '114' },
+            { name: 'apple-touch-icon', size: '120' },
+            { name: 'apple-touch-icon', size: '144' },
+            { name: 'apple-touch-icon', size: '152' },
+            { name: 'apple-touch-icon', size: '180' },
+        ].map(({ name, rel, size }) => ({
+            path: `public/images/favicons/${name}-${size}.png`,
+            attributes: {
+                rel: rel || name,
+                sizes: `${size}x${size}`,
+            },
+        })),
     ],
     append: false,
 });

--- a/packages/trader/build/config.js
+++ b/packages/trader/build/config.js
@@ -6,7 +6,7 @@ const { IS_RELEASE } = require('./constants');
 const generateSWConfig = () => ({
     importWorkboxFrom: 'local',
     cleanupOutdatedCaches: true,
-    exclude: [/CNAME$/, /index\.html$/, /404\.html$/, /^public\/images\/favicons\//],
+    exclude: [/CNAME$/, /index\.html$/, /404\.html$/, /^public\/images\/favicons\//, /^favicon\.ico$/],
     skipWaiting: true,
     clientsClaim: true,
 });

--- a/packages/trader/build/config.js
+++ b/packages/trader/build/config.js
@@ -6,7 +6,7 @@ const { IS_RELEASE } = require('./constants');
 const generateSWConfig = () => ({
     importWorkboxFrom: 'local',
     cleanupOutdatedCaches: true,
-    exclude: [/CNAME$/, /index\.html$/, /404\.html$/],
+    exclude: [/CNAME$/, /index\.html$/, /404\.html$/, /^public\/images\/favicons\//],
     skipWaiting: true,
     clientsClaim: true,
 });

--- a/packages/trader/build/config.js
+++ b/packages/trader/build/config.js
@@ -24,39 +24,39 @@ const htmlOutputConfig = () => ({
           },
 });
 
-const htmlInjectConfig = () => ({
-    links: [
-        {
-            path: 'favicon.ico',
-            attributes: {
-                rel: 'icon',
-            },
-        },
-        ...[
-            { name: 'favicon', rel: 'icon', size: '16' },
-            { name: 'favicon', rel: 'icon', size: '32' },
-            { name: 'favicon', rel: 'icon', size: '96' },
-            { name: 'favicon', rel: 'icon', size: '160' },
-            { name: 'favicon', rel: 'icon', size: '192' },
-            { name: 'apple-touch-icon', size: '57' },
-            { name: 'apple-touch-icon', size: '60' },
-            { name: 'apple-touch-icon', size: '72' },
-            { name: 'apple-touch-icon', size: '76' },
-            { name: 'apple-touch-icon', size: '114' },
-            { name: 'apple-touch-icon', size: '120' },
-            { name: 'apple-touch-icon', size: '144' },
-            { name: 'apple-touch-icon', size: '152' },
-            { name: 'apple-touch-icon', size: '180' },
-        ].map(({ name, rel, size }) => ({
-            path: `public/images/favicons/${name}-${size}.png`,
-            attributes: {
-                rel: rel || name,
-                sizes: `${size}x${size}`,
-            },
-        })),
-    ],
-    append: false,
-});
+// const htmlInjectConfig = () => ({ // commented out in trader/build/constants.js
+//     links: [
+//         {
+//             path: 'favicon.ico',
+//             attributes: {
+//                 rel: 'icon',
+//             },
+//         },
+//         ...[
+//             { name: 'favicon', rel: 'icon', size: '16' },
+//             { name: 'favicon', rel: 'icon', size: '32' },
+//             { name: 'favicon', rel: 'icon', size: '96' },
+//             { name: 'favicon', rel: 'icon', size: '160' },
+//             { name: 'favicon', rel: 'icon', size: '192' },
+//             { name: 'apple-touch-icon', size: '57' },
+//             { name: 'apple-touch-icon', size: '60' },
+//             { name: 'apple-touch-icon', size: '72' },
+//             { name: 'apple-touch-icon', size: '76' },
+//             { name: 'apple-touch-icon', size: '114' },
+//             { name: 'apple-touch-icon', size: '120' },
+//             { name: 'apple-touch-icon', size: '144' },
+//             { name: 'apple-touch-icon', size: '152' },
+//             { name: 'apple-touch-icon', size: '180' },
+//         ].map(({ name, rel, size }) => ({
+//             path: `public/images/favicons/${name}-${size}.png`,
+//             attributes: {
+//                 rel: rel || name,
+//                 sizes: `${size}x${size}`,
+//             },
+//         })),
+//     ],
+//     append: false,
+// });
 
 const cssConfig = () => ({
     filename: 'trader/css/trader.main.[contenthash].css',
@@ -72,7 +72,7 @@ const stylelintConfig = () => ({
 
 module.exports = {
     htmlOutputConfig,
-    htmlInjectConfig,
+    // htmlInjectConfig,
     cssConfig,
     stylelintConfig,
     generateSWConfig,

--- a/packages/trader/build/config.js
+++ b/packages/trader/build/config.js
@@ -24,40 +24,6 @@ const htmlOutputConfig = () => ({
           },
 });
 
-// const htmlInjectConfig = () => ({ // commented out in trader/build/constants.js
-//     links: [
-//         {
-//             path: 'favicon.ico',
-//             attributes: {
-//                 rel: 'icon',
-//             },
-//         },
-//         ...[
-//             { name: 'favicon', rel: 'icon', size: '16' },
-//             { name: 'favicon', rel: 'icon', size: '32' },
-//             { name: 'favicon', rel: 'icon', size: '96' },
-//             { name: 'favicon', rel: 'icon', size: '160' },
-//             { name: 'favicon', rel: 'icon', size: '192' },
-//             { name: 'apple-touch-icon', size: '57' },
-//             { name: 'apple-touch-icon', size: '60' },
-//             { name: 'apple-touch-icon', size: '72' },
-//             { name: 'apple-touch-icon', size: '76' },
-//             { name: 'apple-touch-icon', size: '114' },
-//             { name: 'apple-touch-icon', size: '120' },
-//             { name: 'apple-touch-icon', size: '144' },
-//             { name: 'apple-touch-icon', size: '152' },
-//             { name: 'apple-touch-icon', size: '180' },
-//         ].map(({ name, rel, size }) => ({
-//             path: `public/images/favicons/${name}-${size}.png`,
-//             attributes: {
-//                 rel: rel || name,
-//                 sizes: `${size}x${size}`,
-//             },
-//         })),
-//     ],
-//     append: false,
-// });
-
 const cssConfig = () => ({
     filename: 'trader/css/trader.main.[contenthash].css',
     chunkFilename: 'trader/css/trader.[name].[contenthash].css',
@@ -72,7 +38,6 @@ const stylelintConfig = () => ({
 
 module.exports = {
     htmlOutputConfig,
-    // htmlInjectConfig,
     cssConfig,
     stylelintConfig,
     generateSWConfig,


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-   Loading favicons based on size & excluded them from service worker in order to not load any extra.

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [x] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
