### PR TITLE
Ameerul /P2PS-1577 Change the maximum file upload size to 5 MB in POT popup for FE

### DIFF
--- a/packages/p2p/src/components/modal-manager/modals/order-details-confirm-modal/__tests__/order-details-confirm-modal.spec.js
+++ b/packages/p2p/src/components/modal-manager/modals/order-details-confirm-modal/__tests__/order-details-confirm-modal.spec.js
@@ -73,7 +73,7 @@ describe('<OrderDetailsConfirmModal/>', () => {
         ).toBeInTheDocument();
         expect(screen.getByText('Confirm')).toBeInTheDocument();
         expect(screen.getByText('Go Back')).toBeInTheDocument();
-        expect(screen.getByText('We accept JPG, PDF, or PNG (up to 2MB).')).toBeInTheDocument();
+        expect(screen.getByText('We accept JPG, PDF, or PNG (up to 5MB).')).toBeInTheDocument();
     });
     it('should handle GoBack Click', () => {
         const { hideModal } = useModalManagerContext();

--- a/packages/p2p/src/components/modal-manager/modals/order-details-confirm-modal/order-details-confirm-modal.jsx
+++ b/packages/p2p/src/components/modal-manager/modals/order-details-confirm-modal/order-details-confirm-modal.jsx
@@ -71,7 +71,7 @@ const OrderDetailsConfirmModal = () => {
                         as='div'
                         className='order-details-confirm-modal__file_format'
                     >
-                        <Localize i18n_default_text='We accept JPG, PDF, or PNG (up to 2MB).' />
+                        <Localize i18n_default_text='We accept JPG, PDF, or PNG (up to 5MB).' />
                     </Text>
                     <FileUploaderComponent
                         accept='image/png, image/jpeg, image/jpg, application/pdf'

--- a/packages/p2p/src/utils/file-uploader.js
+++ b/packages/p2p/src/utils/file-uploader.js
@@ -4,7 +4,7 @@ export const convertToMB = bytes => bytes / (1024 * 1024);
 
 export const getPotSupportedFiles = filename => /^.*\.(png|PNG|jpg|JPG|jpeg|JPEG|pdf|PDF)$/.test(filename);
 
-export const max_pot_file_size = 2097152;
+export const max_pot_file_size = 5242880;
 
 export const isImageType = type => ['image/jpeg', 'image/png', 'image/gif'].includes(type);
 
@@ -15,5 +15,5 @@ const isFileSupported = files => files.filter(each_file => getPotSupportedFiles(
 
 export const getErrorMessage = files =>
     isFileTooLarge(files) && isFileSupported(files)
-        ? localize('Cannot upload a file over 2MB')
+        ? localize('Cannot upload a file over 5MB')
         : localize('File uploaded is not supported');


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- Changed maximum upload size for POT from 2MB to 5MB to match mobile team
- Updated strings and test cases where it referenced 2MB

### Screenshots:

Please provide some screenshots of the change.
