### PR TITLE
Maryia/fix: CompositeCalendarMobile loading in Statements

### DIFF
--- a/packages/components/src/components/data-list/data-list-row.jsx
+++ b/packages/components/src/components/data-list/data-list-row.jsx
@@ -23,7 +23,7 @@ const DataListRow = ({
                 measure?.();
             }
         });
-    }, [show_desc, isMounted, is_dynamic_height, measure]);
+    }, [show_desc, is_dynamic_height, measure]);
     return (
         <div className='data-list__row--wrapper' style={{ paddingBottom: `${row_gap || 0}px` }}>
             {destination_link ? (

--- a/packages/reports/src/Components/placeholder-component.jsx
+++ b/packages/reports/src/Components/placeholder-component.jsx
@@ -24,7 +24,7 @@ PlaceholderComponent.propTypes = {
     empty_message_component: PropTypes.func,
     has_selected_date: PropTypes.bool,
     is_empty: PropTypes.bool,
-    is_loading: PropTypes.node,
+    is_loading: PropTypes.bool,
     localized_message: PropTypes.string,
     localized_period_message: PropTypes.string,
 };


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-   fixed CompositeCalendarMobile loading in statements by eliminating DataListRow's infinite update
-   additionally: eliminated some console warnings encountered

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
