### PR TITLE
fix: popup empty for error thrown when activating ad from table

### DIFF
--- a/packages/p2p/src/stores/my-ads-store.js
+++ b/packages/p2p/src/stores/my-ads-store.js
@@ -1,5 +1,5 @@
 import { action, observable, makeObservable, computed } from 'mobx';
-import { getDecimalPlaces } from '@deriv/shared';
+import { getDecimalPlaces, isMobile } from '@deriv/shared';
 import { localize } from 'Components/i18next';
 import { buy_sell } from 'Constants/buy-sell';
 import { ad_type } from 'Constants/floating-rate';
@@ -266,8 +266,9 @@ export default class MyAdsStore extends BaseStore {
                             key: 'ErrorModal',
                             props: {
                                 has_close_icon: false,
-                                message: response.error.message,
-                                title: generateErrorDialogTitle(this.error_code),
+                                error_message: response.error.message,
+                                error_modal_title: generateErrorDialogTitle(this.error_code),
+                                width: isMobile() ? '90rem' : '40rem',
                             },
                         });
                     } else {
@@ -403,8 +404,9 @@ export default class MyAdsStore extends BaseStore {
                     key: 'ErrorModal',
                     props: {
                         has_close_icon: false,
-                        message: response.error.message,
-                        title: generateErrorDialogTitle(this.error_code),
+                        error_message: response.error.message,
+                        error_modal_title: generateErrorDialogTitle(this.error_code),
+                        width: isMobile() ? '90rem' : '40rem',
                     },
                 });
             }


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-   ...pop up modal for error thrown for activating ad from my ads table is empty

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [X] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
