### PR TITLE
Jim/WEBREL-890/p2p-chat-messages-are-disappearing-when-shifting-the-tabs-and-chat-page-is-breaking

### DIFF
--- a/packages/p2p/src/stores/sendbird-store.ts
+++ b/packages/p2p/src/stores/sendbird-store.ts
@@ -1,6 +1,6 @@
 import SendbirdChat, { BaseChannel } from '@sendbird/chat';
 import { epochToMoment, toMoment } from '@deriv/shared';
-import { action, computed, observable, reaction, makeObservable, IReactionDisposer } from 'mobx';
+import { action, computed, observable, reaction, makeObservable, IReactionDisposer, when } from 'mobx';
 import BaseStore from 'Stores/base_store';
 import ChatMessage, { convertFromChannelMessage } from 'Utils/chat-message';
 import { requestWS } from 'Utils/websocket';
@@ -371,16 +371,12 @@ export default class SendbirdStore extends BaseStore {
             { fireImmediately: true }
         );
 
-        this.disposeActiveChatChannelReaction = reaction(
-            () => this.active_chat_channel,
-            (active_chat_channel?: GroupChannel) => {
-                if (active_chat_channel) {
-                    (async () => {
-                        await this.initialiseOrderMessages();
-                    })();
-                } else {
-                    this.setChannelMessages([]);
-                }
+        this.disposeActiveChatChannelReaction = when(
+            () => !!this.active_chat_channel,
+            () => {
+                (async () => {
+                    await this.initialiseOrderMessages();
+                })();
             }
         );
 


### PR DESCRIPTION
## Changes:

- Refactored code from `reaction` to `when`, so that the `initialiseOrderMessages` is called when the user navigates back to the p2p chat page. 

### Screenshots:

