### PR TITLE
Ameerul /Bug 77339 When userA trying to block an advertiser is barred, once userA is unbarred on trying to block advertiser temporary barred error model is displayed

### DIFF
--- a/packages/p2p/src/components/advertiser-page/advertiser-page.jsx
+++ b/packages/p2p/src/components/advertiser-page/advertiser-page.jsx
@@ -85,7 +85,10 @@ const AdvertiserPage = () => {
                 is_error_modal_open={is_error_modal_open}
                 setIsErrorModalOpen={is_open => {
                     if (!is_open) buy_sell_store.hideAdvertiserPage();
+                    advertiser_page_store.onCancel();
+                    general_store.setBlockUnblockUserError('');
                 }}
+                width={isMobile() ? '80rem' : '50rem'}
             />
             <BlockUserModal
                 advertiser_name={name}

--- a/packages/p2p/src/components/advertiser-page/advertiser-page.jsx
+++ b/packages/p2p/src/components/advertiser-page/advertiser-page.jsx
@@ -18,7 +18,7 @@ import AdvertiserPageDropdownMenu from './advertiser-page-dropdown-menu.jsx';
 import TradeBadge from '../trade-badge/trade-badge.jsx';
 import BlockUserOverlay from './block-user/block-user-overlay';
 import BlockUserModal from 'Components/block-user/block-user-modal';
-import ErrorModal from '../error-modal/error-modal.jsx';
+import ErrorModal from 'Components/error-modal/error-modal';
 import classNames from 'classnames';
 import './advertiser-page.scss';
 
@@ -80,7 +80,7 @@ const AdvertiserPage = () => {
             <RateChangeModal onMount={advertiser_page_store.setShowAdPopup} />
             <ErrorModal
                 error_message={general_store.block_unblock_user_error}
-                error_modal_title='Unable to block advertiser.'
+                error_modal_title='Unable to block advertiser'
                 has_close_icon={false}
                 is_error_modal_open={is_error_modal_open}
                 setIsErrorModalOpen={is_open => {
@@ -88,7 +88,7 @@ const AdvertiserPage = () => {
                     advertiser_page_store.onCancel();
                     general_store.setBlockUnblockUserError('');
                 }}
-                width={isMobile() ? '80rem' : '50rem'}
+                small
             />
             <BlockUserModal
                 advertiser_name={name}

--- a/packages/p2p/src/components/error-modal/error-modal.jsx
+++ b/packages/p2p/src/components/error-modal/error-modal.jsx
@@ -4,9 +4,16 @@ import { observer } from 'mobx-react-lite';
 import { Button, Modal } from '@deriv/components';
 import { Localize } from 'Components/i18next';
 
-const ErrorModal = ({ error_message, error_modal_title, has_close_icon, is_error_modal_open, setIsErrorModalOpen }) => {
+const ErrorModal = ({
+    error_message,
+    error_modal_title,
+    has_close_icon,
+    is_error_modal_open,
+    setIsErrorModalOpen,
+    width,
+}) => {
     return (
-        <Modal has_close_icon={has_close_icon} is_open={is_error_modal_open} title={error_modal_title}>
+        <Modal has_close_icon={has_close_icon} is_open={is_error_modal_open} title={error_modal_title} width={width}>
             <Modal.Body>{error_message}</Modal.Body>
             <Modal.Footer>
                 <Button large primary onClick={() => setIsErrorModalOpen(false)}>
@@ -23,6 +30,7 @@ ErrorModal.propTypes = {
     has_close_icon: PropTypes.bool,
     is_error_modal_open: PropTypes.bool,
     setIsErrorModalOpen: PropTypes.func,
+    width: PropTypes.string,
 };
 
 export default observer(ErrorModal);

--- a/packages/p2p/src/components/error-modal/error-modal.jsx
+++ b/packages/p2p/src/components/error-modal/error-modal.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { observer } from 'mobx-react-lite';
 import { Button, Modal } from '@deriv/components';
 import { Localize } from 'Components/i18next';
+import './error-modal.scss';
 
 const ErrorModal = ({
     error_message,
@@ -10,11 +11,17 @@ const ErrorModal = ({
     has_close_icon,
     is_error_modal_open,
     setIsErrorModalOpen,
-    width,
+    small,
 }) => {
     return (
-        <Modal has_close_icon={has_close_icon} is_open={is_error_modal_open} title={error_modal_title} width={width}>
-            <Modal.Body>{error_message}</Modal.Body>
+        <Modal
+            className='error-modal'
+            has_close_icon={has_close_icon}
+            is_open={is_error_modal_open}
+            small={small}
+            title={error_modal_title}
+        >
+            <Modal.Body className='error-modal__body'>{error_message}</Modal.Body>
             <Modal.Footer>
                 <Button large primary onClick={() => setIsErrorModalOpen(false)}>
                     <Localize i18n_default_text='Ok' />
@@ -30,7 +37,7 @@ ErrorModal.propTypes = {
     has_close_icon: PropTypes.bool,
     is_error_modal_open: PropTypes.bool,
     setIsErrorModalOpen: PropTypes.func,
-    width: PropTypes.string,
+    small: PropTypes.bool,
 };
 
 export default observer(ErrorModal);

--- a/packages/p2p/src/components/error-modal/error-modal.scss
+++ b/packages/p2p/src/components/error-modal/error-modal.scss
@@ -1,0 +1,5 @@
+.error-modal {
+    &__body {
+        padding: 0 2.4rem;
+    }
+}

--- a/packages/p2p/src/components/my-profile/block-user/block-user-table/block-user-table.jsx
+++ b/packages/p2p/src/components/my-profile/block-user/block-user-table/block-user-table.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { reaction } from 'mobx';
 import { observer } from 'mobx-react-lite';
 import { InfiniteDataList, Loading, Table, Text } from '@deriv/components';
 import { localize } from 'Components/i18next';
@@ -16,6 +17,15 @@ const BlockUserTable = () => {
         my_profile_store.getBlockedAdvertisersList();
         my_profile_store.setSearchTerm('');
 
+        reaction(
+            () => general_store.is_barred,
+            () => {
+                if (!general_store.is_barred) general_store.setBlockUnblockUserError('');
+                my_profile_store.getBlockedAdvertisersList();
+                my_profile_store.setSearchTerm('');
+            }
+        );
+
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
@@ -23,7 +33,7 @@ const BlockUserTable = () => {
         return <Loading is_fullscreen={isMobile()} />;
     }
 
-    if (general_store.block_unblock_user_error) {
+    if (general_store.block_unblock_user_error && general_store.is_barred) {
         return <BlockUserTableError error_message={general_store.block_unblock_user_error} />;
     }
 

--- a/packages/p2p/src/components/my-profile/block-user/block-user.jsx
+++ b/packages/p2p/src/components/my-profile/block-user/block-user.jsx
@@ -10,7 +10,7 @@ import debounce from 'lodash.debounce';
 import { localize } from 'Components/i18next';
 
 const BlockUserList = observer(() => {
-    const { my_profile_store } = useStores();
+    const { general_store, my_profile_store } = useStores();
 
     const loadBlockedAdvertisers = debounce(search => {
         my_profile_store.setSearchTerm(search.trim());
@@ -32,7 +32,7 @@ const BlockUserList = observer(() => {
 
     return (
         <div className='block-user__list'>
-            {my_profile_store.blocked_advertisers_list.length > 0 && (
+            {my_profile_store.blocked_advertisers_list.length > 0 && !general_store.is_barred && (
                 <SearchBox onClear={onClear} onSearch={onSearch} placeholder={localize('Search')} />
             )}
             <BlockUserTable />


### PR DESCRIPTION
…hanged width for error modal

## Changes:

Please include a summary of the change and which issue is fixed below:
-  fixed error where error modal would appear even when closing it and going back to advertiser's page.
-  Changed styling for error modal width

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
