### PR TITLE
Ameerul /P2PS-868 Add payment method modal is showing in buy/sell page

### DIFF
--- a/packages/p2p/src/components/my-profile/my-profile.jsx
+++ b/packages/p2p/src/components/my-profile/my-profile.jsx
@@ -17,6 +17,7 @@ const MyProfile = () => {
         return () => {
             // leave this in the return otherwise the default isn't set to my stats
             my_profile_store.setActiveTab(my_profile_tabs.MY_STATS);
+            my_profile_store.setShouldShowAddPaymentMethodForm(false);
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- onUnmounting my profile page, setShouldShowAddPaymentMethodForm I passed in false as it was still true when navigating to other pages.

### Screenshots:

Please provide some screenshots of the change.
