### PR TITLE
Ameerul /Bug P2PS-598 Confirmation popup showing 2 times in DP2P

### DIFF
--- a/packages/p2p/src/components/modal-manager/modals/email-link-verified-modal/email-link-verified-modal.jsx
+++ b/packages/p2p/src/components/modal-manager/modals/email-link-verified-modal/email-link-verified-modal.jsx
@@ -33,7 +33,7 @@ const EmailLinkVerifiedModal = () => {
                     large
                     primary
                     onClick={() => {
-                        hideModal();
+                        hideModal({ should_hide_all_modals: true });
                         order_store.confirmOrder(is_buy_order_for_user);
                     }}
                 >


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-   Passed should_hide_all_modals: true to hideModal when clicking Confirm in the modal to make sure this modal will no longer show after clicking confirm

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
