### PR TITLE
shahzaib / WALL-756 / allow idv for vanuatu jurisdiction on MT5

### DIFF
--- a/packages/account/src/Components/poi-poa-docs-submitted/poi-poa-docs-submitted.tsx
+++ b/packages/account/src/Components/poi-poa-docs-submitted/poi-poa-docs-submitted.tsx
@@ -43,11 +43,10 @@ const PoiPoaDocsSubmitted = ({
     const getDescription = () => {
         const { manual_status, poi_verified_for_maltainvest, poi_verified_for_bvi_labuan_vanuatu, poa_pending } =
             getAuthenticationStatusInfo(account_status);
-        const is_vanuatu_or_maltainvest_selected =
-            jurisdiction_selected_shortcode === 'vanuatu' || jurisdiction_selected_shortcode === 'maltainvest';
+        const is_maltainvest_selected = jurisdiction_selected_shortcode === 'maltainvest';
         if (
-            (is_vanuatu_or_maltainvest_selected && poi_verified_for_maltainvest && poa_pending) ||
-            (!is_vanuatu_or_maltainvest_selected && poi_verified_for_bvi_labuan_vanuatu && poa_pending) ||
+            (is_maltainvest_selected && poi_verified_for_maltainvest && poa_pending) ||
+            (!is_maltainvest_selected && poi_verified_for_bvi_labuan_vanuatu && poa_pending) ||
             manual_status === 'pending'
         ) {
             return localize('We’ll review your documents and notify you of its status within 1 - 3 working days.');

--- a/packages/account/src/Components/poi-poa-docs-submitted/poi-poa-docs-submitted.tsx
+++ b/packages/account/src/Components/poi-poa-docs-submitted/poi-poa-docs-submitted.tsx
@@ -41,13 +41,13 @@ const PoiPoaDocsSubmitted = ({
     };
 
     const getDescription = () => {
-        const { manual_status, poi_verified_for_vanuatu_maltainvest, poi_verified_for_bvi_labuan, poa_pending } =
+        const { manual_status, poi_verified_for_maltainvest, poi_verified_for_bvi_labuan_vanuatu, poa_pending } =
             getAuthenticationStatusInfo(account_status);
         const is_vanuatu_or_maltainvest_selected =
             jurisdiction_selected_shortcode === 'vanuatu' || jurisdiction_selected_shortcode === 'maltainvest';
         if (
-            (is_vanuatu_or_maltainvest_selected && poi_verified_for_vanuatu_maltainvest && poa_pending) ||
-            (!is_vanuatu_or_maltainvest_selected && poi_verified_for_bvi_labuan && poa_pending) ||
+            (is_vanuatu_or_maltainvest_selected && poi_verified_for_maltainvest && poa_pending) ||
+            (!is_vanuatu_or_maltainvest_selected && poi_verified_for_bvi_labuan_vanuatu && poa_pending) ||
             manual_status === 'pending'
         ) {
             return localize('We’ll review your documents and notify you of its status within 1 - 3 working days.');

--- a/packages/account/src/Sections/Verification/ProofOfIdentity/proof-of-identity-container-for-mt5.jsx
+++ b/packages/account/src/Sections/Verification/ProofOfIdentity/proof-of-identity-container-for-mt5.jsx
@@ -10,6 +10,7 @@ import { populateVerificationStatus } from '../Helpers/verification';
 
 const ProofOfIdentityContainerForMt5 = ({
     account_status,
+    account_settings,
     fetchResidenceList,
     height,
     is_from_external,
@@ -83,6 +84,7 @@ const ProofOfIdentityContainerForMt5 = ({
             residence_list={residence_list}
             citizen_data={citizen_data}
             has_idv_error={has_idv_error}
+            account_settings={account_settings}
         />
     );
 };

--- a/packages/account/src/Sections/Verification/ProofOfIdentity/proof-of-identity-container-for-mt5.jsx
+++ b/packages/account/src/Sections/Verification/ProofOfIdentity/proof-of-identity-container-for-mt5.jsx
@@ -19,7 +19,7 @@ const ProofOfIdentityContainerForMt5 = ({
     onStateChange,
     refreshNotifications,
     citizen_data,
-    landing_company_shortcode,
+    is_eu_user,
 }) => {
     const [api_error, setAPIError] = React.useState();
     const [residence_list, setResidenceList] = React.useState();
@@ -86,7 +86,7 @@ const ProofOfIdentityContainerForMt5 = ({
             citizen_data={citizen_data}
             has_idv_error={has_idv_error}
             account_settings={account_settings}
-            landing_company_shortcode={landing_company_shortcode}
+            is_eu_user={is_eu_user}
         />
     );
 };

--- a/packages/account/src/Sections/Verification/ProofOfIdentity/proof-of-identity-container-for-mt5.jsx
+++ b/packages/account/src/Sections/Verification/ProofOfIdentity/proof-of-identity-container-for-mt5.jsx
@@ -19,6 +19,7 @@ const ProofOfIdentityContainerForMt5 = ({
     onStateChange,
     refreshNotifications,
     citizen_data,
+    landing_company_shortcode,
 }) => {
     const [api_error, setAPIError] = React.useState();
     const [residence_list, setResidenceList] = React.useState();
@@ -85,6 +86,7 @@ const ProofOfIdentityContainerForMt5 = ({
             citizen_data={citizen_data}
             has_idv_error={has_idv_error}
             account_settings={account_settings}
+            landing_company_shortcode={landing_company_shortcode}
         />
     );
 };

--- a/packages/account/src/Sections/Verification/ProofOfIdentity/proof-of-identity-container-for-mt5.jsx
+++ b/packages/account/src/Sections/Verification/ProofOfIdentity/proof-of-identity-container-for-mt5.jsx
@@ -18,7 +18,6 @@ const ProofOfIdentityContainerForMt5 = ({
     onStateChange,
     refreshNotifications,
     citizen_data,
-    jurisdiction_selected_shortcode,
 }) => {
     const [api_error, setAPIError] = React.useState();
     const [residence_list, setResidenceList] = React.useState();
@@ -84,7 +83,6 @@ const ProofOfIdentityContainerForMt5 = ({
             residence_list={residence_list}
             citizen_data={citizen_data}
             has_idv_error={has_idv_error}
-            jurisdiction_selected_shortcode={jurisdiction_selected_shortcode}
         />
     );
 };

--- a/packages/account/src/Sections/Verification/ProofOfIdentity/proof-of-identity-submission-for-mt5.jsx
+++ b/packages/account/src/Sections/Verification/ProofOfIdentity/proof-of-identity-submission-for-mt5.jsx
@@ -18,7 +18,7 @@ const POISubmissionForMT5 = ({
     has_idv_error,
     residence_list,
     account_settings,
-    landing_company_shortcode,
+    is_eu_user,
 }) => {
     const [submission_status, setSubmissionStatus] = React.useState(); // submitting
     const [submission_service, setSubmissionService] = React.useState();
@@ -28,12 +28,7 @@ const POISubmissionForMT5 = ({
             const { submissions_left: onfido_submissions_left } = onfido;
             const is_idv_supported = isVerificationServiceSupported(residence_list, account_settings, 'idv');
             const is_onfido_supported = isVerificationServiceSupported(residence_list, account_settings, 'onfido');
-            if (
-                is_idv_supported &&
-                Number(idv_submissions_left) > 0 &&
-                !is_idv_disallowed &&
-                landing_company_shortcode !== 'maltainvest'
-            ) {
+            if (is_idv_supported && Number(idv_submissions_left) > 0 && !is_idv_disallowed && !is_eu_user) {
                 setSubmissionService(service_code.idv);
             } else if (onfido_submissions_left && is_onfido_supported) {
                 setSubmissionService(service_code.onfido);

--- a/packages/account/src/Sections/Verification/ProofOfIdentity/proof-of-identity-submission-for-mt5.jsx
+++ b/packages/account/src/Sections/Verification/ProofOfIdentity/proof-of-identity-submission-for-mt5.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import React from 'react';
-import { WS } from '@deriv/shared';
+import { WS, isVerificationServiceSupported } from '@deriv/shared';
 import Unsupported from 'Components/poi/status/unsupported';
 import OnfidoUpload from './onfido-sdk-view.jsx';
 import { identity_status_codes, submission_status_code, service_code } from './proof-of-identity-utils';
@@ -16,6 +16,8 @@ const POISubmissionForMT5 = ({
     refreshNotifications,
     citizen_data,
     has_idv_error,
+    residence_list,
+    account_settings,
 }) => {
     const [submission_status, setSubmissionStatus] = React.useState(); // submitting
     const [submission_service, setSubmissionService] = React.useState();
@@ -23,8 +25,8 @@ const POISubmissionForMT5 = ({
         if (citizen_data) {
             const { submissions_left: idv_submissions_left } = idv;
             const { submissions_left: onfido_submissions_left } = onfido;
-            const is_idv_supported = citizen_data.identity.services.idv.is_country_supported;
-            const is_onfido_supported = citizen_data.identity.services.onfido.is_country_supported;
+            const is_idv_supported = isVerificationServiceSupported(residence_list, account_settings, 'idv');
+            const is_onfido_supported = isVerificationServiceSupported(residence_list, account_settings, 'onfido');
             if (is_idv_supported && Number(idv_submissions_left) > 0 && !is_idv_disallowed) {
                 setSubmissionService(service_code.idv);
             } else if (onfido_submissions_left && is_onfido_supported) {

--- a/packages/account/src/Sections/Verification/ProofOfIdentity/proof-of-identity-submission-for-mt5.jsx
+++ b/packages/account/src/Sections/Verification/ProofOfIdentity/proof-of-identity-submission-for-mt5.jsx
@@ -16,7 +16,6 @@ const POISubmissionForMT5 = ({
     refreshNotifications,
     citizen_data,
     has_idv_error,
-    jurisdiction_selected_shortcode,
 }) => {
     const [submission_status, setSubmissionStatus] = React.useState(); // submitting
     const [submission_service, setSubmissionService] = React.useState();
@@ -26,12 +25,7 @@ const POISubmissionForMT5 = ({
             const { submissions_left: onfido_submissions_left } = onfido;
             const is_idv_supported = citizen_data.identity.services.idv.is_country_supported;
             const is_onfido_supported = citizen_data.identity.services.onfido.is_country_supported;
-            if (
-                is_idv_supported &&
-                Number(idv_submissions_left) > 0 &&
-                !is_idv_disallowed &&
-                jurisdiction_selected_shortcode !== 'vanuatu'
-            ) {
+            if (is_idv_supported && Number(idv_submissions_left) > 0 && !is_idv_disallowed) {
                 setSubmissionService(service_code.idv);
             } else if (onfido_submissions_left && is_onfido_supported) {
                 setSubmissionService(service_code.onfido);

--- a/packages/account/src/Sections/Verification/ProofOfIdentity/proof-of-identity-submission-for-mt5.jsx
+++ b/packages/account/src/Sections/Verification/ProofOfIdentity/proof-of-identity-submission-for-mt5.jsx
@@ -18,6 +18,7 @@ const POISubmissionForMT5 = ({
     has_idv_error,
     residence_list,
     account_settings,
+    landing_company_shortcode,
 }) => {
     const [submission_status, setSubmissionStatus] = React.useState(); // submitting
     const [submission_service, setSubmissionService] = React.useState();
@@ -27,7 +28,12 @@ const POISubmissionForMT5 = ({
             const { submissions_left: onfido_submissions_left } = onfido;
             const is_idv_supported = isVerificationServiceSupported(residence_list, account_settings, 'idv');
             const is_onfido_supported = isVerificationServiceSupported(residence_list, account_settings, 'onfido');
-            if (is_idv_supported && Number(idv_submissions_left) > 0 && !is_idv_disallowed) {
+            if (
+                is_idv_supported &&
+                Number(idv_submissions_left) > 0 &&
+                !is_idv_disallowed &&
+                landing_company_shortcode !== 'maltainvest'
+            ) {
                 setSubmissionService(service_code.idv);
             } else if (onfido_submissions_left && is_onfido_supported) {
                 setSubmissionService(service_code.onfido);

--- a/packages/appstore/src/components/modals/failed-veriification-modal/failed-verification-modal.tsx
+++ b/packages/appstore/src/components/modals/failed-veriification-modal/failed-verification-modal.tsx
@@ -66,7 +66,7 @@ const FailedVerificationModal = () => {
     const { disableApp, enableApp } = ui;
     const is_from_multipliers = open_failed_verification_for === 'multipliers';
 
-    const { poi_resubmit_for_vanuatu_maltainvest, poi_resubmit_for_bvi_labuan, need_poa_resubmission } =
+    const { poi_resubmit_for_maltainvest, poi_resubmit_for_bvi_labuan_vanuatu, need_poa_resubmission } =
         getAuthenticationStatusInfo(account_status);
     const history = useHistory();
 
@@ -93,9 +93,9 @@ const FailedVerificationModal = () => {
             open_failed_verification_for === 'vanuatu' ||
             open_failed_verification_for === 'maltainvest'
         ) {
-            return poi_resubmit_for_vanuatu_maltainvest;
+            return poi_resubmit_for_maltainvest;
         }
-        return poi_resubmit_for_bvi_labuan;
+        return poi_resubmit_for_bvi_labuan_vanuatu;
     };
     const should_resubmit_poa = need_poa_resubmission;
     const from_account_label = is_from_multipliers ? localize('Multipliers') : localize('MT5');

--- a/packages/appstore/src/components/modals/failed-veriification-modal/failed-verification-modal.tsx
+++ b/packages/appstore/src/components/modals/failed-veriification-modal/failed-verification-modal.tsx
@@ -88,11 +88,7 @@ const FailedVerificationModal = () => {
     };
 
     const should_resubmit_poi = () => {
-        if (
-            is_from_multipliers ||
-            open_failed_verification_for === 'vanuatu' ||
-            open_failed_verification_for === 'maltainvest'
-        ) {
+        if (is_from_multipliers || open_failed_verification_for === 'maltainvest') {
             return poi_resubmit_for_maltainvest;
         }
         return poi_resubmit_for_bvi_labuan_vanuatu;

--- a/packages/cfd/src/Components/cfd-poi.tsx
+++ b/packages/cfd/src/Components/cfd-poi.tsx
@@ -40,6 +40,7 @@ export type TCFDPOIProps = {
     account_settings: GetSettings;
     residence_list: ResidenceList;
     jurisdiction_selected_shortcode: string;
+    landing_company_shortcode: string;
 };
 
 const CFDPOI = ({ index, onSave, onSubmit, height, ...props }: TCFDPOIProps) => {
@@ -76,4 +77,5 @@ export default connect(({ client, common, notifications }: RootStore) => ({
     should_allow_authentication: client.should_allow_authentication,
     account_settings: client.account_settings,
     residence_list: client.residence_list,
+    landing_company_shortcode: client.landing_company_shortcode,
 }))(CFDPOI);

--- a/packages/cfd/src/Components/cfd-poi.tsx
+++ b/packages/cfd/src/Components/cfd-poi.tsx
@@ -40,7 +40,7 @@ export type TCFDPOIProps = {
     account_settings: GetSettings;
     residence_list: ResidenceList;
     jurisdiction_selected_shortcode: string;
-    landing_company_shortcode: string;
+    is_eu_user: boolean;
 };
 
 const CFDPOI = ({ index, onSave, onSubmit, height, ...props }: TCFDPOIProps) => {
@@ -64,7 +64,7 @@ const CFDPOI = ({ index, onSave, onSubmit, height, ...props }: TCFDPOIProps) => 
     );
 };
 
-export default connect(({ client, common, notifications }: RootStore) => ({
+export default connect(({ client, common, notifications, traders_hub }: RootStore) => ({
     account_status: client.account_status,
     app_routing_history: common.app_routing_history,
     fetchResidenceList: client.fetchResidenceList,
@@ -77,5 +77,5 @@ export default connect(({ client, common, notifications }: RootStore) => ({
     should_allow_authentication: client.should_allow_authentication,
     account_settings: client.account_settings,
     residence_list: client.residence_list,
-    landing_company_shortcode: client.landing_company_shortcode,
+    is_eu_user: traders_hub.is_eu_user,
 }))(CFDPOI);

--- a/packages/cfd/src/Containers/cfd-dbvi-onboarding.tsx
+++ b/packages/cfd/src/Containers/cfd-dbvi-onboarding.tsx
@@ -61,19 +61,19 @@ const CFDDbviOnboarding = ({
             const { get_account_status } = response;
 
             if (get_account_status?.authentication) {
-                const { poi_acknowledged_for_vanuatu_maltainvest, poi_acknowledged_for_bvi_labuan, poa_acknowledged } =
+                const { poi_acknowledged_for_maltainvest, poi_acknowledged_for_bvi_labuan_vanuatu, poa_acknowledged } =
                     getAuthenticationStatusInfo(get_account_status);
                 if (jurisdiction_selected_shortcode === 'vanuatu') {
                     setShowSubmittedModal(
-                        poi_acknowledged_for_vanuatu_maltainvest &&
-                            poa_acknowledged &&
-                            has_submitted_cfd_personal_details
+                        poi_acknowledged_for_maltainvest && poa_acknowledged && has_submitted_cfd_personal_details
                     );
                 } else if (jurisdiction_selected_shortcode === 'maltainvest') {
-                    setShowSubmittedModal(poi_acknowledged_for_vanuatu_maltainvest && poa_acknowledged);
+                    setShowSubmittedModal(poi_acknowledged_for_maltainvest && poa_acknowledged);
                 } else
                     setShowSubmittedModal(
-                        poi_acknowledged_for_bvi_labuan && poa_acknowledged && has_submitted_cfd_personal_details
+                        poi_acknowledged_for_bvi_labuan_vanuatu &&
+                            poa_acknowledged &&
+                            has_submitted_cfd_personal_details
                     );
             }
 

--- a/packages/cfd/src/Containers/cfd-dbvi-onboarding.tsx
+++ b/packages/cfd/src/Containers/cfd-dbvi-onboarding.tsx
@@ -63,11 +63,7 @@ const CFDDbviOnboarding = ({
             if (get_account_status?.authentication) {
                 const { poi_acknowledged_for_maltainvest, poi_acknowledged_for_bvi_labuan_vanuatu, poa_acknowledged } =
                     getAuthenticationStatusInfo(get_account_status);
-                if (jurisdiction_selected_shortcode === 'vanuatu') {
-                    setShowSubmittedModal(
-                        poi_acknowledged_for_maltainvest && poa_acknowledged && has_submitted_cfd_personal_details
-                    );
-                } else if (jurisdiction_selected_shortcode === 'maltainvest') {
+                if (jurisdiction_selected_shortcode === 'maltainvest') {
                     setShowSubmittedModal(poi_acknowledged_for_maltainvest && poa_acknowledged);
                 } else
                     setShowSubmittedModal(

--- a/packages/cfd/src/Containers/cfd-financial-stp-real-account-signup.tsx
+++ b/packages/cfd/src/Containers/cfd-financial-stp-real-account-signup.tsx
@@ -69,7 +69,7 @@ const CFDFinancialStpRealAccountSignup = (props: TCFDFinancialStpRealAccountSign
     const state_index = step;
     let is_mounted = React.useRef(true).current;
 
-    const { need_poi_for_vanuatu_maltainvest, need_poi_for_bvi_labuan } = getAuthenticationStatusInfo(account_status);
+    const { need_poi_for_maltainvest, need_poi_for_bvi_labuan_vanuatu } = getAuthenticationStatusInfo(account_status);
 
     const poi_config: TItemsState = {
         body: CFDPOI,
@@ -113,9 +113,9 @@ const CFDFinancialStpRealAccountSignup = (props: TCFDFinancialStpRealAccountSign
 
     const should_show_poi = () => {
         if (jurisdiction_selected_shortcode === 'vanuatu' || jurisdiction_selected_shortcode === 'maltainvest') {
-            return need_poi_for_vanuatu_maltainvest;
+            return need_poi_for_maltainvest;
         }
-        return need_poi_for_bvi_labuan;
+        return need_poi_for_bvi_labuan_vanuatu;
     };
     const should_show_poa = !(
         authentication_status.document_status === 'pending' || authentication_status.document_status === 'verified'

--- a/packages/cfd/src/Containers/cfd-financial-stp-real-account-signup.tsx
+++ b/packages/cfd/src/Containers/cfd-financial-stp-real-account-signup.tsx
@@ -112,7 +112,7 @@ const CFDFinancialStpRealAccountSignup = (props: TCFDFinancialStpRealAccountSign
     };
 
     const should_show_poi = () => {
-        if (jurisdiction_selected_shortcode === 'vanuatu' || jurisdiction_selected_shortcode === 'maltainvest') {
+        if (jurisdiction_selected_shortcode === 'maltainvest') {
             return need_poi_for_maltainvest;
         }
         return need_poi_for_bvi_labuan_vanuatu;

--- a/packages/cfd/src/Containers/cfd-password-modal.tsx
+++ b/packages/cfd/src/Containers/cfd-password-modal.tsx
@@ -683,10 +683,8 @@ const CFDPasswordModal = ({
     const getVerificationStatus = () => {
         if (jurisdiction_selected_shortcode === 'svg') {
             setIsSelectedMT5Verified(true);
-        } else if (jurisdiction_selected_shortcode === 'bvi') {
+        } else if (jurisdiction_selected_shortcode === 'bvi' || jurisdiction_selected_shortcode === 'vanuatu') {
             setIsSelectedMT5Verified(poi_verified_for_bvi_labuan_vanuatu);
-        } else if (jurisdiction_selected_shortcode === 'vanuatu') {
-            setIsSelectedMT5Verified(poi_verified_for_maltainvest);
         } else if (jurisdiction_selected_shortcode === 'labuan') {
             setIsSelectedMT5Verified(poi_verified_for_bvi_labuan_vanuatu && poa_verified);
         } else if (jurisdiction_selected_shortcode === 'maltainvest') {

--- a/packages/cfd/src/Containers/cfd-password-modal.tsx
+++ b/packages/cfd/src/Containers/cfd-password-modal.tsx
@@ -675,7 +675,7 @@ const CFDPasswordModal = ({
     const is_password_reset = error_type === 'PasswordReset';
     const [is_sent_email_modal_open, setIsSentEmailModalOpen] = React.useState(false);
 
-    const { poi_verified_for_bvi_labuan, poi_verified_for_vanuatu_maltainvest, poa_verified, manual_status } =
+    const { poi_verified_for_bvi_labuan_vanuatu, poi_verified_for_maltainvest, poa_verified, manual_status } =
         getAuthenticationStatusInfo(account_status);
 
     const [is_selected_mt5_verified, setIsSelectedMT5Verified] = React.useState(false);
@@ -684,13 +684,13 @@ const CFDPasswordModal = ({
         if (jurisdiction_selected_shortcode === 'svg') {
             setIsSelectedMT5Verified(true);
         } else if (jurisdiction_selected_shortcode === 'bvi') {
-            setIsSelectedMT5Verified(poi_verified_for_bvi_labuan);
+            setIsSelectedMT5Verified(poi_verified_for_bvi_labuan_vanuatu);
         } else if (jurisdiction_selected_shortcode === 'vanuatu') {
-            setIsSelectedMT5Verified(poi_verified_for_vanuatu_maltainvest);
+            setIsSelectedMT5Verified(poi_verified_for_maltainvest);
         } else if (jurisdiction_selected_shortcode === 'labuan') {
-            setIsSelectedMT5Verified(poi_verified_for_bvi_labuan && poa_verified);
+            setIsSelectedMT5Verified(poi_verified_for_bvi_labuan_vanuatu && poa_verified);
         } else if (jurisdiction_selected_shortcode === 'maltainvest') {
-            setIsSelectedMT5Verified(poi_verified_for_vanuatu_maltainvest && poa_verified);
+            setIsSelectedMT5Verified(poi_verified_for_maltainvest && poa_verified);
         }
     };
 

--- a/packages/cfd/src/Containers/cfd-password-modal.tsx
+++ b/packages/cfd/src/Containers/cfd-password-modal.tsx
@@ -683,7 +683,7 @@ const CFDPasswordModal = ({
     const getVerificationStatus = () => {
         if (jurisdiction_selected_shortcode === 'svg') {
             setIsSelectedMT5Verified(true);
-        } else if (jurisdiction_selected_shortcode === 'bvi' || jurisdiction_selected_shortcode === 'vanuatu') {
+        } else if (['bvi', 'vanuatu'].includes(jurisdiction_selected_shortcode)) {
             setIsSelectedMT5Verified(poi_verified_for_bvi_labuan_vanuatu);
         } else if (jurisdiction_selected_shortcode === 'labuan') {
             setIsSelectedMT5Verified(poi_verified_for_bvi_labuan_vanuatu && poa_verified);

--- a/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-card-banner.tsx
+++ b/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-card-banner.tsx
@@ -5,9 +5,11 @@ import { getAuthenticationStatusInfo } from '@deriv/shared';
 import { Text } from '@deriv/components';
 import { Localize } from '@deriv/translations';
 import { TVerificationStatusBannerProps } from '../props.types';
+import { ResidenceList } from '@deriv/api-types';
 
 const VerificationStatusBanner = ({
     account_status,
+    account_settings,
     account_type,
     card_classname,
     disabled,
@@ -19,7 +21,16 @@ const VerificationStatusBanner = ({
     real_synthetic_accounts_existing_data,
     real_financial_accounts_existing_data,
     real_swapfree_accounts_existing_data,
+    residence_list,
 }: TVerificationStatusBannerProps) => {
+    const citizen = account_settings?.citizen || account_settings?.country_code;
+    const citizen_data: ResidenceList[0] = residence_list?.find(item => item.value === citizen) as ResidenceList[0];
+    let is_idv_supported: number | undefined = 0;
+
+    if (citizen_data) {
+        is_idv_supported = citizen_data?.identity?.services?.idv?.is_country_supported;
+    }
+
     const {
         poi_not_submitted_for_vanuatu_maltainvest,
         poi_and_poa_not_submitted,
@@ -31,7 +42,7 @@ const VerificationStatusBanner = ({
         poi_acknowledged_for_vanuatu_maltainvest,
         poi_acknowledged_for_bvi_labuan,
         poa_not_submitted,
-    } = getAuthenticationStatusInfo(account_status);
+    } = getAuthenticationStatusInfo(account_status, is_idv_supported);
 
     const getAccountTitle = () => {
         switch (account_type) {
@@ -203,10 +214,12 @@ const JurisdictionCardBanner = (props: TVerificationStatusBannerProps) => {
 
 export default connect(({ modules: { cfd }, client }: RootStore) => ({
     account_status: client.account_status,
+    account_settings: client.account_settings,
     is_virtual: client.is_virtual,
     should_restrict_bvi_account_creation: client.should_restrict_bvi_account_creation,
     should_restrict_vanuatu_account_creation: client.should_restrict_vanuatu_account_creation,
     real_financial_accounts_existing_data: cfd.real_financial_accounts_existing_data,
     real_synthetic_accounts_existing_data: cfd.real_synthetic_accounts_existing_data,
     real_swapfree_accounts_existing_data: cfd.real_swapfree_accounts_existing_data,
+    residence_list: client.residence_list,
 }))(JurisdictionCardBanner);

--- a/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-card-banner.tsx
+++ b/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-card-banner.tsx
@@ -1,18 +1,16 @@
 import React from 'react';
 import RootStore from '../../Stores/index';
 import { connect } from '../../Stores/connect';
-import { getAuthenticationStatusInfo, isVerificationServiceSupported } from '@deriv/shared';
+import { getAuthenticationStatusInfo } from '@deriv/shared';
 import { Text } from '@deriv/components';
 import { Localize } from '@deriv/translations';
 import { TVerificationStatusBannerProps } from '../props.types';
 
 const VerificationStatusBanner = ({
     account_status,
-    account_settings,
     account_type,
     card_classname,
     disabled,
-    context,
     is_virtual,
     type_of_card,
     should_restrict_bvi_account_creation,
@@ -20,22 +18,18 @@ const VerificationStatusBanner = ({
     real_synthetic_accounts_existing_data,
     real_financial_accounts_existing_data,
     real_swapfree_accounts_existing_data,
-    residence_list,
 }: TVerificationStatusBannerProps) => {
-    const is_idv_supported = isVerificationServiceSupported(residence_list, account_settings, 'idv');
-
     const {
-        poi_not_submitted_for_vanuatu_maltainvest,
         poi_and_poa_not_submitted,
-        poi_resubmit_for_vanuatu_maltainvest,
-        poi_resubmit_for_bvi_labuan,
+        poi_resubmit_for_maltainvest,
+        poi_resubmit_for_bvi_labuan_vanuatu,
         need_poa_resubmission,
-        need_poi_for_bvi_labuan,
+        need_poi_for_bvi_labuan_vanuatu,
         poa_pending,
-        poi_acknowledged_for_vanuatu_maltainvest,
-        poi_acknowledged_for_bvi_labuan,
+        poi_acknowledged_for_maltainvest,
+        poi_acknowledged_for_bvi_labuan_vanuatu,
         poa_not_submitted,
-    } = getAuthenticationStatusInfo(account_status, is_idv_supported);
+    } = getAuthenticationStatusInfo(account_status);
 
     const getAccountTitle = () => {
         switch (account_type) {
@@ -124,7 +118,7 @@ const VerificationStatusBanner = ({
                 </Text>
             </div>
         );
-    } else if (is_vanuatu && poi_not_submitted_for_vanuatu_maltainvest) {
+    } else if (is_vanuatu && poa_not_submitted) {
         return (
             <div className={`${card_classname}__verification-status--not_submitted`}>
                 <Text as='p' size='xxs' align='center' color='prominent'>
@@ -153,8 +147,8 @@ const VerificationStatusBanner = ({
             </div>
         );
     } else if (
-        ((is_bvi || is_labuan) && poi_acknowledged_for_vanuatu_maltainvest && poa_not_submitted) ||
-        ((is_vanuatu || is_maltainvest) && poi_acknowledged_for_bvi_labuan && poa_not_submitted)
+        ((is_bvi || is_labuan || is_vanuatu) && poi_acknowledged_for_maltainvest && poa_not_submitted) ||
+        (is_maltainvest && poi_acknowledged_for_bvi_labuan_vanuatu && poa_not_submitted)
     ) {
         return (
             <div className={`${card_classname}__verification-status--failed`}>
@@ -164,8 +158,8 @@ const VerificationStatusBanner = ({
             </div>
         );
     } else if (
-        ((is_bvi || is_labuan) && need_poi_for_bvi_labuan && need_poa_resubmission) ||
-        ((is_vanuatu || is_maltainvest) && poi_resubmit_for_vanuatu_maltainvest && need_poa_resubmission)
+        ((is_bvi || is_labuan || is_vanuatu) && need_poi_for_bvi_labuan_vanuatu && need_poa_resubmission) ||
+        (is_maltainvest && poi_resubmit_for_maltainvest && need_poa_resubmission)
     ) {
         return (
             <div className={`${card_classname}__verification-status--failed`}>
@@ -175,8 +169,8 @@ const VerificationStatusBanner = ({
             </div>
         );
     } else if (
-        ((is_bvi || is_labuan) && poi_resubmit_for_bvi_labuan) ||
-        ((is_vanuatu || is_maltainvest) && poi_resubmit_for_vanuatu_maltainvest)
+        ((is_bvi || is_labuan || is_vanuatu) && poi_resubmit_for_bvi_labuan_vanuatu) ||
+        (is_maltainvest && poi_resubmit_for_maltainvest)
     ) {
         return (
             <div className={`${card_classname}__verification-status--failed`}>
@@ -207,12 +201,10 @@ const JurisdictionCardBanner = (props: TVerificationStatusBannerProps) => {
 
 export default connect(({ modules: { cfd }, client }: RootStore) => ({
     account_status: client.account_status,
-    account_settings: client.account_settings,
     is_virtual: client.is_virtual,
     should_restrict_bvi_account_creation: client.should_restrict_bvi_account_creation,
     should_restrict_vanuatu_account_creation: client.should_restrict_vanuatu_account_creation,
     real_financial_accounts_existing_data: cfd.real_financial_accounts_existing_data,
     real_synthetic_accounts_existing_data: cfd.real_synthetic_accounts_existing_data,
     real_swapfree_accounts_existing_data: cfd.real_swapfree_accounts_existing_data,
-    residence_list: client.residence_list,
 }))(JurisdictionCardBanner);

--- a/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-card-banner.tsx
+++ b/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-card-banner.tsx
@@ -49,6 +49,8 @@ const VerificationStatusBanner = ({
     const is_labuan = type_of_card === 'labuan';
     const is_maltainvest = type_of_card === 'maltainvest';
 
+    const is_bvi_vanuatu_labuan_selected = is_bvi || is_vanuatu || is_labuan;
+
     const getTypeTitle = () => {
         switch (type_of_card) {
             case 'bvi':
@@ -148,7 +150,7 @@ const VerificationStatusBanner = ({
             </div>
         );
     } else if (
-        ((is_bvi || is_labuan || is_vanuatu) && poi_acknowledged_for_bvi_labuan_vanuatu && poa_not_submitted) ||
+        (is_bvi_vanuatu_labuan_selected && poi_acknowledged_for_bvi_labuan_vanuatu && poa_not_submitted) ||
         (is_maltainvest && poi_acknowledged_for_maltainvest && poa_not_submitted)
     ) {
         return (
@@ -159,7 +161,7 @@ const VerificationStatusBanner = ({
             </div>
         );
     } else if (
-        ((is_bvi || is_labuan || is_vanuatu) && need_poi_for_bvi_labuan_vanuatu && need_poa_resubmission) ||
+        (is_bvi_vanuatu_labuan_selected && need_poi_for_bvi_labuan_vanuatu && need_poa_resubmission) ||
         (is_maltainvest && poi_resubmit_for_maltainvest && need_poa_resubmission)
     ) {
         return (
@@ -170,7 +172,7 @@ const VerificationStatusBanner = ({
             </div>
         );
     } else if (
-        ((is_bvi || is_labuan || is_vanuatu) && poi_resubmit_for_bvi_labuan_vanuatu) ||
+        (is_bvi_vanuatu_labuan_selected && poi_resubmit_for_bvi_labuan_vanuatu) ||
         (is_maltainvest && poi_resubmit_for_maltainvest)
     ) {
         return (

--- a/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-card-banner.tsx
+++ b/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-card-banner.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import RootStore from '../../Stores/index';
 import { connect } from '../../Stores/connect';
-import { getAuthenticationStatusInfo } from '@deriv/shared';
+import { getAuthenticationStatusInfo, isResidentIDVSupported } from '@deriv/shared';
 import { Text } from '@deriv/components';
 import { Localize } from '@deriv/translations';
 import { TVerificationStatusBannerProps } from '../props.types';
-import { ResidenceList } from '@deriv/api-types';
 
 const VerificationStatusBanner = ({
     account_status,
@@ -23,13 +22,7 @@ const VerificationStatusBanner = ({
     real_swapfree_accounts_existing_data,
     residence_list,
 }: TVerificationStatusBannerProps) => {
-    const citizen = account_settings?.citizen || account_settings?.country_code;
-    const citizen_data: ResidenceList[0] = residence_list?.find(item => item.value === citizen) as ResidenceList[0];
-    let is_idv_supported: number | undefined = 0;
-
-    if (citizen_data) {
-        is_idv_supported = citizen_data?.identity?.services?.idv?.is_country_supported;
-    }
+    const is_idv_supported = isResidentIDVSupported(residence_list, account_settings);
 
     const {
         poi_not_submitted_for_vanuatu_maltainvest,

--- a/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-card-banner.tsx
+++ b/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-card-banner.tsx
@@ -147,8 +147,8 @@ const VerificationStatusBanner = ({
             </div>
         );
     } else if (
-        ((is_bvi || is_labuan || is_vanuatu) && poi_acknowledged_for_maltainvest && poa_not_submitted) ||
-        (is_maltainvest && poi_acknowledged_for_bvi_labuan_vanuatu && poa_not_submitted)
+        ((is_bvi || is_labuan || is_vanuatu) && poi_acknowledged_for_bvi_labuan_vanuatu && poa_not_submitted) ||
+        (is_maltainvest && poi_acknowledged_for_maltainvest && poa_not_submitted)
     ) {
         return (
             <div className={`${card_classname}__verification-status--failed`}>

--- a/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-card-banner.tsx
+++ b/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-card-banner.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import RootStore from '../../Stores/index';
 import { connect } from '../../Stores/connect';
-import { getAuthenticationStatusInfo, isResidentIDVSupported } from '@deriv/shared';
+import { getAuthenticationStatusInfo, isVerificationServiceSupported } from '@deriv/shared';
 import { Text } from '@deriv/components';
 import { Localize } from '@deriv/translations';
 import { TVerificationStatusBannerProps } from '../props.types';
@@ -22,7 +22,7 @@ const VerificationStatusBanner = ({
     real_swapfree_accounts_existing_data,
     residence_list,
 }: TVerificationStatusBannerProps) => {
-    const is_idv_supported = isResidentIDVSupported(residence_list, account_settings);
+    const is_idv_supported = isVerificationServiceSupported(residence_list, account_settings, 'idv');
 
     const {
         poi_not_submitted_for_vanuatu_maltainvest,

--- a/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-card-banner.tsx
+++ b/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-card-banner.tsx
@@ -29,6 +29,7 @@ const VerificationStatusBanner = ({
         poi_acknowledged_for_maltainvest,
         poi_acknowledged_for_bvi_labuan_vanuatu,
         poa_not_submitted,
+        poi_not_submitted,
     } = getAuthenticationStatusInfo(account_status);
 
     const getAccountTitle = () => {
@@ -118,7 +119,7 @@ const VerificationStatusBanner = ({
                 </Text>
             </div>
         );
-    } else if (is_vanuatu && poa_not_submitted) {
+    } else if (is_vanuatu && poi_not_submitted) {
         return (
             <div className={`${card_classname}__verification-status--not_submitted`}>
                 <Text as='p' size='xxs' align='center' color='prominent'>

--- a/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal.tsx
+++ b/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal.tsx
@@ -140,7 +140,7 @@ const JurisdictionModal = ({
             openPasswordModal(type_of_account);
         } else if (is_vanuatu_selected) {
             if (
-                poi_acknowledged_for_maltainvest &&
+                poi_acknowledged_for_bvi_labuan_vanuatu &&
                 !poi_or_poa_not_submitted &&
                 !should_restrict_vanuatu_account_creation &&
                 poa_acknowledged &&

--- a/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal.tsx
+++ b/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal.tsx
@@ -37,8 +37,8 @@ const JurisdictionModal = ({
 
     const {
         poi_or_poa_not_submitted,
-        poi_acknowledged_for_bvi_labuan,
-        poi_acknowledged_for_vanuatu_maltainvest,
+        poi_acknowledged_for_bvi_labuan_vanuatu,
+        poi_acknowledged_for_maltainvest,
         poa_acknowledged,
         need_poa_resubmission,
     } = getAuthenticationStatusInfo(account_status);
@@ -140,7 +140,7 @@ const JurisdictionModal = ({
             openPasswordModal(type_of_account);
         } else if (is_vanuatu_selected) {
             if (
-                poi_acknowledged_for_vanuatu_maltainvest &&
+                poi_acknowledged_for_maltainvest &&
                 !poi_or_poa_not_submitted &&
                 !should_restrict_vanuatu_account_creation &&
                 poa_acknowledged &&
@@ -152,7 +152,7 @@ const JurisdictionModal = ({
             }
         } else if (is_bvi_selected) {
             if (
-                poi_acknowledged_for_bvi_labuan &&
+                poi_acknowledged_for_bvi_labuan_vanuatu &&
                 !poi_or_poa_not_submitted &&
                 !should_restrict_bvi_account_creation &&
                 poa_acknowledged &&
@@ -163,13 +163,13 @@ const JurisdictionModal = ({
                 toggleCFDVerificationModal();
             }
         } else if (is_labuan_selected) {
-            if (poi_acknowledged_for_bvi_labuan && poa_acknowledged && has_submitted_cfd_personal_details) {
+            if (poi_acknowledged_for_bvi_labuan_vanuatu && poa_acknowledged && has_submitted_cfd_personal_details) {
                 openPasswordModal(type_of_account);
             } else {
                 toggleCFDVerificationModal();
             }
         } else if (is_maltainvest_selected) {
-            if (poi_acknowledged_for_vanuatu_maltainvest && poa_acknowledged) {
+            if (poi_acknowledged_for_maltainvest && poa_acknowledged) {
                 openPasswordModal(type_of_account);
             } else {
                 toggleCFDVerificationModal();

--- a/packages/cfd/src/Containers/mt5-compare-table-content.tsx
+++ b/packages/cfd/src/Containers/mt5-compare-table-content.tsx
@@ -209,8 +209,8 @@ const DMT5CompareModalContent = ({
     const is_high_risk_for_mt5 = synthetic_accounts_count === 1 && financial_accounts_count === 1;
     const {
         poi_or_poa_not_submitted,
-        poi_acknowledged_for_vanuatu_maltainvest,
-        poi_acknowledged_for_bvi_labuan,
+        poi_acknowledged_for_maltainvest,
+        poi_acknowledged_for_bvi_labuan_vanuatu,
         poa_acknowledged,
         poa_pending,
     } = getAuthenticationStatusInfo(account_status);
@@ -320,7 +320,7 @@ const DMT5CompareModalContent = ({
                 setAppstorePlatform(CFD_PLATFORMS.MT5);
                 setJurisdictionSelectedShortcode('bvi');
                 if (
-                    poi_acknowledged_for_bvi_labuan &&
+                    poi_acknowledged_for_bvi_labuan_vanuatu &&
                     !poi_or_poa_not_submitted &&
                     !should_restrict_bvi_account_creation &&
                     has_submitted_personal_details &&
@@ -336,7 +336,7 @@ const DMT5CompareModalContent = ({
                 setAppstorePlatform(CFD_PLATFORMS.MT5);
                 setJurisdictionSelectedShortcode('vanuatu');
                 if (
-                    poi_acknowledged_for_vanuatu_maltainvest &&
+                    poi_acknowledged_for_maltainvest &&
                     !poi_or_poa_not_submitted &&
                     !should_restrict_vanuatu_account_creation &&
                     has_submitted_personal_details &&
@@ -350,7 +350,7 @@ const DMT5CompareModalContent = ({
             case 'financial_labuan':
                 setAppstorePlatform(CFD_PLATFORMS.MT5);
                 setJurisdictionSelectedShortcode('labuan');
-                if (poi_acknowledged_for_bvi_labuan && poa_acknowledged && has_submitted_personal_details) {
+                if (poi_acknowledged_for_bvi_labuan_vanuatu && poa_acknowledged && has_submitted_personal_details) {
                     openPasswordModal(type_of_account);
                 } else {
                     toggleCFDVerificationModal();
@@ -359,7 +359,7 @@ const DMT5CompareModalContent = ({
             case 'financial_maltainvest':
                 setAppstorePlatform(CFD_PLATFORMS.MT5);
                 setJurisdictionSelectedShortcode('maltainvest');
-                if ((poi_acknowledged_for_vanuatu_maltainvest && poa_acknowledged) || is_demo_tab) {
+                if ((poi_acknowledged_for_maltainvest && poa_acknowledged) || is_demo_tab) {
                     openPasswordModal(type_of_account);
                 } else {
                     toggleCFDVerificationModal();

--- a/packages/cfd/src/Containers/mt5-compare-table-content.tsx
+++ b/packages/cfd/src/Containers/mt5-compare-table-content.tsx
@@ -336,7 +336,7 @@ const DMT5CompareModalContent = ({
                 setAppstorePlatform(CFD_PLATFORMS.MT5);
                 setJurisdictionSelectedShortcode('vanuatu');
                 if (
-                    poi_acknowledged_for_maltainvest &&
+                    poi_acknowledged_for_bvi_labuan_vanuatu &&
                     !poi_or_poa_not_submitted &&
                     !should_restrict_vanuatu_account_creation &&
                     has_submitted_personal_details &&

--- a/packages/cfd/src/Containers/props.types.ts
+++ b/packages/cfd/src/Containers/props.types.ts
@@ -177,6 +177,7 @@ export type TJurisdictionCardType = 'svg' | 'bvi' | 'vanuatu' | 'labuan' | 'malt
 
 export type TVerificationStatusBannerProps = {
     account_status: GetAccountStatus;
+    account_settings: GetSettings;
     account_type: string;
     context: RootStore;
     card_classname: string;
@@ -188,6 +189,7 @@ export type TVerificationStatusBannerProps = {
     real_swapfree_accounts_existing_data: TExistingData;
     should_restrict_bvi_account_creation: boolean;
     should_restrict_vanuatu_account_creation: boolean;
+    residence_list: ResidenceList;
 };
 
 export type TJurisdictionCheckBoxProps = {

--- a/packages/shared/src/utils/cfd/cfd.ts
+++ b/packages/shared/src/utils/cfd/cfd.ts
@@ -250,9 +250,11 @@ export const isLandingCompanyEnabled = ({ landing_companies, platform, type }: T
     return false;
 };
 
-export const getAuthenticationStatusInfo = (account_status: GetAccountStatus, is_idv_supported?: number) => {
+export const getAuthenticationStatusInfo = (account_status: GetAccountStatus, is_country_support_idv?: boolean) => {
     const poa_status = account_status?.authentication?.document?.status || '';
     const poi_status = account_status?.authentication?.identity?.status || '';
+
+    const is_idv_disallowed = account_status.status.some(status => status === 'idv_disallowed');
 
     const idv_status = account_status?.authentication?.identity?.services?.idv?.status;
     const onfido_status = account_status?.authentication?.identity?.services?.onfido?.status;
@@ -273,6 +275,8 @@ export const getAuthenticationStatusInfo = (account_status: GetAccountStatus, is
     const poi_and_poa_not_submitted = poa_not_submitted && poi_not_submitted;
 
     //vanuatu-maltainvest
+
+    const is_idv_supported = !is_idv_disallowed && is_country_support_idv;
 
     const poi_verified_for_vanuatu_maltainvest = [
         onfido_status,

--- a/packages/shared/src/utils/cfd/cfd.ts
+++ b/packages/shared/src/utils/cfd/cfd.ts
@@ -308,25 +308,19 @@ export const getAuthenticationStatusInfo = (account_status: GetAccountStatus): T
 
     //vanuatu-maltainvest
 
-    const requiredStatuses: (string | undefined)[] = [onfido_status, manual_status];
-    const submittedStatuses: string[] = requiredStatuses.filter((status: string | undefined) => status) as string[];
-    const allStatuses: (string | undefined)[] = submittedStatuses.concat([
-        idv_status,
-        onfido_status,
-        manual_status,
-    ] as string[]);
+    const required_statuses: (string | undefined)[] = [onfido_status, manual_status];
+    const submitted_statuses: string[] = required_statuses.filter((status: string | undefined) => status) as string[];
+    const all_statuses: string[] = [idv_status, onfido_status, manual_status].map(status => status) as string[];
 
-    const poi_verified_for_maltainvest: boolean = allStatuses.includes('verified');
-    const poi_acknowledged_for_maltainvest: boolean = allStatuses.some((status: string | undefined) =>
-        acknowledged_status.includes(status ?? '')
+    const poi_verified_for_maltainvest: boolean = submitted_statuses.includes('verified');
+    const poi_acknowledged_for_maltainvest: boolean = submitted_statuses.some(status =>
+        acknowledged_status.includes(status)
     );
     const poi_pending_for_maltainvest: boolean =
-        allStatuses.every((status: string | undefined) => status === 'pending') && !poi_verified_for_maltainvest;
+        submitted_statuses.some(status => status === 'pending') && !poi_verified_for_maltainvest;
 
     const need_poi_for_maltainvest = !poi_acknowledged_for_maltainvest;
-    const poi_not_submitted_for_maltainvest: boolean = allStatuses.every(
-        (status: string | undefined) => status === 'none'
-    );
+    const poi_not_submitted_for_maltainvest: boolean = submitted_statuses.every(status => status === 'none');
 
     const poi_resubmit_for_maltainvest: boolean =
         !poi_pending_for_maltainvest && !poi_not_submitted_for_maltainvest && !poi_verified_for_maltainvest;
@@ -334,22 +328,16 @@ export const getAuthenticationStatusInfo = (account_status: GetAccountStatus): T
     const poi_poa_verified_for_maltainvest = poi_verified_for_maltainvest && poa_verified;
 
     //bvi-labuan
-    const poi_acknowledged_for_bvi_labuan_vanuatu: boolean =
-        acknowledged_status.includes(idv_status ?? '') ||
-        acknowledged_status.includes(onfido_status ?? '') ||
-        acknowledged_status.includes(manual_status ?? '');
-
+    const poi_acknowledged_for_bvi_labuan_vanuatu: boolean = all_statuses.some(status =>
+        acknowledged_status.includes(status)
+    );
     const need_poi_for_bvi_labuan_vanuatu = !poi_acknowledged_for_bvi_labuan_vanuatu;
-    const poi_not_submitted_for_bvi_labuan_vanuatu: boolean = [idv_status, onfido_status, manual_status].every(
-        (status: string | undefined) => status === 'none'
-    );
+    const poi_not_submitted_for_bvi_labuan_vanuatu: boolean = all_statuses.every(status => status === 'none');
 
-    const poi_verified_for_bvi_labuan_vanuatu: boolean = [idv_status, onfido_status, manual_status].includes(
-        'verified'
-    );
+    const poi_verified_for_bvi_labuan_vanuatu: boolean = all_statuses.includes('verified');
 
     const poi_pending_for_bvi_labuan_vanuatu: boolean =
-        [idv_status, onfido_status, manual_status].includes('pending') && !poi_verified_for_bvi_labuan_vanuatu;
+        all_statuses.includes('pending') && !poi_verified_for_bvi_labuan_vanuatu;
 
     const poi_resubmit_for_bvi_labuan_vanuatu: boolean =
         !poi_pending_for_bvi_labuan_vanuatu &&

--- a/packages/shared/src/utils/cfd/cfd.ts
+++ b/packages/shared/src/utils/cfd/cfd.ts
@@ -252,11 +252,11 @@ export const isLandingCompanyEnabled = ({ landing_companies, platform, type }: T
 
 // Define the AuthenticationStatusInfo type
 type TAuthenticationStatusInfo = {
-    poa_status: string | undefined;
-    poi_status: string | undefined;
-    idv_status: string | undefined;
-    onfido_status: string | undefined;
-    manual_status: string | undefined;
+    poa_status?: string;
+    poi_status?: string;
+    idv_status?: string;
+    onfido_status?: string;
+    manual_status?: string;
     acknowledged_status: string[];
     poi_acknowledged_for_maltainvest: boolean;
     poi_poa_verified_for_bvi_labuan_vanuatu: boolean;

--- a/packages/shared/src/utils/cfd/cfd.ts
+++ b/packages/shared/src/utils/cfd/cfd.ts
@@ -254,7 +254,7 @@ export const getAuthenticationStatusInfo = (account_status: GetAccountStatus, is
     const poa_status = account_status?.authentication?.document?.status || '';
     const poi_status = account_status?.authentication?.identity?.status || '';
 
-    const is_idv_disallowed = account_status.status.some(status => status === 'idv_disallowed');
+    const is_idv_disallowed = account_status?.status?.some(status => status === 'idv_disallowed');
 
     const idv_status = account_status?.authentication?.identity?.services?.idv?.status;
     const onfido_status = account_status?.authentication?.identity?.services?.onfido?.status;

--- a/packages/shared/src/utils/cfd/cfd.ts
+++ b/packages/shared/src/utils/cfd/cfd.ts
@@ -308,19 +308,24 @@ export const getAuthenticationStatusInfo = (account_status: GetAccountStatus): T
 
     //vanuatu-maltainvest
 
-    const required_statuses: (string | undefined)[] = [onfido_status, manual_status];
-    const submitted_statuses: string[] = required_statuses.filter((status: string | undefined) => status) as string[];
-    const all_statuses: string[] = [idv_status, onfido_status, manual_status].map(status => status) as string[];
+    // mf = maltainvest: only require onfido and manual
+    const mf_jurisdiction_statuses: string[] = [onfido_status, manual_status].filter(
+        (status: string | undefined) => status
+    ) as string[];
+    // other jurisdictions: require idv, onfido and manual
+    const other_jurisdiction_statuses: string[] = [idv_status, onfido_status, manual_status].filter(
+        status => status
+    ) as string[];
 
-    const poi_verified_for_maltainvest: boolean = submitted_statuses.includes('verified');
-    const poi_acknowledged_for_maltainvest: boolean = submitted_statuses.some(status =>
+    const poi_verified_for_maltainvest: boolean = mf_jurisdiction_statuses.includes('verified');
+    const poi_acknowledged_for_maltainvest: boolean = mf_jurisdiction_statuses.some(status =>
         acknowledged_status.includes(status)
     );
     const poi_pending_for_maltainvest: boolean =
-        submitted_statuses.some(status => status === 'pending') && !poi_verified_for_maltainvest;
+        mf_jurisdiction_statuses.some(status => status === 'pending') && !poi_verified_for_maltainvest;
 
     const need_poi_for_maltainvest = !poi_acknowledged_for_maltainvest;
-    const poi_not_submitted_for_maltainvest: boolean = submitted_statuses.every(status => status === 'none');
+    const poi_not_submitted_for_maltainvest: boolean = mf_jurisdiction_statuses.every(status => status === 'none');
 
     const poi_resubmit_for_maltainvest: boolean =
         !poi_pending_for_maltainvest && !poi_not_submitted_for_maltainvest && !poi_verified_for_maltainvest;
@@ -328,16 +333,18 @@ export const getAuthenticationStatusInfo = (account_status: GetAccountStatus): T
     const poi_poa_verified_for_maltainvest = poi_verified_for_maltainvest && poa_verified;
 
     //bvi-labuan
-    const poi_acknowledged_for_bvi_labuan_vanuatu: boolean = all_statuses.some(status =>
+    const poi_acknowledged_for_bvi_labuan_vanuatu: boolean = other_jurisdiction_statuses.some(status =>
         acknowledged_status.includes(status)
     );
     const need_poi_for_bvi_labuan_vanuatu = !poi_acknowledged_for_bvi_labuan_vanuatu;
-    const poi_not_submitted_for_bvi_labuan_vanuatu: boolean = all_statuses.every(status => status === 'none');
+    const poi_not_submitted_for_bvi_labuan_vanuatu: boolean = other_jurisdiction_statuses.every(
+        status => status === 'none'
+    );
 
-    const poi_verified_for_bvi_labuan_vanuatu: boolean = all_statuses.includes('verified');
+    const poi_verified_for_bvi_labuan_vanuatu: boolean = other_jurisdiction_statuses.includes('verified');
 
     const poi_pending_for_bvi_labuan_vanuatu: boolean =
-        all_statuses.includes('pending') && !poi_verified_for_bvi_labuan_vanuatu;
+        other_jurisdiction_statuses.includes('pending') && !poi_verified_for_bvi_labuan_vanuatu;
 
     const poi_resubmit_for_bvi_labuan_vanuatu: boolean =
         !poi_pending_for_bvi_labuan_vanuatu &&

--- a/packages/shared/src/utils/cfd/cfd.ts
+++ b/packages/shared/src/utils/cfd/cfd.ts
@@ -301,19 +301,20 @@ export const getAuthenticationStatusInfo = (account_status: GetAccountStatus): T
     const need_poa_resubmission: boolean = failed_cases.includes(poa_status);
     const poa_verified: boolean = poa_status === 'verified';
     const poa_pending: boolean = poa_status === 'pending';
+    const poa_acknowledged: boolean = acknowledged_status.includes(poa_status);
 
     const poi_not_submitted: boolean = poi_status === 'none';
     const poi_or_poa_not_submitted: boolean = poa_not_submitted || poi_not_submitted;
     const poi_and_poa_not_submitted: boolean = poa_not_submitted && poi_not_submitted;
 
-    //vanuatu-maltainvest
+    //maltainvest
 
     // mf = maltainvest: only require onfido and manual
     const mf_jurisdiction_statuses: string[] = [onfido_status, manual_status].filter(
         (status: string | undefined) => status
     ) as string[];
-    // other jurisdictions: require idv, onfido and manual
-    const other_jurisdiction_statuses: string[] = [idv_status, onfido_status, manual_status].filter(
+    // bvi_labuan_vanuatu jurisdictions: require idv, onfido and manual
+    const bvi_labuan_vanuatu_jurisdiction_statuses: string[] = [idv_status, onfido_status, manual_status].filter(
         status => status
     ) as string[];
 
@@ -332,19 +333,19 @@ export const getAuthenticationStatusInfo = (account_status: GetAccountStatus): T
 
     const poi_poa_verified_for_maltainvest = poi_verified_for_maltainvest && poa_verified;
 
-    //bvi-labuan
-    const poi_acknowledged_for_bvi_labuan_vanuatu: boolean = other_jurisdiction_statuses.some(status =>
+    //bvi-labuan-vanuatu
+    const poi_acknowledged_for_bvi_labuan_vanuatu: boolean = bvi_labuan_vanuatu_jurisdiction_statuses.some(status =>
         acknowledged_status.includes(status)
     );
     const need_poi_for_bvi_labuan_vanuatu = !poi_acknowledged_for_bvi_labuan_vanuatu;
-    const poi_not_submitted_for_bvi_labuan_vanuatu: boolean = other_jurisdiction_statuses.every(
+    const poi_not_submitted_for_bvi_labuan_vanuatu: boolean = bvi_labuan_vanuatu_jurisdiction_statuses.every(
         status => status === 'none'
     );
 
-    const poi_verified_for_bvi_labuan_vanuatu: boolean = other_jurisdiction_statuses.includes('verified');
+    const poi_verified_for_bvi_labuan_vanuatu: boolean = bvi_labuan_vanuatu_jurisdiction_statuses.includes('verified');
 
     const poi_pending_for_bvi_labuan_vanuatu: boolean =
-        other_jurisdiction_statuses.includes('pending') && !poi_verified_for_bvi_labuan_vanuatu;
+        bvi_labuan_vanuatu_jurisdiction_statuses.includes('pending') && !poi_verified_for_bvi_labuan_vanuatu;
 
     const poi_resubmit_for_bvi_labuan_vanuatu: boolean =
         !poi_pending_for_bvi_labuan_vanuatu &&
@@ -362,7 +363,7 @@ export const getAuthenticationStatusInfo = (account_status: GetAccountStatus): T
         acknowledged_status,
         poi_acknowledged_for_maltainvest,
         poi_poa_verified_for_bvi_labuan_vanuatu,
-        poa_acknowledged: acknowledged_status.includes(poa_status),
+        poa_acknowledged,
         poi_poa_verified_for_maltainvest,
         need_poa_submission,
         poi_verified_for_maltainvest,

--- a/packages/shared/src/utils/cfd/cfd.ts
+++ b/packages/shared/src/utils/cfd/cfd.ts
@@ -318,7 +318,7 @@ export const getAuthenticationStatusInfo = (account_status: GetAccountStatus): T
 
     const poi_verified_for_maltainvest: boolean = allStatuses.includes('verified');
     const poi_acknowledged_for_maltainvest: boolean = allStatuses.some((status: string | undefined) =>
-        acknowledged_status.includes(status || '')
+        acknowledged_status.includes(status ?? '')
     );
     const poi_pending_for_maltainvest: boolean =
         allStatuses.every((status: string | undefined) => status === 'pending') && !poi_verified_for_maltainvest;
@@ -335,9 +335,9 @@ export const getAuthenticationStatusInfo = (account_status: GetAccountStatus): T
 
     //bvi-labuan
     const poi_acknowledged_for_bvi_labuan_vanuatu: boolean =
-        acknowledged_status.includes(idv_status || '') ||
-        acknowledged_status.includes(onfido_status || '') ||
-        acknowledged_status.includes(manual_status || '');
+        acknowledged_status.includes(idv_status ?? '') ||
+        acknowledged_status.includes(onfido_status ?? '') ||
+        acknowledged_status.includes(manual_status ?? '');
 
     const need_poi_for_bvi_labuan_vanuatu = !poi_acknowledged_for_bvi_labuan_vanuatu;
     const poi_not_submitted_for_bvi_labuan_vanuatu: boolean = [idv_status, onfido_status, manual_status].every(

--- a/packages/shared/src/utils/helpers/format-response.ts
+++ b/packages/shared/src/utils/helpers/format-response.ts
@@ -56,9 +56,14 @@ export const formatPortfolioPosition = (
     };
 };
 
-export const isResidentIDVSupported = (residence_list: ResidenceList, account_settings: GetSettings): boolean => {
+export const isVerificationServiceSupported = (
+    residence_list: ResidenceList,
+    account_settings: GetSettings,
+    service: 'idv' | 'onfido'
+): boolean => {
     const citizen = account_settings?.citizen || account_settings?.country_code;
     if (!citizen) return false;
     const citizen_data = residence_list.find(item => item.value === citizen);
-    return !!citizen_data?.identity?.services?.idv?.is_country_supported;
+
+    return !!citizen_data?.identity?.services?.[service]?.is_country_supported;
 };

--- a/packages/shared/src/utils/helpers/format-response.ts
+++ b/packages/shared/src/utils/helpers/format-response.ts
@@ -1,3 +1,4 @@
+import { GetSettings, ResidenceList } from '@deriv/api-types';
 import { getUnsupportedContracts } from '../constants';
 import { getSymbolDisplayName, TActiveSymbols } from './active-symbols';
 import { getMarketInformation } from './market-underlying';
@@ -53,4 +54,11 @@ export const formatPortfolioPosition = (
         is_unsupported: isUnSupportedContract(portfolio_pos),
         contract_update: portfolio_pos.limit_order,
     };
+};
+
+export const isResidentIDVSupported = (residence_list: ResidenceList, account_settings: GetSettings): boolean => {
+    const citizen = account_settings?.citizen || account_settings?.country_code;
+    if (!citizen) return false;
+    const citizen_data = residence_list.find(item => item.value === citizen);
+    return !!citizen_data?.identity?.services?.idv?.is_country_supported;
 };


### PR DESCRIPTION
## Changes:

As a user of an IDV supported country, I want to be able to trigger IDV as proof of identity (POI) when creating an MT5 Vanuatu account

### Screenshots:

Please provide some screenshots of the change.
