### PR TITLE
Adrienne / fix issue where rate change modal is shown when buy sell page is loaded for the first time

### DIFF
--- a/packages/p2p/src/components/buy-sell/buy-sell-modal.jsx
+++ b/packages/p2p/src/components/buy-sell/buy-sell-modal.jsx
@@ -122,11 +122,13 @@ const BuySellModal = ({ table_type, selected_ad, should_show_popup, setShouldSho
 
     React.useEffect(() => {
         const disposeHasRateChangedReaction = reaction(
-            () => buy_sell_store?.advert?.rate,
-            (_, previous_rate) => {
-                // check to see if previous rate is not undefined
-                // if it is undefined, we do not want to show rate change modal when store is initialized
-                if (previous_rate) {
+            () => buy_sell_store.advert,
+            (new_advert, previous_advert) => {
+                // check to see if the rate is initialized in the store for the first time (when unitialized it is undefined) AND
+                const rate_has_changed = previous_advert?.rate && previous_advert.rate !== new_advert.rate;
+                // check to see if user is not switching between different adverts, it should not trigger rate change modal
+                const is_the_same_advert = previous_advert?.id === new_advert.id;
+                if (rate_has_changed && is_the_same_advert) {
                     setHasRateChangedRecently(true);
                     setTimeout(() => {
                         setHasRateChangedRecently(false);

--- a/packages/p2p/src/components/buy-sell/buy-sell-modal.jsx
+++ b/packages/p2p/src/components/buy-sell/buy-sell-modal.jsx
@@ -170,22 +170,24 @@ const BuySellModal = ({ table_type, selected_ad, should_show_popup, setShouldSho
 
     const BuySellFormError = () => {
         if (!!error_message && buy_sell_store.form_error_code !== api_error_codes.ORDER_CREATE_FAIL_RATE_CHANGED) {
-            <div className='buy-sell__modal--error-message'>
-                <HintBox
-                    className='buy-sell__modal-danger'
-                    icon='IcAlertDanger'
-                    message={
-                        <Text as='p' size='xxxs' color='prominent' line_height='s'>
-                            {buy_sell_store.form_error_code === api_error_codes.ORDER_CREATE_FAIL_CLIENT_BALANCE ? (
-                                <Localize i18n_default_text="Your Deriv P2P balance isn't enough. Please increase your balance before trying again." />
-                            ) : (
-                                error_message
-                            )}
-                        </Text>
-                    }
-                    is_danger
-                />
-            </div>;
+            return (
+                <div className='buy-sell__modal--error-message'>
+                    <HintBox
+                        className='buy-sell__modal-danger'
+                        icon='IcAlertDanger'
+                        message={
+                            <Text as='p' size='xxxs' color='prominent' line_height='s'>
+                                {buy_sell_store.form_error_code === api_error_codes.ORDER_CREATE_FAIL_CLIENT_BALANCE ? (
+                                    <Localize i18n_default_text="Your Deriv P2P balance isn't enough. Please increase your balance before trying again." />
+                                ) : (
+                                    error_message
+                                )}
+                            </Text>
+                        }
+                        is_danger
+                    />
+                </div>
+            );
         }
         return null;
     };

--- a/packages/p2p/src/components/buy-sell/buy-sell-modal.jsx
+++ b/packages/p2p/src/components/buy-sell/buy-sell-modal.jsx
@@ -63,7 +63,7 @@ BuySellModalFooter.propTypes = {
 
 const generateModalTitle = (formik_ref, my_profile_store, table_type, selected_ad) => {
     if (my_profile_store.should_show_add_payment_method_form) {
-        if (!isMobile()) {
+        if (isDesktop()) {
             return (
                 <React.Fragment>
                     <Icon
@@ -139,7 +139,7 @@ const BuySellModal = ({ table_type, selected_ad, should_show_popup, setShouldSho
             () => buy_sell_store.form_error_code,
             () => {
                 if (buy_sell_store.form_error_code === api_error_codes.ORDER_CREATE_FAIL_RATE_CHANGED) {
-                    if (!isMobile()) {
+                    if (isDesktop()) {
                         buy_sell_store.hidePopup();
                         setTimeout(() => setShowMarketRateChangeErrorModal(true), 280);
                     } else {


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-   Fixed an issue where rate change modal is shown when the advert rate is still not fetched in buy sell page when page is loaded for the first time

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
