### PR TITLE
yauheni / 70841 trackJS setUserId should be string

### DIFF
--- a/packages/core/src/Stores/rudderstack-store.js
+++ b/packages/core/src/Stores/rudderstack-store.js
@@ -19,7 +19,7 @@ export default class RudderStackStore extends BaseStore {
         new Promise(resolve => {
             if (this.is_applicable && !this.has_identified) {
                 BinarySocket.wait('authorize').then(() => {
-                    const user_id = this.root_store.client.user_id;
+                    const user_id = this.root_store.client.user_id.toString();
                     if (user_id) {
                         window.rudderanalytics.identify(user_id, {
                             language: getLanguage().toLowerCase(),


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:

-   accordingly to rudderstack documentation identify method should take first param userId as a string.
currently coming from client-store user_id is number

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
