### PR TITLE
Ameerul /WEBREL-1264 On Responsive for buy ads when trying to add PM using Quick Payment methods Add button is not being enabled

### DIFF
--- a/packages/p2p/src/components/modal-manager/modals/quick-add-modal/quick-add-modal.jsx
+++ b/packages/p2p/src/components/modal-manager/modals/quick-add-modal/quick-add-modal.jsx
@@ -99,7 +99,7 @@ const QuickAddModal = ({ advert }) => {
                     text={localize('Cancel')}
                     renderPageFooterChildren={() =>
                         !my_ads_store.show_filter_payment_methods && (
-                            <>
+                            <Button.Group>
                                 <Button
                                     has_effect
                                     large
@@ -118,7 +118,7 @@ const QuickAddModal = ({ advert }) => {
                                     primary
                                     text={localize('Add')}
                                 />
-                            </>
+                            </Button.Group>
                         )
                     }
                 >

--- a/packages/p2p/src/pages/my-ads/filter-payment-methods/filter-payment-method-results/filter-payment-methods-results.jsx
+++ b/packages/p2p/src/pages/my-ads/filter-payment-methods/filter-payment-method-results/filter-payment-methods-results.jsx
@@ -26,6 +26,7 @@ const FilterPaymentMethodsResults = observer(({ filtered_payment_methods, setSel
                 onToggle={e => {
                     my_ads_store.handleChange();
                     setSelectedMethods(methods => [...methods, e.target.value]);
+                    my_ads_store.payment_method_names.push(e.target.value);
                 }}
                 selected=''
                 required


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- payment_method_names list was not being updated on responsive from filter-payment-methods-results. So added the function to push items to the array so it will be pushed to p2p_advert_update api call 
- Also fixed button styling issue

### Screenshots:

Please provide some screenshots of the change.
