### PR TITLE
fix: :bug: safely pulls lang from query params, defaults to english

### DIFF
--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -38,6 +38,7 @@ import moment from 'moment';
 import { setDeviceDataCookie } from './Helpers/device';
 
 const LANGUAGE_KEY = 'i18n_language';
+const DEFAULT_LANGUAGE = 'EN';
 const storage_key = 'client.accounts';
 const store_name = 'client_store';
 const eu_shortcode_regex = new RegExp('^(maltainvest|malta|iom)$');
@@ -409,13 +410,11 @@ export default class ClientStore extends BaseStore {
             () => [this.account_settings],
             () => {
                 const { trading_hub } = this.account_settings;
-                const lang_from_url = window.location.search.slice(-2);
+                const lang_from_url = new URLSearchParams(window.location.search).get('lang') || DEFAULT_LANGUAGE;
                 this.is_pre_appstore = !!trading_hub;
                 localStorage.setItem('is_pre_appstore', !!trading_hub);
-                if (lang_from_url) {
-                    this.setPreferredLanguage(lang_from_url);
-                    localStorage.setItem(LANGUAGE_KEY, lang_from_url);
-                }
+                this.setPreferredLanguage(lang_from_url);
+                LocalStore.set(LANGUAGE_KEY, lang_from_url);
             }
         );
         // TODO: Remove this after setting trading_hub enabled for all users


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
- On new user sign up and language selection, if a currently unsupported language(country name) is selected, language will be set to english by default.
- Appends the language code 'en' instead of the erroneous 'll' wherever applicable. eg: smarttrader.deriv.com/**en**/trading.html instead of smarttrader.deriv.com/**ll**/trading.html 

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [x] Ensure the language is set to english(en) by default when a new user selects an unsupported language
-   [ ] Ensure utility / function has a test case
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
