### PR TITLE
yauheni / 65898 out of bound index mobx warning

### DIFF
--- a/packages/core/src/App/Containers/Layout/header/default-header.jsx
+++ b/packages/core/src/App/Containers/Layout/header/default-header.jsx
@@ -140,7 +140,7 @@ const DefaultHeader = ({
                             <div className='header__menu-left-extensions'>{header_extension}</div>
                         )}
                     </MobileWrapper>
-                    {menu_items && replaceCashierMenuOnclick()}
+                    {menu_items && is_logged_in && replaceCashierMenuOnclick()}
                     <MenuLinks is_logged_in={is_logged_in} items={menu_items} />
                 </div>
                 <div


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-   we should not call replaceCashierMenuOnclick() being logged out, because cashier menu is not allowed for unlogged users. This function replace cashier object in array in menu-store. But being logged out there is no such object

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
