### PR TITLE
Mahdiyeh/fix: not showing trading assesment modal when switching between account

### DIFF
--- a/packages/core/src/App/Containers/Modals/app-modals.jsx
+++ b/packages/core/src/App/Containers/Modals/app-modals.jsx
@@ -71,6 +71,7 @@ const AppModals = ({
     is_trading_assessment_for_new_user_enabled,
     fetchFinancialAssessment,
     setCFDScore,
+    setIsCFDScoreAvailable,
     content_flag,
     active_account_landing_company,
     is_deriv_account_needed_modal_visible,
@@ -86,7 +87,10 @@ const AppModals = ({
 
     React.useEffect(() => {
         if (is_logged_in) {
-            fetchFinancialAssessment().then(response => setCFDScore(response?.cfd_score ?? 0));
+            fetchFinancialAssessment().then(response => {
+                setCFDScore(response?.cfd_score ?? 0);
+                setIsCFDScoreAvailable(true);
+            });
         }
     }, [is_logged_in]);
 
@@ -176,6 +180,7 @@ export default connect(({ client, ui, traders_hub }) => ({
     has_maltainvest_account: client.has_maltainvest_account,
     fetchFinancialAssessment: client.fetchFinancialAssessment,
     setCFDScore: client.setCFDScore,
+    setIsCFDScoreAvailable: client.setIsCFDScoreAvailable,
     setShouldShowVerifiedAccount: ui.setShouldShowVerifiedAccount,
     should_show_cooldown_modal: ui.should_show_cooldown_modal,
     should_show_assessment_complete_modal: ui.should_show_assessment_complete_modal,

--- a/packages/core/src/App/Containers/Modals/trading-experience-modal.jsx
+++ b/packages/core/src/App/Containers/Modals/trading-experience-modal.jsx
@@ -5,13 +5,14 @@ import { Localize, localize } from '@deriv/translations';
 
 const TradingExperienceModal = ({
     cfd_score,
+    is_cfd_score_available,
     is_trading_experience_incomplete,
     setShouldShowTradingAssessmentModal,
     should_show_trading_assessment_modal,
     setShouldShowTradeAssessmentForm,
 }) => {
     React.useEffect(() => {
-        setShouldShowTradingAssessmentModal(cfd_score === 0);
+        setShouldShowTradingAssessmentModal(cfd_score === 0 && is_cfd_score_available);
     }, []);
 
     const handleOnSubmit = () => {
@@ -50,4 +51,5 @@ export default connect(({ client, ui }) => ({
     should_show_trading_assessment_modal: ui.should_show_trading_assessment_modal,
     setShouldShowTradeAssessmentForm: ui.setShouldShowTradeAssessmentForm,
     cfd_score: client.cfd_score,
+    is_cfd_score_available: client.is_cfd_score_available,
 }))(TradingExperienceModal);

--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -143,6 +143,7 @@ export default class ClientStore extends BaseStore {
     is_cfd_poi_completed = false;
 
     cfd_score = 0;
+    is_cfd_score_available = false;
 
     is_mt5_account_list_updated = false;
 
@@ -199,6 +200,7 @@ export default class ClientStore extends BaseStore {
             dxtrade_disabled_signup_types: observable,
             statement: observable,
             cfd_score: observable,
+            is_cfd_score_available: observable,
             obj_total_balance: observable,
             verification_code: observable,
             new_email: observable,
@@ -306,6 +308,7 @@ export default class ClientStore extends BaseStore {
             setPreferredLanguage: action.bound,
             setCookieAccount: action.bound,
             setCFDScore: action.bound,
+            setIsCFDScoreAvailable: action.bound,
             updateSelfExclusion: action.bound,
             responsePayoutCurrencies: action.bound,
             responseAuthorize: action.bound,
@@ -1212,6 +1215,9 @@ export default class ClientStore extends BaseStore {
     // CFD score is the computed points based on the CFD related questions that the user answers in trading-assessment.
     setCFDScore(score) {
         this.cfd_score = score;
+    }
+    setIsCFDScoreAvailable(is_set) {
+        this.is_cfd_score_set = is_set;
     }
 
     getSelfExclusion() {

--- a/packages/core/src/Stores/notification-store.js
+++ b/packages/core/src/Stores/notification-store.js
@@ -250,7 +250,7 @@ export default class NotificationStore extends BaseStore {
         const { loginid } = this.root_store.client;
         const refined_list = notifications_list[loginid] ? Object.values(notifications_list[loginid]) : [];
         const p2p_settings = LocalStore.getObject('p2p_settings');
-        const is_p2p_notifications_visible = p2p_settings[loginid].is_notifications_visible;
+        const is_p2p_notifications_visible = p2p_settings[loginid]?.is_notifications_visible;
 
         if (refined_list.length) {
             refined_list.map(refined => {


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-   Fix showing Trading assessment popup when cfd_score is not set
-   Fix console error on for `can not get propert is_notifications_visible of undefined`

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
