### PR TITLE
Prince/ updated slack webhook URL

### DIFF
--- a/.github/workflows/push_and_pull_crowdin_translations.yml
+++ b/.github/workflows/push_and_pull_crowdin_translations.yml
@@ -91,11 +91,9 @@ jobs:
 
             # Send a message to Slack (granted we have a webhook secret).
             # This check also allows a repo admin to disable the Slack message by removing the secret.
-            if [ -n "${{ secrets.ANNOUNCE_TRANSLATION_WEBHOOK
- }}" ]; then
+            if [ -n "${{ secrets.ANNOUNCE_TRANSLATION_WEBHOOK }}" ]; then
               echo "Sending message to Slack (#team_translations)"
-              curl -X POST -H 'Content-type: application/json' --data '{"text":"There are new or updated strings available for Deriv.app (https://crowdin.com/project/deriv-app)."}' ${{ secrets.ANNOUNCE_TRANSLATION_WEBHOOK
- }}
+              curl -X POST -H 'Content-type: application/json' --data '{"text":"There are new or updated strings available for Deriv.app (https://crowdin.com/project/deriv-app)."}' ${{ secrets.ANNOUNCE_TRANSLATION_WEBHOOK }}
             fi
           fi
 
@@ -113,11 +111,9 @@ jobs:
 
             # Send a message to Slack (granted we have a webhook secret).
             # This check also allows a repo admin to disable the Slack message by removing the secret.
-            if [ -n "${{ secrets.ANNOUNCE_TRANSLATION_WEBHOOK
- }}" ]; then
+            if [ -n "${{ secrets.ANNOUNCE_TRANSLATION_WEBHOOK }}" ]; then
               echo "Sending message to Slack (#team_translations)"
-              curl -X POST -H 'Content-type: application/json' --data '{"text":"There are new or updated strings available for DP2P (https://crowdin.com/project/deriv-app)."}' ${{ secrets.ANNOUNCE_TRANSLATION_WEBHOOK
- }}
+              curl -X POST -H 'Content-type: application/json' --data '{"text":"There are new or updated strings available for DP2P (https://crowdin.com/project/deriv-app)."}' ${{ secrets.ANNOUNCE_TRANSLATION_WEBHOOK }}
             fi
           fi
 

--- a/.github/workflows/push_and_pull_crowdin_translations.yml
+++ b/.github/workflows/push_and_pull_crowdin_translations.yml
@@ -91,9 +91,11 @@ jobs:
 
             # Send a message to Slack (granted we have a webhook secret).
             # This check also allows a repo admin to disable the Slack message by removing the secret.
-            if [ -n "${{ secrets.TRANSLATIONS_SLACK_WEBHOOK }}" ]; then
+            if [ -n "${{ secrets.ANNOUNCE_TRANSLATION_WEBHOOK
+ }}" ]; then
               echo "Sending message to Slack (#team_translations)"
-              curl -X POST -H 'Content-type: application/json' --data '{"text":"There are new or updated strings available for Deriv.app (https://crowdin.com/project/deriv-app)."}' ${{ secrets.TRANSLATIONS_SLACK_WEBHOOK }}
+              curl -X POST -H 'Content-type: application/json' --data '{"text":"There are new or updated strings available for Deriv.app (https://crowdin.com/project/deriv-app)."}' ${{ secrets.ANNOUNCE_TRANSLATION_WEBHOOK
+ }}
             fi
           fi
 
@@ -111,9 +113,11 @@ jobs:
 
             # Send a message to Slack (granted we have a webhook secret).
             # This check also allows a repo admin to disable the Slack message by removing the secret.
-            if [ -n "${{ secrets.TRANSLATIONS_SLACK_WEBHOOK }}" ]; then
+            if [ -n "${{ secrets.ANNOUNCE_TRANSLATION_WEBHOOK
+ }}" ]; then
               echo "Sending message to Slack (#team_translations)"
-              curl -X POST -H 'Content-type: application/json' --data '{"text":"There are new or updated strings available for DP2P (https://crowdin.com/project/deriv-app)."}' ${{ secrets.TRANSLATIONS_SLACK_WEBHOOK }}
+              curl -X POST -H 'Content-type: application/json' --data '{"text":"There are new or updated strings available for DP2P (https://crowdin.com/project/deriv-app)."}' ${{ secrets.ANNOUNCE_TRANSLATION_WEBHOOK
+ }}
             fi
           fi
 


### PR DESCRIPTION
## Changes:

Translation team wants to standardize all notification for translation request and thus we 
are sending deriv-app translation requests to #announce_translation_request channel on slack

