### PR TITLE
Publish to Cloudflare (on push master, on tag production)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,6 +157,21 @@ commands:
             cd devops-ci-scripts/k8s-build_tools
             echo $CA_CRT | base64 --decode > ca.crt
             ./release.sh << parameters.k8s_service >> ${TAG}
+
+  publish_to_pages_staging:
+    description: "Publish to cloudflare pages"
+    steps:
+      - run:
+          name: "Publish to cloudflare pages (staging)"
+          command: cd packages/core && npx wrangler pages publish dist/ --project-name=deriv-app-pages --branch=staging
+
+  publish_to_pages_production:
+    description: "Publish to cloudflare pages"
+    steps:
+      - run:
+          name: "Publish to cloudflare pages (production)"
+          command: cd packages/core && npx wrangler pages publish dist/ --project-name=deriv-app-pages --branch=main
+
 jobs:
   build:
     docker:
@@ -195,6 +210,10 @@ jobs:
       - build
       - versioning:
           version_name: staging
+      - persist_to_workspace:
+          root: packages
+          paths:
+            - core
       - docker_build_push
       - k8s_deploy
       - notify_slack
@@ -210,11 +229,35 @@ jobs:
       - build
       - versioning:
           version_name: production
+      - persist_to_workspace:
+          root: packages
+          paths:
+            - core
       - docker_build_push:
           docker_image_latest_tag: latest
       - k8s_deploy:
           k8s_namespace: "deriv-app-production"
       - notify_slack
+    environment:
+      NODE_ENV: staging
+
+  publish_cloudflare_staging:
+    docker:
+      - image: circleci/node:16.13.1-stretch
+    steps:
+      - attach_workspace:
+          at: packages
+      - publish_to_pages_staging
+    environment:
+      NODE_ENV: staging
+
+  publish_cloudflare_production:
+    docker:
+      - image: circleci/node:16.13.1-stretch
+    steps:
+      - attach_workspace:
+          at: packages
+      - publish_to_pages_production
     environment:
       NODE_ENV: staging
 
@@ -248,11 +291,25 @@ workflows:
           filters:
             branches:
               only: /^master$/
+      - publish_cloudflare_staging:
+          requires:
+            - release_staging
+          filters:
+            branches:
+              only: /^master$/
 
   release_production:
     jobs:
       - release_production:
           context: binary-frontend-artifact-upload
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^production.*/
+      - publish_cloudflare_production:
+          requires:
+            - release_production
           filters:
             branches:
               ignore: /.*/

--- a/.github/workflows/generate_and_push_deriv_api_types.md
+++ b/.github/workflows/generate_and_push_deriv_api_types.md
@@ -1,6 +1,6 @@
 # Generate and push Deriv API TypeScript types
 
-This action takes Deriv API's JSON schema (published at https://github.com/binary-com/websockets/tree/gh-pages/config/v3) and converts it into consumable TypeScript types. 
+This action takes Deriv API's JSON schema (published at https://github.com/binary-com/websockets/tree/gh-pages/config/v3) and converts it into consumable TypeScript types.
 
 If the action detects the contents of the generated `index.d.ts` file has changed, it will attempt to publish a new version of `@deriv/api-types` to the NPM registry (https://www.npmjs.com/package/@deriv/api-types).
 
@@ -10,5 +10,5 @@ After a new version has been published the action will automatically create a PR
 
 Required GitHub secrets:
 
-- `NPM_ACCESS_TOKEN`: To allow for automatic publishing of new version of `@deriv/api-types`
-- `PERSONAL_ACCESS_TOKEN`: (GitHub PAT) To allow the action to authenticate with Git for git operations.
+-   `NPM_ACCESS_TOKEN`: To allow for automatic publishing of new version of `@deriv/api-types`
+-   `PERSONAL_ACCESS_TOKEN`: (GitHub PAT) To allow the action to authenticate with Git for git operations.

--- a/.github/workflows/push_and_pull_crowdin_translations.md
+++ b/.github/workflows/push_and_pull_crowdin_translations.md
@@ -4,6 +4,6 @@ This action will automatically extract strings from the Deriv.app repo and uploa
 
 Required GitHub secrets:
 
-- `NPM_ACCESS_TOKEN`: To allow for automatic publishing of new version of `@deriv/api-types`
-- `PERSONAL_ACCESS_TOKEN`: (GitHub PAT) To allow the action to authenticate with Git for git operations.
-- `CROWDIN_API_TOKEN`: To allow us to download and upload new language files to and from Crowdin.
+-   `NPM_ACCESS_TOKEN`: To allow for automatic publishing of new version of `@deriv/api-types`
+-   `PERSONAL_ACCESS_TOKEN`: (GitHub PAT) To allow the action to authenticate with Git for git operations.
+-   `CROWDIN_API_TOKEN`: To allow us to download and upload new language files to and from Crowdin.


### PR DESCRIPTION
DO NOT MERGE
- [ ] Add environment variables (Cloudflare account id and token API) to CircleCI deriv-app

## Changes:

- Publish website to Cloudflare pages: [cf-pages-app.deriv.com](https://cf-pages-app.deriv.com/) and [staging.cf-pages-app.deriv.com](https://staging.cf-pages-app.deriv.com)

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [x] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
