### PR TITLE
Kate / OPT-327 / Responsive: tooltips for the 'i' button get cut off

### DIFF
--- a/packages/components/src/components/popover/popover.scss
+++ b/packages/components/src/components/popover/popover.scss
@@ -63,6 +63,9 @@
         &--error {
             background-color: var(--status-danger);
         }
+        @include mobile {
+            max-width: calc(100vw - 6.7rem);
+        }
     }
 }
 

--- a/packages/components/src/components/popover/popover.scss
+++ b/packages/components/src/components/popover/popover.scss
@@ -63,9 +63,17 @@
         &--error {
             background-color: var(--status-danger);
         }
-        @include mobile {
-            max-width: calc(100vw - 6.7rem);
-        }
+    }
+}
+
+#dc_take_profit-checkbox__tooltip,
+#dt_accumulator-stake__tooltip,
+#dc_accu-info-display__tooltip,
+#dc_payout-per-point__tooltip,
+#dt_multiplier-stake__tooltip,
+#dc_stop_loss-checkbox__tooltip {
+    @include mobile {
+        max-width: calc(100vw - 6.7rem);
     }
 }
 

--- a/packages/trader/src/Modules/Trading/Components/Elements/payout-per-point-mobile.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Elements/payout-per-point-mobile.tsx
@@ -57,6 +57,7 @@ const PayoutPerPointMobile = observer(() => {
                 <Popover
                     alignment='top'
                     icon='info'
+                    id='dc_payout-per-point__tooltip'
                     is_bubble_hover_enabled
                     margin={0}
                     zIndex='9999'

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Accumulator/accumulators-info-display.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Accumulator/accumulators-info-display.jsx
@@ -36,6 +36,7 @@ const AccumulatorsInfoDisplay = observer(() => {
                             alignment='left'
                             icon='info'
                             is_bubble_hover_enabled
+                            id={`dc_accu-info-display__tooltip`}
                             message={tooltip_text}
                             margin={isMobile() ? 0 : 216}
                             zIndex='9999'


### PR DESCRIPTION
## Changes:

- CSS changes
- Add id for popover in trader package

### Screenshots:

Please provide some screenshots of the change.
