### PR TITLE
Ameerul /Bug 76645 Block count icon is not greyed out

### DIFF
--- a/packages/p2p/src/components/advertiser-page/block-user/block-user-count.jsx
+++ b/packages/p2p/src/components/advertiser-page/block-user/block-user-count.jsx
@@ -56,7 +56,12 @@ const BlockUserCount = () => {
                     classNameTarget='block-user-count__container'
                     message={getMessage()}
                 >
-                    <Icon className='block-user-count__container--icon' icon='IcUserBlockedOutline' size={16} />
+                    <Icon
+                        className='block-user-count__container--icon'
+                        color='disabled'
+                        icon='IcUserBlockedOutline'
+                        size={16}
+                    />
                     <Text color='less-prominent' line_height='m' size={isDesktop() ? 'xs' : 14}>
                         {blocked_by_count}
                     </Text>


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-   Added the greyed colour (disabled) to Block user icon.
<img width="1614" alt="Screen Shot 2022-09-19 at 12 36 05 PM" src="https://user-images.githubusercontent.com/103412909/191154211-19a0608a-e260-44b9-b7d2-6cc5b9b15fea.png">


## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
