### PR TITLE
Ameerul /WEBREL-1253 P2P Chatbox bot-message is not translated in any of the languages other than English

### DIFF
--- a/packages/p2p/src/utils/chat-message.ts
+++ b/packages/p2p/src/utils/chat-message.ts
@@ -1,4 +1,5 @@
 import { FileMessage, UserMessage } from '@sendbird/chat/message';
+import { localize } from 'Components/i18next';
 
 type TChatMessageArgs = {
     created_at: number;
@@ -87,5 +88,6 @@ export const convertFromChannelMessage = (channel_message: UserMessage | FileMes
     });
 };
 
-export const admin_message =
-    "Hello! This is where you can chat with the counterparty to confirm the order details.\nNote: In case of a dispute, we'll use this chat as a reference.";
+export const admin_message = localize(
+    "Hello! This is where you can chat with the counterparty to confirm the order details.\nNote: In case of a dispute, we'll use this chat as a reference."
+);


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- Wrapped admin message with localize as translations team were not picking up the new string for the chatbox. Should fix the translations issue 

### Screenshots:

Please provide some screenshots of the change.
