### PR TITLE
Hamza/chore: useCreateOtherCFDAccount and useCreateMT5Account hooks added

### DIFF
--- a/packages/api/src/hooks/index.ts
+++ b/packages/api/src/hooks/index.ts
@@ -14,3 +14,5 @@ export { default as useTradingAccountsList } from './useTradingAccountsList';
 export { default as useTradingPlatformAccounts } from './useTradingPlatformAccounts';
 export { default as useTradingPlatformAvailableAccounts } from './useTradingPlatformAvailableAccounts';
 export { default as useWalletAccountsList } from './useWalletAccountsList';
+export { default as useCreateMT5Account } from './useCreateMT5Account';
+export { default as useCreateOtherCFDAccount } from './useCreateOtherCFDAccount';

--- a/packages/api/src/hooks/useCreateMT5Account.ts
+++ b/packages/api/src/hooks/useCreateMT5Account.ts
@@ -18,7 +18,11 @@ const useCreateMT5Account = () => {
         return { ...data?.mt5_new_account };
     }, [data]);
 
-    return { data: modified_data, ...rest };
+    return {
+        /** The response and the mutation of the create MT5 account API request */
+        data: modified_data,
+        ...rest,
+    };
 };
 
 export default useCreateMT5Account;

--- a/packages/api/src/hooks/useCreateMT5Account.ts
+++ b/packages/api/src/hooks/useCreateMT5Account.ts
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+import useRequest from '../useRequest';
+import useInvalidateQuery from '../useInvalidateQuery';
+
+/** A custom hook that creates the MT5 account. */
+const useCreateMT5Account = () => {
+    const invalidate = useInvalidateQuery();
+    const { data, ...rest } = useRequest('mt5_new_account', {
+        onSuccess: () => {
+            invalidate('mt5_login_list');
+        },
+    });
+
+    // Add additional information to the create MT5 account response.
+    const modified_data = useMemo(() => {
+        if (!data?.mt5_new_account) return undefined;
+
+        return { ...data?.mt5_new_account };
+    }, [data]);
+
+    return { data: modified_data, ...rest };
+};
+
+export default useCreateMT5Account;

--- a/packages/api/src/hooks/useCreateOtherCFDAccount.ts
+++ b/packages/api/src/hooks/useCreateOtherCFDAccount.ts
@@ -18,7 +18,11 @@ const useCreateOtherCFDAccount = () => {
         return { ...data };
     }, [data]);
 
-    return { data: modified_data, ...rest };
+    return {
+        /** The response and the mutation of the create Other CFD account API request */
+        data: modified_data,
+        ...rest,
+    };
 };
 
 export default useCreateOtherCFDAccount;

--- a/packages/api/src/hooks/useCreateOtherCFDAccount.ts
+++ b/packages/api/src/hooks/useCreateOtherCFDAccount.ts
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+import useRequest from '../useRequest';
+import useInvalidateQuery from '../useInvalidateQuery';
+
+/** A custom hook that creates the Other CFD account. */
+const useCreateOtherCFDAccount = () => {
+    const invalidate = useInvalidateQuery();
+    const { data, ...rest } = useRequest('trading_platform_new_account', {
+        onSuccess: () => {
+            invalidate('trading_platform_accounts');
+        },
+    });
+
+    // Add additional information to the create Other CFD account response.
+    const modified_data = useMemo(() => {
+        if (!data) return undefined;
+
+        return { ...data };
+    }, [data]);
+
+    return { data: modified_data, ...rest };
+};
+
+export default useCreateOtherCFDAccount;

--- a/packages/api/types.ts
+++ b/packages/api/types.ts
@@ -229,6 +229,121 @@ import type {
 import type { useMutation, useQuery } from '@tanstack/react-query';
 
 type TPrivateSocketEndpoints = {
+    trading_platform_new_account: {
+        request: {
+            /**
+             * Must be `1`
+             */
+            trading_platform_new_account: 1;
+            /**
+             * Account type.
+             */
+            account_type: 'demo' | 'real';
+            /**
+             * [Optional] Name of the client's company (For DerivEZ only)
+             */
+            company?: string;
+            /**
+             * [Optional] Trading account currency, the default value will be the qualified account currency.
+             */
+            currency?: string;
+            /**
+             * [Optional] If set to 1, only validation is performed.
+             */
+            dry_run?: 0 | 1;
+            /**
+             * Market type
+             */
+            market_type: 'financial' | 'synthetic' | 'all';
+            /**
+             * The master password of the account. For validation (Accepts any printable ASCII character. Must be within 8-25 characters, and include numbers, lowercase and uppercase letters. Must not be the same as the user's email address). Only for DXTrade.
+             */
+            password?: string;
+            /**
+             * Name of trading platform.
+             */
+            platform: 'dxtrade' | 'derivez' | 'ctrader';
+            /**
+             * [Optional] Sub account type.
+             */
+            sub_account_type?: 'financial' | 'financial_stp' | 'swap_free';
+            /**
+             * [Optional] Used to pass data through the websocket, which may be retrieved via the `echo_req` output field. Maximum size is 3500 bytes.
+             */
+            passthrough?: {
+                [k: string]: unknown;
+            };
+            /**
+             * [Optional] Used to map request to response.
+             */
+            req_id?: number;
+        };
+        response: {
+            /**
+             * ID of Trading account.
+             */
+            account_id?: string;
+            /**
+             * Account type.
+             */
+            account_type?: 'demo' | 'real' | 'all';
+            /**
+             * Agent Details.
+             */
+            agent?: null | string;
+            /**
+             * Balance of the Trading account.
+             */
+            balance?: number;
+            /**
+             * Currency of the Trading account.
+             */
+            currency?: string;
+            /**
+             * Account balance, formatted to appropriate decimal places.
+             */
+            display_balance?: string;
+            /**
+             * Account enabled status
+             */
+            enabled?: number;
+            /**
+             * Landing company shortcode of the Trading account.
+             */
+            landing_company_short?: 'bvi' | 'labuan' | 'malta' | 'maltainvest' | 'svg' | 'vanuatu' | 'seychelles';
+            /**
+             * Login name used to log in into Trading platform.
+             */
+            login?: string;
+            /**
+             * Market type.
+             */
+            market_type?: 'financial' | 'synthetic' | 'all';
+            /**
+             * Name of trading platform.
+             */
+            platform?: 'dxtrade' | 'derivez' | 'ctrader';
+            /**
+             * Sub account type.
+             */
+            sub_account_type?: 'financial' | 'financial_stp' | 'swap_free';
+        };
+        /**
+         * Echo of the request made.
+         */
+        echo_req: {
+            [k: string]: unknown;
+        };
+        /**
+         * Action name of the request made.
+         */
+        msg_type: 'trading_platform_new_account';
+        /**
+         * Optional field sent in request to map to response, present only when request contains `req_id`.
+         */
+        req_id?: number;
+        [k: string]: unknown;
+    };
     trading_platform_available_accounts: {
         request: {
             /**


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
Create a hook to handle the account creation of all of our CFD platforms.

- useCreateOtherCFDAccount
- useCreateMT5Account

### Screenshots:

```
createMT5Account({
payload: {
  account_type: 'account_type',
  mainPassword: 'password',
  email: 'test@test.com',
  leverage: 500,
  name: 'Johnny Depp',
  mt5_account_type: 'account_type',
  country: 'id',
},
});
```

```
createOtherCFDAccount({
payload: {
  account_type: 'rael',
  password: 'password',
  email: 'test@test.com',
  platform: 'dxtrade'
  market_type: 'all',
  company: '',
},
});
```


Please provide some screenshots of the change.
