### PR TITLE
Maryia/BOT-287/fix: Make Volatility 100 Index as the default asset for the quick str...

### DIFF
--- a/packages/bot-web-ui/src/stores/quick-strategy-store.ts
+++ b/packages/bot-web-ui/src/stores/quick-strategy-store.ts
@@ -87,7 +87,13 @@ export default class QuickStrategyStore {
 
         this.root_store = root_store;
     }
-    selected_symbol: TMarketOption = (this.qs_cache.selected_symbol as TMarketOption) || {};
+    selected_symbol: TMarketOption =
+        (this.qs_cache.selected_symbol as TMarketOption) || {
+            group: 'Continuous Indices',
+            text: 'Volatility 100 Index',
+            value: 'R_100',
+        } ||
+        {};
     selected_trade_type: TTradeType = (this.qs_cache.selected_trade_type as TTradeType) || {};
     selected_type_strategy: TTypeStrategy = (this.qs_cache.selected_type_strategy as TTypeStrategy) || {};
     selected_duration_unit: TDurationOptions = (this.qs_cache.selected_duration_unit as TDurationOptions) || {};


### PR DESCRIPTION
…ategies

## Changes:

fix: Make Volatility 100 Index as the default asset for the quick strategies

### Screenshots:

Please provide some screenshots of the change.
