### PR TITLE
Nijil/Comment out usage of useWalletList and useWalletMigration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "@datadog/browser-logs": "^4.36.0",
                 "@datadog/browser-rum": "^4.37.0",
                 "@deriv/api-types": "^1.0.118",
-                "@deriv/deriv-api": "^1.0.11",
+                "@deriv/deriv-api": "^1.0.13",
                 "@deriv/deriv-charts": "1.3.6",
                 "@deriv/js-interpreter": "^3.0.0",
                 "@deriv/ui": "^0.6.0",
@@ -39,7 +39,9 @@
                 "@types/jsdom": "^20.0.0",
                 "@types/loadjs": "^4.0.1",
                 "@types/lodash.debounce": "^4.0.7",
+                "@types/lodash.groupby": "^4.6.7",
                 "@types/lodash.merge": "^4.6.7",
+                "@types/lodash.pickby": "^4.6.7",
                 "@types/lodash.throttle": "^4.1.7",
                 "@types/object.fromentries": "^2.0.0",
                 "@types/qrcode.react": "^1.0.2",
@@ -79,6 +81,7 @@
                 "eslint-formatter-pretty": "^4.0.0",
                 "eslint-import-resolver-webpack": "^0.13.0",
                 "eslint-plugin-import": "^2.23.4",
+                "eslint-plugin-local-rules": "2.0.0",
                 "eslint-plugin-prettier": "^3.3.1",
                 "eslint-plugin-react": "^7.22.0",
                 "eslint-plugin-react-hooks": "^4.2.0",
@@ -109,7 +112,9 @@
                 "loadjs": "^4.2.0",
                 "localforage": "^1.9.0",
                 "lodash.debounce": "^4.0.8",
+                "lodash.groupby": "^4.6.0",
                 "lodash.merge": "^4.6.2",
+                "lodash.pickby": "^4.6.0",
                 "lodash.throttle": "^4.1.1",
                 "lz-string": "^1.4.4",
                 "mini-css-extract-plugin": "^1.3.4",
@@ -16139,10 +16144,26 @@
                 "@types/lodash": "*"
             }
         },
+        "node_modules/@types/lodash.groupby": {
+            "version": "4.6.7",
+            "resolved": "https://registry.npmjs.org/@types/lodash.groupby/-/lodash.groupby-4.6.7.tgz",
+            "integrity": "sha512-dFUR1pqdMgjIBbgPJ/8axJX6M1C7zsL+HF4qdYMQeJ7XOp0Qbf37I3zh9gpXr/ks6tgEYPDRqyZRAnFYvewYHQ==",
+            "dependencies": {
+                "@types/lodash": "*"
+            }
+        },
         "node_modules/@types/lodash.merge": {
             "version": "4.6.7",
             "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.7.tgz",
             "integrity": "sha512-OwxUJ9E50gw3LnAefSHJPHaBLGEKmQBQ7CZe/xflHkyy/wH2zVyEIAKReHvVrrn7zKdF58p16We9kMfh7v0RRQ==",
+            "dependencies": {
+                "@types/lodash": "*"
+            }
+        },
+        "node_modules/@types/lodash.pickby": {
+            "version": "4.6.7",
+            "resolved": "https://registry.npmjs.org/@types/lodash.pickby/-/lodash.pickby-4.6.7.tgz",
+            "integrity": "sha512-4ebXRusuLflfscbD0PUX4eVknDHD9Yf+uMtBIvA/hrnTqeAzbuHuDjvnYriLjUrI9YrhCPVKUf4wkRSXJQ6gig==",
             "dependencies": {
                 "@types/lodash": "*"
             }
@@ -25231,6 +25252,11 @@
             "dependencies": {
                 "eslint-plugin-playwright": "^0.9.0"
             }
+        },
+        "node_modules/eslint-plugin-local-rules": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-local-rules/-/eslint-plugin-local-rules-2.0.0.tgz",
+            "integrity": "sha512-sWueme0kUcP0JC1+6OBDQ9edBDVFJR92WJHSRbhiRExlenMEuUisdaVBPR+ItFBFXo2Pdw6FD2UfGZWkz8e93g=="
         },
         "node_modules/eslint-plugin-playwright": {
             "version": "0.9.0",
@@ -34371,6 +34397,11 @@
             "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
             "peer": true
         },
