### PR TITLE
Ameerul /Bug 86546 P2P clients (Not POI verified clients) are not temp. banned when we block temporary until 14th of next month or any further dates. 

### DIFF
--- a/packages/p2p/src/stores/general-store.js
+++ b/packages/p2p/src/stores/general-store.js
@@ -397,9 +397,7 @@ export default class GeneralStore extends BaseStore {
                     const server_time = this.props.server_time.get();
                     const blocked_until_moment = toMoment(blocked_until);
 
-                    this.user_blocked_timeout = setTimeout(() => {
-                        this.setUserBlockedUntil(null);
-                    }, blocked_until_moment.diff(server_time));
+                    if (server_time.isAfter(blocked_until_moment)) this.setUserBlockedUntil(null);
                 }
             }
         );

--- a/packages/p2p/src/stores/general-store.js
+++ b/packages/p2p/src/stores/general-store.js
@@ -397,6 +397,7 @@ export default class GeneralStore extends BaseStore {
                     const server_time = this.props.server_time.get();
                     const blocked_until_moment = toMoment(blocked_until);
 
+                    // Need isAfter instead of setTimeout as setTimeout has a max delay of 24.8 days
                     if (server_time.isAfter(blocked_until_moment)) this.setUserBlockedUntil(null);
                 }
             }


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-   Removed SetTimeout as there is a 24.8 day limit for it, so I checked if the date is after instead to set if the user is temp barred to null

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
