### PR TITLE
FarhanNurzi/P2PS-1417/2FA order confirm modal is not showing up on mobile browsers

### DIFF
--- a/packages/p2p/jest.config.js
+++ b/packages/p2p/jest.config.js
@@ -20,7 +20,7 @@ module.exports = {
         '/crowdin/',
         // TODO: Update the test files once the major features are done
         // This is a temporary change, I hope
-        '/src/components/order*',
+        '/src/components/order-details*',
     ],
     coveragePathIgnorePatterns: [
         '<rootDir>/.eslintrc.js',
@@ -29,4 +29,5 @@ module.exports = {
         '<rootDir>/coverage/lcov-report',
         '<rootDir>/dist',
     ],
+    transformIgnorePatterns: ['/node_modules/(?!@sendbird/chat).+\\.js$'],
 };

--- a/packages/p2p/src/components/orders/chat/__tests__/chat.spec.tsx
+++ b/packages/p2p/src/components/orders/chat/__tests__/chat.spec.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { useStores } from 'Stores';
+import Chat from '../chat';
+
+const mock_store: ReturnType<typeof useStores> = {
+    order_store: {
+        onPageReturn: jest.fn(),
+    },
+    sendbird_store: {
+        is_chat_loading: true,
+    },
+};
+
+jest.mock('Stores', () => ({
+    ...jest.requireActual('Stores'),
+    useStores: jest.fn(() => mock_store),
+}));
+
+describe('<Chat />', () => {
+    it('should remove order id and active order during unmount', () => {
+        const { unmount } = render(<Chat />);
+        unmount();
+        expect(mock_store.order_store.onPageReturn).toHaveBeenCalled();
+    });
+});

--- a/packages/p2p/src/components/orders/chat/chat.jsx
+++ b/packages/p2p/src/components/orders/chat/chat.jsx
@@ -11,7 +11,15 @@ import { useStores } from 'Stores';
 import 'Components/orders/chat/chat.scss';
 
 const Chat = observer(() => {
-    const { sendbird_store } = useStores();
+    const { order_store, sendbird_store } = useStores();
+
+    React.useLayoutEffect(() => {
+        return () => {
+            order_store.onPageReturn();
+        };
+
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     if (sendbird_store.is_chat_loading) {
         return (

--- a/packages/p2p/src/components/orders/orders.jsx
+++ b/packages/p2p/src/components/orders/orders.jsx
@@ -35,7 +35,6 @@ const Orders = observer(() => {
         return () => {
             disposeOrderIdReaction();
             disposeOrdersUpdateReaction();
-            order_store.onPageReturn();
             order_store.onUnmount();
         };
 

--- a/packages/p2p/src/stores/buy-sell-store.js
+++ b/packages/p2p/src/stores/buy-sell-store.js
@@ -254,24 +254,26 @@ export default class BuySellStore extends BaseStore {
     handleResponse = async order => {
         const { sendbird_store, order_store, general_store, floating_rate_store } = this.root_store;
         const { setErrorMessage, handleConfirm, handleClose } = this.form_props;
-        if (order.error) {
-            setErrorMessage(order.error.message);
-            this.setFormErrorCode(order.error.code);
+        const { error, p2p_order_create, p2p_order_info, subscription } = order || {};
+
+        if (error) {
+            setErrorMessage(error.message);
+            this.setFormErrorCode(error.code);
         } else {
-            if (order?.subscription?.id && !this.is_create_order_subscribed) {
+            if (subscription?.id && !this.is_create_order_subscribed) {
                 this.setIsCreateOrderSubscribed(true);
             }
             setErrorMessage(null);
             general_store.hideModal();
             floating_rate_store.setIsMarketRateChanged(false);
-            sendbird_store.setChatChannelUrl(order?.p2p_order_create?.chat_channel_url ?? '');
-            if (order?.p2p_order_create?.id) {
-                const response = await requestWS({ p2p_order_info: 1, id: order?.p2p_order_create?.id });
+
+            if (p2p_order_create?.id) {
+                const response = await requestWS({ p2p_order_info: 1, id: p2p_order_create.id });
                 handleConfirm(response?.p2p_order_info);
             }
 
-            if (order?.p2p_order_info?.id && order?.p2p_order_info?.chat_channel_url) {
-                sendbird_store.setChatChannelUrl(order?.p2p_order_info?.chat_channel_url ?? '');
+            if (p2p_order_info?.id && p2p_order_info?.chat_channel_url) {
+                sendbird_store.setChatChannelUrl(p2p_order_info.chat_channel_url);
                 order_store.setOrderDetails(order);
             }
 

--- a/packages/p2p/src/stores/buy-sell-store.js
+++ b/packages/p2p/src/stores/buy-sell-store.js
@@ -269,12 +269,14 @@ export default class BuySellStore extends BaseStore {
                 const response = await requestWS({ p2p_order_info: 1, id: order?.p2p_order_create?.id });
                 handleConfirm(response?.p2p_order_info);
             }
+
+            if (order?.p2p_order_info?.id && order?.p2p_order_info?.chat_channel_url) {
+                sendbird_store.setChatChannelUrl(order?.p2p_order_info?.chat_channel_url ?? '');
+                order_store.setOrderDetails(order);
+            }
+
             handleClose();
             this.payment_method_ids = [];
-        }
-        if (order?.p2p_order_info?.id && order?.p2p_order_info?.chat_channel_url) {
-            sendbird_store.setChatChannelUrl(order?.p2p_order_info?.chat_channel_url ?? '');
-            order_store.setOrderDetails(order);
         }
     };
 


### PR DESCRIPTION
## Changes:
Cleaning order_id and active_channel when we navigate away from `chat` component, instead of cleaning it while navigated away from `orders` page, 

### Screenshots:

https://github.com/binary-com/deriv-app/assets/125247833/016ac243-237f-4182-bbfd-102f11194f38