+        "node_modules/lodash.groupby": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+            "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw=="
+        },
         "node_modules/lodash.invokemap": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/lodash.invokemap/-/lodash.invokemap-4.6.0.tgz",
@@ -34413,6 +34444,11 @@
             "version": "4.6.2",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/lodash.pickby": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
+            "integrity": "sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q=="
         },
         "node_modules/lodash.pullall": {
             "version": "4.2.0",
@@ -60888,6 +60924,19 @@
                 "use-sync-external-store": "^1.2.0"
             }
         },
+        "@tanstack/react-table": {
+            "version": "8.10.3",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.10.3.tgz",
+            "integrity": "sha512-Qya1cJ+91arAlW7IRDWksRDnYw28O446jJ/ljkRSc663EaftJoBCAU10M+VV1K6MpCBLrXq1BD5IQc1zj/ZEjA==",
+            "requires": {
+                "@tanstack/table-core": "8.10.3"
+            }
+        },
+        "@tanstack/table-core": {
+            "version": "8.10.3",
+            "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.10.3.tgz",
+            "integrity": "sha512-hJ55YfJlWbfzRROfcyA/kC1aZr/shsLA8XNAwN8jXylhYWGLnPmiJJISrUfj4dMMWRiFi0xBlnlC7MLH+zSrcw=="
+        },
         "@tensorflow-models/face-detection": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@tensorflow-models/face-detection/-/face-detection-1.0.2.tgz",
@@ -61311,10 +61360,26 @@
                 "@types/lodash": "*"
             }
         },
+        "@types/lodash.groupby": {
+            "version": "4.6.7",
+            "resolved": "https://registry.npmjs.org/@types/lodash.groupby/-/lodash.groupby-4.6.7.tgz",
+            "integrity": "sha512-dFUR1pqdMgjIBbgPJ/8axJX6M1C7zsL+HF4qdYMQeJ7XOp0Qbf37I3zh9gpXr/ks6tgEYPDRqyZRAnFYvewYHQ==",
+            "requires": {
+                "@types/lodash": "*"
+            }
+        },
         "@types/lodash.merge": {
             "version": "4.6.7",
             "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.7.tgz",
             "integrity": "sha512-OwxUJ9E50gw3LnAefSHJPHaBLGEKmQBQ7CZe/xflHkyy/wH2zVyEIAKReHvVrrn7zKdF58p16We9kMfh7v0RRQ==",
+            "requires": {
+                "@types/lodash": "*"
+            }
+        },
+        "@types/lodash.pickby": {
+            "version": "4.6.7",
+            "resolved": "https://registry.npmjs.org/@types/lodash.pickby/-/lodash.pickby-4.6.7.tgz",
+            "integrity": "sha512-4ebXRusuLflfscbD0PUX4eVknDHD9Yf+uMtBIvA/hrnTqeAzbuHuDjvnYriLjUrI9YrhCPVKUf4wkRSXJQ6gig==",
             "requires": {
                 "@types/lodash": "*"
             }
@@ -74313,6 +74378,11 @@
             "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
             "peer": true
         },
+        "lodash.groupby": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+            "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw=="
+        },
         "lodash.invokemap": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/lodash.invokemap/-/lodash.invokemap-4.6.0.tgz",
