### PR TITLE
Rupato/BOT-741/fix: for trackJS SVGGroup_ issue

### DIFF
--- a/packages/bot-skeleton/src/scratch/dbot.js
+++ b/packages/bot-skeleton/src/scratch/dbot.js
@@ -123,7 +123,7 @@ class DBot {
                 this.workspace.addChangeListener(event => updateDisabledBlocks(this.workspace, event));
                 this.workspace.addChangeListener(event => this.workspace.dispatchBlockEventEffects(event));
                 this.workspace.addChangeListener(event => {
-                    if (event.type === 'endDrag') validateErrorOnBlockDelete();
+                    if (event.type === 'endDrag' && !is_mobile) validateErrorOnBlockDelete();
                 });
 
                 Blockly.derivWorkspace = this.workspace;

--- a/packages/bot-skeleton/src/scratch/utils/index.js
+++ b/packages/bot-skeleton/src/scratch/utils/index.js
@@ -28,7 +28,7 @@ export const matchTranslateAttribute = translateString => {
 };
 
 export const extractTranslateValues = () => {
-    const transform_value = Blockly?.derivWorkspace?.trashcan.svgGroup_.getAttribute('transform');
+    const transform_value = Blockly?.derivWorkspace?.trashcan?.svgGroup_.getAttribute('transform');
     const translate_xy = matchTranslateAttribute(transform_value);
 
     if (!translate_xy) {


### PR DESCRIPTION
Added a fix for the Trackjs issue which was because of there was no mobile check and the Blockly used to load first and was not getting the reference resulting null as there is no trashcan on the mobile view.

![image](https://github.com/binary-com/deriv-app/assets/97010868/f5a3d41c-42a8-4bfb-ac5a-379c4d65b3a5)
