### PR TITLE
Kate/ 84780/ trade instruments are flashing after choosing Digits trade type on mobile  

### DIFF
--- a/packages/trader/src/Modules/Trading/Containers/trade.jsx
+++ b/packages/trader/src/Modules/Trading/Containers/trade.jsx
@@ -128,14 +128,17 @@ const Trade = ({
         }
     };
 
-    const topWidgets = ({ ...params }) => (
-        <ChartTopWidgets
-            open_market={open_market}
-            open={try_synthetic_indices || try_open_markets}
-            charts_ref={charts_ref}
-            is_digits_widget_active={is_digits_widget_active}
-            {...params}
-        />
+    const topWidgets = React.useCallback(
+        ({ ...params }) => (
+            <ChartTopWidgets
+                open_market={open_market}
+                open={try_synthetic_indices || try_open_markets}
+                charts_ref={charts_ref}
+                is_digits_widget_active={is_digits_widget_active}
+                {...params}
+            />
+        ),
+        [open_market, try_synthetic_indices, try_open_markets, charts_ref, is_digits_widget_active]
     );
 
     const form_wrapper_class = isMobile() ? 'mobile-wrapper' : 'sidebar__container desktop-only';


### PR DESCRIPTION
## Changes:
Component topWidgets was covered by React.useCallback to avoid its rerendering every time, when new tick / digits was received by parent component <Trade>. Without this memoization, the bug with flashing content of symbols menu (markets)  on mobiles become visible. 

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
