### PR TITLE
fix: issue with page breaking in edit ad form payment methods

### DIFF
--- a/packages/p2p/src/components/my-ads/create-ad-form-payment-methods.jsx
+++ b/packages/p2p/src/components/my-ads/create-ad-form-payment-methods.jsx
@@ -49,7 +49,7 @@ const CreateAdFormPaymentMethods = ({ is_sell_advert, onSelectPaymentMethods }) 
     }, [is_sell_advert, selected_buy_methods, selected_sell_methods]);
 
     if (is_sell_advert) {
-        if (p2p_advertiser_payment_methods.length) {
+        if (p2p_advertiser_payment_methods?.length) {
             return (
                 <SellAdPaymentMethodsList
                     selected_methods={selected_sell_methods}

--- a/packages/p2p/src/components/my-ads/edit-ad-form-payment-methods.jsx
+++ b/packages/p2p/src/components/my-ads/edit-ad-form-payment-methods.jsx
@@ -38,7 +38,7 @@ const EditAdFormPaymentMethods = ({ is_sell_advert, selected_methods, setSelecte
     }, []);
 
     if (is_sell_advert) {
-        if (p2p_advertiser_payment_methods.length) {
+        if (p2p_advertiser_payment_methods?.length) {
             return (
                 <SellAdPaymentMethodsList
                     selected_methods={selected_methods}


### PR DESCRIPTION
## Changes:

Edit ad form payment methods throwing error when payment method is undefined issue fixed

### Screenshots:

Please provide some screenshots of the change.
