### PR TITLE
shontzu/CFDS-1176/Wrong-content-for-dxtrade-password

### DIFF
--- a/packages/cfd/src/Containers/cfd-password-modal.tsx
+++ b/packages/cfd/src/Containers/cfd-password-modal.tsx
@@ -485,7 +485,7 @@ const CFDPasswordForm = ({
         switch (platform) {
             case 'ctrader':
             case 'derivez':
-            case 'derivx':
+            case 'dxtrade':
                 return 'CFD';
             default:
                 return account_title;

--- a/packages/cfd/src/Containers/mt5-compare-table-content.tsx
+++ b/packages/cfd/src/Containers/mt5-compare-table-content.tsx
@@ -391,7 +391,7 @@ const DMT5CompareModalContent = observer(
                         toggleCFDVerificationModal();
                     }
                     break;
-                case 'derivx':
+                case 'dxtrade':
                     setAppstorePlatform(CFD_PLATFORMS.DXTRADE);
                     openPasswordModal(type_of_account);
                     break;


### PR DESCRIPTION
## Changes:

fixed a typo causing misleading text description in password modal

### Screenshots:

<img src="https://github.com/binary-com/deriv-app/assets/108507236/fa19479d-eb4c-4ed0-abab-735e470c62ab" height="200px" />  <img src="https://github.com/binary-com/deriv-app/assets/108507236/c94feca6-12de-4e26-9092-9fdc9f267098" height="200px"  />


