### PR TITLE
Kate/80001/Remove unused query params from the URL on initialize 

### DIFF
--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -1584,6 +1584,29 @@ export default class ClientStore extends BaseStore {
         this.registerReactions();
         this.setIsLoggingIn(false);
         this.setInitialized(true);
+
+        const unusedParams = [
+            'type',
+            'acp',
+            'label',
+            'server',
+            'interface',
+            'cid',
+            'age',
+            'utm_source',
+            'first_name',
+            'second_name',
+            'email',
+            'phone',
+            '_filteredParams',
+        ];
+
+        const all_search_params = new URLSearchParams(search);
+        const filtered_queries = [...all_search_params].filter(kvp => !unusedParams.includes(kvp[0]));
+        const newParams = new URLSearchParams(filtered_queries || '').toString();
+
+        history.replaceState(null, null, window.location.href.replace(`${search}`, newParams));
+
         return true;
     }
 

--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -1604,7 +1604,7 @@ export default class ClientStore extends BaseStore {
         history.replaceState(
             null,
             null,
-            window.location.href.replace(`${search}`, excludeParamsFromUrlQuery(search_params, unused_params))
+            window.location.href.replace(`${search}`, excludeParamsFromUrlQuery(search, unused_params))
         );
 
         return true;

--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -6,6 +6,7 @@ import {
     State,
     deriv_urls,
     filterUrlQuery,
+    excludeParamsFromUrlQuery,
     getPropertyValue,
     getUrlBinaryBot,
     getUrlSmartTrader,
@@ -1462,6 +1463,21 @@ export default class ClientStore extends BaseStore {
         const redirect_url = search_params?.get('redirect_url');
         const code_param = search_params?.get('code');
         const action_param = search_params?.get('action');
+        const unused_params = [
+            'type',
+            'acp',
+            'label',
+            'server',
+            'interface',
+            'cid',
+            'age',
+            'utm_source',
+            'first_name',
+            'second_name',
+            'email',
+            'phone',
+            '_filteredParams',
+        ];
 
         this.setIsLoggingIn(true);
         const authorize_response = await this.setUserLogin(login_new_user);
@@ -1585,27 +1601,11 @@ export default class ClientStore extends BaseStore {
         this.setIsLoggingIn(false);
         this.setInitialized(true);
 
-        const unusedParams = [
-            'type',
-            'acp',
-            'label',
-            'server',
-            'interface',
-            'cid',
-            'age',
-            'utm_source',
-            'first_name',
-            'second_name',
-            'email',
-            'phone',
-            '_filteredParams',
-        ];
-
-        const all_search_params = new URLSearchParams(search);
-        const filtered_queries = [...all_search_params].filter(kvp => !unusedParams.includes(kvp[0]));
-        const newParams = new URLSearchParams(filtered_queries || '').toString();
-
-        history.replaceState(null, null, window.location.href.replace(`${search}`, newParams));
+        history.replaceState(
+            null,
+            null,
+            window.location.href.replace(`${search}`, excludeParamsFromUrlQuery(search_params, unused_params))
+        );
 
         return true;
     }

--- a/packages/shared/src/utils/url/url.ts
+++ b/packages/shared/src/utils/url/url.ts
@@ -172,7 +172,8 @@ export const filterUrlQuery = (search_param: string, allowed_keys: string[]) => 
     return new URLSearchParams(filtered_queries || '').toString();
 };
 
-export const excludeParamsFromUrlQuery = (params_obj: { [key: string]: string }, excluded_keys: string[]) => {
-    const filtered_queries = Object.entries(params_obj).filter(([key]) => !excluded_keys.includes(key));
+export const excludeParamsFromUrlQuery = (search_param: string, excluded_keys: string[]) => {
+    const search_params = new URLSearchParams(search_param);
+    const filtered_queries = [...search_params].filter(([key]) => !excluded_keys.includes(key));
     return new URLSearchParams(filtered_queries || '').toString();
 };

--- a/packages/shared/src/utils/url/url.ts
+++ b/packages/shared/src/utils/url/url.ts
@@ -171,3 +171,8 @@ export const filterUrlQuery = (search_param: string, allowed_keys: string[]) => 
     const filtered_queries = [...search_params].filter(kvp => allowed_keys.includes(kvp[0]));
     return new URLSearchParams(filtered_queries || '').toString();
 };
+
+export const excludeParamsFromUrlQuery = (params_obj: { [key: string]: string }, excluded_keys: string[]) => {
+    const filtered_queries = Object.entries(params_obj).filter(([key]) => !excluded_keys.includes(key));
+    return new URLSearchParams(filtered_queries || '').toString();
+};


### PR DESCRIPTION
## Changes:

Implemented query check for some specific unused query params (which were described in task): created a small ignore list (an array) and with the help of URLSearchParams and filter method query string now can be cleaned from unnecessary params.
All these manipulations were written in the end of init function in order not no delete by chance useful params , because there are extracted above.

Notes: there is a function filterUrlQuery, which can do the opposite action - it takes a string with parameters and an array of allowed parameters and returns a new filtered string. Unfortunately, it can't be used in this case as we don't know which params are allowed, but we do know, which are unnecessary. 

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
