### PR TITLE
refactor: transaction store refactor to adjust trx by loginid

### DIFF
--- a/packages/bot-web-ui/src/components/transaction-details/desktop-transaction-table.tsx
+++ b/packages/bot-web-ui/src/components/transaction-details/desktop-transaction-table.tsx
@@ -80,7 +80,7 @@ export default function DesktopTransactionTable({
                                         convertDateFormat(
                                             data?.date_start,
                                             'YYYY-M-D HH:mm:ss [GMT]',
-                                            'YYYY-MM-DD HH:mm:ss [GMT] ZZ'
+                                            'YYYY-MM-DD HH:mm:ss [GMT]'
                                         )
                                     }
                                     extra_classes={[`${PARENT_CLASS}__table-cell--grow-big`]}

--- a/packages/bot-web-ui/src/components/transaction-details/desktop-transaction-table.tsx
+++ b/packages/bot-web-ui/src/components/transaction-details/desktop-transaction-table.tsx
@@ -57,6 +57,8 @@ export default function DesktopTransactionTable({
     result_columns,
     transactions,
     transaction_columns,
+    account,
+    balance,
 }: TDesktopTransactionTable) {
     return (
         <div data-testid='transaction_details_tables'>
@@ -135,6 +137,7 @@ export default function DesktopTransactionTable({
             <div className={classNames(`${PARENT_CLASS}__table-container`)}>
                 <TableHeader columns={result_columns} />
                 <div className={`${PARENT_CLASS}__table-row`}>
+                    <TableCell label={account} />
                     <TableCell label={result?.number_of_runs} />
                     <TableCell label={Math.abs(result?.total_stake ?? 0).toFixed(2)} />
                     <TableCell label={Math.abs(result?.total_payout ?? 0).toFixed(2)} />
@@ -155,6 +158,7 @@ export default function DesktopTransactionTable({
                             </div>
                         }
                     />
+                    <TableCell label={balance} />
                 </div>
             </div>
         </div>

--- a/packages/bot-web-ui/src/components/transaction-details/mobile-transaction-card.tsx
+++ b/packages/bot-web-ui/src/components/transaction-details/mobile-transaction-card.tsx
@@ -95,7 +95,7 @@ export default function MobileTransactionCards({ transaction }: { transaction: T
                     label={convertDateFormat(
                         transaction?.date_start,
                         'YYYY-M-D HH:mm:ss [GMT]',
-                        'YYYY-MM-DD HH:mm:ss [GMT] ZZ'
+                        'YYYY-MM-DD HH:mm:ss [GMT]'
                     )}
                 />
                 <CardColumn

--- a/packages/bot-web-ui/src/components/transaction-details/transaction-details-desktop.tsx
+++ b/packages/bot-web-ui/src/components/transaction-details/transaction-details-desktop.tsx
@@ -80,8 +80,8 @@ const TransactionDetailsDesktop = observer(() => {
                 transactions={transaction_list}
                 result_columns={result_columns}
                 result={statistics}
-                account={loginid || ''}
-                balance={balance || 0}
+                account={loginid ?? ''}
+                balance={balance ?? 0}
             />
         </Draggable>
     );

--- a/packages/bot-web-ui/src/components/transaction-details/transaction-details-desktop.tsx
+++ b/packages/bot-web-ui/src/components/transaction-details/transaction-details-desktop.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { observer } from '@deriv/stores';
+import { observer, useStore } from '@deriv/stores';
 import { localize } from '@deriv/translations';
 import Draggable from 'Components/draggable';
 import { useDBotStore } from 'Stores/useDBotStore';
@@ -20,20 +20,25 @@ const transaction_columns: TColumn[] = [
 
 /* TODO: Add back account & balance when we have support from transaction store */
 const result_columns: TColumn[] = [
-    // { key: 'account', label: localize('Account') },
+    { key: 'account', label: localize('Account') },
     { key: 'no_of_runs', label: localize('No. of runs') },
     { key: 'total_stake', label: localize('Total stake') },
     { key: 'total_payout', label: localize('Total payout') },
     { key: 'win', label: localize('Win') },
     { key: 'loss', label: localize('Loss') },
     { key: 'total_profit', label: localize('Total profit/loss') },
-    // { key: 'balance', label: localize('Balance') },
+    { key: 'balance', label: localize('Balance') },
 ];
 
 const TransactionDetailsDesktop = observer(() => {
+    const { client } = useStore();
+    const { loginid, balance } = client;
     const { transactions, run_panel } = useDBotStore();
-    const { toggleTransactionDetailsModal, is_transaction_details_modal_open, elements }: Partial<TTransactionStore> =
-        transactions;
+    const {
+        toggleTransactionDetailsModal,
+        is_transaction_details_modal_open,
+        transactions: transaction_list,
+    }: Partial<TTransactionStore> = transactions;
     const { statistics }: Partial<TRunPanelStore> = run_panel;
 
     const [screenDimensions, setScreenDimensions] = useState({ width: 0, height: 0 });
@@ -72,9 +77,11 @@ const TransactionDetailsDesktop = observer(() => {
         >
             <DesktopTransactionTable
                 transaction_columns={transaction_columns}
-                transactions={elements}
+                transactions={transaction_list}
                 result_columns={result_columns}
                 result={statistics}
+                account={loginid || ''}
+                balance={balance || 0}
             />
         </Draggable>
     );

--- a/packages/bot-web-ui/src/components/transaction-details/transaction-details-mobile.tsx
+++ b/packages/bot-web-ui/src/components/transaction-details/transaction-details-mobile.tsx
@@ -48,13 +48,13 @@ const TransactionDetailsMobile = observer(() => {
                     has_started_onboarding_tour={false}
                     currency={client?.currency}
                     is_mobile={true}
-                    lost_contracts={statistics?.lost_contracts || 0}
-                    number_of_runs={statistics?.number_of_runs || 0}
+                    lost_contracts={statistics?.lost_contracts ?? 0}
+                    number_of_runs={statistics?.number_of_runs ?? 0}
                     toggleStatisticsInfoModal={toggleStatisticsInfoModal}
-                    total_payout={statistics?.total_payout || 0}
-                    total_profit={statistics?.total_profit || 0}
-                    total_stake={statistics?.total_stake || 0}
-                    won_contracts={statistics?.won_contracts || 0}
+                    total_payout={statistics?.total_payout ?? 0}
+                    total_profit={statistics?.total_profit ?? 0}
+                    total_stake={statistics?.total_stake ?? 0}
+                    won_contracts={statistics?.won_contracts ?? 0}
                 />
             </div>
         </MobileFullPageModal>

--- a/packages/bot-web-ui/src/components/transaction-details/transaction-details-mobile.tsx
+++ b/packages/bot-web-ui/src/components/transaction-details/transaction-details-mobile.tsx
@@ -12,8 +12,11 @@ import './transaction-details-mobile.scss';
 const TransactionDetailsMobile = observer(() => {
     const { client } = useStore();
     const { transactions, run_panel } = useDBotStore();
-    const { toggleTransactionDetailsModal, is_transaction_details_modal_open, elements }: Partial<TTransactionStore> =
-        transactions;
+    const {
+        toggleTransactionDetailsModal,
+        is_transaction_details_modal_open,
+        transactions: transaction_list,
+    }: Partial<TTransactionStore> = transactions;
     const { statistics, toggleStatisticsInfoModal }: Partial<TRunPanelStore> = run_panel;
 
     return (
@@ -27,7 +30,7 @@ const TransactionDetailsMobile = observer(() => {
             height_offset='80px'
         >
             <div className='transaction-details-modal-mobile__wrapper' data-testid='transaction_details_cards'>
-                {elements?.map(({ data, type }) => {
+                {transaction_list?.map(({ data, type }) => {
                     if (type === transaction_elements.CONTRACT)
                         return <MobileTransactionCards transaction={data} key={data?.transaction_ids?.buy} />;
                     return (
@@ -45,13 +48,13 @@ const TransactionDetailsMobile = observer(() => {
                     has_started_onboarding_tour={false}
                     currency={client?.currency}
                     is_mobile={true}
-                    lost_contracts={statistics?.lost_contracts}
-                    number_of_runs={statistics?.number_of_runs}
+                    lost_contracts={statistics?.lost_contracts || 0}
+                    number_of_runs={statistics?.number_of_runs || 0}
                     toggleStatisticsInfoModal={toggleStatisticsInfoModal}
-                    total_payout={statistics?.total_payout}
-                    total_profit={statistics?.total_profit}
-                    total_stake={statistics?.total_stake}
-                    won_contracts={statistics?.won_contracts}
+                    total_payout={statistics?.total_payout || 0}
+                    total_profit={statistics?.total_profit || 0}
+                    total_stake={statistics?.total_stake || 0}
+                    won_contracts={statistics?.won_contracts || 0}
                 />
             </div>
         </MobileFullPageModal>

--- a/packages/bot-web-ui/src/components/transaction-details/transaction-details.types.ts
+++ b/packages/bot-web-ui/src/components/transaction-details/transaction-details.types.ts
@@ -34,6 +34,7 @@ export type TTransaction = {
 export type TTransactions = {
     data: TTransaction;
     type: 'contract' | 'divider';
+    loginid: string;
 };
 
 export type TStatistics = {
@@ -46,7 +47,7 @@ export type TStatistics = {
 };
 
 export type TTransactionStore = {
-    elements: TTransactions[];
+    transactions: TTransactions[];
     is_transaction_details_modal_open: boolean;
     toggleTransactionDetailsModal: (is_open: boolean) => void;
 };
@@ -61,6 +62,8 @@ export type TDesktopTransactionTable = {
     transactions: TTransactions[] | undefined;
     result_columns: TColumn[];
     result: TStatistics | undefined;
+    account: string;
+    balance: string | number;
 };
 
 export type TTableCell = {

--- a/packages/bot-web-ui/src/components/transactions/transactions.jsx
+++ b/packages/bot-web-ui/src/components/transactions/transactions.jsx
@@ -40,7 +40,7 @@ const TransactionItem = ({ row, is_new_row }) => {
 const Transactions = observer(({ is_drawer_open }) => {
     const { run_panel, transactions } = useDBotStore();
     const { contract_stage } = run_panel;
-    const { elements, onMount, onUnmount, toggleTransactionDetailsModal } = transactions;
+    const { transactions: transaction_list, onMount, onUnmount, toggleTransactionDetailsModal } = transactions;
 
     React.useEffect(() => {
         onMount();
@@ -63,7 +63,7 @@ const Transactions = observer(({ is_drawer_open }) => {
                 <Button
                     id='download__container-view-detail-button'
                     className='download__container-view-detail-button'
-                    is_disabled={!elements.length}
+                    is_disabled={!transaction_list?.length}
                     text={localize('View Detail')}
                     onClick={() => {
                         toggleTransactionDetailsModal(true);
@@ -87,10 +87,10 @@ const Transactions = observer(({ is_drawer_open }) => {
                 })}
             >
                 <div className='transactions__scrollbar'>
-                    {elements.length ? (
+                    {transaction_list?.length ? (
                         <DataList
                             className='transactions'
-                            data_source={elements}
+                            data_source={transaction_list}
                             rowRenderer={props => <TransactionItem {...props} />}
                             keyMapper={row => {
                                 switch (row.type) {
@@ -106,7 +106,7 @@ const Transactions = observer(({ is_drawer_open }) => {
                                 }
                             }}
                             getRowSize={({ index }) => {
-                                const row = elements[index];
+                                const row = transaction_list?.[index];
                                 switch (row.type) {
                                     case transaction_elements.CONTRACT: {
                                         return 50;

--- a/packages/bot-web-ui/src/stores/run-panel-store.js
+++ b/packages/bot-web-ui/src/stores/run-panel-store.js
@@ -140,7 +140,7 @@ export default class RunPanelStore {
         return (
             this.is_running ||
             this.has_open_contract ||
-            (journal.unfiltered_messages.length === 0 && transactions.elements.length === 0)
+            (journal.unfiltered_messages.length === 0 && transactions?.transactions?.length === 0)
         );
     }
 

--- a/packages/bot-web-ui/src/stores/transactions-store.js
+++ b/packages/bot-web-ui/src/stores/transactions-store.js
@@ -84,7 +84,10 @@ export default class TransactionsStore {
         };
 
         if (!this.elements[this.loginid]) {
-            this.elements[this.loginid] = [];
+            this.elements = {
+                ...this.elements,
+                [this.loginid]: [],
+            };
         }
 
         const same_contract_index = this.elements[this.loginid]?.findIndex(


### PR DESCRIPTION
## Changes:

Currently, the transaction is not stored based on the user account (for ex: demo or any real account). In this PR we are solving that issue by
- Storing the transaction by mapping it to the client's loginid
- Changing the transactions if the account is switched and only showing the transactions based on loginid
- Clearing the transactions if the reset button is clicked but only clearing the one on which platform the user is in
- Also we are enabling the account and balance column in the detailed transaction modal/pop-up

### Screenshots:

<img width="1089" alt="Screenshot 2023-09-07 at 5 01 17 PM" src="https://github.com/binary-com/deriv-app/assets/129021108/ad3e017e-f555-458b-ab9c-c25b84c32b2e">
