### PR TITLE
MaryiaF/81969/Quick strategy--On entering 2 in Martingale strategy throwing error message, Create is only displayed instead of Create and Edit

### DIFF
--- a/packages/bot-web-ui/src/components/dashboard/quick-strategy/quick-strategy-components/footer.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/quick-strategy/quick-strategy-components/footer.tsx
@@ -21,7 +21,7 @@ const QuickStrategyFooter = ({
             <Button
                 type='button'
                 id='db-quick-strategy__button-edit'
-                text={localize('Create')}
+                text={localize('Create and edit')}
                 is_disabled={!is_submit_enabled}
                 secondary
                 large

--- a/packages/bot-web-ui/src/components/dashboard/quick-strategy/quick-strategy-components/form.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/quick-strategy/quick-strategy-components/form.tsx
@@ -48,7 +48,7 @@ const QuickStrategyForm = ({
 
         'quick-strategy__stake': setDefaultValidationNumber(),
         'quick-strategy__loss': setDefaultValidationNumber(),
-        'martingale-size': setDefaultValidationNumber().min(3, localize('Must be a number higher than 2')),
+        'martingale-size': setDefaultValidationNumber(),
         'alembert-unit': setDefaultValidationNumber(),
         'oscar-unit': setDefaultValidationNumber(),
         'quick-strategy__profit': setDefaultValidationNumber(),


### PR DESCRIPTION
…reate is only displayed

## Changes:

Please include a summary of the change and which issue is fixed below:
-   Quick strategy--On entering 2 in Martingale strategy throwing error message, Create is only displayed instead of Create and Edit

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [x] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
