### PR TITLE
aum/WALL-1983/fix-description-font-size-in-empty-state

### DIFF
--- a/packages/components/src/components/empty-state/empty-state.scss
+++ b/packages/components/src/components/empty-state/empty-state.scss
@@ -5,4 +5,16 @@
     flex-direction: column;
     align-items: center;
     gap: 2.4rem;
+
+    &__content {
+        display: flex;
+        flex-direction: column;
+        gap: 0.8rem;
+    }
+
+    &__action .dc-btn__text {
+        @include mobile {
+            font-size: var(--text-size-xxs);
+        }
+    }
 }

--- a/packages/components/src/components/empty-state/empty-state.tsx
+++ b/packages/components/src/components/empty-state/empty-state.tsx
@@ -26,7 +26,7 @@ const EmptyState: React.FC<TProps> = ({ icon, title, description, action }) => (
             </Text>
         )}
         {description && (
-            <Text align='center' data-testid='dt_empty_state_description'>
+            <Text size='xs' align='center' data-testid='dt_empty_state_description'>
                 {description}
             </Text>
         )}

--- a/packages/components/src/components/empty-state/empty-state.tsx
+++ b/packages/components/src/components/empty-state/empty-state.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { isMobile } from '@deriv/shared';
 import Button from '../button';
 import Icon from '../icon';
 import Text from '../text';
@@ -20,16 +21,18 @@ export type TProps = {
 const EmptyState: React.FC<TProps> = ({ icon, title, description, action }) => (
     <div className='empty-state'>
         {icon && <Icon icon={icon} size={128} />}
-        {title && (
-            <Text weight='bold' align='center' data-testid='dt_empty_state_title'>
-                {title}
-            </Text>
-        )}
-        {description && (
-            <Text size='xs' align='center' data-testid='dt_empty_state_description'>
-                {description}
-            </Text>
-        )}
+        <div className='empty-state__content'>
+            {title && (
+                <Text weight='bold' align='center' data-testid='dt_empty_state_title' size={isMobile() ? 'xs' : 's'}>
+                    {title}
+                </Text>
+            )}
+            {description && (
+                <Text align='center' data-testid='dt_empty_state_description' size={isMobile() ? 'xs' : 's'}>
+                    {description}
+                </Text>
+            )}
+        </div>
         {action && (
             <Button
                 large
@@ -39,6 +42,7 @@ const EmptyState: React.FC<TProps> = ({ icon, title, description, action }) => (
                 primary={action.primary || true}
                 tertiary={action.tertiary}
                 is_disabled={action.disabled}
+                className='empty-state__action'
                 data-testid='dt_empty_state_action'
             />
         )}


### PR DESCRIPTION
## Changes:

Change of font-size(s) based on the following criteria:

`Desktop`:
Icon - 128x128 px
Title - P1 Bold (16px)
Description - P1 Regular (16px)
CTA button size - 40px
CTA button text size - P2 bold (14px)
Gap between Title-Description => 8px
Gap between each component (Icon/Title - Description/ CTA)  => 24px

`Responsive`:
Icon - 128x128 px
Title - P1 Bold (14px)
Description - P1 Regular (14px)
CTA button size - 40px
CTA button text size - P2 bold (12px)
Gap between Title-Description => 8px
Gap between each component (Icon/Title - Description/ CTA)  => 24px

Note that for the design system:
Desktop P1 = 16 px, P2 = 14 px
Mobile P1 = 14 px, P2= 12 px

Please provide a summary of the change.

### Screenshots:

Please provide some screenshots of the change.
