### PR TITLE
Hamza/chore: Strong password message overlap with progress bar

### DIFF
--- a/packages/appstore/src/components/cfds-listing/cfds-listing.scss
+++ b/packages/appstore/src/components/cfds-listing/cfds-listing.scss
@@ -620,6 +620,9 @@
     }
     &__new-password {
         margin-bottom: 8.6rem;
+        .dc-input__hint {
+            margin: 0 0 -5.3rem 1.3rem;
+        }
     }
     &__actions {
         align-items: center;


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
Go to [app.deriv.com](http://app.deriv.com/)
From Traders hub go to any existing / add MT5 account change password
Switch to investor password
Provide valid passwords in both current and new fields
Notice the progress bar

current behaviour: The progress bar is overlapping with the strong password text

expected behaviour: The progress bar should not overlap with strong password text.

### Screenshots:
<img width="1178" alt="Screenshot 2023-08-17 at 2 35 26 PM" src="https://github.com/binary-com/deriv-app/assets/120543468/41f5d3fb-e2d2-43e8-8bcb-17eb557f91ca">

Please provide some screenshots of the change.
