### PR TITLE
fix: currency icon

### DIFF
--- a/packages/wallets/src/components/DesktopWalletsList/DesktopWalletsList.tsx
+++ b/packages/wallets/src/components/DesktopWalletsList/DesktopWalletsList.tsx
@@ -22,7 +22,7 @@ const DesktopWalletsList: React.FC = () => {
                             <WalletListCard
                                 badge={wallet.landing_company_name}
                                 balance={wallet.display_balance}
-                                currency={wallet.currency_config?.display_code || 'USD'}
+                                currency={wallet.wallet_currency_type || 'USD'}
                                 isActive={wallet.is_active}
                                 isDemo={wallet.is_virtual}
                                 loginid={wallet.loginid}

--- a/packages/wallets/src/components/WalletCard/WalletCard.tsx
+++ b/packages/wallets/src/components/WalletCard/WalletCard.tsx
@@ -13,7 +13,7 @@ const WalletCard: React.FC<TProps> = ({ account }) => {
     return (
         <div className='wallets-card'>
             <WalletGradientBackground
-                currency={account?.currency_config?.display_code || 'USD'}
+                currency={account?.wallet_currency_type || 'USD'}
                 device='mobile'
                 hasShine
                 isDemo={account?.is_virtual}
@@ -33,9 +33,7 @@ const WalletCard: React.FC<TProps> = ({ account }) => {
                     </div>
                     <div className={`wallets-card__details__bottom${account?.is_virtual ? '--virtual' : ''}`}>
                         <p className='wallets-card__details__bottom__currency'>{account?.currency} Wallet</p>
-                        <p className='wallets-card__details__bottom__balance'>
-                            {account?.display_balance} {account?.currency}
-                        </p>
+                        <p className='wallets-card__details__bottom__balance'>{account?.display_balance}</p>
                     </div>
                 </div>
             </WalletGradientBackground>

--- a/packages/wallets/src/components/WalletCardIcon/WalletCardIcon.tsx
+++ b/packages/wallets/src/components/WalletCardIcon/WalletCardIcon.tsx
@@ -18,6 +18,7 @@ const typeToIconMapper = {
     eUSDT: Tether,
     GBP,
     LTC,
+    tUSDT: Tether,
     USD,
     USDC,
     UST: Tether,


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
1. Added missed currency code in mapper
2. Used currency type instead of `display_code` since it doesnt have demo
3. Removed currency from wallet card since we already have it in `display_balance`

### Screenshots:

Please provide some screenshots of the change.
