### PR TITLE
farrah/57001/fixed delete ad modal with active orders

### DIFF
--- a/packages/p2p/src/components/my-ads/my-ads-delete-modal.jsx
+++ b/packages/p2p/src/components/my-ads/my-ads-delete-modal.jsx
@@ -12,8 +12,6 @@ const MyAdsDeleteModal = () => {
     const { my_ads_store } = useStores();
     const isMounted = useIsMounted();
 
-    const [is_delete_error_modal_open, setIsDeleteErrorModalOpen] = React.useState(false);
-
     const onClickCancel = () => {
         my_ads_store.setDeleteErrorMessage('');
         my_ads_store.setSelectedAdId('');
@@ -26,7 +24,7 @@ const MyAdsDeleteModal = () => {
             if (isMounted()) {
                 if (response.error) {
                     my_ads_store.setDeleteErrorMessage(response.error.message);
-                    setIsDeleteErrorModalOpen(true);
+                    my_ads_store.setIsDeleteErrorModalOpen(true);
                 } else {
                     // remove the deleted ad from the list of items
                     const updated_items = my_ads_store.adverts.filter(ad => ad.id !== response.p2p_advert_update.id);
@@ -68,7 +66,7 @@ const MyAdsDeleteModal = () => {
             <Modal
                 className='delete-modal'
                 has_close_icon={false}
-                is_open={is_delete_error_modal_open}
+                is_open={my_ads_store.is_delete_error_modal_open}
                 renderTitle={() => (
                     <Text color='prominent' line-height='m' size={isDesktop() ? 's' : 'xs'} weight='bold'>
                         <Localize i18n_default_text='Do you want to delete this ad?' />
@@ -79,7 +77,7 @@ const MyAdsDeleteModal = () => {
                 <Modal.Body>{my_ads_store.delete_error_message}</Modal.Body>
                 <Modal.Footer>
                     <Button.Group>
-                        <Button primary large onClick={() => setIsDeleteErrorModalOpen(false)}>
+                        <Button primary large onClick={() => my_ads_store.setIsDeleteErrorModalOpen(false)}>
                             <Localize i18n_default_text='Ok' />
                         </Button>
                     </Button.Group>

--- a/packages/p2p/src/stores/my-ads-store.js
+++ b/packages/p2p/src/stores/my-ads-store.js
@@ -26,6 +26,7 @@ export default class MyAdsStore extends BaseStore {
     @observable is_ad_created_modal_visible = false;
     @observable is_ad_exceeds_daily_limit_modal_open = false;
     @observable is_api_error_modal_visible = false;
+    @observable is_delete_error_modal_open = false;
     @observable is_delete_modal_open = false;
     @observable is_edit_ad_error_modal_visible = false;
     @observable is_form_loading = false;
@@ -248,8 +249,24 @@ export default class MyAdsStore extends BaseStore {
     @action.bound
     onClickDelete(id) {
         if (!this.root_store.general_store.is_barred) {
-            this.setSelectedAdId(id);
-            this.setIsDeleteModalOpen(true);
+            requestWS({ p2p_advert_info: 1, id }).then(response => {
+                if (!response?.error) {
+                    const { p2p_advert_info } = response;
+
+                    this.setSelectedAdId(id);
+
+                    if (p2p_advert_info.active_orders > 0) {
+                        this.setDeleteErrorMessage(
+                            localize(
+                                'You have open orders for this ad. Complete all open orders before deleting this ad.'
+                            )
+                        );
+                        this.setIsDeleteErrorModalOpen(true);
+                    } else {
+                        this.setIsDeleteModalOpen(true);
+                    }
+                }
+            });
         }
     }
 
@@ -489,6 +506,11 @@ export default class MyAdsStore extends BaseStore {
     @action.bound
     setIsApiErrorModalVisible(is_api_error_modal_visible) {
         this.is_api_error_modal_visible = is_api_error_modal_visible;
+    }
+
+    @action.bound
+    setIsDeleteErrorModalOpen(is_delete_error_modal_open) {
+        this.is_delete_error_modal_open = is_delete_error_modal_open;
     }
 
     @action.bound


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-   When deleting an advert, only show one confirmation modal if it has active orders.

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
