### PR TITLE
Adrienne /  Changed rate change error message to be shown as modal instead of banner in buy/sell modal

### DIFF
--- a/packages/core/src/App/Components/Layout/Header/toggle-menu-drawer.jsx
+++ b/packages/core/src/App/Components/Layout/Header/toggle-menu-drawer.jsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import React from 'react';
-import { Div100vhContainer, Icon, MobileDrawer, ToggleSwitch, Text, Button } from '@deriv/components';
-import { routes, PlatformContext, getStaticUrl, whatsapp_url } from '@deriv/shared';
+import { Div100vhContainer, Icon, MobileDrawer, ToggleSwitch, Text } from '@deriv/components';
+import { routes, PlatformContext, whatsapp_url } from '@deriv/shared';
 import { localize, getAllowedLanguages, getLanguage } from '@deriv/translations';
 import NetworkStatus from 'App/Components/Layout/Footer';
 import ServerTime from 'App/Containers/server-time.jsx';
@@ -9,7 +9,6 @@ import { BinaryLink } from 'App/Components/Routes';
 import getRoutesConfig from 'App/Constants/routes-config';
 import { changeLanguage } from 'Utils/Language';
 import LiveChat from 'App/Components/Elements/LiveChat';
-import { useLocation, useHistory } from 'react-router-dom';
 import useLiveChat from 'App/Components/Elements/LiveChat/use-livechat.ts';
 
 const MenuLink = ({
@@ -23,8 +22,6 @@ const MenuLink = ({
     text,
     onClickLink,
 }) => {
-    const deriv_static_url = getStaticUrl(link_to);
-
     if (is_language) {
         return (
             <span
@@ -54,27 +51,6 @@ const MenuLink = ({
                 <span className='header__menu-mobile-link-text'>{text}</span>
                 {suffix_icon && <Icon className='header__menu-mobile-link-suffix-icon' icon={suffix_icon} />}
             </div>
-        );
-    } else if (deriv_static_url) {
-        return (
-            <a
-                className={classNames('header__menu-mobile-link', {
-                    'header__menu-mobile-link--disabled': is_disabled,
-                    'header__menu-mobile-link--active': is_active,
-                })}
-                href={link_to}
-            >
-                <Icon className='header__menu-mobile-link-icon' icon={icon} />
-                <Text
-                    className={text === localize('Trade') ? '' : 'header__menu-mobile-link-text'}
-                    as='h3'
-                    size='xs'
-                    weight={window.location.pathname === '/' && text === localize('Trade') ? 'bold' : null}
-                >
-                    {text}
-                </Text>
-                {suffix_icon && <Icon className='header__menu-mobile-link-suffix-icon' icon={suffix_icon} />}
-            </a>
         );
     }
 
@@ -132,14 +108,13 @@ const ToggleMenuDrawer = React.forwardRef(
         const [secondary_routes_config, setSecondaryRoutesConfig] = React.useState([]);
         const [is_submenu_expanded, expandSubMenu] = React.useState(false);
 
-        const { is_appstore, is_pre_appstore, setIsPreAppStore } = React.useContext(PlatformContext);
+        const { is_appstore } = React.useContext(PlatformContext);
 
         React.useEffect(() => {
             const processRoutes = () => {
-                const routes_config = getRoutesConfig({ is_appstore, is_pre_appstore });
+                const routes_config = getRoutesConfig({ is_appstore });
                 let primary_routes = [];
                 let secondary_routes = [];
-                const location = window.location.pathname;
 
                 if (is_appstore) {
                     primary_routes = [
@@ -150,9 +125,6 @@ const ToggleMenuDrawer = React.forwardRef(
                         routes.trade_types,
                         routes.markets,
                     ];
-                    secondary_routes = [];
-                } else if ((is_pre_appstore && location === routes.trading_hub) || is_trading_hub_category) {
-                    primary_routes = [routes.account, routes.cashier];
                     secondary_routes = [];
                 } else {
                     primary_routes = [routes.reports, routes.account, routes.cashier];
@@ -166,7 +138,7 @@ const ToggleMenuDrawer = React.forwardRef(
             if (account_status || should_allow_authentication) {
                 processRoutes();
             }
-        }, [is_appstore, is_pre_appstore, account_status, should_allow_authentication]);
+        }, [is_appstore, account_status, should_allow_authentication]);
 
         const toggleDrawer = React.useCallback(() => {
             setIsOpen(!is_open);
@@ -309,26 +281,6 @@ const ToggleMenuDrawer = React.forwardRef(
                 </MobileDrawer.SubMenu>
             );
         };
-        const { pathname: route } = useLocation();
-
-        const history = useHistory();
-
-        const is_trading_hub_category =
-            route.startsWith(routes.trading_hub) ||
-            route.startsWith(routes.cashier) ||
-            route.startsWith(routes.account);
-
-        const tradingHubRedirect = () => {
-            if (is_pre_appstore) {
-                setIsPreAppStore(false);
-                toggleDrawer();
-                history.push(routes.root);
-            } else {
-                setIsPreAppStore(true);
-                toggleDrawer();
-                history.push(routes.trading_hub);
-            }
-        };
 
         return (
             <React.Fragment>
@@ -361,192 +313,7 @@ const ToggleMenuDrawer = React.forwardRef(
                                     )}
                                 </MobileDrawer.Body>
                             )}
-                            {is_pre_appstore && (
-                                <React.Fragment>
-                                    {is_logged_in && is_trading_hub_category ? (
-                                        <MobileDrawer.SubHeader
-                                            className={classNames({
-                                                'dc-mobile-drawer__subheader--hidden': is_submenu_expanded,
-                                            })}
-                                        >
-                                            <Button
-                                                className={`header__menu--back-to-ui${is_dark_mode ? '--dark' : ''}`}
-                                                type='button'
-                                                large
-                                                onClick={tradingHubRedirect}
-                                            >
-                                                <Text
-                                                    className={`header__menu--back-to-ui-text${
-                                                        is_dark_mode ? '--dark' : ''
-                                                    }`}
-                                                    size='xs'
-                                                >
-                                                    {localize("Exit Trader's hub")}
-                                                </Text>
-                                                <Icon
-                                                    className='header__menu-mobile-right-arrow'
-                                                    icon='IcArrowRight'
-                                                    size={18}
-                                                    color='red'
-                                                />
-                                            </Button>
-                                        </MobileDrawer.SubHeader>
-                                    ) : (
-                                        <MobileDrawer.SubHeader
-                                            className={classNames({
-                                                'dc-mobile-drawer__subheader--hidden': is_submenu_expanded,
-                                            })}
-                                        >
-                                            {platform_switcher}
-                                        </MobileDrawer.SubHeader>
-                                    )}
-                                    <MobileDrawer.Body>
-                                        <div
-                                            className='header__menu-mobile-platform-switcher'
-                                            id='mobile_platform_switcher'
-                                        />
-                                        {is_logged_in && !is_trading_hub_category && (
-                                            <MobileDrawer.Item className='header__menu--back-to-old-ui--dtrader'>
-                                                <Button
-                                                    className={`header__menu--back-to-ui${
-                                                        is_dark_mode ? '--dark' : ''
-                                                    }`}
-                                                    type='button'
-                                                    large
-                                                    onClick={tradingHubRedirect}
-                                                >
-                                                    <Text
-                                                        className={`header__menu--back-to-ui-text${
-                                                            is_dark_mode ? '--dark' : ''
-                                                        }`}
-                                                        size='xs'
-                                                    >
-                                                        {localize("Exit Trader's hub")}
-                                                    </Text>
-                                                    <Icon
-                                                        className='header__menu-mobile-right-arrow'
-                                                        icon='IcArrowRight'
-                                                        size={18}
-                                                        color='red'
-                                                    />
-                                                </Button>
-                                            </MobileDrawer.Item>
-                                        )}
-                                        {is_logged_in && (
-                                            <MobileDrawer.Item>
-                                                <MenuLink
-                                                    link_to={routes.trading_hub}
-                                                    icon={is_dark_mode ? 'IcAppstoreHomeDark' : 'IcAppstoreHome'}
-                                                    text={localize('Trading Hub')}
-                                                    onClickLink={toggleDrawer}
-                                                    changeCurrentLanguage={changeCurrentLanguage}
-                                                />
-                                            </MobileDrawer.Item>
-                                        )}
-                                        {is_logged_in && !is_trading_hub_category && (
-                                            <MobileDrawer.Item>
-                                                <MenuLink
-                                                    link_to={routes.trade}
-                                                    icon='IcTrade'
-                                                    text={localize('Trade')}
-                                                    onClickLink={toggleDrawer}
-                                                    changeCurrentLanguage={changeCurrentLanguage}
-                                                />
-                                            </MobileDrawer.Item>
-                                        )}
-                                        {primary_routes_config.map((route_config, idx) =>
-                                            getRoutesWithSubMenu(route_config, idx)
-                                        )}
-                                        <MobileDrawer.Item
-                                            className='header__menu-mobile-theme--trading-hub'
-                                            onClick={e => {
-                                                e.preventDefault();
-                                                toggleTheme(!is_dark_mode);
-                                            }}
-                                        >
-                                            <div className={classNames('header__menu-mobile-link')}>
-                                                <Icon className='header__menu-mobile-link-icon' icon={'IcTheme'} />
-                                                <span className='header__menu-mobile-link-text'>
-                                                    {localize('Dark theme')}
-                                                </span>
-                                                <ToggleSwitch
-                                                    id='dt_mobile_drawer_theme_toggler'
-                                                    handleToggle={() => toggleTheme(!is_dark_mode)}
-                                                    is_enabled={is_dark_mode}
-                                                />
-                                            </div>
-                                        </MobileDrawer.Item>
-                                        {is_logged_in && (
-                                            <React.Fragment>
-                                                <MobileDrawer.Item>
-                                                    <MenuLink
-                                                        link_to={getStaticUrl('/help-centre')}
-                                                        icon='IcHelpCentre'
-                                                        text={localize('Help centre')}
-                                                        onClickLink={toggleDrawer}
-                                                        changeCurrentLanguage={changeCurrentLanguage}
-                                                    />
-                                                </MobileDrawer.Item>
-                                                <MobileDrawer.Item>
-                                                    <MenuLink
-                                                        link_to={routes.account_limits}
-                                                        icon='IcAccountLimits'
-                                                        text={localize('Account Limits')}
-                                                        onClickLink={toggleDrawer}
-                                                        changeCurrentLanguage={changeCurrentLanguage}
-                                                    />
-                                                </MobileDrawer.Item>
-                                                <MobileDrawer.Item>
-                                                    <MenuLink
-                                                        link_to={getStaticUrl('/responsible')}
-                                                        icon='IcVerification'
-                                                        text={localize('Responsible trading')}
-                                                        onClickLink={toggleDrawer}
-                                                        changeCurrentLanguage={changeCurrentLanguage}
-                                                    />
-                                                </MobileDrawer.Item>
-                                                <MobileDrawer.Item>
-                                                    <MenuLink
-                                                        link_to={getStaticUrl('/regulatory')}
-                                                        icon='IcRegulatoryInformation'
-                                                        text={localize('Regulatory information')}
-                                                        onClickLink={toggleDrawer}
-                                                        changeCurrentLanguage={changeCurrentLanguage}
-                                                    />
-                                                </MobileDrawer.Item>
-                                                <MobileDrawer.Item className='header__menu-mobile-theme'>
-                                                    <MenuLink
-                                                        link_to={getStaticUrl('/')}
-                                                        icon='IcDerivOutline'
-                                                        text={localize('Go to Deriv.com')}
-                                                        onClickLink={toggleDrawer}
-                                                        changeCurrentLanguage={changeCurrentLanguage}
-                                                    />
-                                                </MobileDrawer.Item>
-                                                <MobileDrawer.Item
-                                                    onClick={() => {
-                                                        logoutClient();
-                                                        toggleDrawer();
-                                                    }}
-                                                    className='dc-mobile-drawer__item--logout'
-                                                >
-                                                    <MenuLink
-                                                        link_to={routes.index}
-                                                        icon='IcLogout'
-                                                        text={localize('Log out')}
-                                                    />
-                                                </MobileDrawer.Item>
-                                                <MobileDrawer.Footer className='dc-mobile-drawer__footer--servertime'>
-                                                    <ServerTime is_mobile />
-                                                    <NetworkStatus is_mobile />
-                                                </MobileDrawer.Footer>
-                                            </React.Fragment>
-                                        )}
-                                    </MobileDrawer.Body>
-                                </React.Fragment>
-                            )}
-
-                            {!is_appstore && !is_pre_appstore && (
+                            {!is_appstore && (
                                 <React.Fragment>
                                     <MobileDrawer.SubHeader
                                         className={classNames({
@@ -560,26 +327,6 @@ const ToggleMenuDrawer = React.forwardRef(
                                             className='header__menu-mobile-platform-switcher'
                                             id='mobile_platform_switcher'
                                         />
-                                        <MobileDrawer.Item className='header__menu--trading-hub'>
-                                            <Button
-                                                className={`header__menu--explore-trading-hub ${
-                                                    is_dark_mode ? 'header__menu--explore-trading-hub--dark' : ''
-                                                }`}
-                                                type='button'
-                                                large
-                                                onClick={tradingHubRedirect}
-                                            >
-                                                <Text className='header__menu--trading-hub-text' size='xs'>
-                                                    {localize("Trader's hub beta")}
-                                                </Text>
-                                                <Icon
-                                                    className='header__menu-mobile-right-arrow'
-                                                    icon='IcArrowRight'
-                                                    size={18}
-                                                    color='red'
-                                                />
-                                            </Button>
-                                        </MobileDrawer.Item>
                                         <MobileDrawer.Item>
                                             <MenuLink
                                                 link_to={routes.trade}
@@ -647,12 +394,10 @@ const ToggleMenuDrawer = React.forwardRef(
                                 </React.Fragment>
                             )}
                         </div>
-                        {!is_pre_appstore && (
-                            <MobileDrawer.Footer>
-                                <ServerTime is_mobile />
-                                <NetworkStatus is_mobile />
-                            </MobileDrawer.Footer>
-                        )}
+                        <MobileDrawer.Footer>
+                            <ServerTime is_mobile />
+                            <NetworkStatus is_mobile />
+                        </MobileDrawer.Footer>
                     </Div100vhContainer>
                 </MobileDrawer>
             </React.Fragment>

--- a/packages/core/src/App/Components/Layout/Header/toggle-menu-drawer.jsx
+++ b/packages/core/src/App/Components/Layout/Header/toggle-menu-drawer.jsx
@@ -9,7 +9,7 @@ import { BinaryLink } from 'App/Components/Routes';
 import getRoutesConfig from 'App/Constants/routes-config';
 import { changeLanguage } from 'Utils/Language';
 import LiveChat from 'App/Components/Elements/LiveChat';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useHistory } from 'react-router-dom';
 import useLiveChat from 'App/Components/Elements/LiveChat/use-livechat.ts';
 
 const MenuLink = ({
@@ -311,10 +311,24 @@ const ToggleMenuDrawer = React.forwardRef(
         };
         const { pathname: route } = useLocation();
 
+        const history = useHistory();
+
         const is_trading_hub_category =
             route.startsWith(routes.trading_hub) ||
             route.startsWith(routes.cashier) ||
             route.startsWith(routes.account);
+
+        const tradingHubRedirect = () => {
+            if (is_pre_appstore) {
+                setIsPreAppStore(false);
+                toggleDrawer();
+                history.push(routes.root);
+            } else {
+                setIsPreAppStore(true);
+                toggleDrawer();
+                history.push(routes.trading_hub);
+            }
+        };
 
         return (
             <React.Fragment>
@@ -359,10 +373,7 @@ const ToggleMenuDrawer = React.forwardRef(
                                                 className={`header__menu--back-to-ui${is_dark_mode ? '--dark' : ''}`}
                                                 type='button'
                                                 large
-                                                onClick={() => {
-                                                    setIsPreAppStore(false);
-                                                    toggleDrawer();
-                                                }}
+                                                onClick={tradingHubRedirect}
                                             >
                                                 <Text
                                                     className={`header__menu--back-to-ui-text${
@@ -402,10 +413,7 @@ const ToggleMenuDrawer = React.forwardRef(
                                                     }`}
                                                     type='button'
                                                     large
-                                                    onClick={() => {
-                                                        setIsPreAppStore(false);
-                                                        toggleDrawer();
-                                                    }}
+                                                    onClick={tradingHubRedirect}
                                                 >
                                                     <Text
                                                         className={`header__menu--back-to-ui-text${
@@ -559,10 +567,7 @@ const ToggleMenuDrawer = React.forwardRef(
                                                 }`}
                                                 type='button'
                                                 large
-                                                onClick={() => {
-                                                    setIsPreAppStore(true);
-                                                    toggleDrawer();
-                                                }}
+                                                onClick={tradingHubRedirect}
                                             >
                                                 <Text className='header__menu--trading-hub-text' size='xs'>
                                                     {localize("Trader's hub beta")}

--- a/packages/core/src/App/Components/Layout/Header/toggle-menu-drawer.jsx
+++ b/packages/core/src/App/Components/Layout/Header/toggle-menu-drawer.jsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import React from 'react';
-import { Div100vhContainer, Icon, MobileDrawer, ToggleSwitch, Text } from '@deriv/components';
-import { routes, PlatformContext, whatsapp_url } from '@deriv/shared';
+import { Div100vhContainer, Icon, MobileDrawer, ToggleSwitch, Text, Button } from '@deriv/components';
+import { routes, PlatformContext, getStaticUrl, whatsapp_url } from '@deriv/shared';
 import { localize, getAllowedLanguages, getLanguage } from '@deriv/translations';
 import NetworkStatus from 'App/Components/Layout/Footer';
 import ServerTime from 'App/Containers/server-time.jsx';
@@ -9,6 +9,7 @@ import { BinaryLink } from 'App/Components/Routes';
 import getRoutesConfig from 'App/Constants/routes-config';
 import { changeLanguage } from 'Utils/Language';
 import LiveChat from 'App/Components/Elements/LiveChat';
+import { useLocation } from 'react-router-dom';
 import useLiveChat from 'App/Components/Elements/LiveChat/use-livechat.ts';
 
 const MenuLink = ({
@@ -22,6 +23,8 @@ const MenuLink = ({
     text,
     onClickLink,
 }) => {
+    const deriv_static_url = getStaticUrl(link_to);
+
     if (is_language) {
         return (
             <span
@@ -51,6 +54,27 @@ const MenuLink = ({
                 <span className='header__menu-mobile-link-text'>{text}</span>
                 {suffix_icon && <Icon className='header__menu-mobile-link-suffix-icon' icon={suffix_icon} />}
             </div>
+        );
+    } else if (deriv_static_url) {
+        return (
+            <a
+                className={classNames('header__menu-mobile-link', {
+                    'header__menu-mobile-link--disabled': is_disabled,
+                    'header__menu-mobile-link--active': is_active,
+                })}
+                href={link_to}
+            >
+                <Icon className='header__menu-mobile-link-icon' icon={icon} />
+                <Text
+                    className={text === localize('Trade') ? '' : 'header__menu-mobile-link-text'}
+                    as='h3'
+                    size='xs'
+                    weight={window.location.pathname === '/' && text === localize('Trade') ? 'bold' : null}
+                >
+                    {text}
+                </Text>
+                {suffix_icon && <Icon className='header__menu-mobile-link-suffix-icon' icon={suffix_icon} />}
+            </a>
         );
     }
 
@@ -108,13 +132,14 @@ const ToggleMenuDrawer = React.forwardRef(
         const [secondary_routes_config, setSecondaryRoutesConfig] = React.useState([]);
         const [is_submenu_expanded, expandSubMenu] = React.useState(false);
 
-        const { is_appstore } = React.useContext(PlatformContext);
+        const { is_appstore, is_pre_appstore, setIsPreAppStore } = React.useContext(PlatformContext);
 
         React.useEffect(() => {
             const processRoutes = () => {
-                const routes_config = getRoutesConfig({ is_appstore });
+                const routes_config = getRoutesConfig({ is_appstore, is_pre_appstore });
                 let primary_routes = [];
                 let secondary_routes = [];
+                const location = window.location.pathname;
 
                 if (is_appstore) {
                     primary_routes = [
@@ -125,6 +150,9 @@ const ToggleMenuDrawer = React.forwardRef(
                         routes.trade_types,
                         routes.markets,
                     ];
+                    secondary_routes = [];
+                } else if ((is_pre_appstore && location === routes.trading_hub) || is_trading_hub_category) {
+                    primary_routes = [routes.account, routes.cashier];
                     secondary_routes = [];
                 } else {
                     primary_routes = [routes.reports, routes.account, routes.cashier];
@@ -138,7 +166,7 @@ const ToggleMenuDrawer = React.forwardRef(
             if (account_status || should_allow_authentication) {
                 processRoutes();
             }
-        }, [is_appstore, account_status, should_allow_authentication]);
+        }, [is_appstore, is_pre_appstore, account_status, should_allow_authentication]);
 
         const toggleDrawer = React.useCallback(() => {
             setIsOpen(!is_open);
@@ -281,6 +309,12 @@ const ToggleMenuDrawer = React.forwardRef(
                 </MobileDrawer.SubMenu>
             );
         };
+        const { pathname: route } = useLocation();
+
+        const is_trading_hub_category =
+            route.startsWith(routes.trading_hub) ||
+            route.startsWith(routes.cashier) ||
+            route.startsWith(routes.account);
 
         return (
             <React.Fragment>
@@ -313,7 +347,198 @@ const ToggleMenuDrawer = React.forwardRef(
                                     )}
                                 </MobileDrawer.Body>
                             )}
-                            {!is_appstore && (
+                            {is_pre_appstore && (
+                                <React.Fragment>
+                                    {is_logged_in && is_trading_hub_category ? (
+                                        <MobileDrawer.SubHeader
+                                            className={classNames({
+                                                'dc-mobile-drawer__subheader--hidden': is_submenu_expanded,
+                                            })}
+                                        >
+                                            <Button
+                                                className={`header__menu--back-to-ui${is_dark_mode ? '--dark' : ''}`}
+                                                type='button'
+                                                large
+                                                onClick={() => {
+                                                    setIsPreAppStore(false);
+                                                    toggleDrawer();
+                                                }}
+                                            >
+                                                <Text
+                                                    className={`header__menu--back-to-ui-text${
+                                                        is_dark_mode ? '--dark' : ''
+                                                    }`}
+                                                    size='xs'
+                                                >
+                                                    {localize("Exit Trader's hub")}
+                                                </Text>
+                                                <Icon
+                                                    className='header__menu-mobile-right-arrow'
+                                                    icon='IcArrowRight'
+                                                    size={18}
+                                                    color='red'
+                                                />
+                                            </Button>
+                                        </MobileDrawer.SubHeader>
+                                    ) : (
+                                        <MobileDrawer.SubHeader
+                                            className={classNames({
+                                                'dc-mobile-drawer__subheader--hidden': is_submenu_expanded,
+                                            })}
+                                        >
+                                            {platform_switcher}
+                                        </MobileDrawer.SubHeader>
+                                    )}
+                                    <MobileDrawer.Body>
+                                        <div
+                                            className='header__menu-mobile-platform-switcher'
+                                            id='mobile_platform_switcher'
+                                        />
+                                        {is_logged_in && !is_trading_hub_category && (
+                                            <MobileDrawer.Item className='header__menu--back-to-old-ui--dtrader'>
+                                                <Button
+                                                    className={`header__menu--back-to-ui${
+                                                        is_dark_mode ? '--dark' : ''
+                                                    }`}
+                                                    type='button'
+                                                    large
+                                                    onClick={() => {
+                                                        setIsPreAppStore(false);
+                                                        toggleDrawer();
+                                                    }}
+                                                >
+                                                    <Text
+                                                        className={`header__menu--back-to-ui-text${
+                                                            is_dark_mode ? '--dark' : ''
+                                                        }`}
+                                                        size='xs'
+                                                    >
+                                                        {localize("Exit Trader's hub")}
+                                                    </Text>
+                                                    <Icon
+                                                        className='header__menu-mobile-right-arrow'
+                                                        icon='IcArrowRight'
+                                                        size={18}
+                                                        color='red'
+                                                    />
+                                                </Button>
+                                            </MobileDrawer.Item>
+                                        )}
+                                        {is_logged_in && (
+                                            <MobileDrawer.Item>
+                                                <MenuLink
+                                                    link_to={routes.trading_hub}
+                                                    icon={is_dark_mode ? 'IcAppstoreHomeDark' : 'IcAppstoreHome'}
+                                                    text={localize('Trading Hub')}
+                                                    onClickLink={toggleDrawer}
+                                                    changeCurrentLanguage={changeCurrentLanguage}
+                                                />
+                                            </MobileDrawer.Item>
+                                        )}
+                                        {is_logged_in && !is_trading_hub_category && (
+                                            <MobileDrawer.Item>
+                                                <MenuLink
+                                                    link_to={routes.trade}
+                                                    icon='IcTrade'
+                                                    text={localize('Trade')}
+                                                    onClickLink={toggleDrawer}
+                                                    changeCurrentLanguage={changeCurrentLanguage}
+                                                />
+                                            </MobileDrawer.Item>
+                                        )}
+                                        {primary_routes_config.map((route_config, idx) =>
+                                            getRoutesWithSubMenu(route_config, idx)
+                                        )}
+                                        <MobileDrawer.Item
+                                            className='header__menu-mobile-theme--trading-hub'
+                                            onClick={e => {
+                                                e.preventDefault();
+                                                toggleTheme(!is_dark_mode);
+                                            }}
+                                        >
+                                            <div className={classNames('header__menu-mobile-link')}>
+                                                <Icon className='header__menu-mobile-link-icon' icon={'IcTheme'} />
+                                                <span className='header__menu-mobile-link-text'>
+                                                    {localize('Dark theme')}
+                                                </span>
+                                                <ToggleSwitch
+                                                    id='dt_mobile_drawer_theme_toggler'
+                                                    handleToggle={() => toggleTheme(!is_dark_mode)}
+                                                    is_enabled={is_dark_mode}
+                                                />
+                                            </div>
+                                        </MobileDrawer.Item>
+                                        {is_logged_in && (
+                                            <React.Fragment>
+                                                <MobileDrawer.Item>
+                                                    <MenuLink
+                                                        link_to={getStaticUrl('/help-centre')}
+                                                        icon='IcHelpCentre'
+                                                        text={localize('Help centre')}
+                                                        onClickLink={toggleDrawer}
+                                                        changeCurrentLanguage={changeCurrentLanguage}
+                                                    />
+                                                </MobileDrawer.Item>
+                                                <MobileDrawer.Item>
+                                                    <MenuLink
+                                                        link_to={routes.account_limits}
+                                                        icon='IcAccountLimits'
+                                                        text={localize('Account Limits')}
+                                                        onClickLink={toggleDrawer}
+                                                        changeCurrentLanguage={changeCurrentLanguage}
+                                                    />
+                                                </MobileDrawer.Item>
+                                                <MobileDrawer.Item>
+                                                    <MenuLink
+                                                        link_to={getStaticUrl('/responsible')}
+                                                        icon='IcVerification'
+                                                        text={localize('Responsible trading')}
+                                                        onClickLink={toggleDrawer}
+                                                        changeCurrentLanguage={changeCurrentLanguage}
+                                                    />
+                                                </MobileDrawer.Item>
+                                                <MobileDrawer.Item>
+                                                    <MenuLink
+                                                        link_to={getStaticUrl('/regulatory')}
+                                                        icon='IcRegulatoryInformation'
+                                                        text={localize('Regulatory information')}
+                                                        onClickLink={toggleDrawer}
+                                                        changeCurrentLanguage={changeCurrentLanguage}
+                                                    />
+                                                </MobileDrawer.Item>
+                                                <MobileDrawer.Item className='header__menu-mobile-theme'>
+                                                    <MenuLink
+                                                        link_to={getStaticUrl('/')}
+                                                        icon='IcDerivOutline'
+                                                        text={localize('Go to Deriv.com')}
+                                                        onClickLink={toggleDrawer}
+                                                        changeCurrentLanguage={changeCurrentLanguage}
+                                                    />
+                                                </MobileDrawer.Item>
+                                                <MobileDrawer.Item
+                                                    onClick={() => {
+                                                        logoutClient();
+                                                        toggleDrawer();
+                                                    }}
+                                                    className='dc-mobile-drawer__item--logout'
+                                                >
+                                                    <MenuLink
+                                                        link_to={routes.index}
+                                                        icon='IcLogout'
+                                                        text={localize('Log out')}
+                                                    />
+                                                </MobileDrawer.Item>
+                                                <MobileDrawer.Footer className='dc-mobile-drawer__footer--servertime'>
+                                                    <ServerTime is_mobile />
+                                                    <NetworkStatus is_mobile />
+                                                </MobileDrawer.Footer>
+                                            </React.Fragment>
+                                        )}
+                                    </MobileDrawer.Body>
+                                </React.Fragment>
+                            )}
+
+                            {!is_appstore && !is_pre_appstore && (
                                 <React.Fragment>
                                     <MobileDrawer.SubHeader
                                         className={classNames({
@@ -327,6 +552,29 @@ const ToggleMenuDrawer = React.forwardRef(
                                             className='header__menu-mobile-platform-switcher'
                                             id='mobile_platform_switcher'
                                         />
+                                        <MobileDrawer.Item className='header__menu--trading-hub'>
+                                            <Button
+                                                className={`header__menu--explore-trading-hub ${
+                                                    is_dark_mode ? 'header__menu--explore-trading-hub--dark' : ''
+                                                }`}
+                                                type='button'
+                                                large
+                                                onClick={() => {
+                                                    setIsPreAppStore(true);
+                                                    toggleDrawer();
+                                                }}
+                                            >
+                                                <Text className='header__menu--trading-hub-text' size='xs'>
+                                                    {localize("Trader's hub beta")}
+                                                </Text>
+                                                <Icon
+                                                    className='header__menu-mobile-right-arrow'
+                                                    icon='IcArrowRight'
+                                                    size={18}
+                                                    color='red'
+                                                />
+                                            </Button>
+                                        </MobileDrawer.Item>
                                         <MobileDrawer.Item>
                                             <MenuLink
                                                 link_to={routes.trade}
@@ -394,10 +642,12 @@ const ToggleMenuDrawer = React.forwardRef(
                                 </React.Fragment>
                             )}
                         </div>
-                        <MobileDrawer.Footer>
-                            <ServerTime is_mobile />
-                            <NetworkStatus is_mobile />
-                        </MobileDrawer.Footer>
+                        {!is_pre_appstore && (
+                            <MobileDrawer.Footer>
+                                <ServerTime is_mobile />
+                                <NetworkStatus is_mobile />
+                            </MobileDrawer.Footer>
+                        )}
                     </Div100vhContainer>
                 </MobileDrawer>
             </React.Fragment>

--- a/packages/p2p/src/components/buy-sell/buy-sell-modal.jsx
+++ b/packages/p2p/src/components/buy-sell/buy-sell-modal.jsx
@@ -122,7 +122,27 @@ const BuySellModal = ({ table_type, selected_ad, should_show_popup, setShouldSho
     );
     const [is_account_balance_low, setIsAccountBalanceLow] = React.useState(false);
     const [show_market_rate_change_error_modal, setShowMarketRateChangeErrorModal] = React.useState(false);
+    const [has_rate_changed_recently, setHasRateChangedRecently] = React.useState(false);
     const formik_ref = React.useRef();
+    const MAX_ALLOWED_RATE_CHANGED_WARNING_DELAY = 1050;
+
+    React.useEffect(() => {
+        const disposer = reaction(
+            () => buy_sell_store?.advert?.rate,
+            () => {
+                setHasRateChangedRecently(true);
+                setTimeout(() => {
+                    setHasRateChangedRecently(false);
+                }, MAX_ALLOWED_RATE_CHANGED_WARNING_DELAY);
+            }
+        );
+        return disposer;
+    }, []);
+
+    const onSubmitWhenRateChanged = () => {
+        setShouldShowPopup(false);
+        setTimeout(() => setShowMarketRateChangeErrorModal(true), my_profile_store.MODAL_TRANSITION_DURATION);
+    };
 
     const BuySellFormError = () => (
         <div className='buy-sell__modal--error-message'>
@@ -295,7 +315,7 @@ const BuySellModal = ({ table_type, selected_ad, should_show_popup, setShouldSho
                                 <BuySellModalFooter
                                     is_submit_disabled={is_submit_disabled}
                                     onCancel={onCancel}
-                                    onSubmit={submitForm.current}
+                                    onSubmit={!has_rate_changed_recently ? submitForm.current : onSubmitWhenRateChanged}
                                 />
                             )}
                         </Modal.Footer>

--- a/packages/p2p/src/components/buy-sell/buy-sell-modal.jsx
+++ b/packages/p2p/src/components/buy-sell/buy-sell-modal.jsx
@@ -124,26 +124,24 @@ const BuySellModal = ({ table_type, selected_ad, should_show_popup, setShouldSho
     const [show_market_rate_change_error_modal, setShowMarketRateChangeErrorModal] = React.useState(false);
     const formik_ref = React.useRef();
 
-    const BuySellFormError = () => {
-        return (
-            <div className='buy-sell__modal--error-message'>
-                <HintBox
-                    className='buy-sell__modal-danger'
-                    icon='IcAlertDanger'
-                    message={
-                        <Text as='p' size='xxxs' color='prominent' line_height='s'>
-                            {buy_sell_store.form_error_code === api_error_codes.INSUFFICIENT_BALANCE ? (
-                                <Localize i18n_default_text="Your Deriv P2P balance isn't enough. Please increase your balance before trying again." />
-                            ) : (
-                                error_message
-                            )}
-                        </Text>
-                    }
-                    is_danger
-                />
-            </div>
-        );
-    };
+    const BuySellFormError = () => (
+        <div className='buy-sell__modal--error-message'>
+            <HintBox
+                className='buy-sell__modal-danger'
+                icon='IcAlertDanger'
+                message={
+                    <Text as='p' size='xxxs' color='prominent' line_height='s'>
+                        {buy_sell_store.form_error_code === api_error_codes.INSUFFICIENT_BALANCE ? (
+                            <Localize i18n_default_text="Your Deriv P2P balance isn't enough. Please increase your balance before trying again." />
+                        ) : (
+                            error_message
+                        )}
+                    </Text>
+                }
+                is_danger
+            />
+        </div>
+    );
 
     const onCancel = () => {
         if (my_profile_store.should_show_add_payment_method_form) {

--- a/packages/p2p/src/components/buy-sell/buy-sell-modal.jsx
+++ b/packages/p2p/src/components/buy-sell/buy-sell-modal.jsx
@@ -185,7 +185,7 @@ const BuySellModal = ({ table_type, selected_ad, should_show_popup, setShouldSho
     const setSubmitForm = submitFormFn => (submitForm.current = submitFormFn);
 
     React.useEffect(() => {
-        const disposer = reaction(
+        const disposeFormErrorCodeReaction = reaction(
             () => buy_sell_store.form_error_code,
             () => {
                 if (buy_sell_store.form_error_code === api_error_codes.MARKET_RATE_CHANGE) {
@@ -201,7 +201,7 @@ const BuySellModal = ({ table_type, selected_ad, should_show_popup, setShouldSho
             }
         );
 
-        return disposer;
+        return disposeFormErrorCodeReaction;
     }, []);
 
     React.useEffect(() => {

--- a/packages/p2p/src/components/buy-sell/buy-sell-modal.jsx
+++ b/packages/p2p/src/components/buy-sell/buy-sell-modal.jsx
@@ -90,7 +90,7 @@ const generateModalTitle = (formik_ref, my_profile_store, table_type, selected_a
 };
 
 const MarketRateChangeErrorModal = ({ is_open, closeModal, setShouldShowPopup }) => (
-    <Modal is_open={is_open} small className='rate-changed-modal' onExited={() => setShouldShowPopup(true)}>
+    <Modal className='rate-changed-modal' is_open={is_open} onExited={() => setShouldShowPopup(true)} small>
         <Modal.Body>
             <Text
                 as='p'

--- a/packages/p2p/src/components/buy-sell/buy-sell-modal.jsx
+++ b/packages/p2p/src/components/buy-sell/buy-sell-modal.jsx
@@ -118,7 +118,7 @@ const BuySellModal = ({ table_type, selected_ad, should_show_popup, setShouldSho
     const [show_market_rate_change_error_modal, setShowMarketRateChangeErrorModal] = React.useState(false);
     const [has_rate_changed_recently, setHasRateChangedRecently] = React.useState(false);
     const formik_ref = React.useRef();
-    const MAX_ALLOWED_RATE_CHANGED_WARNING_DELAY = 1000;
+    const MAX_ALLOWED_RATE_CHANGED_WARNING_DELAY = 2000;
 
     React.useEffect(() => {
         const disposeHasRateChangedReaction = reaction(
@@ -245,7 +245,7 @@ const BuySellModal = ({ table_type, selected_ad, should_show_popup, setShouldSho
                             <BuySellModalFooter
                                 is_submit_disabled={is_submit_disabled}
                                 onCancel={onCancel}
-                                onSubmit={!has_rate_changed_recently ? submitForm.current : onSubmitWhenRateChanged}
+                                onSubmit={has_rate_changed_recently ? onSubmitWhenRateChanged : submitForm.current}
                             />
                         )
                     }
@@ -309,7 +309,7 @@ const BuySellModal = ({ table_type, selected_ad, should_show_popup, setShouldSho
                                 <BuySellModalFooter
                                     is_submit_disabled={is_submit_disabled}
                                     onCancel={onCancel}
-                                    onSubmit={!has_rate_changed_recently ? submitForm.current : onSubmitWhenRateChanged}
+                                    onSubmit={has_rate_changed_recently ? onSubmitWhenRateChanged : submitForm.current}
                                 />
                             )}
                         </Modal.Footer>

--- a/packages/p2p/src/components/buy-sell/buy-sell-modal.jsx
+++ b/packages/p2p/src/components/buy-sell/buy-sell-modal.jsx
@@ -125,27 +125,24 @@ const BuySellModal = ({ table_type, selected_ad, should_show_popup, setShouldSho
     const formik_ref = React.useRef();
 
     const BuySellFormError = () => {
-        if (buy_sell_store.form_error_code !== api_error_codes.MARKET_RATE_CHANGE) {
-            return (
-                <div className='buy-sell__modal--error-message'>
-                    <HintBox
-                        className='buy-sell__modal-danger'
-                        icon='IcAlertDanger'
-                        message={
-                            <Text as='p' size='xxxs' color='prominent' line_height='s'>
-                                {buy_sell_store.form_error_code === api_error_codes.INSUFFICIENT_BALANCE ? (
-                                    <Localize i18n_default_text="Your Deriv P2P balance isn't enough. Please increase your balance before trying again." />
-                                ) : (
-                                    error_message
-                                )}
-                            </Text>
-                        }
-                        is_danger
-                    />
-                </div>
-            );
-        }
-        return null;
+        return (
+            <div className='buy-sell__modal--error-message'>
+                <HintBox
+                    className='buy-sell__modal-danger'
+                    icon='IcAlertDanger'
+                    message={
+                        <Text as='p' size='xxxs' color='prominent' line_height='s'>
+                            {buy_sell_store.form_error_code === api_error_codes.INSUFFICIENT_BALANCE ? (
+                                <Localize i18n_default_text="Your Deriv P2P balance isn't enough. Please increase your balance before trying again." />
+                            ) : (
+                                error_message
+                            )}
+                        </Text>
+                    }
+                    is_danger
+                />
+            </div>
+        );
     };
 
     const onCancel = () => {
@@ -183,6 +180,7 @@ const BuySellModal = ({ table_type, selected_ad, should_show_popup, setShouldSho
                         setShowMarketRateChangeErrorModal(true);
                     }
                     buy_sell_store.setFormErrorCode('');
+                    setErrorMessage(null);
                 }
             }
         );
@@ -246,7 +244,9 @@ const BuySellModal = ({ table_type, selected_ad, should_show_popup, setShouldSho
                     }
                 >
                     {table_type === buy_sell.SELL && is_account_balance_low && <LowBalanceMessage />}
-                    {!!error_message && <BuySellFormError />}
+                    {!!error_message && buy_sell_store.form_error_code !== api_error_codes.MARKET_RATE_CHANGE && (
+                        <BuySellFormError />
+                    )}
                     {my_profile_store.should_show_add_payment_method_form ? (
                         <AddPaymentMethodForm formik_ref={formik_ref} should_show_separated_footer={true} />
                     ) : (

--- a/packages/p2p/src/components/buy-sell/buy-sell-modal.jsx
+++ b/packages/p2p/src/components/buy-sell/buy-sell-modal.jsx
@@ -92,13 +92,7 @@ const generateModalTitle = (formik_ref, my_profile_store, table_type, selected_a
 const MarketRateChangeErrorModal = ({ is_open, closeModal, setShouldShowPopup }) => (
     <Modal className='rate-changed-modal' is_open={is_open} onExited={() => setShouldShowPopup(true)} small>
         <Modal.Body>
-            <Text
-                as='p'
-                align='left'
-                className='rate-changed-modal__message'
-                size={isMobile() ? 'xxs' : 'xs'}
-                line_height='s'
-            >
+            <Text as='p' className='rate-changed-modal__message' size={isMobile() ? 'xxs' : 'xs'} line_height='s'>
                 <Localize i18n_default_text={'The advertiser changed the rate before you confirmed the order.'} />
             </Text>
         </Modal.Body>
@@ -127,7 +121,7 @@ const BuySellModal = ({ table_type, selected_ad, should_show_popup, setShouldSho
     const MAX_ALLOWED_RATE_CHANGED_WARNING_DELAY = 1000;
 
     React.useEffect(() => {
-        const disposer = reaction(
+        const disposeHasRateChangedReaction = reaction(
             () => buy_sell_store?.advert?.rate,
             () => {
                 setHasRateChangedRecently(true);
@@ -136,7 +130,7 @@ const BuySellModal = ({ table_type, selected_ad, should_show_popup, setShouldSho
                 }, MAX_ALLOWED_RATE_CHANGED_WARNING_DELAY);
             }
         );
-        return disposer;
+        return disposeHasRateChangedReaction;
     }, []);
 
     const onSubmitWhenRateChanged = () => {

--- a/packages/p2p/src/components/buy-sell/buy-sell-modal.jsx
+++ b/packages/p2p/src/components/buy-sell/buy-sell-modal.jsx
@@ -2,9 +2,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {
     Button,
+    DesktopWrapper,
     HintBox,
     Icon,
     MobileFullPageModal,
+    MobileWrapper,
     Modal,
     Text,
     ThemedScrollbars,
@@ -12,7 +14,7 @@ import {
 } from '@deriv/components';
 import { isMobile } from '@deriv/shared';
 import { observer } from 'mobx-react-lite';
-import { when } from 'mobx';
+import { reaction } from 'mobx';
 import { buy_sell } from 'Constants/buy-sell';
 import { localize, Localize } from 'Components/i18next';
 import { useStores } from 'Stores';
@@ -170,33 +172,23 @@ const BuySellModal = ({ table_type, selected_ad, should_show_popup, setShouldSho
     const setSubmitForm = submitFormFn => (submitForm.current = submitFormFn);
 
     React.useEffect(() => {
-        const disposer = when(
-            () => buy_sell_store.form_error_code === api_error_codes.MARKET_RATE_CHANGE,
+        const disposer = reaction(
+            () => buy_sell_store.form_error_code,
             () => {
-                if (!isMobile()) {
-                    buy_sell_store.hidePopup();
-                    setTimeout(() => setShowMarketRateChangeErrorModal(true), 250);
-                } else {
-                    setShowMarketRateChangeErrorModal(true);
+                if (buy_sell_store.form_error_code === api_error_codes.MARKET_RATE_CHANGE) {
+                    if (!isMobile()) {
+                        buy_sell_store.hidePopup();
+                        setTimeout(() => setShowMarketRateChangeErrorModal(true), 280);
+                    } else {
+                        setShowMarketRateChangeErrorModal(true);
+                    }
+                    buy_sell_store.setFormErrorCode('');
                 }
-                buy_sell_store.setFormErrorCode('');
             }
         );
 
         return disposer;
     }, []);
-
-    // React.useEffect(() => {
-    //     if (buy_sell_store.form_error_code === api_error_codes.MARKET_RATE_CHANGE) {
-    //         if (!isMobile()) {
-    //             buy_sell_store.hidePopup();
-    //             setTimeout(() => setShowMarketRateChangeErrorModal(true), 250);
-    //         } else {
-    //             setShowMarketRateChangeErrorModal(true);
-    //         }
-    //         buy_sell_store.setFormErrorCode('');
-    //     }
-    // }, [error_message]);
 
     React.useEffect(() => {
         const balance_check =
@@ -227,7 +219,7 @@ const BuySellModal = ({ table_type, selected_ad, should_show_popup, setShouldSho
                     setShowMarketRateChangeErrorModal(false);
                 }}
             />
-            {isMobile() && (
+            <MobileWrapper>
                 <MobileFullPageModal
                     body_className='buy-sell__modal-body'
                     className='buy-sell__modal'
@@ -269,8 +261,8 @@ const BuySellModal = ({ table_type, selected_ad, should_show_popup, setShouldSho
                         />
                     )}
                 </MobileFullPageModal>
-            )}
-            {!isMobile() && should_show_popup && (
+            </MobileWrapper>
+            <DesktopWrapper>
                 <Modal
                     className='buy-sell__modal'
                     height={table_type === buy_sell.BUY ? 'auto' : '649px'}
@@ -311,7 +303,7 @@ const BuySellModal = ({ table_type, selected_ad, should_show_popup, setShouldSho
                         </Modal.Footer>
                     )}
                 </Modal>
-            )}
+            </DesktopWrapper>
         </React.Fragment>
     );
 };

--- a/packages/p2p/src/components/buy-sell/buy-sell-modal.jsx
+++ b/packages/p2p/src/components/buy-sell/buy-sell-modal.jsx
@@ -209,8 +209,8 @@ const BuySellModal = ({ table_type, selected_ad, should_show_popup, setShouldSho
             <MarketRateChangeErrorModal
                 is_open={show_market_rate_change_error_modal}
                 closeModal={() => {
-                    if (!isMobile()) {
-                        setTimeout(() => setShouldShowPopup(true), 350);
+                    if (isDesktop()) {
+                        setTimeout(() => setShouldShowPopup(true), my_profile_store.MODAL_TRANSITION_DURATION);
                     }
                     setShowMarketRateChangeErrorModal(false);
                 }}

--- a/packages/p2p/src/constants/api-error-codes.js
+++ b/packages/p2p/src/constants/api-error-codes.js
@@ -7,6 +7,7 @@ export const api_error_codes = Object.freeze({
     INVALID_VERIFICATION_TOKEN: 'InvalidVerificationToken',
     ORDER_EMAIL_VERIFICATION_REQUIRED: 'OrderEmailVerificationRequired',
     ORDER_CREATE_FAIL_CLIENT_BALANCE: 'OrderCreateFailClientBalance',
+    ORDER_CREATE_FAIL_RATE_CHANGED: 'OrderCreateFailRateChanged',
     PERMISSION_DENIED: 'PermissionDenied',
     RESTRICTED_COUNTRY: 'RestrictedCountry',
 });

--- a/packages/p2p/src/stores/buy-sell-store.js
+++ b/packages/p2p/src/stores/buy-sell-store.js
@@ -104,6 +104,7 @@ export default class BuySellStore extends BaseStore {
             handleChange: action.bound,
             handleSubmit: action.bound,
             hideAdvertiserPage: action.bound,
+            hidePopup: action.bound,
             hideVerification: action.bound,
             loadMoreItems: action.bound,
             onCancelClick: action.bound,
@@ -316,6 +317,10 @@ export default class BuySellStore extends BaseStore {
 
     hideAdvertiserPage() {
         this.setShowAdvertiserPage(false);
+    }
+
+    hidePopup() {
+        this.should_show_popup = false;
     }
 
     hideVerification() {

--- a/packages/p2p/src/stores/my-profile-store.js
+++ b/packages/p2p/src/stores/my-profile-store.js
@@ -39,6 +39,9 @@ export default class MyProfileStore extends BaseStore {
     should_show_add_payment_method_form = false;
     should_show_edit_payment_method_form = false;
 
+    // TODO: Refactor this out once modal management refactoring is completed
+    MODAL_TRANSITION_DURATION = 280;
+
     constructor(root_store) {
         // TODO: [mobx-undecorate] verify the constructor arguments and the arguments of this automatically generated super call
         super(root_store);


### PR DESCRIPTION
## Changes:
- Previously, rate change scenarios between advertiser and buyer shows the rate change error message indication as banner, now it is to be shown as a modal instead:
![Screenshot 2022-09-01 at 2 24 38 PM](https://user-images.githubusercontent.com/103016120/187846558-d7b77be3-b90c-4b60-937f-b4a6646fd91b.png)

![Screenshot 2022-09-01 at 2 09 14 PM](https://user-images.githubusercontent.com/103016120/187846585-462064f1-cc09-4ed1-95c3-aff60726628a.png)



Please include a summary of the change and which issue is fixed below:
-   ...

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
