### PR TITLE
yauheni / 73173 mobx circular dependecy fix

### DIFF
--- a/packages/core/src/Stores/Modules/index.js
+++ b/packages/core/src/Stores/Modules/index.js
@@ -1,8 +1,4 @@
 export default class ModulesStore {
-    constructor(root_store) {
-        this.root_store = root_store;
-    }
-
     attachModule(name, module) {
         this[name] = module;
     }

--- a/packages/core/src/Stores/index.js
+++ b/packages/core/src/Stores/index.js
@@ -17,7 +17,7 @@ export default class RootStore {
     constructor() {
         this.client = new ClientStore(this);
         this.common = new CommonStore(this);
-        this.modules = new ModulesStore(this);
+        this.modules = new ModulesStore();
         this.ui = new UIStore(this);
         this.gtm = new GTMStore(this);
         this.rudderstack = new RudderStackStore(this);


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-   we had circular dependency because during creation instance of RootStore we pass 'this' into ModulesStore, and then save it to instance of ModulesStore, and inside of this instance we will have reference to root_store, which has a modules...and so on...

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
