### PR TITLE
Hamza/Hotfix: regression bug regarding market offerings

### DIFF
--- a/packages/cfd/src/Helpers/compare-accounts-config.ts
+++ b/packages/cfd/src/Helpers/compare-accounts-config.ts
@@ -19,7 +19,8 @@ const getHighlightedIconLabel = (
         ['financial_labuan', 'financial_vanuatu'].includes(market_type_shortcode) ||
         is_demo ||
         trading_platforms.platform === CFD_PLATFORMS.DXTRADE ||
-        selected_region === 'EU'
+        selected_region === 'EU' ||
+        (trading_platforms.platform === CFD_PLATFORMS.MT5 && market_type_shortcode === 'all_svg')
             ? localize('Forex')
             : localize('Forex: standard/micro');
 
@@ -74,11 +75,11 @@ const getHighlightedIconLabel = (
             }
         case 'all':
         default:
-            if (trading_platforms.platform === 'mt5') {
+            if (trading_platforms.platform === CFD_PLATFORMS.MT5) {
                 return [
                     { icon: 'Synthetics', text: localize('Synthetics'), highlighted: true },
                     { icon: 'Baskets', text: localize('Baskets'), highlighted: false },
-                    { icon: 'DerivedFX', text: localize('Derived FX'), highlighted: true },
+                    { icon: 'DerivedFX', text: localize('Derived FX'), highlighted: false },
                     { icon: 'Stocks', text: localize('Stocks'), highlighted: true },
                     { icon: 'StockIndices', text: localize('Stock indices'), highlighted: true },
                     { icon: 'Commodities', text: localize('Commodities'), highlighted: false },


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
Baskets, Commodities, Derived FX and Forex micro are  not offering in MT5 Swap Free account.Hence Derived FX should be disabled and Forex:standard/micro needs to be updated in Real.

### Screenshots:

Please provide some screenshots of the change.
