### PR TITLE
Farabi/bot 533/contract result overlay test case

### DIFF
--- a/packages/bot-web-ui/src/components/contract-result-overlay/contract-result-overlay.spec.tsx
+++ b/packages/bot-web-ui/src/components/contract-result-overlay/contract-result-overlay.spec.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { mockStore, StoreProvider } from '@deriv/stores';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { render, screen } from '@testing-library/react';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import RootStore from 'Stores/index';
+import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
+import ContractResultOverlay from './contract-result-overlay';
+
+jest.mock('@deriv/bot-skeleton/src/scratch/blockly', () => jest.fn());
+jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => ({
+    saveRecentWorkspace: jest.fn(),
+    unHighlightAllBlocks: jest.fn(),
+}));
+jest.mock('@deriv/bot-skeleton/src/scratch/hooks/block_svg', () => jest.fn());
+
+const mock_ws = {
+    authorized: {
+        subscribeProposalOpenContract: jest.fn(),
+        send: jest.fn(),
+    },
+    storage: {
+        send: jest.fn(),
+    },
+    contractUpdate: jest.fn(),
+    subscribeTicksHistory: jest.fn(),
+    forgetStream: jest.fn(),
+    activeSymbols: jest.fn(),
+    send: jest.fn(),
+};
+describe('ContractResultOverlay', () => {
+    let wrapper: ({ children }: { children: JSX.Element }) => JSX.Element, mock_DBot_store: RootStore | undefined;
+
+    beforeEach(() => {
+        jest.resetModules();
+        const mock_store = mockStore({});
+        mock_DBot_store = mockDBotStore(mock_store, mock_ws);
+
+        wrapper = ({ children }: { children: JSX.Element }) => (
+            <StoreProvider store={mock_store}>
+                <DBotStoreProvider ws={mock_ws} mock={mock_DBot_store}>
+                    {children}
+                </DBotStoreProvider>
+            </StoreProvider>
+        );
+    });
+
+    it('should render the ContractResultOverlay component', () => {
+        const { container } = render(<ContractResultOverlay profit={0} className={''} />, {
+            wrapper,
+        });
+        expect(container).toBeInTheDocument();
+    });
+
+    it('should show contract won', () => {
+        render(<ContractResultOverlay profit={0} className={''} />, {
+            wrapper,
+        });
+        expect(screen.getByText('Won')).toBeInTheDocument();
+    });
+
+    it('should show contract lost', () => {
+        render(<ContractResultOverlay profit={-1} className={''} />, {
+            wrapper,
+        });
+        expect(screen.getByText('Lost')).toBeInTheDocument();
+    });
+});

--- a/packages/bot-web-ui/src/components/contract-result-overlay/contract-result-overlay.spec.tsx
+++ b/packages/bot-web-ui/src/components/contract-result-overlay/contract-result-overlay.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { mockStore, StoreProvider } from '@deriv/stores';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { render, screen } from '@testing-library/react';
-// eslint-disable-next-line import/no-extraneous-dependencies
+import { mock_ws } from 'Utils/mock';
 import RootStore from 'Stores/index';
 import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
 import ContractResultOverlay from './contract-result-overlay';
@@ -14,20 +14,6 @@ jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => ({
 }));
 jest.mock('@deriv/bot-skeleton/src/scratch/hooks/block_svg', () => jest.fn());
 
-const mock_ws = {
-    authorized: {
-        subscribeProposalOpenContract: jest.fn(),
-        send: jest.fn(),
-    },
-    storage: {
-        send: jest.fn(),
-    },
-    contractUpdate: jest.fn(),
-    subscribeTicksHistory: jest.fn(),
-    forgetStream: jest.fn(),
-    activeSymbols: jest.fn(),
-    send: jest.fn(),
-};
 describe('ContractResultOverlay', () => {
     let wrapper: ({ children }: { children: JSX.Element }) => JSX.Element, mock_DBot_store: RootStore | undefined;
 


### PR DESCRIPTION
## Changes:

- Added test case for contract result overlay
- Testing for contract result overlay component to be rendered
- Testing if contract is won or loss based on profit value