### PR TITLE
shontzu/CFDS-928/Redirect-clients-to-new-MT5-webtrader-URL-based-on-their-MT5-server

### DIFF
--- a/packages/cfd/src/Containers/dmt5-trade-modal.tsx
+++ b/packages/cfd/src/Containers/dmt5-trade-modal.tsx
@@ -19,7 +19,9 @@ import TradingPlatformIcon from '../Assets/svgs/trading-platform';
 import { TCFDPasswordReset } from './props.types';
 
 type TMT5TradeModalProps = {
-    mt5_trade_account: DetailsOfEachMT5Loginid;
+    mt5_trade_account: DetailsOfEachMT5Loginid & {
+        webtrader_url?: string;
+    };
     show_eu_related_content: boolean;
     onPasswordManager: (
         arg1: string | undefined,

--- a/packages/cfd/src/Containers/dmt5-trade-modal.tsx
+++ b/packages/cfd/src/Containers/dmt5-trade-modal.tsx
@@ -212,7 +212,9 @@ const DMT5TradeModal = ({
                     <a
                         className='dc-btn cfd-trade-modal__download-center-app--option-link'
                         type='button'
-                        href={mt5_trade_account.webtrader_url}
+                        href={`${mt5_trade_account.webtrader_url}&login=${
+                            (mt5_trade_account as TTradingPlatformAccounts)?.display_login
+                        }`}
                         target='_blank'
                         rel='noopener noreferrer'
                     >

--- a/packages/cfd/src/Containers/dmt5-trade-modal.tsx
+++ b/packages/cfd/src/Containers/dmt5-trade-modal.tsx
@@ -212,7 +212,7 @@ const DMT5TradeModal = ({
                     <a
                         className='dc-btn cfd-trade-modal__download-center-app--option-link'
                         type='button'
-                        href={`${mt5_trade_account.webtrader_url}&login=${
+                        href={`${mt5_trade_account.webtrader_url}?login=${
                             (mt5_trade_account as TTradingPlatformAccounts)?.display_login
                         }`}
                         target='_blank'

--- a/packages/cfd/src/Containers/dmt5-trade-modal.tsx
+++ b/packages/cfd/src/Containers/dmt5-trade-modal.tsx
@@ -14,7 +14,7 @@ import {
 } from '@deriv/shared';
 import { Localize, localize } from '@deriv/translations';
 import { CFDAccountCopy } from '../Components/cfd-account-copy';
-import { getPlatformMt5DownloadLink, getMT5WebTerminalLink } from '../Helpers/constants';
+import { getPlatformMt5DownloadLink } from '../Helpers/constants';
 import TradingPlatformIcon from '../Assets/svgs/trading-platform';
 import { TCFDPasswordReset } from './props.types';
 
@@ -210,11 +210,7 @@ const DMT5TradeModal = ({
                     <a
                         className='dc-btn cfd-trade-modal__download-center-app--option-link'
                         type='button'
-                        href={getMT5WebTerminalLink({
-                            category: mt5_trade_account.account_type,
-                            loginid: (mt5_trade_account as TTradingPlatformAccounts).display_login,
-                            server_name: (mt5_trade_account as DetailsOfEachMT5Loginid)?.server_info?.environment,
-                        })}
+                        href={mt5_trade_account.webtrader_url}
                         target='_blank'
                         rel='noopener noreferrer'
                     >

--- a/packages/cfd/src/Helpers/constants.ts
+++ b/packages/cfd/src/Helpers/constants.ts
@@ -37,9 +37,7 @@ const REAL_DXTRADE_URL = 'https://dx.deriv.com';
 const DEMO_DXTRADE_URL = 'https://dx-demo.deriv.com';
 
 const CTRADER_DESKTOP_DOWNLOAD = 'https://getctrader.com/deriv/ctrader-deriv-setup.exe';
-
 const CTRADER_DOWNLOAD_LINK = 'https://ctrader.com/download/';
-
 const CTRADER_URL = 'https://ct.deriv.com/';
 
 const DERIVEZ_URL = 'https://dqwsqxuu0r6t9.cloudfront.net/';
@@ -117,7 +115,7 @@ const getPlatformMt5DownloadLink = (platform: string | undefined = undefined) =>
         case 'android':
             return 'https://download.mql5.com/cdn/mobile/mt5/android?server=Deriv-Demo,Deriv-Server,Deriv-Server-02';
         default:
-            return getMT5WebTerminalLink({ category: 'real' }); // Web
+            return '';
     }
 };
 
@@ -145,22 +143,6 @@ const getDerivEzWebTerminalLink = (category: string, token?: string) => {
     return url;
 };
 
-const getMT5WebTerminalLink = ({
-    category,
-    loginid,
-    server_name = 'Deriv-Server',
-}: {
-    category?: string;
-    loginid?: string;
-    server_name?: string;
-}) => {
-    const is_demo = category === 'demo';
-    const server = is_demo ? 'Deriv-Demo' : server_name;
-    const login = loginid ?? '';
-
-    return `https://metatraderweb.app/trade?servers=${server}&trade_server=${server}${login && `&login=${login}`}`;
-};
-
 export {
     REAL_DXTRADE_URL,
     DEMO_DXTRADE_URL,
@@ -179,6 +161,5 @@ export {
     platformsIcons,
     getTitle,
     getDerivEzWebTerminalLink,
-    getMT5WebTerminalLink,
     getTopUpConfig,
 };


### PR DESCRIPTION
## Changes:

remove hardcoding mt5 webtrader url, get from api

### Screenshots:

Please provide some screenshots of the change.
