### PR TITLE
fix: remove bot bundle chunk from landing page

### DIFF
--- a/packages/core/src/App/Constants/routes-config.js
+++ b/packages/core/src/App/Constants/routes-config.js
@@ -46,7 +46,7 @@ const Cashier = React.lazy(() =>
 const Bot = React.lazy(() =>
     moduleLoader(() => {
         // eslint-disable-next-line import/no-unresolved
-        return import(/* webpackChunkName: "bot" */ '@deriv/bot-web-ui');
+        return import(/* webpackChunkName: "bot-web-ui-app" */ '@deriv/bot-web-ui');
     })
 );
 


### PR DESCRIPTION
## Changes:

Bot bundle is loading on the homepage.

- changed the webpackChunkName from bot to bot-web-ui-app
