### PR TITLE
Ako/ fix `Cannot read properties of null (reading 'Login ID')` on PushWoosh 

### DIFF
--- a/packages/core/src/Stores/pushwoosh-store.js
+++ b/packages/core/src/Stores/pushwoosh-store.js
@@ -62,7 +62,7 @@ export default class PushwooshStore extends BaseStore {
     sendTags = api => {
         api.getTags()
             .then(result => {
-                if (!result.result['Login ID'] || !result.result['Site Language'] || !result.result.Residence) {
+                if (!result?.result?.['Login ID'] || !result?.result?.['Site Language'] || !result?.result?.Residence) {
                     return api.setTags({
                         'Login ID': this.root_store.client.loginid,
                         'Site Language': getLanguage().toLowerCase(),


### PR DESCRIPTION
## Changes:

Just added optional chaining in order to fix the newly introduced push-woosh issue

### Screenshots:

Please provide some screenshots of the change.
