### PR TITLE
Maryia/85246/on the responsive dashboard should have 4 icons in 1 line on the big screen like iPhone 13 Pro Max

### DIFF
--- a/packages/bot-web-ui/src/components/dashboard/dashboard-component/index.scss
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard-component/index.scss
@@ -346,7 +346,7 @@
         }
 
         &__table {
-            width: 90%;
+            width: 88%;
             &--minimized {
                 width: 100%;
             }


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-   fix: on the responsive dashboard should have 4 icons in 1 line on the big screen like iPhone 13 Pro Max
to check it we should set 428 width in the browser

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [x] Ensure all the tests are passing

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [x] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
