### PR TITLE
Ako/ remove react-query-devtools as it showing up in staging server

### DIFF
--- a/packages/api/src/APIProvider.tsx
+++ b/packages/api/src/APIProvider.tsx
@@ -3,7 +3,7 @@ import React, { PropsWithChildren } from 'react';
 import DerivAPIBasic from '@deriv/deriv-api/dist/DerivAPIBasic';
 import { getAppId, getSocketURL, useWS } from '@deriv/shared';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+// import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import APIContext from './APIContext';
 
 declare global {
@@ -60,7 +60,7 @@ const APIProvider = ({ children, standalone = false }: PropsWithChildren<TProps>
         <APIContext.Provider value={active_connection}>
             <QueryClientProvider client={queryClient}>
                 {children}
-                <ReactQueryDevtools />
+                {/* <ReactQueryDevtools /> */}
             </QueryClientProvider>
         </APIContext.Provider>
     );


### PR DESCRIPTION
## Changes:

This is to temporarily removing react query dev tools as its showing up in staging server even tho we have NODE_ENV as staging.
 
### Screenshots:

Please provide some screenshots of the change.
