### PR TITLE
Rupato/fix  eslint order sort

### DIFF
--- a/packages/bot-web-ui/src/components/dashboard/dbot-tours/mobile-tours/__tests__/bot-builder-tour.spec.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dbot-tours/mobile-tours/__tests__/bot-builder-tour.spec.tsx
@@ -1,8 +1,7 @@
 // eslint-disable-next-line simple-import-sort/imports
+import '@testing-library/react/dont-cleanup-after-each';
 import React from 'react';
 import { mockStore, StoreProvider } from '@deriv/stores';
-// eslint-disable-next-line simple-import-sort/imports
-import '@testing-library/react/dont-cleanup-after-each';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { mock_ws } from 'Utils/mock';

--- a/packages/bot-web-ui/src/components/dashboard/dbot-tours/mobile-tours/__tests__/bot-builder-tour.spec.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dbot-tours/mobile-tours/__tests__/bot-builder-tour.spec.tsx
@@ -1,6 +1,7 @@
 // eslint-disable-next-line simple-import-sort/imports
 import React from 'react';
 import { mockStore, StoreProvider } from '@deriv/stores';
+// eslint-disable-next-line simple-import-sort/imports
 import '@testing-library/react/dont-cleanup-after-each';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/packages/bot-web-ui/src/components/dashboard/dbot-tours/mobile-tours/__tests__/bot-builder-tour.spec.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dbot-tours/mobile-tours/__tests__/bot-builder-tour.spec.tsx
@@ -1,13 +1,13 @@
+// eslint-disable-next-line simple-import-sort/imports
 import React from 'react';
 import { mockStore, StoreProvider } from '@deriv/stores';
+import '@testing-library/react/dont-cleanup-after-each';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { mock_ws } from 'Utils/mock';
 import RootStore from 'Stores/root-store';
 import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
 import BotBuilderTour from '../bot-builder-tour';
-// eslint-disable-next-line simple-import-sort/imports
-import '@testing-library/react/dont-cleanup-after-each';
 
 jest.mock('@deriv/bot-skeleton/src/scratch/blockly', () => jest.fn());
 jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => jest.fn());

--- a/packages/bot-web-ui/src/components/dashboard/dbot-tours/mobile-tours/__tests__/bot-builder-tour.spec.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dbot-tours/mobile-tours/__tests__/bot-builder-tour.spec.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line simple-import-sort/imports
 import React from 'react';
 import { mockStore, StoreProvider } from '@deriv/stores';
 import { render, screen, waitFor } from '@testing-library/react';
@@ -7,6 +6,7 @@ import { mock_ws } from 'Utils/mock';
 import RootStore from 'Stores/root-store';
 import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
 import BotBuilderTour from '../bot-builder-tour';
+// eslint-disable-next-line simple-import-sort/imports
 import '@testing-library/react/dont-cleanup-after-each';
 
 jest.mock('@deriv/bot-skeleton/src/scratch/blockly', () => jest.fn());

--- a/packages/bot-web-ui/src/components/dashboard/dbot-tours/mobile-tours/__tests__/onboarding-tour.spec.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dbot-tours/mobile-tours/__tests__/onboarding-tour.spec.tsx
@@ -1,8 +1,7 @@
 // eslint-disable-next-line simple-import-sort/imports
+import '@testing-library/react/dont-cleanup-after-each';
 import React from 'react';
 import { mockStore, StoreProvider } from '@deriv/stores';
-// eslint-disable-next-line simple-import-sort/imports
-import '@testing-library/react/dont-cleanup-after-each';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { mock_ws } from 'Utils/mock';

--- a/packages/bot-web-ui/src/components/dashboard/dbot-tours/mobile-tours/__tests__/onboarding-tour.spec.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dbot-tours/mobile-tours/__tests__/onboarding-tour.spec.tsx
@@ -1,13 +1,14 @@
+// eslint-disable-next-line simple-import-sort/imports
 import React from 'react';
 import { mockStore, StoreProvider } from '@deriv/stores';
+// eslint-disable-next-line simple-import-sort/imports
+import '@testing-library/react/dont-cleanup-after-each';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { mock_ws } from 'Utils/mock';
 import RootStore from 'Stores/root-store';
 import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
 import OnboardingTour from '../onboarding-tour';
-// eslint-disable-next-line simple-import-sort/imports
-import '@testing-library/react/dont-cleanup-after-each';
 
 jest.mock('@deriv/bot-skeleton/src/scratch/blockly', () => jest.fn());
 jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => jest.fn());

--- a/packages/bot-web-ui/src/components/dashboard/dbot-tours/mobile-tours/__tests__/onboarding-tour.spec.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dbot-tours/mobile-tours/__tests__/onboarding-tour.spec.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line simple-import-sort/imports
 import React from 'react';
 import { mockStore, StoreProvider } from '@deriv/stores';
 import { render, screen, waitFor } from '@testing-library/react';
@@ -7,6 +6,7 @@ import { mock_ws } from 'Utils/mock';
 import RootStore from 'Stores/root-store';
 import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
 import OnboardingTour from '../onboarding-tour';
+// eslint-disable-next-line simple-import-sort/imports
 import '@testing-library/react/dont-cleanup-after-each';
 
 jest.mock('@deriv/bot-skeleton/src/scratch/blockly', () => jest.fn());


### PR DESCRIPTION
Added` eslint-disable-next-line simple-import-sort/imports` to exempt the import order from ESLint's automatic sorting. This change was necessary because our project requires a specific, predefined import order, which was causing test failures on Circle CI when ESLint reordered the imports automatically.
