### PR TITLE
fix: disabled buttons until chat url is updated

### DIFF
--- a/packages/p2p/src/components/order-details/order-details-footer.jsx
+++ b/packages/p2p/src/components/order-details/order-details-footer.jsx
@@ -15,6 +15,7 @@ const OrderDetailsFooter = observer(() => {
         should_show_complain_and_received_button,
         should_show_only_received_button,
         should_show_only_complain_button,
+        chat_channel_url,
     } = order_store.order_information;
 
     const [should_show_complain_modal, setShouldShowComplainModal] = React.useState(false);
@@ -50,10 +51,10 @@ const OrderDetailsFooter = observer(() => {
                 <div className='order-details-card__footer'>
                     <div className='order-details-card__footer--right'>
                         <Button.Group>
-                            <Button large secondary onClick={showCancelOrderModal}>
+                            <Button large secondary onClick={showCancelOrderModal} is_disabled={!chat_channel_url}>
                                 <Localize i18n_default_text='Cancel order' />
                             </Button>
-                            <Button large primary onClick={showConfirmOrderModal}>
+                            <Button large primary onClick={showConfirmOrderModal} is_disabled={!chat_channel_url}>
                                 <Localize i18n_default_text="I've paid" />
                             </Button>
                         </Button.Group>


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-   ... Disabled popup buttons until page is completely rendered.

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
