### PR TITLE
Hamza/chore: remove the broker code mt5 notification from traders hub

### DIFF
--- a/packages/core/src/App/Containers/app-notification-messages.jsx
+++ b/packages/core/src/App/Containers/app-notification-messages.jsx
@@ -146,7 +146,6 @@ const AppNotificationMessages = ({
                   'tnc',
                   'trustpilot',
                   'unwelcome',
-                  'mt5_notification',
               ].includes(message.key) || message.type === 'p2p_completed_order'
             : true;
 

--- a/packages/core/src/Stores/Helpers/client-notifications.js
+++ b/packages/core/src/Stores/Helpers/client-notifications.js
@@ -72,6 +72,5 @@ export const priority_toast_messages = [
     'p2p_daily_limit_increase',
     'authenticate',
     'notify_financial_assessment',
-    'mt5_notification',
     ...maintenance_notifications,
 ];

--- a/packages/core/src/Stores/notification-store.js
+++ b/packages/core/src/Stores/notification-store.js
@@ -586,9 +586,6 @@ export default class NotificationStore extends BaseStore {
                     this.addNotificationMessage(this.client_notifications.svg_poi_expired);
                 }
             }
-            if (client && this.root_store.client.mt5_login_list.length > 0) {
-                this.addNotificationMessage(this.client_notifications.mt5_notification);
-            }
         }
 
         if (!is_eu && isMultiplierContract(selected_contract_type) && current_language === 'EN' && is_logged_in) {


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
User Story: As a [type of user], I want [an action] so that [a benefit/a value].
As a user I do not want to see the MT5 broker name change pop-up notification on Trader's Hub since this issue no longer happens.

CU Card: https://app.clickup.com/t/20696747/CFDS-925

### Screenshots:
<img width="1301" alt="Screenshot 2023-08-17 at 9 21 26 AM" src="https://github.com/binary-com/deriv-app/assets/120543468/a848c185-a3e8-45f5-9e5b-30cd3789b1a5">

Please provide some screenshots of the change.
