### PR TITLE
Amina/fix: next button enabled for svg account even after account added

### DIFF
--- a/packages/cfd/src/Containers/jurisdiction-modal.tsx
+++ b/packages/cfd/src/Containers/jurisdiction-modal.tsx
@@ -3,7 +3,13 @@ import { Button, Modal, DesktopWrapper, MobileDialog, MobileWrapper, UILoader } 
 import { localize, Localize } from '@deriv/translations';
 import { connect } from 'Stores/connect';
 import RootStore from 'Stores/index';
-import { GetAccountSettingsResponse, GetSettings, LandingCompany, GetAccountStatus } from '@deriv/api-types';
+import {
+    GetAccountSettingsResponse,
+    GetSettings,
+    LandingCompany,
+    GetAccountStatus,
+    DetailsOfEachMT5Loginid,
+} from '@deriv/api-types';
 import JurisdictionModalContent from './jurisdiction-modal-content';
 import { WS, getIdentityStatusInfo } from '@deriv/shared';
 import { TTradingPlatformAvailableAccount } from '../Components/props.types';
@@ -47,6 +53,7 @@ type TJurisdictionModalProps = TCompareAccountsReusedProps & {
     setJurisdictionSelectedShortcode: (shortcode: string) => void;
     toggleCFDVerificationModal: () => void;
     account_status: GetAccountStatus;
+    mt5_login_list: DetailsOfEachMT5Loginid[];
 };
 
 const JurisdictionModal = ({
@@ -67,6 +74,7 @@ const JurisdictionModal = ({
     setJurisdictionSelectedShortcode,
     toggleCFDVerificationModal,
     account_status,
+    mt5_login_list,
 }: TJurisdictionModalProps) => {
     const [checked, setChecked] = React.useState(false);
     const [has_submitted_personal_details, setHasSubmittedPersonalDetails] = React.useState(false);
@@ -92,13 +100,26 @@ const JurisdictionModal = ({
     const poa_failed = poa_status === 'suspected' || poa_status === 'rejected' || poa_status === 'expired';
     const poi_poa_not_submitted = poi_status === 'none' || poa_status === 'none';
 
-    React.useEffect(() => {
-        if (is_jurisdiction_modal_visible) {
-            if ((poa_status === 'pending' || poi_status === 'pending') && !is_eu) {
+    const selectSVGJurisdiction = () => {
+        if (account_type.type && account_type.category && !is_eu) {
+            const created_svg_accounts = mt5_login_list.filter(
+                data =>
+                    data.market_type === account_type.type &&
+                    data.landing_company_short === 'svg' &&
+                    data.account_type === 'real'
+            );
+            if (!created_svg_accounts.length && (poa_status === 'pending' || poi_status === 'pending')) {
                 setJurisdictionSelectedShortcode('svg');
             } else {
                 setJurisdictionSelectedShortcode('');
             }
+        } else {
+            setJurisdictionSelectedShortcode('');
+        }
+    };
+    React.useEffect(() => {
+        if (is_jurisdiction_modal_visible) {
+            selectSVGJurisdiction();
             if (!has_submitted_personal_details) {
                 let get_settings_response: GetSettings = {};
                 if (!account_settings) {
@@ -351,4 +372,5 @@ export default connect(({ modules, ui, client }: RootStore) => ({
     toggleCFDVerificationModal: modules.cfd.toggleCFDVerificationModal,
     setJurisdictionSelectedShortcode: modules.cfd.setJurisdictionSelectedShortcode,
     account_status: client.account_status,
+    mt5_login_list: client.mt5_login_list,
 }))(JurisdictionModal);

--- a/packages/cfd/src/Containers/jurisdiction-modal.tsx
+++ b/packages/cfd/src/Containers/jurisdiction-modal.tsx
@@ -101,7 +101,7 @@ const JurisdictionModal = ({
     const poi_poa_not_submitted = poi_status === 'none' || poa_status === 'none';
 
     const selectSVGJurisdiction = () => {
-        if (account_type.type && account_type.category && !is_eu) {
+        if (account_type.type && !is_eu) {
             const created_svg_accounts = mt5_login_list.filter(
                 data =>
                     data.market_type === account_type.type &&


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
- Adding condition to check if svg account is already created 
-   
- ## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
