### PR TITLE
Ako/ Use prod build script on staging release

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -60,5 +60,5 @@ runs:
       RUDDERSTACK_STAGING_KEY: ${{ inputs.RUDDERSTACK_STAGING_KEY }}
       RUDDERSTACK_URL: ${{ inputs.RUDDERSTACK_URL }}
 
-    run: npm run build:all
+    run: npm run build:prod
     shell: bash

--- a/.github/workflows/release_production.yml
+++ b/.github/workflows/release_production.yml
@@ -28,7 +28,7 @@ jobs:
         GD_API_KEY: ${{ secrets.GD_API_KEY }}
         GD_APP_ID: ${{ secrets.GD_APP_ID }}
         GD_CLIENT_ID: ${{ secrets.GD_CLIENT_ID }}
-        RUDDERSTACK_PRODUCTION_KEY: ${{ vars.RUDDERSTACK_STAGING_KEY }}
+        RUDDERSTACK_PRODUCTION_KEY: ${{ vars.RUDDERSTACK_PRODUCTION_KEY }}
         RUDDERSTACK_URL: ${{ vars.RUDDERSTACK_URL }}
     - name: Run tests
       run: npm test


### PR DESCRIPTION
## Changes:

To Use correct rudderstack key on production release.
Use prod build script for staging release

### Screenshots:

Please provide some screenshots of the change.
