### PR TITLE
fix: update bot name on saving bot

### DIFF
--- a/packages/bot-web-ui/src/stores/save-modal-store.ts
+++ b/packages/bot-web-ui/src/stores/save-modal-store.ts
@@ -160,6 +160,7 @@ export default class SaveModalStore implements ISaveModalStore {
             this.setButtonStatus(button_status.COMPLETED);
         }
 
+        this.updateBotName(bot_name);
         if (active_tab === 0) {
             const workspace_id = selected_strategy.id || Blockly?.utils?.genUid();
             await this.addStrategyToWorkspace(workspace_id, is_local, save_as_collection, bot_name, xml);
@@ -167,7 +168,6 @@ export default class SaveModalStore implements ISaveModalStore {
         } else {
             await saveWorkspaceToRecent(xml, is_local ? save_types.LOCAL : save_types.GOOGLE_DRIVE);
         }
-        this.updateBotName(bot_name);
         this.toggleSaveModal();
     }
 

--- a/packages/bot-web-ui/src/stores/save-modal-store.ts
+++ b/packages/bot-web-ui/src/stores/save-modal-store.ts
@@ -161,6 +161,7 @@ export default class SaveModalStore implements ISaveModalStore {
         }
 
         this.updateBotName(bot_name);
+
         if (active_tab === 0) {
             const workspace_id = selected_strategy.id || Blockly?.utils?.genUid();
             await this.addStrategyToWorkspace(workspace_id, is_local, save_as_collection, bot_name, xml);


### PR DESCRIPTION
The strategy name is not updated under the "Your bots" section on the dashboard on saving from the bot builder page.

## Changes:

- Changed the sequence of code execution order. 
- Updated the bot name in the store first and then called the saving method.