### PR TITLE
Kate/78088/fix: trimming POA input fields

### DIFF
--- a/packages/account/src/Sections/Verification/ProofOfAddress/proof-of-address-form.jsx
+++ b/packages/account/src/Sections/Verification/ProofOfAddress/proof-of-address-form.jsx
@@ -87,8 +87,7 @@ const ProofOfAddressForm = ({
     }, [account_settings, fetchResidenceList, fetchStatesList, is_eu, setFormValues]);
 
     const validateFields = values => {
-        //use trim() for all of five inputs; arr[0] input name, arr[1] input value
-        Object.entries(values).forEach(arr => (values[arr[0]] = arr[1].trim()));
+        Object.entries(values).forEach(([key, value]) => (values[key] = value.trim()));
 
         setFormState({ ...form_state, ...{ should_allow_submit: false } });
         const errors = {};

--- a/packages/account/src/Sections/Verification/ProofOfAddress/proof-of-address-form.jsx
+++ b/packages/account/src/Sections/Verification/ProofOfAddress/proof-of-address-form.jsx
@@ -87,6 +87,9 @@ const ProofOfAddressForm = ({
     }, [account_settings, fetchResidenceList, fetchStatesList, is_eu, setFormValues]);
 
     const validateFields = values => {
+        //use trim() for all of five inputs; arr[0] input name, arr[1] input value
+        Object.entries(values).forEach(arr => (values[arr[0]] = arr[1].trim()));
+
         setFormState({ ...form_state, ...{ should_allow_submit: false } });
         const errors = {};
         const validateValues = validate(errors, values);


### PR DESCRIPTION
## Changes:
- trim() was implemented in validateFields function in order to clean value (for each value from all 5 inputs) from extra spaces. 
- bug was connected only with 2 inputs (Town/City, Postal/ZIP code), but in order to make everything in same style, all of the inputs were trimmed. 

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
