### PR TITLE
Kate/ 84150/ Cannot read properties of undefined (reading 'min')

### DIFF
--- a/packages/trader/src/Modules/Trading/Components/Form/DatePicker/trading-date-picker.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/DatePicker/trading-date-picker.jsx
@@ -45,7 +45,7 @@ const TradingDatePicker = ({
     const getMinDuration = () => {
         return hasIntradayDurationUnit(duration_units_list)
             ? toMoment(server_time).clone()
-            : toMoment(server_time).clone().add(duration_min_max.daily.min, 'second');
+            : toMoment(server_time).clone().add(duration_min_max?.daily?.min, 'second');
     };
 
     const getMomentContractStartDateTime = () => {


### PR DESCRIPTION
## Changes:
Added optional chaining in getMinDuration function, because in some scenarios one variable in that function, called duration_min_max, is equal to {}, so we can't get 'min' from empty object and as a result get error.

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
