### PR TITLE
Jim/WEBREL-902/when-advertiser-is-having-multiple-orders-chats-are-overlapping-each-other

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "@deriv/js-interpreter": "^3.0.0",
                 "@deriv/ui": "^0.6.0",
                 "@livechat/customer-sdk": "^2.0.4",
-                "@sendbird/chat": "^4.9.5",
+                "@sendbird/chat": "^4.9.7",
                 "@storybook/addon-actions": "^6.5.10",
                 "@storybook/addon-docs": "^6.5.10",
                 "@storybook/addon-essentials": "^6.5.10",
@@ -8091,9 +8091,9 @@
             "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
         },
         "node_modules/@sendbird/chat": {
-            "version": "4.9.6",
-            "resolved": "https://registry.npmjs.org/@sendbird/chat/-/chat-4.9.6.tgz",
-            "integrity": "sha512-ijg3W7ewFgnhxPUKvpLL3S+Z6oGaBZRvUvJq2fwJhHhB3zE0iqDZnJ+PvutfRvzAWio8w30pEZe1xyo3dAuhUw==",
+            "version": "4.9.7",
+            "resolved": "https://registry.npmjs.org/@sendbird/chat/-/chat-4.9.7.tgz",
+            "integrity": "sha512-VNipPeJT7B6hD/OBDi6IjcGW+Y8fJHNkVUkvFk0BUkkZLY1eefUmtrv2CWWbJ0hxfGFWe+wRVEjsdWDXqLN/DA==",
             "peerDependencies": {
                 "@react-native-async-storage/async-storage": "^1.17.6"
             },
@@ -16680,9 +16680,9 @@
         },
         "node_modules/@typescript/lib-dom": {
             "name": "@types/web",
-            "version": "0.0.111",
-            "resolved": "https://registry.npmjs.org/@types/web/-/web-0.0.111.tgz",
-            "integrity": "sha512-OnLWZBNMXlvTsAalsPcVyVkxW76yG2QQsRPbRijMQxCG791IH9sAIAsg1tcDDK8p5JwHW0GV3/uYOg+RRqGrOw=="
+            "version": "0.0.112",
+            "resolved": "https://registry.npmjs.org/@types/web/-/web-0.0.112.tgz",
+            "integrity": "sha512-IAsSIAwlo7vru2yrEOFTUZNbSwhZKTVeVs8fD4zk/wk8WtYX6Z5ZnpkoWv/nop6Bz9ghrYL9fX6alO2uxEvOgw=="
         },
         "node_modules/@webassemblyjs/ast": {
             "version": "1.11.5",
@@ -54921,9 +54921,9 @@
             }
         },
         "@sendbird/chat": {
-            "version": "4.9.6",
-            "resolved": "https://registry.npmjs.org/@sendbird/chat/-/chat-4.9.6.tgz",
-            "integrity": "sha512-ijg3W7ewFgnhxPUKvpLL3S+Z6oGaBZRvUvJq2fwJhHhB3zE0iqDZnJ+PvutfRvzAWio8w30pEZe1xyo3dAuhUw==",
+            "version": "4.9.7",
+            "resolved": "https://registry.npmjs.org/@sendbird/chat/-/chat-4.9.7.tgz",
+            "integrity": "sha512-VNipPeJT7B6hD/OBDi6IjcGW+Y8fJHNkVUkvFk0BUkkZLY1eefUmtrv2CWWbJ0hxfGFWe+wRVEjsdWDXqLN/DA==",
             "requires": {}
         },
         "@sentry-internal/tracing": {
@@ -61384,9 +61384,9 @@
             }
         },
         "@typescript/lib-dom": {
-            "version": "npm:@types/web@0.0.111",
-            "resolved": "https://registry.npmjs.org/@types/web/-/web-0.0.111.tgz",
-            "integrity": "sha512-OnLWZBNMXlvTsAalsPcVyVkxW76yG2QQsRPbRijMQxCG791IH9sAIAsg1tcDDK8p5JwHW0GV3/uYOg+RRqGrOw=="
+            "version": "npm:@types/web@0.0.112",
+            "resolved": "https://registry.npmjs.org/@types/web/-/web-0.0.112.tgz",
+            "integrity": "sha512-IAsSIAwlo7vru2yrEOFTUZNbSwhZKTVeVs8fD4zk/wk8WtYX6Z5ZnpkoWv/nop6Bz9ghrYL9fX6alO2uxEvOgw=="
         },
         "@webassemblyjs/ast": {
             "version": "1.11.5",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     },
     "dependencies": {
         "@babel/preset-typescript": "^7.16.5",
-        "@sendbird/chat": "^4.9.5",
+        "@sendbird/chat": "^4.9.7",
         "@types/react-transition-group": "^4.4.4",
         "babel-jest": "^27.3.1",
         "dotenv": "^8.2.0",

--- a/packages/p2p/package.json
+++ b/packages/p2p/package.json
@@ -56,7 +56,7 @@
         "react-simple-star-rating": "4.0.4",
         "react-svg-loader": "^3.0.3",
         "react-transition-group": "4.4.2",
-        "@sendbird/chat": "^4.9.5"
+        "@sendbird/chat": "^4.9.7"
     },
     "devDependencies": {
         "@babel/eslint-parser": "^7.17.0",

--- a/packages/p2p/src/components/orders/orders.jsx
+++ b/packages/p2p/src/components/orders/orders.jsx
@@ -35,6 +35,7 @@ const Orders = observer(() => {
         return () => {
             disposeOrderIdReaction();
             disposeOrdersUpdateReaction();
+            order_store.onPageReturn();
             order_store.onUnmount();
         };
 

--- a/packages/p2p/src/stores/sendbird-store.ts
+++ b/packages/p2p/src/stores/sendbird-store.ts
@@ -386,8 +386,7 @@ export default class SendbirdStore extends BaseStore {
                 } else {
                     this.setChannelMessages([]);
                 }
-            },
-            { fireImmediately: true }
+            }
         );
 
         return () => {


### PR DESCRIPTION
## Changes:

- Added call to the `order_store.onPageReturn();` function inside of `orders.jsx`, to clear the `order_id` every time we navigate away from the orders page. This is just like it's done when the `Back Button` is clicked, this will allow the triggering of this `reaction`, which clears the `ChatMessages` and the rest of the properties listed below

```
this.disposeOrderIdReaction = reaction(
            () => this.root_store.order_store.order_id,
            (order_id: string) => {
                if (!order_id) {
                    this.setChatChannelUrl(null);
                    this.setChannelMessages([]);
                    this.setIsChatLoading(true);
                    this.setShouldShowChatModal(false);
                    this.setActiveChatChannel(null);
                }
            }
        );
```

- Updated `sendbird` to the `latest version` (released yesterday!)

