### PR TITLE
Kate / DTRA-432 / [Bug] Spot alignment in Vanillas trade type

### DIFF
--- a/packages/trader/src/sass/app/modules/trading.scss
+++ b/packages/trader/src/sass/app/modules/trading.scss
@@ -745,7 +745,7 @@
         gap: 0.8rem;
 
         .strike-field--text {
-            margin-top: 0.8rem;
+            margin-top: 1.8rem;
         }
     }
 


### PR DESCRIPTION
## Changes:

- Only CSS: change `margin-top` in order to put word 'Spot' on its normal place. Most probably, the original style was overwritten by the release of old PRs. As I checked, `strike-field--text` class is being used only for `<Strike />` component (for desktop).

### Screenshots:

Please provide some screenshots of the change.
