### PR TITLE
Matin / cTrader trading_platform_available_accounts API call is removed.

### DIFF
--- a/packages/account/src/Sections/Security/Passwords/deriv-password.jsx
+++ b/packages/account/src/Sections/Security/Passwords/deriv-password.jsx
@@ -17,7 +17,11 @@ const DerivPassword = ({
     const [is_sent_email_modal_open, setIsSentEmailModalOpen] = React.useState(false);
 
     const onClickSendEmail = () => {
-        WS.verifyEmail(email, 'reset_password');
+        if (social_identity_provider === 'apple') {
+            WS.verifyEmail(email, 'request_email');
+        } else {
+            WS.verifyEmail(email, 'reset_password');
+        }
         setIsSentEmailModalOpen(true);
     };
 

--- a/packages/account/src/Sections/Security/Passwords/deriv-password.jsx
+++ b/packages/account/src/Sections/Security/Passwords/deriv-password.jsx
@@ -17,11 +17,7 @@ const DerivPassword = ({
     const [is_sent_email_modal_open, setIsSentEmailModalOpen] = React.useState(false);
 
     const onClickSendEmail = () => {
-        if (social_identity_provider === 'apple') {
-            WS.verifyEmail(email, 'request_email');
-        } else {
-            WS.verifyEmail(email, 'reset_password');
-        }
+        WS.verifyEmail(email, 'reset_password');
         setIsSentEmailModalOpen(true);
     };
 

--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -52,7 +52,6 @@ export default class ClientStore extends BaseStore {
     email;
     accounts = {};
     trading_platform_available_accounts = [];
-    ctrader_available_accounts = [];
     derivez_available_accounts = [];
     pre_switch_broadcast = false;
     switched = '';
@@ -171,7 +170,6 @@ export default class ClientStore extends BaseStore {
             email: observable,
             accounts: observable,
             trading_platform_available_accounts: observable,
-            ctrader_available_accounts: observable,
             derivez_available_accounts: observable,
             pre_switch_broadcast: observable,
             switched: observable,
@@ -391,7 +389,6 @@ export default class ClientStore extends BaseStore {
             responseTradingPlatformAvailableAccounts: action.bound,
             responseDerivezAvailableAccounts: action.bound,
             responseTradingPlatformAccountsList: action.bound,
-            responseCTraderAvailableAccounts: action.bound,
             responseStatement: action.bound,
             getChangeableFields: action.bound,
             syncWithLegacyPlatforms: action.bound,
@@ -1727,7 +1724,6 @@ export default class ClientStore extends BaseStore {
             WS.tradingPlatformAvailableAccounts(CFD_PLATFORMS.MT5).then(this.responseTradingPlatformAvailableAccounts);
             WS.tradingPlatformAccountsList(CFD_PLATFORMS.DXTRADE).then(this.responseTradingPlatformAccountsList);
             WS.tradingPlatformAccountsList(CFD_PLATFORMS.CTRADER).then(this.responseTradingPlatformAccountsList);
-            WS.tradingPlatformAvailableAccounts(CFD_PLATFORMS.CTRADER).then(this.responseCTraderAvailableAccounts);
             WS.tradingServers(CFD_PLATFORMS.DXTRADE).then(this.responseDxtradeTradingServers);
             WS.tradingPlatformAccountsList(CFD_PLATFORMS.DERIVEZ).then(this.responseTradingPlatformAccountsList);
             WS.tradingPlatformAccountsList(CFD_PLATFORMS.DERIVEZ).then(this.responseDerivezAvailableAccounts);
@@ -2547,12 +2543,6 @@ export default class ClientStore extends BaseStore {
     responseTradingPlatformAvailableAccounts(response) {
         if (!response.error) {
             this.trading_platform_available_accounts = response.trading_platform_available_accounts;
-        }
-    }
-
-    responseCTraderAvailableAccounts(response) {
-        if (!response.error) {
-            this.ctrader_available_accounts = response.trading_platform_available_accounts;
         }
     }
 


### PR DESCRIPTION
## Changes:

cTrader `trading_platform_available_accounts` API call is removed because it is not needed nor it is being used.

### Screenshots:

<img width="669" alt="Screenshot 2023-09-18 at 3 19 05 PM" src="https://github.com/binary-com/deriv-app/assets/70938039/cea96e1b-81a2-4011-8e26-97d6bece34d9">
