### PR TITLE
Ameerul /Bug 84324 Instruction details added in Profile page are not field automatically when creating an Ad

### DIFF
--- a/packages/p2p/src/components/my-ads/create-ad-form.jsx
+++ b/packages/p2p/src/components/my-ads/create-ad-form.jsx
@@ -95,7 +95,7 @@ const CreateAdForm = () => {
             <Formik
                 initialValues={{
                     contact_info: general_store.contact_info,
-                    default_advert_description: my_ads_store.default_advert_description,
+                    default_advert_description: general_store.default_advert_description,
                     max_transaction: '',
                     min_transaction: '',
                     offer_amount: '',


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-   Changed call to get default_advert_description from my_ads_store to general_store

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
