### PR TITLE
Ameerul /Bug 77176 The Block modal keep on looping for Disable P2P user 

### DIFF
--- a/packages/p2p/src/components/advertiser-page/advertiser-page.jsx
+++ b/packages/p2p/src/components/advertiser-page/advertiser-page.jsx
@@ -18,6 +18,7 @@ import AdvertiserPageDropdownMenu from './advertiser-page-dropdown-menu.jsx';
 import TradeBadge from '../trade-badge/trade-badge.jsx';
 import BlockUserOverlay from './block-user/block-user-overlay';
 import BlockUserModal from 'Components/block-user/block-user-modal';
+import ErrorModal from '../error-modal/error-modal.jsx';
 import classNames from 'classnames';
 import './advertiser-page.scss';
 
@@ -44,14 +45,18 @@ const AdvertiserPage = () => {
     const rating_average_decimal = rating_average ? Number(rating_average).toFixed(1) : null;
     const joined_since = daysSince(created_time);
     const is_my_advert = id === general_store.advertiser_id;
+    const [is_error_modal_open, setIsErrorModalOpen] = React.useState(false);
 
     React.useEffect(() => {
         advertiser_page_store.onMount();
         advertiser_page_store.setIsDropdownMenuVisible(false);
 
         return reaction(
-            () => advertiser_page_store.active_index,
-            () => advertiser_page_store.onTabChange(),
+            () => [advertiser_page_store.active_index, general_store.block_unblock_user_error],
+            () => {
+                advertiser_page_store.onTabChange();
+                if (general_store.block_unblock_user_error) setIsErrorModalOpen(true);
+            },
             { fireImmediately: true }
         );
 
@@ -73,10 +78,20 @@ const AdvertiserPage = () => {
             })}
         >
             <RateChangeModal onMount={advertiser_page_store.setShowAdPopup} />
+            <ErrorModal
+                error_message={general_store.block_unblock_user_error}
+                error_modal_title='Unable to block advertiser.'
+                is_error_modal_open={is_error_modal_open}
+                setIsErrorModalOpen={is_open => {
+                    if (is_open === false) buy_sell_store.hideAdvertiserPage();
+                }}
+            />
             <BlockUserModal
                 advertiser_name={name}
                 is_advertiser_blocked={!!advertiser_page_store.is_counterparty_advertiser_blocked}
-                is_block_user_modal_open={general_store.is_block_user_modal_open}
+                is_block_user_modal_open={
+                    general_store.is_block_user_modal_open && !general_store.block_unblock_user_error
+                }
                 onCancel={advertiser_page_store.onCancel}
                 onSubmit={advertiser_page_store.onSubmit}
             />

--- a/packages/p2p/src/components/advertiser-page/advertiser-page.jsx
+++ b/packages/p2p/src/components/advertiser-page/advertiser-page.jsx
@@ -81,9 +81,10 @@ const AdvertiserPage = () => {
             <ErrorModal
                 error_message={general_store.block_unblock_user_error}
                 error_modal_title='Unable to block advertiser.'
+                has_close_icon={false}
                 is_error_modal_open={is_error_modal_open}
                 setIsErrorModalOpen={is_open => {
-                    if (is_open === false) buy_sell_store.hideAdvertiserPage();
+                    if (!is_open) buy_sell_store.hideAdvertiserPage();
                 }}
             />
             <BlockUserModal

--- a/packages/p2p/src/components/error-modal/error-modal.jsx
+++ b/packages/p2p/src/components/error-modal/error-modal.jsx
@@ -20,6 +20,7 @@ const ErrorModal = ({ error_message, error_modal_title, has_close_icon, is_error
 ErrorModal.propTypes = {
     error_message: PropTypes.string,
     error_modal_title: PropTypes.string,
+    has_close_icon: PropTypes.bool,
     is_error_modal_open: PropTypes.bool,
     setIsErrorModalOpen: PropTypes.func,
 };

--- a/packages/p2p/src/components/error-modal/error-modal.jsx
+++ b/packages/p2p/src/components/error-modal/error-modal.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { observer } from 'mobx-react-lite';
 import { Button, Modal } from '@deriv/components';
 import { Localize } from 'Components/i18next';
 
@@ -22,3 +23,5 @@ ErrorModal.propTypes = {
     is_error_modal_open: PropTypes.bool,
     setIsErrorModalOpen: PropTypes.func,
 };
+
+export default observer(ErrorModal);

--- a/packages/p2p/src/components/error-modal/error-modal.jsx
+++ b/packages/p2p/src/components/error-modal/error-modal.jsx
@@ -4,9 +4,9 @@ import { observer } from 'mobx-react-lite';
 import { Button, Modal } from '@deriv/components';
 import { Localize } from 'Components/i18next';
 
-const ErrorModal = ({ error_message, error_modal_title, is_error_modal_open, setIsErrorModalOpen }) => {
+const ErrorModal = ({ error_message, error_modal_title, has_close_icon, is_error_modal_open, setIsErrorModalOpen }) => {
     return (
-        <Modal is_open={is_error_modal_open} title={error_modal_title}>
+        <Modal has_close_icon={has_close_icon} is_open={is_error_modal_open} title={error_modal_title}>
             <Modal.Body>{error_message}</Modal.Body>
             <Modal.Footer>
                 <Button large primary onClick={() => setIsErrorModalOpen(false)}>

--- a/packages/p2p/src/stores/general-store.js
+++ b/packages/p2p/src/stores/general-store.js
@@ -13,7 +13,7 @@ export default class GeneralStore extends BaseStore {
     @observable active_index = 0;
     @observable active_notification_count = 0;
     @observable advertiser_id = null;
-    @observable block_unblock_user_error = null;
+    @observable block_unblock_user_error = '';
     @observable balance;
     @observable inactive_notification_count = 0;
     @observable is_advertiser = false;
@@ -108,7 +108,7 @@ export default class GeneralStore extends BaseStore {
                         );
                     }
                 } else {
-                    this.setBlockUnblockUserError(response.error);
+                    this.setBlockUnblockUserError(response.error.message);
                 }
             }
             this.setIsBlockUnblockUserLoading(false);


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-   Added error modal in advertiser page to handle any error messages when blocking the advertiser.

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
