### PR TITLE
chris-g/build: Setup a UAT environment deployment step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,6 +171,24 @@ jobs:
     environment:
       NODE_ENV: staging
 
+  release_uat:
+    docker:
+      - image: cimg/node:18.16.0
+    resource_class: xlarge
+    steps:
+      - git_checkout_from_cache
+      - npm_install_from_cache
+      - build
+      - versioning:
+          version_name: uat
+      - persist_to_workspace:
+          root: packages
+          paths:
+            - core
+      - notify_slack
+    environment:
+      NODE_ENV: uat
+
   release_production:
     docker:
       - image: cimg/node:18.16.0
@@ -200,6 +218,16 @@ jobs:
       - publish_to_pages_staging
     environment:
       NODE_ENV: staging
+
+  publish_cloudflare_uat:
+    docker:
+      - image: cimg/node:18.16.0
+    steps:
+      - attach_workspace:
+          at: packages
+      - publish_to_pages_uat
+    environment:
+      NODE_ENV: uat
 
   publish_cloudflare_production:
     docker:
@@ -272,6 +300,21 @@ workflows:
           context: binary-frontend-artifact-upload
           requires:
             - release_staging
+          filters:
+            branches:
+              only: /^master$/
+
+  release_uat:
+    jobs:
+      - release_uat:
+          context: binary-frontend-artifact-upload
+          filters:
+            branches:
+              only: /^master$/
+      - publish_cloudflare_uat:
+          context: binary-frontend-artifact-upload
+          requires:
+            - release_uat
           filters:
             branches:
               only: /^master$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ commands:
           command: echo "<< parameters.version_name >>-$(date -u +"%Y-%m-%dT%H:%M:%SZ")" > packages/core/dist/version
 
   publish_to_pages_staging:
-    description: "Publish to cloudflare pages"
+    description: "Publish to cloudflare pages (staging)"
     steps:
       - run:
           name: "Publish to cloudflare pages (staging)"
@@ -120,6 +120,17 @@ commands:
             cd packages/core
             npx wrangler pages deploy dist/ --project-name=deriv-app-pages --branch=staging
             echo "New staging website - http://staging.cf-pages-deriv-app.deriv.com"
+
+  publish_to_pages_uat:
+    description: "Publish to cloudflare pages (user acceptance testing)"
+    steps:
+      - run:
+          name: "Publish to cloudflare pages (uat)"
+          command: |
+            npm i wrangler@3.1.0
+            cd packages/core
+            npx wrangler pages deploy dist/ --project-name=deriv-app-pages --branch=uat
+            echo "New uat website - http://uat.cf-pages-deriv-app.deriv.com"
 
   publish_to_pages_production:
     description: "Publish to cloudflare pages"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,10 +311,14 @@ workflows:
           filters:
             branches:
               only: /^master$/
+      - hold:
+          type: approval
+          requires:
+           - release_uat
       - publish_cloudflare_uat:
           context: binary-frontend-artifact-upload
           requires:
-            - release_uat
+            - hold
           filters:
             branches:
               only: /^master$/


### PR DESCRIPTION
## Changes:

Adds the build step to push to a User Acceptance Testing environment on CloudFlare for Deriv-app.

To push to UAT instead of Staging, then we call the `publish_to_pages_uat` step.

This will push it to a 'preview' branch in CloudFlare which will be mapped to: http://uat.cf-pages-deriv-app.deriv.com

