### PR TITLE
Ameerul /P2PS-1704 Overlap of buy modal when sellers instructions are too long

### DIFF
--- a/packages/p2p/src/pages/buy-sell/buy-sell-form.scss
+++ b/packages/p2p/src/pages/buy-sell/buy-sell-form.scss
@@ -16,7 +16,6 @@
     &__field {
         margin-bottom: 0 !important;
         flex: 1;
-        height: 4rem;
 
         .dc-input__container {
             width: 91%;

--- a/packages/p2p/src/pages/my-profile/payment-methods/add-payment-method/add-payment-method-form.scss
+++ b/packages/p2p/src/pages/my-profile/payment-methods/add-payment-method/add-payment-method-form.scss
@@ -60,6 +60,10 @@
                     padding-right: 0;
                 }
             }
+
+            & .dc-field--error {
+                top: 9.8rem;
+            }
         }
     }
 }


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- removed style `height: 4rem` which causes the field to always be that height
- fixed error not showing on the bottom of the text-area field

### Screenshots:

Please provide some screenshots of the change.
<img width="492" alt="Screenshot 2023-10-03 at 11 52 02 AM" src="https://github.com/binary-com/deriv-app/assets/103412909/a37abd0f-932b-4e3d-8420-8f10ba710bb5">
<img width="486" alt="Screenshot 2023-10-03 at 11 51 45 AM" src="https://github.com/binary-com/deriv-app/assets/103412909/2209d674-0104-405e-9833-d057c3774dea">
<img width="444" alt="Screenshot 2023-10-03 at 5 11 27 PM" src="https://github.com/binary-com/deriv-app/assets/103412909/cc3c156b-2e8d-4baa-b555-863e80924e59">


