### PR TITLE
Kate / OPT-328 / Responsive: tooltips for Take profit get cut off

### DIFF
--- a/packages/components/src/components/input-field/input-field.tsx
+++ b/packages/components/src/components/input-field/input-field.tsx
@@ -122,7 +122,7 @@ const InputField = ({
 }: TInputField) => {
     const [local_value, setLocalValue] = React.useState<string>();
     const Icon = icon as React.ElementType;
-    const has_error = error_messages && !!error_messages.length;
+    const has_error = error_messages && !!error_messages.length && !is_error_tooltip_hidden;
     const max_is_disabled = max_value && (+value >= +max_value || Number(local_value) >= +max_value);
     const min_is_disabled = min_value && (+value <= +min_value || Number(local_value) <= +min_value);
     let has_valid_length = true;
@@ -304,7 +304,7 @@ const InputField = ({
                 is_increment_input ? 'dc-input-wrapper__input' : '',
                 inline_prefix ? 'input--has-inline-prefix' : '',
                 'input',
-                { 'input--error': has_error },
+                { 'input--error': error_messages && !!error_messages.length },
                 classNameInput
             )}
             classNameDynamicSuffix={classNameDynamicSuffix}
@@ -355,7 +355,7 @@ const InputField = ({
             className={classNames('trade-container__tooltip', { 'dc-tooltip--with-label': label })}
             alignment={error_message_alignment || 'left'}
             message={has_error ? error_messages[0] : null}
-            has_error={!is_error_tooltip_hidden && has_error}
+            has_error={has_error}
         >
             {!!label && (
                 <label htmlFor={name} className='dc-input-field__label'>

--- a/packages/components/src/components/tooltip/tooltip.scss
+++ b/packages/components/src/components/tooltip/tooltip.scss
@@ -153,14 +153,3 @@
         }
     }
 }
-
-.trade-container__fieldset {
-    @include mobile {
-        .dc-tooltip[data-tooltip] {
-            &:before,
-            &:after {
-                display: none;
-            }
-        }
-    }
-}

--- a/packages/components/src/components/tooltip/tooltip.scss
+++ b/packages/components/src/components/tooltip/tooltip.scss
@@ -153,3 +153,14 @@
         }
     }
 }
+
+.trade-container__fieldset {
+    @include mobile {
+        .dc-tooltip[data-tooltip] {
+            &:before,
+            &:after {
+                display: none;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Changes:

- Changes will be applied to those components, which are importing `<InputWithCheckbox />` as there we pass a prop to `<InputField />` : `is_error_tooltip_hidden={isMobile()}`. Currently it's only `<StopLoss />` and <`TakeProfit />` from trader package (no other package should be affected)

### Screenshots:

Please provide some screenshots of the change.
