### PR TITLE
maryia/92212/fix: RadioGroupOptionsModal for Multiplier options in all languages

### DIFF
--- a/packages/trader/src/Modules/Trading/Containers/radio-group-options-modal.jsx
+++ b/packages/trader/src/Modules/Trading/Containers/radio-group-options-modal.jsx
@@ -36,7 +36,7 @@ const RadioGroupOptionsModal = ({
                 title={modal_title}
             >
                 <Div100vhContainer className='mobile-widget-dialog__wrapper' max_autoheight_offset='48px'>
-                    {modal_title.toLowerCase() === 'multiplier' ? (
+                    {modal_title === localize('Multiplier') ? (
                         <MultiplierOptions toggleModal={toggleModal} />
                     ) : (
                         <RadioGroupWithInfoMobile


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-   To fix: RadioGroupOptionsModal for Multiplier options to display for all languages, not only EN

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
