### PR TITLE
lubega/FEQ-743/fix: dtrader account selector alignment

### DIFF
--- a/packages/appstore/src/components/modals/wallet-modal/wallet-modal.scss
+++ b/packages/appstore/src/components/modals/wallet-modal/wallet-modal.scss
@@ -144,8 +144,6 @@
         }
     }
     &__list {
-        padding: 0 4rem;
-
         @include mobile {
             padding: 0 1.6rem;
         }
@@ -181,12 +179,6 @@
     }
 
     &__item {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        padding: 0 3.2rem;
-        height: 4.8rem;
-
         @include mobile {
             padding: 0 1.6rem;
             height: 4rem;
@@ -208,9 +200,6 @@
         width: 100%;
         font-size: var(--text-size-l);
         color: var(--text-prominent);
-        display: flex;
-        align-items: center;
-        justify-content: center;
 
         @include mobile {
             font-size: var(--text-size-xs);

--- a/packages/components/src/components/tabs/tabs.scss
+++ b/packages/components/src/components/tabs/tabs.scss
@@ -119,7 +119,8 @@
         display: block;
         position: absolute;
         left: 0;
-        height: 2px;
+        width: 16rem;
+        height: 0.2rem;
         background: var(--brand-red-coral);
         transition: all ease-in-out 0.3s;
 

--- a/packages/core/src/sass/app/_common/components/account-switcher.scss
+++ b/packages/core/src/sass/app/_common/components/account-switcher.scss
@@ -193,6 +193,7 @@
     margin: 0 0.8rem;
     height: 4rem;
     position: relative;
+    line-height: 0.6rem;
 
     &--is-loading {
         position: absolute;


### PR DESCRIPTION
## Changes:

Added some design changes and removed some styling which diverged from core to fix the alignment issue on the Dtrader page account selector:

- Removed the diverging styling for the list, item and content
- Adjusted the width for the active-line below the header
- Altered line height for title inside content

### Screenshots:
Before:

<img width="348" alt="image" src="https://github.com/binary-com/deriv-app/assets/142860499/073c7537-f1be-4666-b31a-42abbbf77832">



After:

<img width="348" alt="image" src="https://github.com/binary-com/deriv-app/assets/142860499/d911adbe-5a84-4ead-a4e8-6d383f215026">

