### PR TITLE
fix: replace MobxContentProvider with StoreProvider

### DIFF
--- a/packages/bot-web-ui/src/app/app.jsx
+++ b/packages/bot-web-ui/src/app/app.jsx
@@ -11,7 +11,7 @@ import {
     RoutePromptDialog,
 } from 'Components';
 import BlocklyLoading from '../components/blockly-loading';
-import { MobxContentProvider } from 'Stores/connect';
+import { StoreProvider } from '@deriv/stores';
 import RootStore from 'Stores';
 import GTM from 'Utils/gtm';
 import BotBuilder from 'Components/dashboard/bot-builder';
@@ -84,7 +84,7 @@ const App = ({ passthrough }) => {
     return is_loading ? (
         <Loading />
     ) : (
-        <MobxContentProvider store={root_store_instance.current}>
+        <StoreProvider store={{ ...root_store_instance.current, ...root_store_instance.current.core }}>
             <BlocklyLoading />
             <div className='bot-dashboard bot'>
                 <Audio />
@@ -95,7 +95,7 @@ const App = ({ passthrough }) => {
                 <BotBuilder />
                 <RoutePromptDialog />
             </div>
-        </MobxContentProvider>
+        </StoreProvider>
     );
 };
 

--- a/packages/bot-web-ui/src/stores/connect.js
+++ b/packages/bot-web-ui/src/stores/connect.js
@@ -1,15 +1,12 @@
-import { useObserver } from 'mobx-react';
 import React from 'react';
+import { useStore, observer } from '@deriv/stores';
 
 const isClassComponent = Component =>
     !!(typeof Component === 'function' && Component.prototype && Component.prototype.isReactComponent);
 
-export const MobxContent = React.createContext(null);
-
 function injectStorePropsToComponent(propsToSelectFn, BaseComponent) {
     const Component = own_props => {
-        const store = React.useContext(MobxContent);
-
+        const store = useStore();
         let ObservedComponent = BaseComponent;
 
         if (isClassComponent(BaseComponent)) {
@@ -17,15 +14,11 @@ function injectStorePropsToComponent(propsToSelectFn, BaseComponent) {
             ObservedComponent = FunctionalWrapperComponent;
         }
 
-        return useObserver(() => ObservedComponent({ ...own_props, ...propsToSelectFn(store, own_props) }));
+        return ObservedComponent({ ...own_props, ...propsToSelectFn(store, own_props) });
     };
 
     Component.displayName = BaseComponent.name;
-    return Component;
+    return observer(Component);
 }
-
-export const MobxContentProvider = ({ store, children }) => {
-    return <MobxContent.Provider value={{ ...store, ...store.core }}>{children}</MobxContent.Provider>;
-};
 
 export const connect = propsToSelectFn => Component => injectStorePropsToComponent(propsToSelectFn, Component);

--- a/packages/bot-web-ui/webpack.config.js
+++ b/packages/bot-web-ui/webpack.config.js
@@ -88,11 +88,6 @@ module.exports = function (env) {
                 {
                     test: /\.(js|jsx|ts|tsx)$/,
                     exclude: /node_modules/,
-                    loader: '@deriv/shared/src/loaders/react-import-loader.js',
-                },
-                {
-                    test: /\.(js|jsx|ts|tsx)$/,
-                    exclude: /node_modules/,
                     loader: 'babel-loader',
                     options: {
                         rootMode: 'upward',


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-   replace MobxContentProvider from bot-web-ui with StoreProvider from @deriv/stores

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
