### PR TITLE
Adrienne / Advertiser page not scrollable when no ads in responsive

### DIFF
--- a/packages/p2p/src/components/advertiser-page/advertiser-page.scss
+++ b/packages/p2p/src/components/advertiser-page/advertiser-page.scss
@@ -262,7 +262,7 @@
             display: flex;
 
             @media (max-height: 580px) {
-                height: 10rem;
+                height: 5rem;
             }
             @include mobile {
                 display: flex;
@@ -340,7 +340,6 @@
             @include mobile {
                 display: flex;
                 flex-flow: column;
-                margin-top: 1rem;
                 width: 100vw;
             }
 

--- a/packages/p2p/src/components/advertiser-page/advertiser-page.scss
+++ b/packages/p2p/src/components/advertiser-page/advertiser-page.scss
@@ -5,7 +5,8 @@
 
     @include mobile {
         overflow-y: auto;
-        -webkit-overflow-scrolling: touch;
+        overflow-x: hidden;
+        position: relative;
     }
 
     &__dropdown {

--- a/packages/p2p/src/components/advertiser-page/advertiser-page.scss
+++ b/packages/p2p/src/components/advertiser-page/advertiser-page.scss
@@ -3,6 +3,10 @@
     display: flex;
     flex-direction: column;
 
+    @include mobile {
+        overflow-y: auto;
+    }
+
     &__dropdown {
         box-shadow: 0 1rem 2rem var(--shadow-menu);
         border-radius: $BORDER_RADIUS;

--- a/packages/p2p/src/components/advertiser-page/advertiser-page.scss
+++ b/packages/p2p/src/components/advertiser-page/advertiser-page.scss
@@ -5,6 +5,7 @@
 
     @include mobile {
         overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
     }
 
     &__dropdown {

--- a/packages/p2p/src/components/advertiser-page/advertiser-page.scss
+++ b/packages/p2p/src/components/advertiser-page/advertiser-page.scss
@@ -4,12 +4,7 @@
     flex-direction: column;
 
     @include mobile {
-        overflow: auto;
         overflow-y: auto;
-        overflow-x: hidden;
-        position: relative;
-        scroll-behavior: smooth;
-        -webkit-overflow-scrolling: touch;
     }
 
     &__dropdown {

--- a/packages/p2p/src/components/advertiser-page/advertiser-page.scss
+++ b/packages/p2p/src/components/advertiser-page/advertiser-page.scss
@@ -4,9 +4,12 @@
     flex-direction: column;
 
     @include mobile {
+        overflow: auto;
         overflow-y: auto;
         overflow-x: hidden;
         position: relative;
+        scroll-behavior: smooth;
+        -webkit-overflow-scrolling: touch;
     }
 
     &__dropdown {


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-   Fixed an issue where advertiser page is not scrollable in responsive when there are no ads

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
