### PR TITLE
MaryiaF/fix:  Quick Strategy - Size textbox error always displays as …

### DIFF
--- a/packages/bot-web-ui/src/components/quick-strategy/quick-strategy.jsx
+++ b/packages/bot-web-ui/src/components/quick-strategy/quick-strategy.jsx
@@ -35,6 +35,10 @@ const InputSize = ({
     touched,
     is_mobile,
     getFieldNames,
+    toggleValuesFlags,
+    setValidationErrors,
+    validateQuickStrategy,
+    values,
 }) => {
     const input_name = Object.freeze({
         0: 'input_size',
@@ -58,7 +62,11 @@ const InputSize = ({
                         onChangeInputValue(input_name[active_index], e);
                     }}
                     onFocus={e => setCurrentFocus(e.currentTarget.name)}
-                    onBlur={() => setCurrentFocus(null)}
+                    onBlur={e => {
+                        setCurrentFocus(null);
+                        toggleValuesFlags(e.currentTarget.name);
+                        setValidationErrors(validateQuickStrategy(values));
+                    }}
                     placeholder='2'
                     trailing_icon={
                         <Popover
@@ -98,374 +106,424 @@ const QuickStrategyForm = ({
     description,
     setCurrentFocus,
     getFieldNames,
-}) => (
-    <Formik
-        initialValues={initial_values}
-        validate={validateQuickStrategy}
-        onSubmit={createStrategy}
-        enableReinitialize={true}
-    >
-        {({ errors, handleChange, values, isSubmitting, setFieldValue, touched, submitForm }) => {
-            // Check values in favour of isValid, this is a hack to persist validation through tab switching.
-            const validation_errors = validateQuickStrategy(values);
-            const is_valid = Object.keys(validation_errors).length === 0;
+    toggleValuesFlags,
+}) => {
+    const [validation_errors, setValidationErrors] = React.useState({});
+    let formValues = {};
+    React.useEffect(() => {
+        // Check values in favour of isValid, this is a hack to persist validation through tab switching.
+        setValidationErrors(validateQuickStrategy(formValues));
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return (
+        <Formik
+            initialValues={initial_values}
+            validate={validateQuickStrategy}
+            onSubmit={createStrategy}
+            enableReinitialize={true}
+        >
+            {({ errors, handleChange, values, isSubmitting, setFieldValue, touched, submitForm }) => {
+                formValues = values;
+                const is_valid = Object.keys(validation_errors).length === 0;
+                const is_submit_enabled = !isSubmitting && is_valid;
 
-            const is_submit_enabled = !isSubmitting && is_valid;
-
-            return (
-                <Form
-                    className={classNames('quick-strategy__form', {
-                        'quick-strategy__form--active-keyboard': is_onscreen_keyboard_active,
-                    })}
-                >
-                    <ThemedScrollbars height='430px' autohide is_bypassed={is_mobile}>
-                        <div
-                            className={classNames('quick-strategy__form-content', {
-                                'quick-strategy__form-content--active-keyboard': is_onscreen_keyboard_active,
-                                'quick-strategy__form-content--safari-fix': isSafari(),
-                            })}
-                        >
-                            <div className='quick-strategy__description'>{description}</div>
-                            <div className='quick-strategy__form-row'>
-                                <Field name='quick-strategy__symbol'>
-                                    {({ field }) => (
-                                        <>
-                                            {is_mobile ? (
-                                                <SelectNative
-                                                    list_items={symbol_dropdown}
-                                                    value={selected_symbol.value}
-                                                    label={localize('Asset')}
-                                                    should_show_empty_option={false}
-                                                    onChange={e => {
-                                                        onChangeDropdownItem('symbol', e.target.value, setFieldValue);
-                                                    }}
-                                                />
-                                            ) : (
-                                                <Autocomplete
-                                                    {...field}
-                                                    autoComplete='off'
-                                                    className='quick-strategy__dropdown quick-strategy__leading'
-                                                    type='text'
-                                                    label={localize('Asset')}
-                                                    list_items={symbol_dropdown}
-                                                    onHideDropdownList={() => {
-                                                        onHideDropdownList('symbol', values[field.name], setFieldValue);
-                                                    }}
-                                                    onItemSelection={({ value }) => {
-                                                        onChangeDropdownItem('symbol', value, setFieldValue);
-                                                    }}
-                                                    onScrollStop={() => onScrollStopDropdownList('symbol')}
-                                                    leading_icon={
-                                                        selected_symbol.value && (
-                                                            <Icon
-                                                                icon={`IcUnderlying${selected_symbol.value}`}
-                                                                size={24}
-                                                            />
-                                                        )
-                                                    }
-                                                />
-                                            )}
-                                        </>
-                                    )}
-                                </Field>
-                            </div>
-                            <div className='quick-strategy__form-row'>
-                                <Field name='quick-strategy__trade-type'>
-                                    {({ field }) => (
-                                        <>
-                                            {is_mobile ? (
-                                                <SelectNative
-                                                    list_items={trade_type_dropdown}
-                                                    value={selected_trade_type.value}
-                                                    label={localize('Trade type')}
-                                                    should_show_empty_option={false}
-                                                    onChange={e => {
-                                                        onChangeDropdownItem(
-                                                            'trade-type',
-                                                            e.target.value,
-                                                            setFieldValue
-                                                        );
-                                                    }}
-                                                />
-                                            ) : (
-                                                <Autocomplete
-                                                    {...field}
-                                                    autoComplete='off'
-                                                    className='quick-strategy__dropdown quick-strategy__leading'
-                                                    type='text'
-                                                    label={localize('Trade type')}
-                                                    list_items={trade_type_dropdown}
-                                                    onHideDropdownList={() => {
-                                                        onHideDropdownList(
-                                                            'trade-type',
-                                                            values[field.name],
-                                                            setFieldValue
-                                                        );
-                                                    }}
-                                                    onItemSelection={({ value }) => {
-                                                        onChangeDropdownItem('trade-type', value, setFieldValue);
-                                                    }}
-                                                    onScrollStop={() => onScrollStopDropdownList('trade-type')}
-                                                    leading_icon={
-                                                        selected_trade_type.icon && (
-                                                            <Text>
-                                                                <IconTradeTypes type={selected_trade_type.icon[0]} />
-                                                                <IconTradeTypes type={selected_trade_type.icon[1]} />
-                                                            </Text>
-                                                        )
-                                                    }
-                                                />
-                                            )}
-                                        </>
-                                    )}
-                                </Field>
-                            </div>
-                            <div
-                                className={classNames('quick-strategy__form-row', {
-                                    'quick-strategy__form-row--multiple': !is_mobile,
-                                })}
-                            >
-                                <Field name='quick-strategy__duration-unit'>
-                                    {({ field }) => (
-                                        <>
-                                            {is_mobile ? (
-                                                <SelectNative
-                                                    list_items={duration_unit_dropdown}
-                                                    value={selected_duration_unit.value}
-                                                    label={localize('Duration unit')}
-                                                    should_show_empty_option={false}
-                                                    onChange={e => {
-                                                        onChangeDropdownItem(
-                                                            'duration-unit',
-                                                            e.target.value,
-                                                            setFieldValue
-                                                        );
-                                                    }}
-                                                />
-                                            ) : (
-                                                <Autocomplete
-                                                    {...field}
-                                                    autoComplete='off'
-                                                    type='text'
-                                                    label={localize('Duration unit')}
-                                                    list_items={duration_unit_dropdown}
-                                                    disabled={duration_unit_dropdown.length === 1}
-                                                    onHideDropdownList={() => {
-                                                        onHideDropdownList(
-                                                            'duration-unit',
-                                                            values[field.name],
-                                                            setFieldValue
-                                                        );
-                                                    }}
-                                                    onItemSelection={({ value }) => {
-                                                        onChangeDropdownItem('duration-unit', value, setFieldValue);
-                                                    }}
-                                                    onScrollStop={() => onScrollStopDropdownList('duration-unit')}
-                                                />
-                                            )}
-                                        </>
-                                    )}
-                                </Field>
-                                <Field name='quick-strategy__duration-value'>
-                                    {({ field }) => (
-                                        <Input
-                                            {...field}
-                                            className='quick-strategy__input'
-                                            label_className='quick-strategy__input-label'
-                                            field_className='quick-strategy__input-field'
-                                            type='text'
-                                            error={
-                                                initial_errors[field.name] ||
-                                                (touched[field.name] && errors[field.name])
-                                            }
-                                            label={localize('Duration value')}
-                                            onChange={e => {
-                                                handleChange(e);
-                                                onChangeInputValue('input_duration_value', e);
-                                            }}
-                                            onFocus={e => setCurrentFocus(e.currentTarget.name)}
-                                            onBlur={() => setCurrentFocus(null)}
-                                            placeholder='5'
-                                            trailing_icon={
-                                                <Popover
-                                                    alignment={is_mobile ? 'top' : 'bottom'}
-                                                    message={localize('The trade length of your purchased contract.')}
-                                                    zIndex={popover_zindex.QUICK_STRATEGY}
-                                                >
-                                                    <Icon icon='IcInfoOutline' />
-                                                </Popover>
-                                            }
-                                        />
-                                    )}
-                                </Field>
-                            </div>
-                            <div
-                                className={classNames('quick-strategy__form-row', {
-                                    'quick-strategy__form-row--multiple': !is_mobile,
-                                })}
-                            >
-                                <Field name='quick-strategy__stake'>
-                                    {({ field }) => (
-                                        <Input
-                                            {...field}
-                                            className='quick-strategy__input'
-                                            label_className='quick-strategy__input-label'
-                                            field_className='quick-strategy__input-field'
-                                            type='text'
-                                            error={
-                                                initial_errors[field.name] ||
-                                                (touched[field.name] && errors[field.name])
-                                            }
-                                            label={localize('Initial stake')}
-                                            onChange={e => {
-                                                handleChange(e);
-                                                onChangeInputValue('input_stake', e);
-                                            }}
-                                            onFocus={e => setCurrentFocus(e.currentTarget.name)}
-                                            onBlur={() => setCurrentFocus(null)}
-                                            placeholder='10'
-                                            trailing_icon={
-                                                <Popover
-                                                    alignment={is_mobile ? 'top' : 'bottom'}
-                                                    message={localize('The amount that you pay to enter a trade.')}
-                                                    zIndex={popover_zindex.QUICK_STRATEGY}
-                                                >
-                                                    <Icon icon='IcInfoOutline' />
-                                                </Popover>
-                                            }
-                                        />
-                                    )}
-                                </Field>
-                                <Field name='quick-strategy__loss'>
-                                    {({ field }) => (
-                                        <Input
-                                            {...field}
-                                            className='quick-strategy__input'
-                                            label_className='quick-strategy__input-label'
-                                            field_className='quick-strategy__input-field'
-                                            type='text'
-                                            error={
-                                                initial_errors[field.name] ||
-                                                (touched[field.name] && errors[field.name])
-                                            }
-                                            label={localize('Loss threshold')}
-                                            onChange={e => {
-                                                handleChange(e);
-                                                onChangeInputValue('input_loss', e);
-                                            }}
-                                            onFocus={e => setCurrentFocus(e.currentTarget.name)}
-                                            onBlur={() => setCurrentFocus(null)}
-                                            placeholder='5000'
-                                            trailing_icon={
-                                                <Popover
-                                                    alignment={is_mobile ? 'top' : 'bottom'}
-                                                    message={localize(
-                                                        'The bot will stop trading if your total loss exceeds this amount.'
-                                                    )}
-                                                    zIndex={popover_zindex.QUICK_STRATEGY}
-                                                >
-                                                    <Icon icon='IcInfoOutline' />
-                                                </Popover>
-                                            }
-                                        />
-                                    )}
-                                </Field>
-                            </div>
-                            <div
-                                className={classNames('quick-strategy__form-row', {
-                                    'quick-strategy__form-row--multiple': !is_mobile,
-                                })}
-                            >
-                                <InputSize
-                                    onChangeInputValue={onChangeInputValue}
-                                    handleChange={handleChange}
-                                    active_index={active_index}
-                                    getSizeDesc={getSizeDesc}
-                                    getSizeText={getSizeText}
-                                    initial_errors={validation_errors}
-                                    errors={errors}
-                                    setCurrentFocus={setCurrentFocus}
-                                    touched={touched}
-                                    is_mobile={is_mobile}
-                                    getFieldNames={getFieldNames}
-                                />
-
-                                <Field name='quick-strategy__profit'>
-                                    {({ field }) => (
-                                        <Input
-                                            {...field}
-                                            className='quick-strategy__input'
-                                            label_className='quick-strategy__input-label'
-                                            field_className='quick-strategy__input-field'
-                                            type='text'
-                                            error={
-                                                initial_errors[field.name] ||
-                                                (touched[field.name] && errors[field.name])
-                                            }
-                                            label={localize('Profit threshold')}
-                                            onChange={e => {
-                                                handleChange(e);
-                                                onChangeInputValue('input_profit', e);
-                                            }}
-                                            onFocus={e => setCurrentFocus(e.currentTarget.name)}
-                                            onBlur={() => setCurrentFocus(null)}
-                                            placeholder='5000'
-                                            trailing_icon={
-                                                <Popover
-                                                    alignment={is_mobile ? 'top' : 'bottom'}
-                                                    message={localize(
-                                                        'The bot will stop trading if your total profit exceeds this amount.'
-                                                    )}
-                                                    zIndex={popover_zindex.QUICK_STRATEGY}
-                                                >
-                                                    <Icon icon='IcInfoOutline' />
-                                                </Popover>
-                                            }
-                                        />
-                                    )}
-                                </Field>
-                            </div>
-                        </div>
-                    </ThemedScrollbars>
-                    <div
-                        className={classNames('quick-strategy__form-footer', {
-                            'quick-strategy__form-footer--active-keyboard': is_onscreen_keyboard_active,
+                return (
+                    <Form
+                        className={classNames('quick-strategy__form', {
+                            'quick-strategy__form--active-keyboard': is_onscreen_keyboard_active,
                         })}
                     >
-                        <Button.Group>
-                            {!is_mobile && (
+                        <ThemedScrollbars height='430px' autohide is_bypassed={is_mobile}>
+                            <div
+                                className={classNames('quick-strategy__form-content', {
+                                    'quick-strategy__form-content--active-keyboard': is_onscreen_keyboard_active,
+                                    'quick-strategy__form-content--safari-fix': isSafari(),
+                                })}
+                            >
+                                <div className='quick-strategy__description'>{description}</div>
+                                <div className='quick-strategy__form-row'>
+                                    <Field name='quick-strategy__symbol'>
+                                        {({ field }) => (
+                                            <>
+                                                {is_mobile ? (
+                                                    <SelectNative
+                                                        list_items={symbol_dropdown}
+                                                        value={selected_symbol.value}
+                                                        label={localize('Asset')}
+                                                        should_show_empty_option={false}
+                                                        onChange={e => {
+                                                            onChangeDropdownItem(
+                                                                'symbol',
+                                                                e.target.value,
+                                                                setFieldValue
+                                                            );
+                                                        }}
+                                                    />
+                                                ) : (
+                                                    <Autocomplete
+                                                        {...field}
+                                                        autoComplete='off'
+                                                        className='quick-strategy__dropdown quick-strategy__leading'
+                                                        type='text'
+                                                        label={localize('Asset')}
+                                                        list_items={symbol_dropdown}
+                                                        onHideDropdownList={() => {
+                                                            onHideDropdownList(
+                                                                'symbol',
+                                                                values[field.name],
+                                                                setFieldValue
+                                                            );
+                                                        }}
+                                                        onItemSelection={({ value }) => {
+                                                            onChangeDropdownItem('symbol', value, setFieldValue);
+                                                        }}
+                                                        onScrollStop={() => onScrollStopDropdownList('symbol')}
+                                                        leading_icon={
+                                                            selected_symbol.value && (
+                                                                <Icon
+                                                                    icon={`IcUnderlying${selected_symbol.value}`}
+                                                                    size={24}
+                                                                />
+                                                            )
+                                                        }
+                                                    />
+                                                )}
+                                            </>
+                                        )}
+                                    </Field>
+                                </div>
+                                <div className='quick-strategy__form-row'>
+                                    <Field name='quick-strategy__trade-type'>
+                                        {({ field }) => (
+                                            <>
+                                                {is_mobile ? (
+                                                    <SelectNative
+                                                        list_items={trade_type_dropdown}
+                                                        value={selected_trade_type.value}
+                                                        label={localize('Trade type')}
+                                                        should_show_empty_option={false}
+                                                        onChange={e => {
+                                                            onChangeDropdownItem(
+                                                                'trade-type',
+                                                                e.target.value,
+                                                                setFieldValue
+                                                            );
+                                                        }}
+                                                    />
+                                                ) : (
+                                                    <Autocomplete
+                                                        {...field}
+                                                        autoComplete='off'
+                                                        className='quick-strategy__dropdown quick-strategy__leading'
+                                                        type='text'
+                                                        label={localize('Trade type')}
+                                                        list_items={trade_type_dropdown}
+                                                        onHideDropdownList={() => {
+                                                            onHideDropdownList(
+                                                                'trade-type',
+                                                                values[field.name],
+                                                                setFieldValue
+                                                            );
+                                                        }}
+                                                        onItemSelection={({ value }) => {
+                                                            onChangeDropdownItem('trade-type', value, setFieldValue);
+                                                        }}
+                                                        onScrollStop={() => onScrollStopDropdownList('trade-type')}
+                                                        leading_icon={
+                                                            selected_trade_type.icon && (
+                                                                <Text>
+                                                                    <IconTradeTypes
+                                                                        type={selected_trade_type.icon[0]}
+                                                                    />
+                                                                    <IconTradeTypes
+                                                                        type={selected_trade_type.icon[1]}
+                                                                    />
+                                                                </Text>
+                                                            )
+                                                        }
+                                                    />
+                                                )}
+                                            </>
+                                        )}
+                                    </Field>
+                                </div>
+                                <div
+                                    className={classNames('quick-strategy__form-row', {
+                                        'quick-strategy__form-row--multiple': !is_mobile,
+                                    })}
+                                >
+                                    <Field name='quick-strategy__duration-unit'>
+                                        {({ field }) => (
+                                            <>
+                                                {is_mobile ? (
+                                                    <SelectNative
+                                                        list_items={duration_unit_dropdown}
+                                                        value={selected_duration_unit.value}
+                                                        label={localize('Duration unit')}
+                                                        should_show_empty_option={false}
+                                                        onChange={e => {
+                                                            onChangeDropdownItem(
+                                                                'duration-unit',
+                                                                e.target.value,
+                                                                setFieldValue
+                                                            );
+                                                        }}
+                                                    />
+                                                ) : (
+                                                    <Autocomplete
+                                                        {...field}
+                                                        autoComplete='off'
+                                                        type='text'
+                                                        label={localize('Duration unit')}
+                                                        list_items={duration_unit_dropdown}
+                                                        disabled={duration_unit_dropdown.length === 1}
+                                                        onHideDropdownList={() => {
+                                                            onHideDropdownList(
+                                                                'duration-unit',
+                                                                values[field.name],
+                                                                setFieldValue
+                                                            );
+                                                        }}
+                                                        onItemSelection={({ value }) => {
+                                                            onChangeDropdownItem('duration-unit', value, setFieldValue);
+                                                        }}
+                                                        onScrollStop={() => onScrollStopDropdownList('duration-unit')}
+                                                    />
+                                                )}
+                                            </>
+                                        )}
+                                    </Field>
+                                    <Field name='quick-strategy__duration-value'>
+                                        {({ field }) => (
+                                            <Input
+                                                {...field}
+                                                className='quick-strategy__input'
+                                                label_className='quick-strategy__input-label'
+                                                field_className='quick-strategy__input-field'
+                                                type='text'
+                                                error={
+                                                    initial_errors[field.name] ||
+                                                    //this condition should be changed because affects to other types of strategies, but without validation_errors we never display some error messages
+                                                    (active_index === 0 ? validation_errors[field.name] : null) ||
+                                                    (touched[field.name] && errors[field.name])
+                                                }
+                                                label={localize('Duration value')}
+                                                onChange={e => {
+                                                    handleChange(e);
+                                                    onChangeInputValue('input_duration_value', e);
+                                                }}
+                                                onFocus={e => setCurrentFocus(e.currentTarget.name)}
+                                                onBlur={e => {
+                                                    setCurrentFocus(null);
+                                                    toggleValuesFlags(e.currentTarget.name);
+                                                    setValidationErrors(validateQuickStrategy(values));
+                                                }}
+                                                placeholder='5'
+                                                trailing_icon={
+                                                    <Popover
+                                                        alignment={is_mobile ? 'top' : 'bottom'}
+                                                        message={localize(
+                                                            'The trade length of your purchased contract.'
+                                                        )}
+                                                        zIndex={popover_zindex.QUICK_STRATEGY}
+                                                    >
+                                                        <Icon icon='IcInfoOutline' />
+                                                    </Popover>
+                                                }
+                                            />
+                                        )}
+                                    </Field>
+                                </div>
+                                <div
+                                    className={classNames('quick-strategy__form-row', {
+                                        'quick-strategy__form-row--multiple': !is_mobile,
+                                    })}
+                                >
+                                    <Field name='quick-strategy__stake'>
+                                        {({ field }) => (
+                                            <Input
+                                                {...field}
+                                                className='quick-strategy__input'
+                                                label_className='quick-strategy__input-label'
+                                                field_className='quick-strategy__input-field'
+                                                type='text'
+                                                error={
+                                                    initial_errors[field.name] ||
+                                                    //this condition should be changed because affects to other types of strategies, but without validation_errors we never display some error messages
+                                                    (active_index === 0 ? validation_errors[field.name] : null) ||
+                                                    (touched[field.name] && errors[field.name])
+                                                }
+                                                label={localize('Initial stake')}
+                                                onChange={e => {
+                                                    handleChange(e);
+                                                    onChangeInputValue('input_stake', e);
+                                                }}
+                                                onFocus={e => setCurrentFocus(e.currentTarget.name)}
+                                                onBlur={e => {
+                                                    setCurrentFocus(null);
+                                                    toggleValuesFlags(e.currentTarget.name);
+                                                    setValidationErrors(validateQuickStrategy(values));
+                                                }}
+                                                placeholder='10'
+                                                trailing_icon={
+                                                    <Popover
+                                                        alignment={is_mobile ? 'top' : 'bottom'}
+                                                        message={localize('The amount that you pay to enter a trade.')}
+                                                        zIndex={popover_zindex.QUICK_STRATEGY}
+                                                    >
+                                                        <Icon icon='IcInfoOutline' />
+                                                    </Popover>
+                                                }
+                                            />
+                                        )}
+                                    </Field>
+                                    <Field name='quick-strategy__loss'>
+                                        {({ field }) => (
+                                            <Input
+                                                {...field}
+                                                className='quick-strategy__input'
+                                                label_className='quick-strategy__input-label'
+                                                field_className='quick-strategy__input-field'
+                                                type='text'
+                                                error={
+                                                    initial_errors[field.name] ||
+                                                    //this condition should be changed because affects to other types of strategies, but without validation_errors we never display some error messages
+                                                    (active_index === 0 ? validation_errors[field.name] : null) ||
+                                                    (touched[field.name] && errors[field.name])
+                                                }
+                                                label={localize('Loss threshold')}
+                                                onChange={e => {
+                                                    handleChange(e);
+                                                    onChangeInputValue('input_loss', e);
+                                                }}
+                                                onFocus={e => {
+                                                    setCurrentFocus(e.currentTarget.name);
+                                                    toggleValuesFlags(e.currentTarget.name);
+                                                    setValidationErrors(validateQuickStrategy(values));
+                                                }}
+                                                onBlur={() => setCurrentFocus(null)}
+                                                placeholder='5000'
+                                                trailing_icon={
+                                                    <Popover
+                                                        alignment={is_mobile ? 'top' : 'bottom'}
+                                                        message={localize(
+                                                            'The bot will stop trading if your total loss exceeds this amount.'
+                                                        )}
+                                                        zIndex={popover_zindex.QUICK_STRATEGY}
+                                                    >
+                                                        <Icon icon='IcInfoOutline' />
+                                                    </Popover>
+                                                }
+                                            />
+                                        )}
+                                    </Field>
+                                </div>
+                                <div
+                                    className={classNames('quick-strategy__form-row', {
+                                        'quick-strategy__form-row--multiple': !is_mobile,
+                                    })}
+                                >
+                                    <InputSize
+                                        onChangeInputValue={onChangeInputValue}
+                                        handleChange={handleChange}
+                                        active_index={active_index}
+                                        getSizeDesc={getSizeDesc}
+                                        getSizeText={getSizeText}
+                                        initial_errors={validation_errors}
+                                        errors={errors}
+                                        setCurrentFocus={setCurrentFocus}
+                                        touched={touched}
+                                        is_mobile={is_mobile}
+                                        getFieldNames={getFieldNames}
+                                        toggleValuesFlags={toggleValuesFlags}
+                                        setValidationErrors={setValidationErrors}
+                                        validateQuickStrategy={validateQuickStrategy}
+                                        values={values}
+                                    />
+
+                                    <Field name='quick-strategy__profit'>
+                                        {({ field }) => (
+                                            <Input
+                                                {...field}
+                                                className='quick-strategy__input'
+                                                label_className='quick-strategy__input-label'
+                                                field_className='quick-strategy__input-field'
+                                                type='text'
+                                                error={
+                                                    initial_errors[field.name] ||
+                                                    //this condition should be changed because affects to other types of strategies, but without validation_errors we never display some error messages
+                                                    (active_index === 0 ? validation_errors[field.name] : null) ||
+                                                    (touched[field.name] && errors[field.name])
+                                                }
+                                                label={localize('Profit threshold')}
+                                                onChange={e => {
+                                                    handleChange(e);
+                                                    onChangeInputValue('input_profit', e);
+                                                }}
+                                                onFocus={e => {
+                                                    setCurrentFocus(e.currentTarget.name);
+                                                    toggleValuesFlags(e.currentTarget.name);
+                                                    setValidationErrors(validateQuickStrategy(values));
+                                                }}
+                                                onBlur={() => setCurrentFocus(null)}
+                                                placeholder='5000'
+                                                trailing_icon={
+                                                    <Popover
+                                                        alignment={is_mobile ? 'top' : 'bottom'}
+                                                        message={localize(
+                                                            'The bot will stop trading if your total profit exceeds this amount.'
+                                                        )}
+                                                        zIndex={popover_zindex.QUICK_STRATEGY}
+                                                    >
+                                                        <Icon icon='IcInfoOutline' />
+                                                    </Popover>
+                                                }
+                                            />
+                                        )}
+                                    </Field>
+                                </div>
+                            </div>
+                        </ThemedScrollbars>
+                        <div
+                            className={classNames('quick-strategy__form-footer', {
+                                'quick-strategy__form-footer--active-keyboard': is_onscreen_keyboard_active,
+                            })}
+                        >
+                            <Button.Group>
+                                {!is_mobile && (
+                                    <Button
+                                        type='button'
+                                        id='db-quick-strategy__button-edit'
+                                        text={localize('Create and edit')}
+                                        is_disabled={!is_submit_enabled}
+                                        secondary
+                                        large
+                                        onClick={() => {
+                                            setFieldValue('button', 'edit');
+                                            submitForm();
+                                        }}
+                                    />
+                                )}
                                 <Button
                                     type='button'
-                                    id='db-quick-strategy__button-edit'
-                                    text={localize('Create and edit')}
-                                    is_disabled={!is_submit_enabled}
-                                    secondary
+                                    id='db-quick-strategy__button-run'
+                                    text={localize('Run')}
+                                    is_disabled={!is_submit_enabled || is_stop_button_visible}
+                                    primary
                                     large
                                     onClick={() => {
-                                        setFieldValue('button', 'edit');
+                                        setFieldValue('button', 'run');
                                         submitForm();
                                     }}
                                 />
-                            )}
-                            <Button
-                                type='button'
-                                id='db-quick-strategy__button-run'
-                                text={localize('Run')}
-                                is_disabled={!is_submit_enabled || is_stop_button_visible}
-                                primary
-                                large
-                                onClick={() => {
-                                    setFieldValue('button', 'run');
-                                    submitForm();
-                                }}
-                            />
-                        </Button.Group>
-                    </div>
-                </Form>
-            );
-        }}
-    </Formik>
-);
+                            </Button.Group>
+                        </div>
+                    </Form>
+                );
+            }}
+        </Formik>
+    );
+};
 
 const MarketOption = ({ symbol }) => (
     <div key={symbol.value} className='quick-strategy__option'>
@@ -511,6 +569,7 @@ const ContentRenderer = props => {
         selected_trade_type,
         setCurrentFocus,
         selected_duration_unit,
+        toggleValuesFlags,
     } = props;
     const symbol_dropdown_options = symbol_dropdown
         .map(symbol => ({
@@ -553,6 +612,7 @@ const ContentRenderer = props => {
                             selected_duration_unit={selected_duration_unit}
                             description={description}
                             setCurrentFocus={setCurrentFocus}
+                            toggleValuesFlags={toggleValuesFlags}
                         />
                     </div>
                 );
@@ -624,6 +684,7 @@ QuickStrategy.propTypes = {
 
 export default connect(({ run_panel, quick_strategy, ui }) => ({
     active_index: quick_strategy.active_index,
+    toggleValuesFlags: quick_strategy.toggleValuesFlags,
     createStrategy: quick_strategy.createStrategy,
     duration_unit_dropdown: quick_strategy.duration_unit_dropdown,
     getSizeDesc: quick_strategy.getSizeDesc,

--- a/packages/bot-web-ui/src/stores/quick-strategy-store.js
+++ b/packages/bot-web-ui/src/stores/quick-strategy-store.js
@@ -26,6 +26,7 @@ export default class QuickStrategyStore {
     @observable symbol_dropdown = [];
     @observable trade_type_dropdown = [];
     @observable duration_unit_dropdown = [];
+    @observable values_flags = [];
 
     @computed
     get initial_values() {
@@ -173,6 +174,13 @@ export default class QuickStrategyStore {
 
         if (this.is_strategy_modal_open) {
             await this.updateSymbolDropdown();
+        }
+    }
+
+    @action.bound
+    toggleValuesFlags(value_flag) {
+        if (!this.values_flags.includes(value_flag)) {
+            this.values_flags.push(value_flag);
         }
     }
 
@@ -450,7 +458,7 @@ export default class QuickStrategyStore {
                 return;
             }
 
-            if (number_fields.includes(key)) {
+            if (this.values_flags.includes(key) && number_fields.includes(key)) {
                 if (isNaN(value)) {
                     errors[key] = localize('Must be a number');
                 } else if (value <= 0) {
@@ -460,12 +468,11 @@ export default class QuickStrategyStore {
                 }
             }
 
-            if (value === '') {
+            if (this.values_flags.includes(key) && value === '') {
                 errors[key] = localize('Field cannot be empty');
             }
         });
-
-        if (this.active_index === 0 && values['quick-strategy__size'] < 2) {
+        if (this.active_index === 0 && values['quick-strategy__size'] > 0 && values['quick-strategy__size'] < 2) {
             errors['quick-strategy__size'] = localize('Value must be higher than 2');
         }
 


### PR DESCRIPTION
…soon as Quick Strategy is opened

## Changes:

Please include a summary of the change and which issue is fixed below:
-   fix:  Quick Strategy - Size textbox error always displays as soon as Quick Strategy is opened

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [x] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
