### PR TITLE
shontzu-deriv:shontzu/PRODQA-1335/Swap-free-jurisdiction-modal-has-extra-spaces-and-Next-button-not-visible-on-mobile

### DIFF
--- a/packages/bot-web-ui/src/components/dashboard/tour-guide.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/tour-guide.tsx
@@ -30,40 +30,42 @@ const TourGuide = observer(
                             </span>
                         </div>
                     )}
-                    <div className='onboard__label'>
-                        <Text as='h' line_height='l' weight='bold'>
-                            {label}
-                        </Text>
-                    </div>
+                    <div className='onboard__steps'>
+                        <div className='onboard__label'>
+                            <Text as='h' line_height='l' weight='bold'>
+                                {label}
+                            </Text>
+                        </div>
 
-                    {media && (
-                        <video
-                            autoPlay={true}
-                            loop
-                            controls
-                            preload='auto'
-                            playsInline
-                            disablePictureInPicture
-                            controlsList='nodownload'
-                            style={{ width: '100%' }}
-                            src={media}
-                        />
-                    )}
+                        {media && (
+                            <video
+                                autoPlay={true}
+                                loop
+                                controls
+                                preload='auto'
+                                playsInline
+                                disablePictureInPicture
+                                controlsList='nodownload'
+                                style={{ width: '100%' }}
+                                src={media}
+                            />
+                        )}
 
-                    <div className='onboard__content'>
-                        <>
-                            {content.map((content_data, index) => {
-                                return has_localize_component ? (
-                                    content_data
-                                ) : (
-                                    <div className='onboard__content__block' key={`onboard--${index}`}>
-                                        <Text align='left' as='h' size='xs' line_height='l'>
-                                            {content_data}
-                                        </Text>
-                                    </div>
-                                );
-                            })}
-                        </>
+                        <div className='onboard__content'>
+                            <>
+                                {content.map((content_data, index) => {
+                                    return has_localize_component ? (
+                                        content_data
+                                    ) : (
+                                        <div className='onboard__content__block' key={`onboard--${index}`}>
+                                            <Text align='left' as='h' size='xs' line_height='l'>
+                                                {content_data}
+                                            </Text>
+                                        </div>
+                                    );
+                                })}
+                            </>
+                        </div>
                     </div>
                 </div>
             </React.Fragment>

--- a/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal.tsx
+++ b/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal.tsx
@@ -37,7 +37,7 @@ const JurisdictionModal = observer(({ openPasswordModal }: TJurisdictionModalPro
             })}
         >
             <JurisdictionModalContentWrapper openPasswordModal={openPasswordModal} />
-            <DynamicLeverageModalContent />
+            {account_type.type === 'financial' && <DynamicLeverageModalContent />}
         </div>
     );
 


### PR DESCRIPTION
## Changes:
- white spaces caused by invisible dynamic leverage modal 
- dynamic leverage modal should only render when account_type is  financial 
- [CU](https://app.clickup.com/t/20696747/PRODQA-1335)

### Screenshots:
<img src="https://github.com/binary-com/deriv-app/assets/108507236/3aa2f4c9-f122-4463-beff-9d3b6b1ce104" alt="Before" width="40%">
<img src="https://github.com/binary-com/deriv-app/assets/108507236/27bbb816-cac8-4514-82b1-d5914b189b80" alt="After" width="40%">


