### PR TITLE
Maryia/91511/fix: verify_email counter in withdrawal

### DIFF
--- a/packages/cashier/src/components/email-verification-empty-state/email-verification-empty-state.tsx
+++ b/packages/cashier/src/components/email-verification-empty-state/email-verification-empty-state.tsx
@@ -22,9 +22,9 @@ const EmailVerificationEmptyState = ({ verify }: TEmailVerificationEmptyStatePro
                 icon='IcEmailSent'
                 title={localize("We've sent you an email.")}
                 description={localize('Please check your email for the verification link to complete the process.')}
-                action={verify.has_been_sent ? undefined : action}
+                action={verify.sent_count > 1 ? undefined : action}
             />
-            {verify.has_been_sent && (
+            {verify.sent_count > 1 && (
                 <EmailVerificationResendEmptyState
                     is_counter_running={verify.is_counter_running}
                     counter={verify.counter}

--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -2221,6 +2221,7 @@ export default class ClientStore extends BaseStore {
         } else {
             LocalStore.remove(`verification_code.${action}`);
         }
+        if (action.includes('withdraw')) sessionStorage.removeItem('sent_verify_emails_data');
         if (action === 'signup') {
             // TODO: add await if error handling needs to happen before AccountSignup is initialised
             this.fetchResidenceList(); // Prefetch for use in account signup process

--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -1182,7 +1182,7 @@ export default class ClientStore extends BaseStore {
 
     setSentVerifyEmailsData(sent_verify_emails_data) {
         this.sent_verify_emails_data = sent_verify_emails_data;
-        LocalStore.setObject('sent_verify_emails_data', sent_verify_emails_data);
+        sessionStorage.setItem('sent_verify_emails_data', JSON.stringify(sent_verify_emails_data));
     }
 
     setCookieAccount() {
@@ -1591,7 +1591,7 @@ export default class ClientStore extends BaseStore {
 
         this.setLoginId(LocalStore.get('active_loginid'));
         this.setAccounts(LocalStore.getObject(storage_key));
-        this.setSentVerifyEmailsData(LocalStore.getObject('sent_verify_emails_data'));
+        this.setSentVerifyEmailsData(JSON.parse(sessionStorage.getItem('sent_verify_emails_data')));
         this.setSwitched('');
         const client = this.accounts[this.loginid];
         // If there is an authorize_response, it means it was the first login

--- a/packages/hooks/src/useVerifyEmail.ts
+++ b/packages/hooks/src/useVerifyEmail.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useWS } from '@deriv/api';
 import { useStore } from '@deriv/stores';
 import type { TSocketEndpoints } from '@deriv/api/types';
@@ -11,24 +12,29 @@ const useVerifyEmail = (type: TEmailVerificationType) => {
     const WS = useWS('verify_email');
     const { client } = useStore();
     const { setSentVerifyEmailsData, sent_verify_emails_data } = client;
-    const { last_time_sent_seconds = 0, sent_count = 0 } = sent_verify_emails_data?.[type] || {};
+    const { last_time_sent_seconds = 0, sent_count: prev_sent_count = 0 } = sent_verify_emails_data?.[type] || {};
+    const [sent_count, setSentCount] = React.useState(prev_sent_count);
     const time_now_seconds = Math.floor(Date.now() / 1000);
     const seconds_left = last_time_sent_seconds + RESEND_COUNTDOWN - time_now_seconds;
     const should_not_allow_resend =
         last_time_sent_seconds && time_now_seconds < last_time_sent_seconds + RESEND_COUNTDOWN;
     const countdown = should_not_allow_resend ? seconds_left : RESEND_COUNTDOWN;
-    const counter = useCountdown({ from: countdown });
+    const { count, is_running, reset, start } = useCountdown({ from: countdown });
 
-    if (!counter.is_running && should_not_allow_resend) {
-        counter.start();
+    if (!is_running && should_not_allow_resend) {
+        start();
+    } else if (!should_not_allow_resend && count === RESEND_COUNTDOWN && last_time_sent_seconds && sent_count > 0) {
+        if (is_running) reset();
+        setSentVerifyEmailsData({ ...sent_verify_emails_data, [type]: {} });
+        setSentCount(0);
     }
 
     const send = () => {
-        if (!client.email || counter.is_running) return;
+        if (!client.email || is_running) return;
 
         if (sent_count > 0) {
-            counter.reset();
-            counter.start();
+            reset();
+            start();
         }
 
         const sent_emails_data = {
@@ -39,6 +45,7 @@ const useVerifyEmail = (type: TEmailVerificationType) => {
             },
         };
         setSentVerifyEmailsData(sent_emails_data);
+        setSentCount(sent_count + 1);
 
         WS.send({ verify_email: client.email, type });
     };
@@ -47,8 +54,8 @@ const useVerifyEmail = (type: TEmailVerificationType) => {
         is_loading: WS.is_loading,
         error: WS.error,
         data: WS.data,
-        counter: counter.count,
-        is_counter_running: counter.is_running,
+        counter: count,
+        is_counter_running: is_running,
         sent_count,
         has_been_sent: sent_count !== 0,
         send,

--- a/packages/hooks/src/useVerifyEmail.ts
+++ b/packages/hooks/src/useVerifyEmail.ts
@@ -11,7 +11,7 @@ const useVerifyEmail = (type: TEmailVerificationType) => {
     const WS = useWS('verify_email');
     const { client } = useStore();
     const { setSentVerifyEmailsData, sent_verify_emails_data } = client;
-    const { last_time_sent_seconds = 0, sent_count = 0 } = sent_verify_emails_data[type] || {};
+    const { last_time_sent_seconds = 0, sent_count = 0 } = sent_verify_emails_data?.[type] || {};
     const time_now_seconds = Math.floor(Date.now() / 1000);
     const seconds_left = last_time_sent_seconds + RESEND_COUNTDOWN - time_now_seconds;
     const should_not_allow_resend =
@@ -24,14 +24,19 @@ const useVerifyEmail = (type: TEmailVerificationType) => {
     }
 
     const send = () => {
-        if (!client.email) return;
-        if (counter.is_running) return;
+        if (!client.email || counter.is_running) return;
 
-        counter.reset();
-        counter.start();
+        if (sent_count > 0) {
+            counter.reset();
+            counter.start();
+        }
+
         const sent_emails_data = {
             ...sent_verify_emails_data,
-            [type]: { last_time_sent_seconds: time_now_seconds, sent_count: sent_count + 1 },
+            [type]: {
+                last_time_sent_seconds: sent_count && time_now_seconds,
+                sent_count: sent_count + 1,
+            },
         };
         setSentVerifyEmailsData(sent_emails_data);
 

--- a/packages/hooks/src/useVerifyEmail.ts
+++ b/packages/hooks/src/useVerifyEmail.ts
@@ -12,18 +12,24 @@ const useVerifyEmail = (type: TEmailVerificationType) => {
     const WS = useWS('verify_email');
     const { client } = useStore();
     const { setSentVerifyEmailsData, sent_verify_emails_data } = client;
-    const { last_time_sent_seconds = 0, sent_count: prev_sent_count = 0 } = sent_verify_emails_data?.[type] || {};
-    const [sent_count, setSentCount] = React.useState(prev_sent_count);
+    const { resend_email_requested_time = 0, sent_count: current_sent_count = 0 } =
+        sent_verify_emails_data?.[type] || {};
+    const [sent_count, setSentCount] = React.useState(current_sent_count);
     const time_now_seconds = Math.floor(Date.now() / 1000);
-    const seconds_left = last_time_sent_seconds + RESEND_COUNTDOWN - time_now_seconds;
+    const seconds_left = resend_email_requested_time + RESEND_COUNTDOWN - time_now_seconds;
     const should_not_allow_resend =
-        last_time_sent_seconds && time_now_seconds < last_time_sent_seconds + RESEND_COUNTDOWN;
+        resend_email_requested_time && time_now_seconds < resend_email_requested_time + RESEND_COUNTDOWN;
     const countdown = should_not_allow_resend ? seconds_left : RESEND_COUNTDOWN;
     const { count, is_running, reset, start } = useCountdown({ from: countdown });
 
     if (!is_running && should_not_allow_resend) {
         start();
-    } else if (!should_not_allow_resend && count === RESEND_COUNTDOWN && last_time_sent_seconds && sent_count > 0) {
+    } else if (
+        !should_not_allow_resend &&
+        count === RESEND_COUNTDOWN &&
+        resend_email_requested_time &&
+        sent_count > 0
+    ) {
         if (is_running) reset();
         setSentVerifyEmailsData({ ...sent_verify_emails_data, [type]: {} });
         setSentCount(0);
@@ -40,7 +46,7 @@ const useVerifyEmail = (type: TEmailVerificationType) => {
         const sent_emails_data = {
             ...sent_verify_emails_data,
             [type]: {
-                last_time_sent_seconds: sent_count && time_now_seconds,
+                resend_email_requested_time: sent_count && time_now_seconds,
                 sent_count: sent_count + 1,
             },
         };

--- a/packages/stores/types.ts
+++ b/packages/stores/types.ts
@@ -184,7 +184,7 @@ type TSentVerifyEmailsData = Partial<
     Record<
         TEmailVerificationType,
         {
-            last_time_sent_seconds: number;
+            resend_email_requested_time: number;
             sent_count: number;
         }
     >


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-   to ensure Didn't Receive an email is shown before counter starts
-   to start verify_email counter in withdrawal only after second request
-   to store verify_email data in sessionStorage

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