@@ -74349,6 +74419,11 @@
         "lodash.mergewith": {
             "version": "4.6.2",
             "dev": true
+        },
+        "lodash.pickby": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
+            "integrity": "sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q=="
         },
         "lodash.pullall": {
             "version": "4.2.0",

--- a/packages/appstore/src/components/main-title-bar/__tests__/index.spec.tsx
+++ b/packages/appstore/src/components/main-title-bar/__tests__/index.spec.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { StoreProvider, mockStore } from '@deriv/stores';
-import { APIProvider, useFetch } from '@deriv/api';
+import { APIProvider /*useFetch*/ } from '@deriv/api';
 import MainTitleBar from '..';
 
-jest.mock('Components/wallets-banner', () => jest.fn(() => 'WalletsBanner'));
+// jest.mock('Components/wallets-banner', () => jest.fn(() => 'WalletsBanner'));
 
-const mockUseFetch = useFetch as jest.MockedFunction<typeof useFetch<'authorize'>>;
+// const mockUseFetch = useFetch as jest.MockedFunction<typeof useFetch<'authorize'>>;
 
 jest.mock('@deriv/api', () => ({
     ...jest.requireActual('@deriv/api'),
@@ -72,35 +72,36 @@ describe('MainTitleBar', () => {
         expect(container).toBeInTheDocument();
     });
 
-    it('should not render WalletsBanner component if wallet feature flag is disabled', () => {
-        render_container();
-        expect(screen.queryByText('WalletsBanner')).not.toBeInTheDocument();
-    });
+    //TODO: Uncomment once useWalletMigration hook is optimized for production release.
+    // it('should not render WalletsBanner component if wallet feature flag is disabled', () => {
+    //     render_container();
+    //     expect(screen.queryByText('WalletsBanner')).not.toBeInTheDocument();
+    // });
 
-    it('should render WalletsBanner component if wallet feature flag is enabled', () => {
-        const mock_store = mockStore({
-            client: { accounts: { CR123456: { token: '12345' } }, loginid: 'CR123456' },
-            feature_flags: { data: { wallet: true } },
-        });
+    // it('should render WalletsBanner component if wallet feature flag is enabled', () => {
+    //     const mock_store = mockStore({
+    //         client: { accounts: { CR123456: { token: '12345' } }, loginid: 'CR123456' },
+    //         feature_flags: { data: { wallet: true } },
+    //     });
 
-        // @ts-expect-error need to come up with a way to mock the return type of useFetch
-        mockUseFetch.mockReturnValue({
-            data: {
-                authorize: {
-                    account_list: [
-                        {
-                            account_category: 'trading',
-                            currency: 'USD',
-                            is_virtual: 0,
-                        },
-                    ],
-                },
-            },
-        });
+    //     // @ts-expect-error need to come up with a way to mock the return type of useFetch
+    //     mockUseFetch.mockReturnValue({
+    //         data: {
+    //             authorize: {
+    //                 account_list: [
+    //                     {
+    //                         account_category: 'trading',
+    //                         currency: 'USD',
+    //                         is_virtual: 0,
+    //                     },
+    //                 ],
+    //             },
+    //         },
+    //     });
 
-        render_container(mock_store);
-        expect(screen.getByText('WalletsBanner')).toBeInTheDocument();
-    });
+    //     render_container(mock_store);
+    //     expect(screen.getByText('WalletsBanner')).toBeInTheDocument();
+    // });
 
     it('should render the correct title text', () => {
         render_container();

--- a/packages/appstore/src/components/main-title-bar/__tests__/index.spec.tsx
+++ b/packages/appstore/src/components/main-title-bar/__tests__/index.spec.tsx
@@ -4,8 +4,8 @@ import { StoreProvider, mockStore } from '@deriv/stores';
 import { APIProvider /*useFetch*/ } from '@deriv/api';
 import MainTitleBar from '..';
 
+//TODO: Uncomment once useWalletMigration hook is optimized for production release.
 // jest.mock('Components/wallets-banner', () => jest.fn(() => 'WalletsBanner'));
-
 // const mockUseFetch = useFetch as jest.MockedFunction<typeof useFetch<'authorize'>>;
 
 jest.mock('@deriv/api', () => ({
@@ -78,12 +78,12 @@ describe('MainTitleBar', () => {
     //     expect(screen.queryByText('WalletsBanner')).not.toBeInTheDocument();
     // });
 
+    //TODO: Uncomment once useWalletMigration hook is optimized for production release.
     // it('should render WalletsBanner component if wallet feature flag is enabled', () => {
     //     const mock_store = mockStore({
     //         client: { accounts: { CR123456: { token: '12345' } }, loginid: 'CR123456' },
     //         feature_flags: { data: { wallet: true } },
     //     });
-
     //     // @ts-expect-error need to come up with a way to mock the return type of useFetch
     //     mockUseFetch.mockReturnValue({
     //         data: {
@@ -98,7 +98,6 @@ describe('MainTitleBar', () => {
     //             },
     //         },
     //     });
-
     //     render_container(mock_store);
     //     expect(screen.getByText('WalletsBanner')).toBeInTheDocument();
     // });

--- a/packages/appstore/src/components/main-title-bar/index.tsx
+++ b/packages/appstore/src/components/main-title-bar/index.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Text, DesktopWrapper, MobileWrapper, Tabs, Icon } from '@deriv/components';
-import { useFeatureFlags } from '@deriv/hooks';
+// import { useFeatureFlags } from '@deriv/hooks';
 import { ContentFlag } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
 import { Localize, localize } from '@deriv/translations';
 import RegulationsSwitcherLoader from 'Components/pre-loader/regulations-switcher-loader';
-import WalletsBanner from 'Components/wallets-banner';
+// import WalletsBanner from 'Components/wallets-banner';
 import AccountTypeDropdown from './account-type-dropdown';
 import AssetSummary from './asset-summary';
 import RegulatorSwitcher from './regulators-switcher';
@@ -24,7 +24,7 @@ const MainTitleBar = () => {
         setActiveIndex(selected_region === 'Non-EU' ? 0 : 1);
     }, [selected_region]);
 
-    const { is_wallet_enabled } = useFeatureFlags();
+    // const { is_wallet_enabled } = useFeatureFlags();
 
     // TODO: Remove this when we have BE API ready
     removeAllNotificationMessages(true);
@@ -36,7 +36,8 @@ const MainTitleBar = () => {
 
     return (
         <React.Fragment>
-            {is_wallet_enabled && <WalletsBanner />}
+            {/* TODO: Uncomment once useWalletMigration hook is optimized for production release. */}
+            {/* {is_wallet_enabled && <WalletsBanner />} */}
             <DesktopWrapper>
                 <div className='main-title-bar'>
                     <div className='main-title-bar__right'>

--- a/packages/appstore/src/components/main-title-bar/index.tsx
+++ b/packages/appstore/src/components/main-title-bar/index.tsx
@@ -24,6 +24,7 @@ const MainTitleBar = () => {
         setActiveIndex(selected_region === 'Non-EU' ? 0 : 1);
     }, [selected_region]);
 
+    // TODO: Uncomment once useWalletMigration hook is optimized for production release.
     // const { is_wallet_enabled } = useFeatureFlags();
 
     // TODO: Remove this when we have BE API ready

--- a/packages/appstore/src/components/modals/modal-manager.tsx
+++ b/packages/appstore/src/components/modals/modal-manager.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { observer } from 'mobx-react-lite';
 import { ResetTradingPasswordModal } from '@deriv/account';
+import { useFeatureFlags } from '@deriv/hooks';
 import { TTradingPlatformAvailableAccount } from './account-type-modal/types';
 import MT5AccountTypeModal from './account-type-modal';
 import RegulatorsCompareModal from './regulators-compare-modal';
@@ -28,6 +29,7 @@ type TCurrentList = DetailsOfEachMT5Loginid & {
 
 const ModalManager = () => {
     const store = useStores();
+    const { is_wallet_enabled } = useFeatureFlags();
     const { common, client, modules, traders_hub, ui } = store;
     const {
         is_logged_in,
@@ -172,7 +174,7 @@ const ModalManager = () => {
             <FailedVerificationModal />
             {is_real_wallets_upgrade_on && <RealWalletsUpgrade />}
             <WalletsMigrationFailed />
-            <WalletModal />
+            {is_wallet_enabled && <WalletModal />}
         </React.Fragment>
     );
 };

--- a/packages/appstore/src/components/routes/routes.tsx
+++ b/packages/appstore/src/components/routes/routes.tsx
@@ -1,28 +1,29 @@
 import * as React from 'react';
-import { Loading } from '@deriv/components';
-import { useFeatureFlags, useWalletsList } from '@deriv/hooks';
+// import { Loading } from '@deriv/components';
+import { useFeatureFlags /*useWalletsList*/ } from '@deriv/hooks';
 import { observer } from '@deriv/stores';
 import { Localize, localize } from '@deriv/translations';
 import Wallets from '@deriv/wallets';
 import Onboarding from 'Modules/onboarding';
 import TradersHub from 'Modules/traders-hub';
-import { WalletsModule } from 'Modules/wallets';
+// import { WalletsModule } from 'Modules/wallets';
 import { Switch } from 'react-router-dom';
 import RouteWithSubroutes from './route-with-sub-routes.jsx';
 
 const Routes: React.FC = observer(() => {
-    const { is_wallet_enabled, is_next_wallet_enabled } = useFeatureFlags();
-    const { has_wallet, isLoading } = useWalletsList();
+    //TODO: useWalletList is making redundant authorize requests eventhough it's not required until Wallets is launched. This needs to be handled more elegantly.
+    const { /*is_wallet_enabled,*/ is_next_wallet_enabled } = useFeatureFlags();
+    // const { has_wallet, isLoading } = useWalletsList();
+    // const should_show_wallets = is_wallet_enabled && has_wallet;
 
-    const should_show_wallets = is_wallet_enabled && has_wallet;
     let content: React.FC = TradersHub;
     if (is_next_wallet_enabled) {
         content = Wallets;
-    } else if (should_show_wallets) {
-        content = WalletsModule;
     }
-
-    if (isLoading) return <Loading />;
+    // else if (should_show_wallets) {
+    //     content = WalletsModule;
+    // }
+    // if (isLoading) return <Loading />;
 
     return (
         <React.Suspense

--- a/packages/appstore/src/components/routes/routes.tsx
+++ b/packages/appstore/src/components/routes/routes.tsx
@@ -11,7 +11,7 @@ import { Switch } from 'react-router-dom';
 import RouteWithSubroutes from './route-with-sub-routes.jsx';
 
 const Routes: React.FC = observer(() => {
-    //TODO: useWalletList is making redundant authorize requests eventhough it's not required until Wallets is launched. This needs to be handled more elegantly.
+    //TODO: Uncomment once useWalletList hook is optimized for production release.
     const { /*is_wallet_enabled,*/ is_next_wallet_enabled } = useFeatureFlags();
     // const { has_wallet, isLoading } = useWalletsList();
     // const should_show_wallets = is_wallet_enabled && has_wallet;

--- a/packages/appstore/src/components/wallet-cards-carousel/__tests__/wallet-cards-carousel.spec.tsx
+++ b/packages/appstore/src/components/wallet-cards-carousel/__tests__/wallet-cards-carousel.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { APIProvider } from '@deriv/api';
+import { APIProvider, useFetch } from '@deriv/api';
 import { mockStore, StoreProvider } from '@deriv/stores';
 import WalletCardsCarousel from '..';
 
@@ -96,6 +96,7 @@ jest.mock('@deriv/api', () => ({
 }));
 
 jest.mock('./../cards-slider-swiper', () => jest.fn(() => <div>slider</div>));
+const mockUseFetch = useFetch as jest.MockedFunction<typeof useFetch<'authorize'>>;
 
 describe('<WalletCardsCarousel />', () => {
     const wrapper = (mock: ReturnType<typeof mockStore>) => {
@@ -133,6 +134,23 @@ describe('<WalletCardsCarousel />', () => {
 
     it('Should render buttons for DEMO', () => {
         const mock = mockStore({ client: { accounts: { VRW10001: { token: '12345' } }, loginid: 'VRW10001' } });
+
+        mockUseFetch.mockReturnValue({
+            data: {
+                authorize: {
+                    account_list: [
+                        {
+                            account_category: 'wallet',
+                            account_type: 'doughflow',
+                            currency: 'USD',
+                            is_virtual: 1,
+                            loginid: 'VRW10001',
+                        },
+                    ],
+                    loginid: 'VRW10001',
+                },
+            },
+        } as unknown as ReturnType<typeof mockUseFetch>);
 
         render(<WalletCardsCarousel />, { wrapper: wrapper(mock) });
 

--- a/packages/core/src/App/Containers/Layout/header/dtrader-header.jsx
+++ b/packages/core/src/App/Containers/Layout/header/dtrader-header.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { withRouter } from 'react-router-dom';
 import { DesktopWrapper, MobileWrapper } from '@deriv/components';
 import { routes, isMobile, getDecimalPlaces, platforms } from '@deriv/shared';
-import { useWalletMigration } from '@deriv/hooks';
+// import { useWalletMigration } from '@deriv/hooks';
 import { AccountActions, MenuLinks, PlatformSwitcher } from 'App/Components/Layout/Header';
 import platform_config from 'App/Constants/platform-config.ts';
 import RealAccountSignup from 'App/Containers/RealAccountSignup';
@@ -60,9 +60,10 @@ const DTraderHeader = ({
         [removeNotificationMessage]
     );
 
-    const { is_migrated, is_failed } = useWalletMigration();
-    if (is_migrated) addNotificationMessage(client_notifications.wallets_migrated);
-    if (is_failed) addNotificationMessage(client_notifications.wallets_failed);
+    //TODO: Uncomment once useWalletMigration hook is optimized for production release.
+    // const { is_migrated, is_failed } = useWalletMigration();
+    // if (is_migrated) addNotificationMessage(client_notifications.wallets_migrated);
+    // if (is_failed) addNotificationMessage(client_notifications.wallets_failed);
 
     React.useEffect(() => {
         document.addEventListener('IgnorePWAUpdate', removeUpdateNotification);

--- a/packages/hooks/src/__tests__/useActiveWallet.spec.tsx
+++ b/packages/hooks/src/__tests__/useActiveWallet.spec.tsx
@@ -40,6 +40,7 @@ jest.mock('@deriv/api', () => ({
                                 currency: 'BTC',
                             },
                         ],
+                        loginid: 'CRW000000',
                     },
                 },
             };

--- a/packages/hooks/src/__tests__/useTransferBetweenAccounts.spec.tsx
+++ b/packages/hooks/src/__tests__/useTransferBetweenAccounts.spec.tsx
@@ -42,6 +42,7 @@ jest.mock('@deriv/api', () => ({
                                 loginid: 'CRW1030',
                             },
                         ],
+                        loginid: 'CRW1030',
                     },
                 },
             };

--- a/packages/hooks/src/__tests__/useWalletTransactions.spec.tsx
+++ b/packages/hooks/src/__tests__/useWalletTransactions.spec.tsx
@@ -32,6 +32,7 @@ describe('useWalletsList', () => {
                             loginid: 'CRW909900',
                         },
                     ],
+                    loginid: 'CRW909900',
                 },
                 statement: {
                     transactions: [

--- a/packages/wallets/src/components/WalletTransactions/WalletTransactions.tsx
+++ b/packages/wallets/src/components/WalletTransactions/WalletTransactions.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps } from 'react';
+import React, { ComponentProps, useState } from 'react';
 import { WalletTransactionsCrypto } from '../WalletTransactionsCrypto';
 import { WalletTransactionsFilter } from '../WalletTransactionsFilter';
 import './WalletTransactions.scss';


### PR DESCRIPTION
`useWalletList` and `useWalletMigration` are being used in different parts of the code right now, these hooks are in-turn triggering redundant `authorize` calls. Most probably because of which, chances of hitting `RateLimit` is increased. What I suggest as stop gap for now is to comment out the pieces of code utilising `useWalletList` and `useWalletMigration` because we’re never going to need it until Wallet is launched. So, commenting out these hooks won’t affect production behaviour, but we’ll have some time to investigate and find ways to handle this more elegantly.