### PR TITLE
Hamza/ hotfix: compare account text size difference

### DIFF
--- a/packages/appstore/src/components/compare-account/compare-account.tsx
+++ b/packages/appstore/src/components/compare-account/compare-account.tsx
@@ -18,7 +18,13 @@ const CompareAccount = ({ accounts_sub_text, is_desktop }: TCompareAccount) => {
                 history.push(routes.compare_cfds);
             }}
         >
-            <Text size='xs' color='red' weight='bold' line_height='s' styles={is_desktop ? { marginLeft: '1rem' } : ''}>
+            <Text
+                size='xxs'
+                color='red'
+                weight='bold'
+                line_height='s'
+                styles={is_desktop ? { marginLeft: '1rem' } : ''}
+            >
                 <Localize i18n_default_text={accounts_sub_text} />
             </Text>
         </div>

--- a/packages/appstore/src/components/compare-account/compare-account.tsx
+++ b/packages/appstore/src/components/compare-account/compare-account.tsx
@@ -19,7 +19,7 @@ const CompareAccount = ({ accounts_sub_text, is_desktop }: TCompareAccount) => {
             }}
         >
             <Text
-                size='xxs'
+                size={is_desktop ? 'xxs' : 'xs'}
                 color='red'
                 weight='bold'
                 line_height='s'


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
Compare accounts and Account Information link in CFD section is shown little bigger than the production.

### Screenshots:

Please provide some screenshots of the change.
![image](https://github.com/binary-com/deriv-app/assets/120543468/dbccf07e-c25b-4f1d-84d8-d1ad2b42db44)
![image](https://github.com/binary-com/deriv-app/assets/120543468/dd241ad2-c348-467c-a909-5e0c6d48fdfd)

