### PR TITLE
Ameerul /Bug 73568 Unable to click on +Add button under My Ads

### DIFF
--- a/packages/p2p/src/components/my-ads/my-ads.scss
+++ b/packages/p2p/src/components/my-ads/my-ads.scss
@@ -18,6 +18,9 @@
                 padding-top: 0.4rem;
             }
         }
+        .dc-mobile-full-page-modal {
+            opacity: 1 !important;
+        }
     }
 
     .dc-input__wrapper {


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-   Forced the quick add modal to have opacity: 1 as when the user goes outside of p2p, then to p2p, and then to my-ads, if they click the Add button, modal does not show, but it is rendered on the dom with an opacity of 0

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
