### PR TITLE
henry/dtra-422/fix: hide deal cancellation component when cancellation is not available

### DIFF
--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/cancel-deal.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/cancel-deal.jsx
@@ -43,60 +43,64 @@ const CancelDeal = observer(() => {
     );
 
     return (
-        <Fieldset className='trade-container__fieldset'>
-            <div className='dc-input-wrapper--inline'>
-                {should_show_popover ? (
-                    <Popover
-                        alignment='left'
-                        classNameBubble='trade-container__popover'
-                        is_bubble_hover_enabled
-                        margin={2}
-                        message={
-                            <PopoverMessageCheckbox
-                                defaultChecked={is_do_not_show_selected}
-                                checkboxLabel={localize("Don't show this again")}
-                                message={localize(
-                                    'Take profit and/or stop loss are not available while deal cancellation is active.'
-                                )}
-                                name='should_show_cancellation_warning'
-                                onChange={onPopoverCheckboxChange}
-                            />
-                        }
-                        onBubbleClose={onPopoverClose}
-                        relative_render
-                    >
-                        {input}
-                    </Popover>
-                ) : (
-                    <React.Fragment>{input}</React.Fragment>
-                )}
-                <Popover
-                    alignment='left'
-                    icon='info'
-                    id='dt_cancellation-checkbox__tooltip'
-                    is_bubble_hover_enabled
-                    message={localize(
-                        'Cancel your trade anytime within a chosen time-frame. Triggered automatically if your trade reaches the stop out level within the chosen time-frame.'
+        <React.Fragment>
+            {!!cancellation_range_list.length && (
+                <Fieldset className='trade-container__fieldset'>
+                    <div className='dc-input-wrapper--inline'>
+                        {should_show_popover ? (
+                            <Popover
+                                alignment='left'
+                                classNameBubble='trade-container__popover'
+                                is_bubble_hover_enabled
+                                margin={2}
+                                message={
+                                    <PopoverMessageCheckbox
+                                        defaultChecked={is_do_not_show_selected}
+                                        checkboxLabel={localize("Don't show this again")}
+                                        message={localize(
+                                            'Take profit and/or stop loss are not available while deal cancellation is active.'
+                                        )}
+                                        name='should_show_cancellation_warning'
+                                        onChange={onPopoverCheckboxChange}
+                                    />
+                                }
+                                onBubbleClose={onPopoverClose}
+                                relative_render
+                            >
+                                {input}
+                            </Popover>
+                        ) : (
+                            <React.Fragment>{input}</React.Fragment>
+                        )}
+                        <Popover
+                            alignment='left'
+                            icon='info'
+                            id='dt_cancellation-checkbox__tooltip'
+                            is_bubble_hover_enabled
+                            message={localize(
+                                'Cancel your trade anytime within a chosen time-frame. Triggered automatically if your trade reaches the stop out level within the chosen time-frame.'
+                            )}
+                            classNameBubble='trade-container__deal-cancellation-popover'
+                            margin={216}
+                            relative_render
+                        />
+                    </div>
+                    {has_cancellation && (
+                        <Dropdown
+                            id='dt_cancellation_range'
+                            className='trade-container__multiplier-dropdown'
+                            is_alignment_left
+                            is_nativepicker={false}
+                            list={cancellation_range_list}
+                            name='cancellation_duration'
+                            no_border={true}
+                            value={cancellation_duration}
+                            onChange={event => onChangeCancellationDuration({ event, onChangeMultiple })}
+                        />
                     )}
-                    classNameBubble='trade-container__deal-cancellation-popover'
-                    margin={216}
-                    relative_render
-                />
-            </div>
-            {has_cancellation && (
-                <Dropdown
-                    id='dt_cancellation_range'
-                    className='trade-container__multiplier-dropdown'
-                    is_alignment_left
-                    is_nativepicker={false}
-                    list={cancellation_range_list}
-                    name='cancellation_duration'
-                    no_border={true}
-                    value={cancellation_duration}
-                    onChange={event => onChangeCancellationDuration({ event, onChangeMultiple })}
-                />
+                </Fieldset>
             )}
-        </Fieldset>
+        </React.Fragment>
     );
 });
 


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.

Deal cancellation should only be available for symbols/contracts with `cancellation_range_list` with length bigger than 0. `cancellation_range_list` comes from `contracts_for` response and comes back with empty array when deal cancellation is not be available.

### Screenshots:

Please provide some screenshots of the change.
