### PR TITLE
feat: date filter in past orders

### DIFF
--- a/packages/components/src/components/input-field/input-field.tsx
+++ b/packages/components/src/components/input-field/input-field.tsx
@@ -14,7 +14,7 @@ export type TButtonType = 'button' | 'submit' | 'reset';
 // supports more than two different types of 'value' as a prop.
 // Quick Solution - Pass two different props to input field.
 type TInputField = {
-    ariaLabel: string;
+    ariaLabel?: string;
     checked?: boolean;
     className?: string;
     classNameDynamicSuffix?: string;
@@ -22,7 +22,7 @@ type TInputField = {
     classNameInput?: string;
     classNamePrefix?: string;
     classNameWrapper?: string; // CSS class for the component wrapper
-    currency: string;
+    currency?: string;
     current_focus?: string | null;
     data_testid?: string;
     data_tip?: string;
@@ -31,44 +31,44 @@ type TInputField = {
     error_message_alignment?: string;
     error_messages?: string[];
     format?: (new_value?: string) => string;
-    fractional_digits: number;
+    fractional_digits?: number;
     helper?: string;
     icon?: React.ElementType;
     id?: string;
     increment_button_type?: TButtonType;
     inline_prefix?: string;
     inputmode?: TInputMode;
-    is_autocomplete_disabled: boolean;
+    is_autocomplete_disabled?: boolean;
     is_disabled?: boolean;
-    is_error_tooltip_hidden: boolean;
-    is_float: boolean;
-    is_hj_whitelisted: boolean;
+    is_error_tooltip_hidden?: boolean;
+    is_float?: boolean;
+    is_hj_whitelisted?: boolean;
     is_incrementable_on_long_press?: boolean;
-    is_incrementable: boolean;
-    is_negative_disabled: boolean;
+    is_incrementable?: boolean;
+    is_negative_disabled?: boolean;
     is_read_only?: boolean;
     is_signed?: boolean;
     is_unit_at_right?: boolean;
     label?: string;
-    max_length: number;
+    max_length?: number;
     max_value?: number;
     min_value?: number;
     name: string;
     onBlur?: React.FocusEventHandler<HTMLInputElement>;
-    onChange: (e: TChangeEvent) => void;
+    onChange?: (e: TChangeEvent) => void;
     onClick?: React.MouseEventHandler<HTMLInputElement>;
     onClickInputWrapper?: React.MouseEventHandler<HTMLDivElement>;
     placeholder?: string;
     prefix?: string;
     required?: boolean;
     setCurrentFocus: (name: string | null) => void;
-    type: string;
+    type?: string;
     unit?: string;
     value: number | string;
 };
 
 const InputField = ({
-    ariaLabel,
+    ariaLabel = '',
     checked,
     className,
     classNameDynamicSuffix,
@@ -76,46 +76,48 @@ const InputField = ({
     classNameInput,
     classNamePrefix,
     classNameWrapper,
-    currency,
+    currency = '',
     current_focus,
     data_tip,
     data_value,
     decimal_point_change,
     error_messages,
     error_message_alignment,
-    fractional_digits,
+    fractional_digits = 0,
     helper,
     icon,
     id,
     inline_prefix,
-    is_autocomplete_disabled,
+    is_autocomplete_disabled = false,
     is_disabled,
     is_error_tooltip_hidden = false,
-    is_float,
+    is_float = false,
     is_hj_whitelisted = false,
-    is_incrementable,
+    is_incrementable = false,
     is_incrementable_on_long_press,
-    is_negative_disabled,
+    is_negative_disabled = false,
     is_read_only = false,
     is_signed = false,
     is_unit_at_right = false,
     inputmode,
     increment_button_type,
     label,
-    max_length,
+    max_length = 0,
     max_value,
     min_value,
     name,
     format,
     onBlur,
-    onChange,
+    onChange = () => {
+        // do nothing
+    },
     onClick,
     onClickInputWrapper,
     placeholder,
     prefix,
     required,
     setCurrentFocus,
-    type,
+    type = '',
     unit,
     value,
     data_testid,

--- a/packages/p2p/src/components/composite-calendar/__tests__/calendar-icon.spec.tsx
+++ b/packages/p2p/src/components/composite-calendar/__tests__/calendar-icon.spec.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import CalendarIcon from '../calendar-icon';
+import userEvent from '@testing-library/user-event';
+
+describe('<CalendarIcon />', () => {
+    it('should render icon', () => {
+        render(<CalendarIcon onClick={jest.fn()} />);
+        expect(screen.getByTestId('dt_calendar_icon')).toBeInTheDocument();
+    });
+});

--- a/packages/p2p/src/components/composite-calendar/__tests__/composite-calendar.spec.tsx
+++ b/packages/p2p/src/components/composite-calendar/__tests__/composite-calendar.spec.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { StoreProvider, mockStore } from '@deriv/stores';
+import CompositeCalendar from '../composite-calendar';
+import TwoMonthPicker from '../two-month-picker';
+import { toMoment } from '@deriv/shared';
+
+const mock_props = {
+    input_date_range: {
+        value: 'last_7_days',
+        label: 'Last 7 days',
+        duration: 7,
+        onClick: jest.fn(),
+    },
+    from: 1696319493,
+    onChange: jest.fn(),
+    to: 1696928512,
+};
+
+jest.mock('../composite-calendar-mobile', () => jest.fn(() => <div>CompositeCalendarMobile</div>));
+
+// jest.mock('../calendar-side-list', () =>jest.fn(() => <div>CalendarSideList</div>));
+
+jest.mock('../two-month-picker', () => jest.fn(() => <div>TwoMonthPicker</div>));
+
+describe('<CompositeCalendar />', () => {
+    const wrapper = ({ children }: { children: JSX.Element }) => (
+        <StoreProvider store={mockStore({})}>{children}</StoreProvider>
+    );
+    it('should render the component', () => {
+        render(<CompositeCalendar {...mock_props} />, { wrapper });
+        expect(screen.getByTestId('dt_calendar_input_from')).toBeInTheDocument();
+        expect(screen.getByTestId('dt_calendar_input_to')).toBeInTheDocument();
+    });
+    it('should handle onclick for "from date" input', () => {
+        render(<CompositeCalendar {...mock_props} />, { wrapper });
+        const from_input = screen.getByTestId('dt_calendar_input_from');
+        userEvent.click(from_input);
+        expect(screen.getByText('Last 7 days')).toBeInTheDocument();
+    });
+    it('should handle onclick for "to date" input', () => {
+        render(<CompositeCalendar {...mock_props} />, { wrapper });
+        const to_input = screen.getByTestId('dt_calendar_input_to');
+        userEvent.click(to_input);
+        expect(screen.getByText('Last 7 days')).toBeInTheDocument();
+    });
+    it('should handle setToDate function click', async () => {
+        render(<CompositeCalendar {...mock_props} />, { wrapper });
+        const to_input = screen.getByTestId('dt_calendar_input_to');
+        userEvent.click(to_input);
+        act(() => {
+            (TwoMonthPicker as unknown as jest.Mock).mock.calls[0][0].onChange();
+        });
+        await waitFor(() => {
+            expect(mock_props.onChange).toHaveBeenCalled();
+        });
+    });
+    it('should handle setFromDate function click', async () => {
+        render(<CompositeCalendar {...mock_props} />, { wrapper });
+        const from_input = screen.getByTestId('dt_calendar_input_from');
+        userEvent.click(from_input);
+        act(() => {
+            (TwoMonthPicker as unknown as jest.Mock).mock.calls[0][0].onChange();
+        });
+        await waitFor(() => {
+            expect(mock_props.onChange).toHaveBeenCalled();
+        });
+    });
+    it('should handle onclick for "All time" option', () => {
+        render(<CompositeCalendar {...mock_props} />, { wrapper });
+        const from_input = screen.getByTestId('dt_calendar_input_from');
+        userEvent.click(from_input);
+        userEvent.click(screen.getByText('All time'));
+        expect(mock_props.onChange).toHaveBeenCalled();
+    });
+    it('should handle onclick for "Today" option', () => {
+        render(<CompositeCalendar {...mock_props} />, { wrapper });
+        const from_input = screen.getByTestId('dt_calendar_input_from');
+        userEvent.click(from_input);
+        userEvent.click(screen.getByText('Today'));
+        expect(mock_props.onChange).toHaveBeenCalled();
+    });
+    it('should handle onclick for "Last 7 days" option', () => {
+        render(<CompositeCalendar {...mock_props} />, { wrapper });
+        const from_input = screen.getByTestId('dt_calendar_input_from');
+        userEvent.click(from_input);
+        userEvent.click(screen.getByText('Last 7 days'));
+        expect(mock_props.onChange).toHaveBeenCalled();
+    });
+    it('should handle onclick for "Last 30 days" option', () => {
+        render(<CompositeCalendar {...mock_props} />, { wrapper });
+        const from_input = screen.getByTestId('dt_calendar_input_from');
+        userEvent.click(from_input);
+        userEvent.click(screen.getByText('Last 30 days'));
+        expect(mock_props.onChange).toHaveBeenCalled();
+    });
+    it('should handle onclick for "Last quarter" option', () => {
+        render(<CompositeCalendar {...mock_props} />, { wrapper });
+        const from_input = screen.getByTestId('dt_calendar_input_from');
+        userEvent.click(from_input);
+        userEvent.click(screen.getByText('Last quarter'));
+        expect(mock_props.onChange).toHaveBeenCalled();
+    });
+    it('should disable date before from date in "to input" section ', () => {
+        render(<CompositeCalendar {...mock_props} />, { wrapper });
+        const to_input = screen.getByTestId('dt_calendar_input_to');
+        userEvent.click(to_input);
+        expect(
+            (TwoMonthPicker as unknown as jest.Mock).mock.calls[0][0].isPeriodDisabled(toMoment('2023-10-02'))
+        ).toBeTruthy();
+    });
+    it('should disable date after to date in "from input" section ', () => {
+        render(<CompositeCalendar {...mock_props} />, { wrapper });
+        const from_input = screen.getByTestId('dt_calendar_input_from');
+        userEvent.click(from_input);
+        expect(
+            (TwoMonthPicker as unknown as jest.Mock).mock.calls[0][0].isPeriodDisabled(toMoment('2023-10-02'))
+        ).toBeFalsy();
+        expect(
+            (TwoMonthPicker as unknown as jest.Mock).mock.calls[0][0].isPeriodDisabled(toMoment('2023-10-12'))
+        ).toBeTruthy();
+    });
+});

--- a/packages/p2p/src/components/composite-calendar/__tests__/two-month-picker.spec.tsx
+++ b/packages/p2p/src/components/composite-calendar/__tests__/two-month-picker.spec.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import TwoMonthPicker from '../two-month-picker';
+
+const mock_props = {
+    onChange: jest.fn(),
+    isPeriodDisabled: jest.fn(),
+    value: 1696319493, // 2023-10-04
+};
+
+describe('TwoMonthPicker', () => {
+    it('should render the component', () => {
+        render(<TwoMonthPicker {...mock_props} />);
+        expect(screen.getByText('Sep')).toBeInTheDocument();
+    });
+});

--- a/packages/p2p/src/components/composite-calendar/calendar-icon.tsx
+++ b/packages/p2p/src/components/composite-calendar/calendar-icon.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Icon } from '@deriv/components';
+
+type TCalendarIcon = {
+    onClick: () => void;
+};
+
+const CalendarIcon = ({ onClick }: TCalendarIcon) => (
+    <Icon onClick={onClick} icon='IcCalendarDatefrom' className='inline-icon' data_testid='dt_calendar_icon' />
+);
+
+export default CalendarIcon;

--- a/packages/p2p/src/components/composite-calendar/calendar-radio-buton/__tests__/calendar-radio-button.spec.tsx
+++ b/packages/p2p/src/components/composite-calendar/calendar-radio-buton/__tests__/calendar-radio-button.spec.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CalendarRadioButton from '../calendar-radio-button';
+
+const mock_props = {
+    id: '1',
+    value: 'all_time',
+    label: 'All time',
+    onChange: jest.fn(),
+};
+
+describe('CalendarRadioButton', () => {
+    it('should render the radio button', () => {
+        render(<CalendarRadioButton {...mock_props} />);
+        expect(screen.getByText('All time')).toBeInTheDocument();
+    });
+    it('should handle on click of radio button', () => {
+        render(<CalendarRadioButton {...mock_props} />);
+        userEvent.click(screen.getByText('All time'));
+        expect(mock_props.onChange).toHaveBeenCalled();
+    });
+});

--- a/packages/p2p/src/components/composite-calendar/calendar-radio-buton/calendar-radio-button.scss
+++ b/packages/p2p/src/components/composite-calendar/calendar-radio-buton/calendar-radio-button.scss
@@ -1,0 +1,32 @@
+.calendar-radio-button {
+    display: flex;
+    align-items: center;
+    padding: 0.7rem 0.8rem;
+    border: 1px solid;
+    border-color: var(--border-normal);
+    border-radius: 4px;
+    margin: 0.8rem 0.8rem 2.4rem;
+
+    &__input {
+        display: none;
+    }
+    &__circle {
+        border: 2px solid var(--text-less-prominent);
+        border-radius: 50%;
+        box-shadow: 0 0 1px 0 var(--shadow-menu);
+        width: 1.6rem;
+        height: 1.6rem;
+        transition: all 0.3s ease-in-out;
+        margin-right: 0.8rem;
+        align-self: center;
+
+        &--selected {
+            border-width: 4px;
+            border-color: var(--brand-red-coral);
+        }
+    }
+    &--selected {
+        border-color: var(--brand-secondary);
+        font-weight: bold;
+    }
+}

--- a/packages/p2p/src/components/composite-calendar/calendar-radio-buton/calendar-radio-button.tsx
+++ b/packages/p2p/src/components/composite-calendar/calendar-radio-buton/calendar-radio-button.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import classNames from 'classnames';
+import { Text } from '@deriv/components';
+
+type TCalendarRadioButtonProps = {
+    id: string;
+    className?: string;
+    selected_value?: string;
+    value: string;
+    label: string;
+    onChange: (value: { label?: string; value?: string }) => void;
+};
+
+const CalendarRadioButton = ({ id, className, selected_value, value, label, onChange }: TCalendarRadioButtonProps) => {
+    return (
+        <label
+            htmlFor={id}
+            className={classNames('calendar-radio-button', className, {
+                'calendar-radio-button--selected': selected_value === value,
+            })}
+            onClick={() => onChange({ label, value })}
+        >
+            <input className='calendar-radio-button__input' id={id} type='radio' value={value} />
+            <span
+                className={classNames('calendar-radio-button__circle', {
+                    'calendar-radio-button__circle--selected': selected_value === value,
+                })}
+            />
+            <Text
+                as='p'
+                color='prominent'
+                size='xs'
+                line_height='unset'
+                weight={selected_value === value ? 'bold' : 'normal'}
+            >
+                {label}
+            </Text>
+        </label>
+    );
+};
+
+export default CalendarRadioButton;

--- a/packages/p2p/src/components/composite-calendar/calendar-radio-buton/index.ts
+++ b/packages/p2p/src/components/composite-calendar/calendar-radio-buton/index.ts
@@ -1,0 +1,4 @@
+import CalendarRadioButton from './calendar-radio-button';
+import './calendar-radio-button.scss';
+
+export default CalendarRadioButton;

--- a/packages/p2p/src/components/composite-calendar/calendar-side-list/__tests__/calendar-side-list.spec.tsx
+++ b/packages/p2p/src/components/composite-calendar/calendar-side-list/__tests__/calendar-side-list.spec.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import CalendarSideList from '../calendar-side-list';
+
+const mock_props = {
+    from: 0,
+    items: [
+        {
+            value: 'all_time',
+            label: 'All time',
+            onClick: jest.fn(),
+            duration: 0,
+        },
+    ],
+    to: 0,
+};
+
+describe('CalendarSideList', () => {
+    it('should render the side list for duration as 0', () => {
+        render(<CalendarSideList {...mock_props} />);
+        expect(screen.getByText('All time')).toBeInTheDocument();
+    });
+    it('should render the side list for duation as non-zero', () => {
+        const new_props = {
+            ...mock_props,
+            items: [
+                {
+                    value: 'last_7_days',
+                    label: 'Last 7 days',
+                    onClick: jest.fn(),
+                    duration: 7,
+                },
+            ],
+        };
+        render(<CalendarSideList {...new_props} />);
+        expect(screen.getByText('Last 7 days')).toBeInTheDocument();
+    });
+});

--- a/packages/p2p/src/components/composite-calendar/calendar-side-list/__tests__/list-item.spec.tsx
+++ b/packages/p2p/src/components/composite-calendar/calendar-side-list/__tests__/list-item.spec.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ListItem from '../list-item';
+import userEvent from '@testing-library/user-event';
+
+const mock_props = {
+    label: 'All time',
+    is_active: true,
+    onClick: jest.fn(),
+};
+
+describe('ListItem', () => {
+    it('should render the list item', () => {
+        render(<ListItem {...mock_props} />);
+        expect(screen.getByText('All time')).toBeInTheDocument();
+    });
+    it('should handle onclick for label', () => {
+        render(<ListItem {...mock_props} />);
+        userEvent.click(screen.getByText('All time'));
+        expect(mock_props.onClick).toHaveBeenCalled();
+    });
+});

--- a/packages/p2p/src/components/composite-calendar/calendar-side-list/calendar-side-list.scss
+++ b/packages/p2p/src/components/composite-calendar/calendar-side-list/calendar-side-list.scss
@@ -1,0 +1,24 @@
+.calendar-side-list {
+    padding-top: 50px;
+    @include typeface(--paragraph-center-normal-black);
+    color: var(--text-prominent);
+    background: var(--general-section-1);
+    border-radius: 0.4rem 0 0 0.4rem;
+
+    &--is-active {
+        color: var(--text-prominent);
+        background-color: var(--state-active);
+        font-weight: bold;
+    }
+    & li {
+        cursor: pointer;
+        padding: 6px 6px 6px 16px;
+        height: 32px;
+        display: flex;
+        align-items: center;
+
+        &:hover:not(.calendar-side-list--is-active) {
+            background: var(--state-hover);
+        }
+    }
+}

--- a/packages/p2p/src/components/composite-calendar/calendar-side-list/calendar-side-list.tsx
+++ b/packages/p2p/src/components/composite-calendar/calendar-side-list/calendar-side-list.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { toMoment } from '@deriv/shared';
+import ListItem from './list-item';
+
+type TItem = {
+    value: string;
+    label: string;
+    onClick: () => void;
+    duration: number;
+};
+
+type TCalendarSideListProps = {
+    from: number;
+    items: Array<TItem>;
+    to: number;
+};
+
+const isActive = (from: number, to: number, flag: number) => {
+    if (flag === 0) {
+        return toMoment().endOf('day').unix() === to && from === null;
+    }
+    return Math.ceil(to / 86400) - Math.ceil(from / 86400) === flag;
+};
+
+const CalendarSideList = ({ items, from, to }: TCalendarSideListProps) => (
+    <ul className='calendar-side-list'>
+        {items.map(({ duration, label, onClick }) => {
+            const is_active = isActive(from, to, duration);
+            return <ListItem key={duration} is_active={is_active} label={label} onClick={onClick} />;
+        })}
+    </ul>
+);
+
+export default CalendarSideList;

--- a/packages/p2p/src/components/composite-calendar/calendar-side-list/index.ts
+++ b/packages/p2p/src/components/composite-calendar/calendar-side-list/index.ts
@@ -1,0 +1,4 @@
+import CalendarSideList from './calendar-side-list';
+import './calendar-side-list.scss';
+
+export default CalendarSideList;

--- a/packages/p2p/src/components/composite-calendar/calendar-side-list/list-item.tsx
+++ b/packages/p2p/src/components/composite-calendar/calendar-side-list/list-item.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import classNames from 'classnames';
+
+type TListItem = {
+    label: string | React.ReactElement | Array<string>;
+    is_active: boolean;
+    onClick: () => void;
+};
+
+const ListItem = ({ onClick, is_active, label }: TListItem) => (
+    <li
+        className={classNames({
+            'calendar-side-list--is-active': is_active,
+        })}
+        onClick={onClick}
+    >
+        {label}
+    </li>
+);
+
+export default ListItem;

--- a/packages/p2p/src/components/composite-calendar/composite-calendar-mobile/__tests__/composite-calendar-mobile-footer.spec.tsx
+++ b/packages/p2p/src/components/composite-calendar/composite-calendar-mobile/__tests__/composite-calendar-mobile-footer.spec.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import CompositeCalendarMobileFooter from '../composite-calendar-mobile-footer';
+import userEvent from '@testing-library/user-event';
+
+const mock_props = {
+    setIsOpen: jest.fn(),
+    applyDateRange: jest.fn(),
+};
+
+describe('CompositeCalendarMobileFooter', () => {
+    it('should render the component', () => {
+        render(<CompositeCalendarMobileFooter {...mock_props} />);
+        expect(screen.getByText('Cancel')).toBeInTheDocument();
+        expect(screen.getByText('OK')).toBeInTheDocument();
+    });
+    it('should handle Cancel click', () => {
+        render(<CompositeCalendarMobileFooter {...mock_props} />);
+        userEvent.click(screen.getByText('Cancel'));
+        expect(mock_props.setIsOpen).toHaveBeenCalled();
+    });
+    it('should handle OK button click', () => {
+        render(<CompositeCalendarMobileFooter {...mock_props} />);
+        userEvent.click(screen.getByText('OK'));
+        expect(mock_props.applyDateRange).toHaveBeenCalled();
+    });
+});

--- a/packages/p2p/src/components/composite-calendar/composite-calendar-mobile/__tests__/composite-calendar-mobile.spec.tsx
+++ b/packages/p2p/src/components/composite-calendar/composite-calendar-mobile/__tests__/composite-calendar-mobile.spec.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CompositeCalendarMobile from '../composite-calendar-mobile';
+import { DatePicker, InputField, MobileDialog } from '@deriv/components';
+
+const mock_props = {
+    duration_list: [
+        { value: 'all_time', label: 'All time', onClick: jest.fn() },
+        { value: 'last_7_days', label: 'Last 7 days', onClick: jest.fn() },
+        { value: 'last_30_days', label: 'Last 30 days' },
+        { value: 'last_365_days', label: 'Last 365 days' },
+    ],
+    from: 1696319493,
+    to: 1696319494,
+    onChange: jest.fn(),
+};
+
+jest.mock('@deriv/components', () => ({
+    ...jest.requireActual('@deriv/components'),
+    InputField: jest.fn(({ onClick }) => <div onClick={onClick}>Input Field</div>),
+    MobileDialog: jest.fn(({ children }) => <div>{children}</div>),
+    DatePicker: jest.fn(({ onChange }) => <div onChange={onChange}>DatePicker</div>),
+}));
+
+describe('CompositeCalendarMobile', () => {
+    let modal_root_el: HTMLElement;
+
+    beforeAll(() => {
+        modal_root_el = document.createElement('div');
+        modal_root_el.setAttribute('id', 'modal_root');
+        document.body.appendChild(modal_root_el);
+    });
+
+    afterAll(() => {
+        document.body.removeChild(modal_root_el);
+    });
+    it('should render the component', () => {
+        render(<CompositeCalendarMobile {...mock_props} />);
+        expect(screen.getByText('Input Field')).toBeInTheDocument();
+    });
+    it('should open the mobile dialog on clicking the calendar field', () => {
+        render(<CompositeCalendarMobile {...mock_props} />);
+        userEvent.click(screen.getByText('Input Field'));
+        expect(screen.getByText('Back to today')).toBeInTheDocument();
+    });
+    it('should handle backtotoday button click', () => {
+        render(<CompositeCalendarMobile {...mock_props} />);
+        userEvent.click(screen.getByText('Input Field'));
+        userEvent.click(screen.getByRole('button', { name: 'Back to today' }));
+        expect(mock_props.onChange).toHaveBeenCalled();
+    });
+    it('should close the modal on close click', async () => {
+        render(<CompositeCalendarMobile {...mock_props} />);
+        userEvent.click(screen.getByText('Input Field'));
+        act(() => {
+            (MobileDialog as jest.Mock).mock.calls[0][0].onClose();
+        });
+        expect(MobileDialog).toHaveBeenLastCalledWith(expect.objectContaining({ visible: false }), {});
+    });
+    it('should handle applydaterange function', () => {
+        render(<CompositeCalendarMobile {...mock_props} />);
+        userEvent.click(screen.getByText('Input Field'));
+        act(() => {
+            (MobileDialog as jest.Mock).mock.calls[0][0].footer.props.applyDateRange();
+        });
+        expect(mock_props.onChange).toHaveBeenCalled();
+    });
+    it('should handle DatePicker onChange function with from date', () => {
+        render(<CompositeCalendarMobile {...mock_props} />);
+        userEvent.click(screen.getByText('Input Field'));
+        act(() => {
+            (DatePicker as unknown as jest.Mock).mock.calls[0][0].onChange({ target: { value: '2021-09-01' } }, 'from');
+        });
+    });
+});

--- a/packages/p2p/src/components/composite-calendar/composite-calendar-mobile/composite-calendar-mobile-footer.tsx
+++ b/packages/p2p/src/components/composite-calendar/composite-calendar-mobile/composite-calendar-mobile-footer.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Button } from '@deriv/components';
+import { Localize } from 'Components/i18next';
+
+type TCompositeCalendarMobileFooterProps = {
+    setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+    applyDateRange: () => void;
+};
+const CompositeCalendarMobileFooter = ({ applyDateRange, setIsOpen }: TCompositeCalendarMobileFooterProps) => {
+    return (
+        <div className='composite-calendar-mobile__actions'>
+            <Button onClick={() => setIsOpen(false)} has_effect secondary large>
+                <Localize i18n_default_text='Cancel' />
+            </Button>
+            <Button onClick={applyDateRange} has_effect primary large>
+                <Localize i18n_default_text='OK' />
+            </Button>
+        </div>
+    );
+};
+
+export default CompositeCalendarMobileFooter;

--- a/packages/p2p/src/components/composite-calendar/composite-calendar-mobile/composite-calendar-mobile.scss
+++ b/packages/p2p/src/components/composite-calendar/composite-calendar-mobile/composite-calendar-mobile.scss
@@ -1,0 +1,44 @@
+.composite-calendar-mobile {
+    &__actions {
+        display: flex;
+        padding: 1.6rem;
+        border-top: 2px solid var(--border-disabled);
+
+        > * {
+            flex: 1;
+            margin: 0.8rem;
+        }
+        &-today {
+            width: 100%;
+        }
+    }
+    &__radio-group {
+        padding: 1.6rem 1.6rem 0;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        box-shadow: inset 0px -1px 0px var(--general-section-1);
+    }
+
+    &__custom {
+        padding: 16px;
+        &__wrapper {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+        }
+        &-radio {
+            display: inline-flex;
+        }
+        &-date-range {
+            margin: 0.8rem;
+            display: flex;
+            flex-direction: column;
+
+            &-start-date {
+                margin: 1.6rem 0;
+            }
+            &-end-date {
+                margin-bottom: 0.8rem;
+            }
+        }
+    }
+}

--- a/packages/p2p/src/components/composite-calendar/composite-calendar-mobile/composite-calendar-mobile.tsx
+++ b/packages/p2p/src/components/composite-calendar/composite-calendar-mobile/composite-calendar-mobile.tsx
@@ -1,0 +1,196 @@
+import React from 'react';
+import { Button, DatePicker, Icon, InputField, MobileDialog } from '@deriv/components';
+import { Localize, localize } from '@deriv/translations';
+import { toMoment } from '@deriv/shared';
+import CompositeCalendarMobileFooter from './composite-calendar-mobile-footer';
+import CalendarRadioButton from '../calendar-radio-buton';
+import { TInputDateRange } from '../composite-calendar';
+
+const CUSTOM_KEY = 'custom';
+
+type TCompositeCalendarMobileProps = {
+    current_focus?: string | null;
+    duration_list?: Array<TInputDateRange>;
+    input_date_range?: TInputDateRange;
+    onChange: (
+        value: { from?: moment.Moment; to?: moment.Moment; is_batch?: boolean },
+        extra_data?: { date_range: TInputDateRange }
+    ) => void;
+    setCurrentFocus?: (focus: string) => void;
+    from: number;
+    to: number;
+};
+
+const CompositeCalendarMobile = ({
+    current_focus,
+    duration_list,
+    input_date_range,
+    onChange,
+    setCurrentFocus,
+    from,
+    to,
+}: TCompositeCalendarMobileProps) => {
+    const date_range = input_date_range || duration_list?.find(range => range.value === 'all_time');
+
+    const [from_date, setFrom] = React.useState(from ? toMoment(from).format('YYYY-MM-DD') : undefined);
+    const [to_date, setTo] = React.useState(to ? toMoment(to).format('YYYY-MM-DD') : undefined);
+    const [is_open, setIsOpen] = React.useState(false);
+
+    const [applied_date_range, setAppliedDateRange] = React.useState(date_range);
+    const [selected_date_range, setSelectedDateRange] = React.useState(date_range);
+    const today = toMoment().format('YYYY-MM-DD');
+
+    const selectDateRange = (selected_date_range: TInputDateRange, is_today?: boolean) => {
+        const new_from = selected_date_range.duration;
+        onChange(
+            {
+                from:
+                    is_today || new_from ? toMoment().startOf('day').subtract(new_from, 'day').add(1, 's') : undefined,
+                to: toMoment().endOf('day'),
+                is_batch: true,
+            },
+            {
+                date_range: selected_date_range,
+            }
+        );
+    };
+
+    const selectCustomDateRange = () => {
+        const new_from = from_date || to_date || today;
+        const new_to = to_date || today;
+
+        const new_date_range = Object.assign(selected_date_range as TInputDateRange, {
+            label: `${toMoment(new_from).format('DD MMM YYYY')} - ${toMoment(new_to).format('DD MMM YYYY')}`,
+        });
+
+        onChange(
+            {
+                from: toMoment(new_from).startOf('day').add(1, 's'),
+                to: toMoment(new_to).endOf('day'),
+                is_batch: true,
+            },
+            {
+                date_range: new_date_range,
+            }
+        );
+    };
+
+    const applyDateRange = () => {
+        if (selected_date_range?.onClick) {
+            selectDateRange(selected_date_range);
+        } else if (selected_date_range?.value === CUSTOM_KEY) {
+            selectCustomDateRange();
+        }
+        setAppliedDateRange(selected_date_range);
+        setIsOpen(false);
+    };
+
+    const selectToday = () => {
+        const new_date_range = {
+            duration: 0,
+            label: localize('Today'),
+        };
+        selectDateRange(new_date_range, true);
+        setAppliedDateRange(new_date_range);
+        setSelectedDateRange(new_date_range);
+        setIsOpen(false);
+    };
+
+    const selectDate = (e: React.ChangeEvent<HTMLInputElement>, key: string) => {
+        setSelectedDateRange({ value: CUSTOM_KEY });
+
+        if (key === 'from') setFrom(e.target?.value);
+        else setTo(e.target?.value);
+    };
+
+    const onDateRangeChange = (date_range: TInputDateRange) => {
+        setSelectedDateRange(
+            duration_list?.find(range => date_range && range.value === date_range.value) || date_range
+        );
+    };
+
+    const openDialog = () => {
+        setSelectedDateRange(applied_date_range);
+        setIsOpen(true);
+    };
+
+    return (
+        <React.Fragment>
+            <div className='composite-calendar__input-fields composite-calendar__input-fields--fill'>
+                <InputField
+                    id='dt_calendar_input'
+                    current_focus={current_focus}
+                    is_read_only
+                    icon={() => <Icon icon='IcCalendarDatefrom' className='inline-icon' />}
+                    onClick={openDialog}
+                    setCurrentFocus={setCurrentFocus}
+                    value={applied_date_range?.label}
+                />
+            </div>
+            <MobileDialog
+                portal_element_id='modal_root'
+                title={localize('Please select duration')}
+                visible={is_open}
+                has_content_scroll
+                onClose={() => setIsOpen(false)}
+                content_height_offset='94px'
+                footer={<CompositeCalendarMobileFooter setIsOpen={setIsOpen} applyDateRange={applyDateRange} />}
+            >
+                <div className='composite-calendar-mobile'>
+                    <div className='composite-calendar-mobile__radio-group'>
+                        {duration_list?.map(({ value, label }) => (
+                            <CalendarRadioButton
+                                id={`composite-calendar-mobile__radio__${value}`}
+                                key={value}
+                                value={value ?? ''}
+                                label={label ?? ''}
+                                selected_value={selected_date_range?.value}
+                                onChange={onDateRangeChange}
+                            />
+                        ))}
+                    </div>
+                    <div className='composite-calendar-mobile__custom'>
+                        <CalendarRadioButton
+                            id={'composite-calendar-mobile__custom-radio'}
+                            className='composite-calendar-mobile__custom-radio'
+                            value={CUSTOM_KEY}
+                            label={localize('Custom')}
+                            selected_value={selected_date_range?.value}
+                            onChange={onDateRangeChange}
+                        />
+                        <div className='composite-calendar-mobile__custom-date-range'>
+                            <DatePicker
+                                className='composite-calendar-mobile__custom-date-range-start-date'
+                                is_nativepicker
+                                placeholder={localize('Start date')}
+                                value={from_date}
+                                max_date={to_date || today}
+                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => selectDate(e, 'from')}
+                            />
+                            <DatePicker
+                                className='composite-calendar-mobile__custom-date-range-end-date'
+                                is_nativepicker
+                                placeholder={localize('End date')}
+                                value={to_date}
+                                max_date={today}
+                                min_date={from_date}
+                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => selectDate(e, 'to')}
+                            />
+                        </div>
+                    </div>
+                    <Button
+                        className='composite-calendar-mobile__actions-today'
+                        onClick={selectToday}
+                        has_effect
+                        tertiary
+                        large
+                    >
+                        <Localize i18n_default_text='Back to today' />
+                    </Button>
+                </div>
+            </MobileDialog>
+        </React.Fragment>
+    );
+};
+
+export default React.memo(CompositeCalendarMobile);

--- a/packages/p2p/src/components/composite-calendar/composite-calendar-mobile/index.ts
+++ b/packages/p2p/src/components/composite-calendar/composite-calendar-mobile/index.ts
@@ -1,0 +1,4 @@
+import CompositeCalendarMobile from './composite-calendar-mobile';
+import './composite-calendar-mobile.scss';
+
+export default CompositeCalendarMobile;

--- a/packages/p2p/src/components/composite-calendar/composite-calendar.scss
+++ b/packages/p2p/src/components/composite-calendar/composite-calendar.scss
@@ -1,0 +1,82 @@
+/* @define .composite-calendar; weak; */
+.composite-calendar {
+    display: grid;
+    grid-template-columns: minmax(max-content, 158px) minmax(min-content, 280px) minmax(min-content, 280px);
+    position: absolute;
+    top: 36px;
+    right: 0;
+    z-index: 99;
+    border-radius: $BORDER_RADIUS;
+    background-color: var(--general-main-2);
+    box-shadow: 0 2px 16px 8px var(--shadow-menu);
+
+    .composite-wrapper {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        background-color: var(--general-main-1);
+        z-index: 98;
+    }
+    &__input-fields {
+        display: flex;
+        border-radius: $BORDER_RADIUS;
+        width: 100%;
+
+        &--fill {
+            width: 100%;
+
+            & > .dc-input-field {
+                width: 100%;
+            }
+        }
+        & > .dc-input-field {
+            margin: 0;
+            width: 100%;
+
+            @include desktop {
+                max-width: 17.6rem;
+            }
+
+            @include mobile {
+                .inline-icon {
+                    top: 1.2rem;
+                }
+            }
+
+            @include colorIcon(var(--text-prominent));
+
+            & .input {
+                height: 3.2rem;
+                background-color: var(--fill-normal);
+                border: 1px solid var(--border-normal);
+                appearance: none;
+
+                @include mobile {
+                    height: 4rem;
+                    text-align: left;
+                    padding-left: 3rem;
+                }
+
+                &:hover {
+                    border-color: var(--border-hover);
+                }
+                &:focus,
+                &:active {
+                    border-color: var(--border-active);
+                }
+                &::placeholder {
+                    color: var(--text-general);
+                }
+            }
+        }
+        & > .dc-input-field:not(:first-child) {
+            margin-left: 8px;
+        }
+    }
+    & > .first-month,
+    & > .second-month {
+        .dc-calendar__body {
+            border-bottom: none;
+        }
+    }
+}

--- a/packages/p2p/src/components/composite-calendar/composite-calendar.tsx
+++ b/packages/p2p/src/components/composite-calendar/composite-calendar.tsx
@@ -1,0 +1,199 @@
+import React from 'react';
+import moment from 'moment';
+import Loadable from 'react-loadable';
+import { DesktopWrapper, InputField, MobileWrapper, useOnClickOutside } from '@deriv/components';
+import { daysFromTodayTo, toMoment } from '@deriv/shared';
+import { observer, useStore } from '@deriv/stores';
+import { localize } from '@deriv/translations';
+import CalendarIcon from './calendar-icon';
+import CalendarSideList from './calendar-side-list';
+import CompositeCalendarMobile from './composite-calendar-mobile';
+
+export type TInputDateRange = {
+    value?: string;
+    label?: string;
+    duration?: number;
+    onClick?: () => void;
+};
+
+type TCompositeCalendarProps = {
+    input_date_range: TInputDateRange;
+    onChange: (values: { to?: moment.Moment; from?: moment.Moment; is_batch?: boolean }) => void;
+    to: number;
+    from: number;
+};
+
+const TwoMonthPickerLoadable = Loadable({
+    loader: () => import(/* webpackChunkName: "two-month-picker" */ './two-month-picker'),
+    loading: () => null,
+    render(loaded, props) {
+        const Component = loaded.default;
+        return <Component {...props} />;
+    },
+});
+
+const CompositeCalendar = (props: TCompositeCalendarProps) => {
+    const { ui } = useStore();
+    const { current_focus, setCurrentFocus } = ui;
+    const { from, to, onChange } = props;
+
+    const [show_to, setShowTo] = React.useState(false);
+    const [show_from, setShowFrom] = React.useState(false);
+    const [days_duration_list] = React.useState([
+        {
+            value: 'all_time',
+            label: localize('All time'),
+            onClick: () => selectDateRange(),
+            duration: 0,
+        },
+        {
+            value: 'today',
+            label: localize('Today'),
+            onClick: () => selectDateRange(1),
+            duration: 1,
+        },
+        {
+            value: 'last_7_days',
+            label: localize('Last 7 days'),
+            onClick: () => selectDateRange(7),
+            duration: 7,
+        },
+        {
+            value: 'last_30_days',
+            label: localize('Last 30 days'),
+            onClick: () => selectDateRange(30),
+            duration: 30,
+        },
+        {
+            value: 'last_60_days',
+            label: localize('Last 60 days'),
+            onClick: () => selectDateRange(60),
+            duration: 60,
+        },
+        {
+            value: 'last_quarter',
+            label: localize('Last quarter'),
+            onClick: () => selectDateRange(90),
+            duration: 90,
+        },
+    ]);
+
+    const wrapper_ref = React.useRef<HTMLInputElement>(null);
+
+    const validateClickOutside = (event: MouseEvent) => !wrapper_ref.current?.contains(event.target as Node);
+
+    const selectDateRange = (new_from?: number) => {
+        hideCalendar();
+        onChange({
+            from: new_from ? toMoment().startOf('day').subtract(new_from, 'day').add(1, 's') : undefined,
+            to: toMoment().endOf('day'),
+            is_batch: true,
+        });
+    };
+
+    const getToDateLabel = () => {
+        const date = toMoment(to);
+        return daysFromTodayTo(date) === 0 ? localize('Today') : date.format('MMM, DD YYYY');
+    };
+
+    const getFromDateLabel = () => {
+        const date = toMoment(from);
+        return from ? date.format('MMM, DD YYYY') : '';
+    };
+
+    const hideCalendar = () => {
+        setShowFrom(false);
+        setShowTo(false);
+    };
+
+    const showCalendar = (e: string) => {
+        if (e === 'from') {
+            setShowFrom(true);
+        }
+        if (e === 'to') {
+            setShowTo(true);
+        }
+    };
+
+    useOnClickOutside(
+        wrapper_ref,
+        (event: MouseEvent) => {
+            event?.stopPropagation();
+            event?.preventDefault();
+            hideCalendar();
+        },
+        validateClickOutside
+    );
+
+    const setToDate = (date: moment.Moment) => {
+        onChange({ to: toMoment(date).endOf('day') });
+    };
+
+    const setFromDate = (date: moment.Moment) => {
+        onChange({ from: toMoment(date) });
+        hideCalendar();
+    };
+
+    const isPeriodDisabledTo = (date: moment.Moment) => {
+        return date.unix() < from || date.unix() > toMoment().endOf('day').unix();
+    };
+
+    const isPeriodDisabledFrom = (date: moment.Moment) => date.unix() > to;
+
+    return (
+        <React.Fragment>
+            <DesktopWrapper>
+                <div className='composite-calendar__input-fields'>
+                    <InputField
+                        current_focus={current_focus}
+                        data_testid='dt_calendar_input_from'
+                        icon={CalendarIcon}
+                        is_read_only
+                        name='from_date'
+                        onClick={() => showCalendar('from')}
+                        placeholder={localize('Date from')}
+                        setCurrentFocus={setCurrentFocus}
+                        value={getFromDateLabel()}
+                    />
+                    <InputField
+                        current_focus={current_focus}
+                        data_testid='dt_calendar_input_to'
+                        icon={CalendarIcon}
+                        is_read_only
+                        name='to_date'
+                        onClick={() => showCalendar('to')}
+                        placeholder={localize('Date to')}
+                        setCurrentFocus={setCurrentFocus}
+                        value={getToDateLabel()}
+                    />
+                </div>
+                {show_to && (
+                    <div className='composite-calendar' ref={wrapper_ref}>
+                        <CalendarSideList from={from} to={to} items={days_duration_list} />
+                        <TwoMonthPickerLoadable value={to} onChange={setToDate} isPeriodDisabled={isPeriodDisabledTo} />
+                    </div>
+                )}
+                {show_from && (
+                    <div className='composite-calendar' ref={wrapper_ref}>
+                        <CalendarSideList from={from} to={to} items={days_duration_list} />
+                        <TwoMonthPickerLoadable
+                            value={from}
+                            onChange={setFromDate}
+                            isPeriodDisabled={isPeriodDisabledFrom}
+                        />
+                    </div>
+                )}
+            </DesktopWrapper>
+            <MobileWrapper>
+                <CompositeCalendarMobile
+                    duration_list={days_duration_list}
+                    current_focus={current_focus}
+                    setCurrentFocus={setCurrentFocus}
+                    {...props}
+                />
+            </MobileWrapper>
+        </React.Fragment>
+    );
+};
+
+export default React.memo(observer(CompositeCalendar));

--- a/packages/p2p/src/components/composite-calendar/index.ts
+++ b/packages/p2p/src/components/composite-calendar/index.ts
@@ -1,0 +1,4 @@
+import CompositeCalendar from './composite-calendar';
+import './composite-calendar.scss';
+
+export default CompositeCalendar;

--- a/packages/p2p/src/components/composite-calendar/two-month-picker.tsx
+++ b/packages/p2p/src/components/composite-calendar/two-month-picker.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import moment from 'moment';
+import { Calendar } from '@deriv/components';
+import { addMonths, diffInMonths, subMonths, toMoment } from '@deriv/shared';
+
+type TTwoMonthPickerProps = {
+    onChange: (date: moment.MomentInput) => void;
+    isPeriodDisabled: (date: moment.Moment) => boolean;
+    value: moment.Moment | number;
+};
+
+const TwoMonthPicker = ({ onChange, isPeriodDisabled, value }: TTwoMonthPickerProps) => {
+    const [left_pane_date, setLeftPaneDate] = React.useState(toMoment(value).clone().subtract(1, 'month'));
+    const [right_pane_date, setRightPaneDate] = React.useState(value);
+
+    /**
+     * Navigate from date
+     *
+     * @param {moment.Moment} date
+     */
+    const navigateFrom = (date: moment.Moment) => {
+        setLeftPaneDate(date);
+        setRightPaneDate(addMonths(date.toISOString(), 1));
+    };
+
+    /**
+     * Navigate to date
+     *
+     * @param {moment.Moment} date
+     */
+    const navigateTo = (date: moment.Moment) => {
+        setLeftPaneDate(subMonths(date.toISOString(), 1));
+        setRightPaneDate(toMoment(date));
+    };
+
+    /**
+     * Only allow previous months to be available to navigate. Disable other periods
+     *
+     * @param {moment.Moment} date
+     */
+    const validateFromArrows = (date: moment.Moment) => {
+        return diffInMonths(toMoment(left_pane_date), date) !== -1;
+    };
+
+    /**
+     * Only allow next month to be available to navigate (unless next month is in the future).
+     * Disable other periods
+     *
+     * @param {moment.Moment} date
+     */
+    const validateToArrows = (date: moment.Moment) => {
+        const r_date = toMoment(right_pane_date).startOf('month');
+        if (diffInMonths(toMoment().startOf('month'), r_date) === 0) return true; // future months are disallowed
+        return diffInMonths(r_date, date) !== 1;
+    };
+
+    /**
+     * Validate values to be date_from < date_to
+     *
+     * @param {moment.Moment} date
+     */
+    const shouldDisableDate = (date: moment.Moment) => {
+        return isPeriodDisabled(date);
+    };
+
+    const updateSelectedDate = (e: React.MouseEvent<HTMLElement>) => {
+        onChange(moment.utc(e.currentTarget.dataset.date, 'YYYY-MM-DD'));
+    };
+
+    return (
+        <React.Fragment>
+            <div className='first-month'>
+                <Calendar.Header
+                    calendar_date={left_pane_date}
+                    calendar_view='date'
+                    hide_disabled_periods
+                    isPeriodDisabled={validateFromArrows}
+                    navigateTo={navigateFrom}
+                    switchView={() => ({})}
+                />
+                <Calendar.Body
+                    calendar_view='date'
+                    calendar_date={left_pane_date}
+                    date_format='YYYY-MM-DD'
+                    isPeriodDisabled={shouldDisableDate}
+                    hide_others
+                    selected_date={value}
+                    updateSelected={updateSelectedDate}
+                />
+            </div>
+            <div className='second-month'>
+                <Calendar.Header
+                    calendar_date={right_pane_date}
+                    calendar_view='date'
+                    hide_disabled_periods
+                    isPeriodDisabled={validateToArrows}
+                    navigateTo={navigateTo}
+                    switchView={() => ({})}
+                />
+                <Calendar.Body
+                    calendar_view='date'
+                    calendar_date={right_pane_date}
+                    date_format='YYYY-MM-DD'
+                    hide_others
+                    isPeriodDisabled={shouldDisableDate}
+                    selected_date={value}
+                    updateSelected={updateSelectedDate}
+                />
+            </div>
+        </React.Fragment>
+    );
+};
+
+export default React.memo(TwoMonthPicker);

--- a/packages/p2p/src/pages/orders/order-table/__test__/order-table.spec.js
+++ b/packages/p2p/src/pages/orders/order-table/__test__/order-table.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import OrderTable from '../order-table.jsx';
+import { StoreProvider, mockStore } from '@deriv/stores';
 
 jest.mock('Stores', () => ({
     ...jest.requireActual('Stores'),
@@ -9,6 +10,12 @@ jest.mock('Stores', () => ({
             active_notification_count: 0,
             inactive_notification_count: 0,
             order_table_type: false,
+        },
+        order_store: {
+            date_from: '',
+            date_to: '',
+            filtered_date_range: '',
+            handleDateChange: jest.fn(),
         },
     }),
 }));
@@ -23,7 +30,11 @@ jest.mock('@deriv/components', () => ({
 
 describe('<Orders/>', () => {
     it('should pass the values into OrderTableContent', () => {
-        render(<OrderTable />);
+        render(
+            <StoreProvider store={mockStore({})}>
+                <OrderTable />
+            </StoreProvider>
+        );
         expect(screen.getByText('Order Table Content')).toBeInTheDocument();
     });
 });

--- a/packages/p2p/src/pages/orders/order-table/order-table.jsx
+++ b/packages/p2p/src/pages/orders/order-table/order-table.jsx
@@ -4,13 +4,15 @@ import { ButtonToggle } from '@deriv/components';
 import { observer } from 'mobx-react-lite';
 import { localize } from 'Components/i18next';
 import ToggleContainer from 'Components/toggle-container';
+import CompositeCalendar from 'Components/composite-calendar';
 import { order_list } from 'Constants/order-list';
 import { useStores } from 'Stores';
 import OrderTableContent from './order-table-content.jsx';
 import './order-table.scss';
 
 const OrderTable = ({ showDetails }) => {
-    const { general_store } = useStores();
+    const { general_store, order_store } = useStores();
+    const { date_from, date_to, filtered_date_range, handleDateChange } = order_store;
 
     const orders_list_filters = [
         {
@@ -41,6 +43,16 @@ const OrderTable = ({ showDetails }) => {
                             has_rounded_button
                         />
                     </ToggleContainer>
+                    {!is_active_tab && (
+                        <div className='order-table__toggle-wrapper--search'>
+                            <CompositeCalendar
+                                input_date_range={filtered_date_range}
+                                onChange={handleDateChange}
+                                from={date_from}
+                                to={date_to}
+                            />
+                        </div>
+                    )}
                 </div>
             </div>
             <OrderTableContent showDetails={showDetails} is_active={is_active_tab} />

--- a/packages/p2p/src/pages/orders/order-table/order-table.scss
+++ b/packages/p2p/src/pages/orders/order-table/order-table.scss
@@ -1,16 +1,17 @@
 .order-table {
     @include mobile {
-        height: 7.7rem;
-        width: 100%;
-        display: flex;
-        justify-content: center;
-        flex-direction: column;
         border-bottom: 1px solid var(--general-section-1);
     }
 
     &__toggle-wrapper {
-        width: fit-content;
+        .toggle-container {
+            @include tablet-up {
+                margin: 2.4rem 0 4.8rem;
+            }
+        }
         border-radius: 4px;
+        display: flex;
+        justify-content: space-between;
 
         &-filter {
             .dc-button-menu__wrapper {
@@ -24,6 +25,34 @@
         }
         @include mobile {
             align-self: center;
+            flex-direction: column;
+            width: 100%;
+        }
+        &--search {
+            display: flex;
+            margin: 2.4rem 0 4.8rem;
+            gap: 0.8rem;
+            align-items: center;
+
+            @include mobile {
+                margin: 0 1.6rem 3.2rem;
+            }
+
+            &-icon {
+                border: 1px solid var(--general-active);
+                align-self: center;
+                border-radius: 0.4rem;
+                padding: 0.6rem 0.8rem;
+                width: 3.2rem;
+                height: 3.2rem;
+                &:hover {
+                    cursor: pointer;
+                }
+                @include mobile {
+                    width: 4rem;
+                    height: 4rem;
+                }
+            }
         }
     }
 

--- a/packages/p2p/src/stores/general-store.js
+++ b/packages/p2p/src/stores/general-store.js
@@ -56,7 +56,7 @@ export default class GeneralStore extends BaseStore {
     user_blocked_until = null;
     is_modal_open = false;
 
-    list_item_limit = isMobile() ? 10 : 50;
+    list_item_limit = isMobile() ? 10 : 5;
     path = {
         buy_sell: 0,
         orders: 1,

--- a/packages/reports/src/Components/Form/CompositeCalendar/composite-calendar-mobile.tsx
+++ b/packages/reports/src/Components/Form/CompositeCalendar/composite-calendar-mobile.tsx
@@ -185,7 +185,7 @@ const CompositeCalendarMobile = React.memo(
                         icon={() => <Icon icon='IcCalendarDatefrom' className='inline-icon' />}
                         onClick={openDialog}
                         setCurrentFocus={setCurrentFocus}
-                        value={applied_date_range?.label}
+                        value={applied_date_range?.label ?? ''}
                     />
                 </div>
                 <MobileDialog


### PR DESCRIPTION
## Changes:

Implemented date selection filter in past orders section

### Screenshots:

![Screenshot 2023-10-04 at 2 53 07 PM](https://github.com/binary-com/deriv-app/assets/122768621/89a8f87a-e595-408c-8ff1-ce18529bdc81)
![Screenshot 2023-10-04 at 2 53 13 PM](https://github.com/binary-com/deriv-app/assets/122768621/6d31d811-aeba-4ab1-aa9d-9ec4545ae052)
![Screenshot 2023-10-04 at 2 53 44 PM](https://github.com/binary-com/deriv-app/assets/122768621/e23b03fa-8d42-4287-a388-2b5828877e61)
