### PR TITLE
shontzu/CFDS-605/When-refresh-the-page-incorrect-Total-Asset-is-displayed-for-few-second

### DIFF
--- a/packages/appstore/src/components/main-title-bar/__tests__/index.spec.tsx
+++ b/packages/appstore/src/components/main-title-bar/__tests__/index.spec.tsx
@@ -4,9 +4,14 @@ import { StoreProvider, mockStore } from '@deriv/stores';
 import MainTitleBar from '..';
 
 describe('MainTitleBar', () => {
+    const mock = mockStore({
+        exchange_rates: {
+            data: {
+                date: 1631032849924,
+            },
+        },
+    });
     const render_container = () => {
-        const mock = mockStore({});
-
         const wrapper = ({ children }: { children: JSX.Element }) => (
             <StoreProvider store={mock}>{children}</StoreProvider>
         );
@@ -26,7 +31,13 @@ describe('MainTitleBar', () => {
         expect(screen.getByText(/Trader's Hub/)).toBeInTheDocument();
     });
 
-    it('should render the total assets text', () => {
+    it('should shouw total assets loader when platforms are not yet loaded', () => {
+        render_container();
+        expect(screen.getByText(/Loading/)).toBeInTheDocument();
+    });
+
+    it('should render the total assets text when platforms are loaded', () => {
+        mock.client.is_landing_company_loaded = true;
         render_container();
         expect(screen.getByText(/Total assets/)).toBeInTheDocument();
     });

--- a/packages/appstore/src/components/main-title-bar/asset-summary.tsx
+++ b/packages/appstore/src/components/main-title-bar/asset-summary.tsx
@@ -6,12 +6,16 @@ import BalanceText from 'Components/elements/text/balance-text';
 import { observer, useStore } from '@deriv/stores';
 import './asset-summary.scss';
 import TotalAssetsLoader from 'Components/pre-loader/total-assets-loader';
-import { useTotalAccountBalance, useCFDAccounts, usePlatformAccounts } from '@deriv/hooks';
+import { useTotalAccountBalance, useCFDAccounts, usePlatformAccounts, useExchangeRate } from '@deriv/hooks';
+import { useCashierStore } from '../../../../cashier/src/stores/useCashierStores';
 
 const AssetSummary = observer(() => {
+    const { last_update } = useExchangeRate();
+    const { account_transfer, general_store } = useCashierStore();
     const { traders_hub, client, common } = useStore();
     const { selected_account_type, is_eu_user, no_CR_account, no_MF_account } = traders_hub;
-    const { is_logging_in, is_switching, default_currency } = client;
+    const { is_logging_in, is_switching, default_currency, is_landing_company_loaded } = client;
+    const { is_transfer_confirm } = account_transfer;
     const { current_language } = common;
     const { real: platform_real_accounts, demo: platform_demo_account } = usePlatformAccounts();
     const { real: cfd_real_accounts, demo: cfd_demo_accounts } = useCFDAccounts();
@@ -21,13 +25,20 @@ const AssetSummary = observer(() => {
     const is_real = selected_account_type === 'real';
     const real_total_balance = platform_real_balance.balance + cfd_real_balance.balance;
     const demo_total_balance = (platform_demo_account?.balance || 0) + cfd_demo_balance.balance;
+    const { is_loading } = general_store;
 
     const has_active_related_deriv_account = !((no_CR_account && !is_eu_user) || (no_MF_account && is_eu_user)); // if selected region is non-eu, check active cr accounts, if selected region is eu- check active mf accounts
     const eu_account = is_eu_user && !no_MF_account;
     const cr_account = !is_eu_user && !no_CR_account;
 
     //dont show loader if user has no respective regional account
-    if ((is_switching || is_logging_in) && (eu_account || cr_account)) {
+    if (
+        ((is_switching || is_logging_in) && (eu_account || cr_account)) ||
+        !is_landing_company_loaded ||
+        !last_update ||
+        is_loading ||
+        is_transfer_confirm
+    ) {
         return (
             <React.Fragment>
                 <div className='asset-summary__container content-loader'>


### PR DESCRIPTION
## Changes:

- [CU](https://app.clickup.com/t/20696747/CFDS-605)
- wait for all platform to load first before showing `total_balance`
- show `TotalAssetsLoader` when platform is not loaded yet 

### Screenshots:

![Screenshot 2023-09-06 at 4 54 10 PM](https://github.com/binary-com/deriv-app/assets/108507236/94f312c6-34f8-4806-87ea-8521277d1db4)
