### PR TITLE
Kate / DTRA-371 / Lines of the candlestick, hollow and OHLC changes to dash after purchasing a contract

### DIFF
--- a/packages/trader/src/Modules/SmartChart/Components/all-markers.jsx
+++ b/packages/trader/src/Modules/SmartChart/Components/all-markers.jsx
@@ -370,6 +370,7 @@ const TickContract = RawMarkerMaker(
         }
         if (is_in_contract_details) return;
 
+        ctx.save();
         ctx.strokeStyle = color;
         ctx.fillStyle = color;
 


### PR DESCRIPTION
## Changes:

- Added `ctx.save()` in order to avoid situations when we entered the condition where there are no ticks and restored canvas without saving (line line 393):

```
if (!ticks.length || !barrier) {
            ctx.restore();
            return;
}
```

### Screenshots:

Please provide some screenshots of the change.
