### PR TITLE
Ameerul /WEBREL-1255 Created payment method is not reflected from Add payment methods model for SELL ads

### DIFF
--- a/packages/p2p/src/components/modal-manager/modals/quick-add-modal/quick-add-modal.jsx
+++ b/packages/p2p/src/components/modal-manager/modals/quick-add-modal/quick-add-modal.jsx
@@ -302,6 +302,7 @@ const QuickAddModal = ({ advert }) => {
                             onClickPaymentMethodCard={onClickPaymentMethodCard}
                             selected_methods={selected_methods}
                             onClickAdd={() => my_ads_store.setShouldShowAddPaymentMethod(true)}
+                            p2p_advertiser_payment_methods={p2p_advertiser_payment_methods}
                         />
                     </>
                 )}

--- a/packages/p2p/src/components/modal-manager/modals/quick-add-modal/quick-add-modal.jsx
+++ b/packages/p2p/src/components/modal-manager/modals/quick-add-modal/quick-add-modal.jsx
@@ -30,11 +30,6 @@ const QuickAddModal = ({ advert }) => {
         is_sell_ad_add_payment_methods_selected || is_buy_ad_add_payment_methods_selected;
 
     React.useEffect(() => {
-        const saved_selected_methods = localStorage.getItem('selected_methods');
-        if (saved_selected_methods) {
-            setSelectedMethods(JSON.parse(saved_selected_methods));
-            localStorage.removeItem('selected_methods');
-        }
         my_profile_store.getPaymentMethodsList();
 
         // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- Added missing p2p_advertiser_payment_methods prop to SellAdPaymentMethodsList 

### Screenshots:

Please provide some screenshots of the change.
