### PR TITLE
Ameerul /Bug 80941 Wrong error modal when creating ads while pausing ads

### DIFF
--- a/packages/p2p/src/stores/my-ads-store.js
+++ b/packages/p2p/src/stores/my-ads-store.js
@@ -280,6 +280,8 @@ export default class MyAdsStore extends BaseStore {
                     } else if (!this.is_api_error_modal_visible && !this.is_ad_created_modal_visible) {
                         if (!response.p2p_advert_create.is_visible) {
                             this.setAdvertDetails(response.p2p_advert_create);
+                        }
+                        if (this.advert_details?.visibility_status?.includes('advertiser_daily_limit')) {
                             this.setIsAdExceedsDailyLimitModalOpen(true);
                         }
                         this.setShowAdForm(false);


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-   Fixed logic to show AdExceedsDailyLimitModal when user's daily limit is less than the min order set when creating an advert

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
