### PR TITLE
Change  resource_class to large

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,7 +251,7 @@ jobs:
   build_and_test:
     docker:
       - image: cimg/node:18.16.0
-    resource_class: xlarge
+    resource_class: large
     steps:
       - git_checkout_from_cache
       - npm_install_from_cache


### PR DESCRIPTION
## Changes:
- Change resource_class to large for jobs possibly running on user CircleCI

Some users report issues running builds after they set up CircleCI on their forks:
```Resource class docker for xlarge is not available for your project, or is not a valid resource class. This message will often appear if the pricing plan for this project does not support docker use.```

While it seems a configuration issue (not all users impacted, some had the issue and it's fixed now), better to use `resource_class: large` so we won't have this issue anymore. We can still add again `xlarge` later.

According to [CircleCI resource classes](https://circleci.com/product/features/resource-classes/), the `large` resource class should be available to everyone and faster than what was the default 1 month ago (it was often resolving to `medium`)

![circle-ci-plan-resource-class](https://github.com/binary-com/deriv-app/assets/104425314/bf5ae658-6962-48fa-9c63-a58955270dae)

I changed the resource class *only* for job running on pull request (others can run but it's more rare and would fail for othe reasons)


