### PR TITLE
Kate/89075/Trade type name and back arrow is missing in the Mobile version

### DIFF
--- a/packages/trader/src/Modules/Trading/Components/Form/ContractType/contract-type-dialog.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/ContractType/contract-type-dialog.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { DesktopWrapper, MobileDialog, MobileWrapper } from '@deriv/components';
+import { Header } from './ContractTypeInfo';
 import { localize } from '@deriv/translations';
 import ContractTypeMenu from './ContractTypeMenu';
 
@@ -17,39 +18,47 @@ const ContractTypeDialog = ({
     onChangeInput,
     onCategoryClick,
     show_loading,
-}) => (
-    <React.Fragment>
-        <MobileWrapper>
-            <span className='contract-type-widget__select-arrow' />
-            <MobileDialog
-                portal_element_id='modal_root'
-                title={localize('Trade type')}
-                wrapper_classname='contracts-modal-list'
-                visible={is_open}
-                onClose={onClose}
-                has_content_scroll
-            >
-                {children}
-            </MobileDialog>
-        </MobileWrapper>
-        <DesktopWrapper>
-            <ContractTypeMenu
-                is_info_dialog_open={is_info_dialog_open}
-                is_open={is_open}
-                item={item}
-                list={list}
-                selected={selected}
-                categories={categories}
-                onBackButtonClick={onBackButtonClick}
-                onChangeInput={onChangeInput}
-                onCategoryClick={onCategoryClick}
-                show_loading={show_loading}
-            >
-                {children}
-            </ContractTypeMenu>
-        </DesktopWrapper>
-    </React.Fragment>
-);
+}) => {
+    const current_mobile_title = is_info_dialog_open ? (
+        <Header title={item.text} onClickGoBack={onBackButtonClick} text_size='xs' />
+    ) : (
+        localize('Trade type')
+    );
+    return (
+        <React.Fragment>
+            <MobileWrapper>
+                <span className='contract-type-widget__select-arrow' />
+                <MobileDialog
+                    portal_element_id='modal_root'
+                    title={current_mobile_title}
+                    header_classname='contract-type-widget__header'
+                    wrapper_classname='contracts-modal-list'
+                    visible={is_open}
+                    onClose={onClose}
+                    has_content_scroll
+                >
+                    {children}
+                </MobileDialog>
+            </MobileWrapper>
+            <DesktopWrapper>
+                <ContractTypeMenu
+                    is_info_dialog_open={is_info_dialog_open}
+                    is_open={is_open}
+                    item={item}
+                    list={list}
+                    selected={selected}
+                    categories={categories}
+                    onBackButtonClick={onBackButtonClick}
+                    onChangeInput={onChangeInput}
+                    onCategoryClick={onCategoryClick}
+                    show_loading={show_loading}
+                >
+                    {children}
+                </ContractTypeMenu>
+            </DesktopWrapper>
+        </React.Fragment>
+    );
+};
 
 ContractTypeDialog.propTypes = {
     categories: PropTypes.array,

--- a/packages/trader/src/Modules/Trading/Components/Form/ContractType/contract-type-item.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/ContractType/contract-type-item.jsx
@@ -2,7 +2,7 @@ import { PropTypes as MobxPropTypes } from 'mobx-react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Icon, DesktopWrapper, Text } from '@deriv/components';
+import { Icon, Text } from '@deriv/components';
 import IconTradeCategory from 'Assets/Trading/Categories/icon-trade-categories.jsx';
 
 const Item = ({ contract_types, handleInfoClick, handleSelect, name, value }) =>
@@ -22,11 +22,9 @@ const Item = ({ contract_types, handleInfoClick, handleSelect, name, value }) =>
             <Text size='xs' className='contract-type-item__title'>
                 {type.text}
             </Text>
-            <DesktopWrapper>
-                <div id='info-icon' className='contract-type-item__icon' onClick={() => handleInfoClick(type)}>
-                    <Icon icon='IcInfoOutline' />
-                </div>
-            </DesktopWrapper>
+            <div id='info-icon' className='contract-type-item__icon' onClick={() => handleInfoClick(type)}>
+                <Icon icon='IcInfoOutline' />
+            </div>
         </div>
     ));
 

--- a/packages/trader/src/sass/app/_common/components/contract-type-info.scss
+++ b/packages/trader/src/sass/app/_common/components/contract-type-info.scss
@@ -21,6 +21,10 @@
         @media screen and (min-height: 821px) {
             min-height: 535px;
         }
+        @include mobile {
+            min-height: calc(100vh - 140px);
+            padding: 0;
+        }
     }
     &__content {
         overflow: hidden;

--- a/packages/trader/src/sass/app/_common/components/contract-type-info.scss
+++ b/packages/trader/src/sass/app/_common/components/contract-type-info.scss
@@ -59,6 +59,10 @@
         align-items: center;
         justify-content: center;
         width: 100%;
+
+        @include mobile {
+            gap: 2.4rem;
+        }
     }
     &__title {
         margin: auto;

--- a/packages/trader/src/sass/app/_common/components/contract-type-list.scss
+++ b/packages/trader/src/sass/app/_common/components/contract-type-list.scss
@@ -34,16 +34,11 @@
 
     &:hover {
         background-color: var(--state-hover);
-
-        .contract-type-item__icon {
-            display: block;
-        }
     }
     &__title {
         padding-left: 1.6rem;
     }
     &__icon {
-        display: none;
         margin-left: auto;
 
         /* postcss-bem-linter: ignore */


### PR DESCRIPTION
## Changes:

- Refactor code in order to show trade type and back arrow in trade type info in mobile.

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [x] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
