### PR TITLE
maryia/WEBREL-1166/build: update deriv-charts version to 1.3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@datadog/browser-rum": "^4.37.0",
                 "@deriv/api-types": "^1.0.118",
                 "@deriv/deriv-api": "^1.0.11",
-                "@deriv/deriv-charts": "1.3.2",
+                "@deriv/deriv-charts": "1.3.5",
                 "@deriv/js-interpreter": "^3.0.0",
                 "@deriv/ui": "^0.6.0",
                 "@livechat/customer-sdk": "^2.0.4",
@@ -2896,9 +2896,9 @@
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@deriv/deriv-charts": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-1.3.2.tgz",
-            "integrity": "sha512-j1xgloqF9jVPiCsfQJGKduivU7r42vQCeT+URCKz82dltlJAw7dmfxY3GgQHjBobkG+SK7ANG/rBzK1vyZn7bA==",
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-1.3.5.tgz",
+            "integrity": "sha512-qD4R/Lanf3xXBsOhTjubPcdXL6QMy7zR0O+Zq9KQiGx4lf3LES0FbQsLRlE2ebwAUK8hxD10jsUqTTS+zCpWBw==",
             "dependencies": {
                 "@welldone-software/why-did-you-render": "^3.3.8",
                 "classnames": "^2.3.1",
@@ -51542,9 +51542,9 @@
             }
         },
         "@deriv/deriv-charts": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-1.3.2.tgz",
-            "integrity": "sha512-j1xgloqF9jVPiCsfQJGKduivU7r42vQCeT+URCKz82dltlJAw7dmfxY3GgQHjBobkG+SK7ANG/rBzK1vyZn7bA==",
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-1.3.5.tgz",
+            "integrity": "sha512-qD4R/Lanf3xXBsOhTjubPcdXL6QMy7zR0O+Zq9KQiGx4lf3LES0FbQsLRlE2ebwAUK8hxD10jsUqTTS+zCpWBw==",
             "requires": {
                 "@welldone-software/why-did-you-render": "^3.3.8",
                 "classnames": "^2.3.1",

--- a/packages/bot-web-ui/package.json
+++ b/packages/bot-web-ui/package.json
@@ -70,7 +70,7 @@
         "@datadog/browser-logs": "^4.36.0",
         "@deriv/bot-skeleton": "^1.0.0",
         "@deriv/components": "^1.0.0",
-        "@deriv/deriv-charts": "1.3.2",
+        "@deriv/deriv-charts": "1.3.5",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",
         "@deriv/translations": "^1.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -96,7 +96,7 @@
         "@deriv/cfd": "^1.0.0",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.11",
-        "@deriv/deriv-charts": "1.3.2",
+        "@deriv/deriv-charts": "1.3.5",
         "@deriv/hooks": "^1.0.0",
         "@deriv/p2p": "^0.7.3",
         "@deriv/reports": "^1.0.0",

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -85,7 +85,7 @@
     "dependencies": {
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.11",
-        "@deriv/deriv-charts": "1.3.2",
+        "@deriv/deriv-charts": "1.3.5",
         "@deriv/reports": "^1.0.0",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",


### PR DESCRIPTION
## Changes:

- update deriv-charts version to 1.3.5

### Screenshots:

Please provide some screenshots of the change.
