### PR TITLE
fix: trx dwnld btn should be disabled if bot is running

### DIFF
--- a/packages/bot-web-ui/src/components/download/download.tsx
+++ b/packages/bot-web-ui/src/components/download/download.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
-
 import { Button, Icon, Popover } from '@deriv/components';
 import { observer } from '@deriv/stores';
 import { localize } from '@deriv/translations';
-
 import { useDBotStore } from 'Stores/useDBotStore';
 
 type TDownloadProps = {
@@ -12,7 +10,7 @@ type TDownloadProps = {
 
 const Download = observer(({ tab }: TDownloadProps) => {
     const { download, run_panel, transactions } = useDBotStore();
-    const { is_clear_stat_disabled } = run_panel;
+    const { is_clear_stat_disabled, is_running } = run_panel;
     const { onClickDownloadTransaction, onClickDownloadJournal } = download;
     const { transactions: transaction_list } = transactions;
     let disabled = false;
@@ -20,7 +18,7 @@ const Download = observer(({ tab }: TDownloadProps) => {
     if (tab === 'transactions') {
         clickFunction = onClickDownloadTransaction;
         popover_message = localize('Download your transaction history.');
-        disabled = !transaction_list.length;
+        disabled = !transaction_list.length || is_running;
     } else if (tab === 'journal') {
         clickFunction = onClickDownloadJournal;
         popover_message = localize('Download your journal.');


### PR DESCRIPTION
## Changes:

- Transaction download button should be disabled if bot is running
