### PR TITLE
Kate/86838/ add one more available proptype for component DigitDisplay

### DIFF
--- a/packages/trader/src/Modules/Contract/Components/LastDigitPrediction/digit-display.jsx
+++ b/packages/trader/src/Modules/Contract/Components/LastDigitPrediction/digit-display.jsx
@@ -92,7 +92,7 @@ DigitDisplay.propTypes = {
     latest_digit: PropTypes.object,
     onLastDigitSpot: PropTypes.func,
     onSelect: PropTypes.func,
-    selected_digit: PropTypes.number,
+    selected_digit: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
     stats: PropTypes.number,
     status: PropTypes.string,
     value: PropTypes.number,


### PR DESCRIPTION
## Changes:

Add one more available proptype (_selected_digit: PropTypes.oneOfType([PropTypes.number, PropTypes.bool])_) for component DigitDisplay as in some cases we pass not a number, but a boolean value (below you can see a line of code from parent component):

 _selected_digit={isSelectableDigitType() ? selected_digit : false}_

selected_digit is number, but if isSelectableDigitType() returns false, we pass boolean.

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
