### PR TITLE
Amina/ refresh_poa_page_error

### DIFF
--- a/packages/core/src/Stores/notification-store.js
+++ b/packages/core/src/Stores/notification-store.js
@@ -327,7 +327,7 @@ export default class NotificationStore extends BaseStore {
                 if (is_p2p_visible) {
                     this.addNotificationMessage(this.client_notifications.dp2p);
                 } else {
-                    this.removeNotificationMessageByKey({ key: this.client_notifications.dp2p.key });
+                    this.removeNotificationMessageByKey({ key: this.client_notifications?.dp2p?.key });
                 }
 
                 if (is_website_up && !has_trustpilot) {
@@ -350,7 +350,7 @@ export default class NotificationStore extends BaseStore {
         if (!is_eu && isMultiplierContract(selected_contract_type) && current_language === 'EN' && is_logged_in) {
             this.addNotificationMessage(this.client_notifications.deriv_go);
         } else {
-            this.removeNotificationMessageByKey({ key: this.client_notifications.deriv_go.key });
+            this.removeNotificationMessageByKey({ key: this.client_notifications?.deriv_go?.key });
         }
         this.setShouldShowPopups(true);
     }

--- a/packages/core/src/Stores/notification-store.js
+++ b/packages/core/src/Stores/notification-store.js
@@ -191,7 +191,7 @@ export default class NotificationStore extends BaseStore {
         const virtual_account = landing_company_shortcode === 'virtual';
         const is_website_up = website_status.site_status === 'up';
         const has_trustpilot = LocalStore.getObject('notification_messages')[loginid]?.includes(
-            this.client_notifications.trustpilot.key
+            this.client_notifications?.trustpilot?.key
         );
 
         let has_missing_required_field;


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-   Removing dp2p and deriv_go notifications only if they exist
- Redmine card - https://redmine.deriv.cloud/issues/62853#Refreshing_POA_page_gives_error_page 
## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
