### PR TITLE
Maryia/Bot-123/Being able to see the charts while building a bot

### DIFF
--- a/packages/bot-web-ui/src/components/chart/chart.scss
+++ b/packages/bot-web-ui/src/components/chart/chart.scss
@@ -2,12 +2,14 @@
     &__chart-container {
         position: relative;
         top: 0;
+
         &-wrapper {
             position: absolute;
             top: 0;
             width: 100vw;
             background-color: var(--general-main-1);
         }
+
         .cq-context {
             div.ciq-chart {
                 div.stx_jump_today.home > svg {
@@ -18,10 +20,12 @@
                 }
             }
         }
+
         .injectionDiv {
             // Hide scratch workspace when switch to chart
             display: none;
         }
+
         .cq-dialog-portal {
             position: absolute;
         }
@@ -38,6 +42,7 @@
                 &.ciq-disabled {
                     display: none;
                 }
+
                 @include mobile {
                     min-width: 17rem;
                     max-width: 26rem;
@@ -46,6 +51,7 @@
                     .cq-menu-btn {
                         padding: 0.2rem;
                     }
+
                     .cq-symbol-select-btn {
                         margin: 0.2rem;
 
@@ -53,9 +59,11 @@
                             transform: scale(1);
                             margin-left: auto;
                         }
+
                         .cq-symbol {
                             font-size: 1.2rem;
                         }
+
                         .cq-chart-price {
                             display: none;
                         }
@@ -99,12 +107,14 @@
                             top: 0.8rem;
                             left: 0.8rem;
                         }
+
                         & > .ic-icon {
                             top: 0.6rem;
                         }
                     }
                 }
             }
+
             .app-contents .ciq-menu {
                 margin: 0;
             }
@@ -114,6 +124,7 @@
     .smartcharts-mobile {
         .cq-context {
             z-index: 99;
+
             .sc-mcd__category:last-child {
                 margin-bottom: 3rem !important;
             }
@@ -122,10 +133,13 @@
         & .cq-chart-title .cq-menu-dropdown {
             position: fixed;
             height: 100% !important;
+
             .sc-dialog {
                 height: 100% !important;
+
                 &__body {
                     height: inherit !important;
+
                     .sc-mcd {
                         height: inherit !important;
                         min-width: auto !important;

--- a/packages/bot-web-ui/src/components/chart/chart.tsx
+++ b/packages/bot-web-ui/src/components/chart/chart.tsx
@@ -12,7 +12,7 @@ import ToolbarWidgets from './toolbar-widgets';
 const Chart = observer(({ show_digits_stats }: { show_digits_stats: boolean }) => {
     const barriers: [] = [];
     const { common, ui } = useStore();
-    const { chart_store, run_panel } = useDBotStore();
+    const { chart_store, run_panel, dashboard } = useDBotStore();
 
     const {
         chart_type,
@@ -29,6 +29,7 @@ const Chart = observer(({ show_digits_stats }: { show_digits_stats: boolean }) =
         wsSubscribe,
     } = chart_store;
     const { is_drawer_open } = run_panel;
+    const { is_enabled_modal_chart } = dashboard;
     const is_socket_opened = common.is_socket_opened;
     const settings = {
         assetInformation: false, // ui.is_chart_asset_info_visible,
@@ -43,6 +44,7 @@ const Chart = observer(({ show_digits_stats }: { show_digits_stats: boolean }) =
         <div
             className={classNames('dashboard__chart-wrapper', {
                 'dashboard__chart-wrapper--expanded': is_drawer_open && !isMobile(),
+                'dashboard__chart-wrapper--modal': is_enabled_modal_chart && !isMobile(),
             })}
         >
             <SmartChart

--- a/packages/bot-web-ui/src/components/dashboard/bot-builder/toolbar/workspace-group.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/bot-builder/toolbar/workspace-group.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { isMobile } from '@deriv/shared';
 import { observer } from '@deriv/stores';
 import { localize } from '@deriv/translations';
 import { useDBotStore } from 'Stores/useDBotStore';
@@ -27,7 +28,7 @@ const WorkspaceGroup = observer(
         toggleSaveModal,
     }: TWorkspaceGroup) => {
         const { dashboard } = useDBotStore();
-        const { setPreviewOnPopup } = dashboard;
+        const { setPreviewOnPopup, setEnabledModalChart } = dashboard;
 
         return (
             <div className='toolbar__group toolbar__group-btn'>
@@ -58,6 +59,14 @@ const WorkspaceGroup = observer(
                     icon_id='db-toolbar__sort-button'
                     action={onSortClick}
                 />
+                {!isMobile() && (
+                    <ToolbarIcon
+                        popover_message={localize('Charts')}
+                        icon='IcChartsTabDbot'
+                        icon_id='db-toolbar__sort-button'
+                        action={() => setEnabledModalChart()}
+                    />
+                )}
                 <div className='vertical-divider' />
                 <ToolbarIcon
                     popover_message={localize('Undo')}

--- a/packages/bot-web-ui/src/components/dashboard/dashboard-component/chart-modal/chart-modal.scss
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard-component/chart-modal/chart-modal.scss
@@ -1,0 +1,137 @@
+$value-cubic-bezier: cubic-bezier(0.25, 0.1, 0.1, 0.25);
+
+@mixin align-items-center {
+    display: flex;
+    align-items: center;
+}
+
+.bot-dashboard:has(.chart-modal-dialog) {
+    #id-charts {
+        color: var(--fill-normal-1);
+        stroke-opacity: 30%;
+        pointer-events: none;
+    }
+
+    .chart-modal-dialog {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 100%;
+        height: 100%;
+
+        @include align-items-center;
+        justify-content: center;
+        z-index: 999;
+        transition: opacity 0.25s $value-cubic-bezier;
+
+        .sc-navigation-widget {
+            display: none;
+        }
+
+        .cq-symbols-display {
+            .cq-menu-btn {
+                padding: 0.2rem;
+            }
+
+            .cq-symbol-select-btn {
+                margin: 0.2rem;
+
+                .cq-symbol-dropdown {
+                    transform: scale(1);
+                    margin-left: auto;
+                }
+
+                .cq-symbol {
+                    font-size: 1.4rem;
+                }
+
+                .cq-chart-price {
+                    display: none;
+                }
+
+                .cq-symbol-info {
+                    min-height: unset;
+                }
+            }
+        }
+
+        .sc-toolbar-widget {
+            bottom: 4vh;
+            top: unset;
+            border-width: 0;
+            border-radius: 2rem;
+            cursor: pointer;
+            background: var(--general-section-1);
+
+            .sc-tooltip:not(:first-child) {
+                display: none;
+            }
+
+            .cq-menu-btn {
+                .sc-chart-mode__menu__timeperiod {
+                    top: 0.6rem;
+                    left: 1rem;
+                }
+            }
+
+            .cq-menu-btn:hover {
+                background: none;
+            }
+        }
+
+        &__dialog {
+            max-width: 56rem;
+            max-height: 48.1rem;
+            min-width: 42.6rem;
+            min-height: 17.6rem;
+
+            margin-top: -4.8rem;
+            padding: 0 0.45rem;
+            border-radius: 0.8rem;
+            box-sizing: border-box;
+
+            @include align-items-center;
+            justify-content: space-around;
+            flex-direction: column;
+            box-shadow: 0 2px 8px 0 var(--shadow-menu);
+            background-color: var(--general-main-2);
+            transition: transform 0.25s $value-cubic-bezier, opacity 0.25s $value-cubic-bezier;
+        }
+
+        &__header-wrapper {
+            width: 100%;
+            @include align-items-center;
+            justify-content: space-between;
+
+            margin-top: 1.4rem;
+            margin-bottom: 1rem;
+            padding-left: 2.4rem;
+            padding-right: 2.4rem;
+
+            .chart-modal-dialog__header--close {
+                cursor: pointer;
+            }
+        }
+
+        .cq-chart-title {
+            .cq-menu-dropdown {
+                position: fixed;
+                height: 46rem;
+                left: unset;
+
+                .sc-dialog {
+                    height: 100% !important;
+
+                    &__body {
+                        height: inherit !important;
+
+                        .sc-mcd {
+                            height: inherit !important;
+                            min-width: auto !important;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/bot-web-ui/src/components/dashboard/dashboard-component/chart-modal/chart-modal.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard-component/chart-modal/chart-modal.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Text } from '@deriv/components';
+import { Localize, localize } from '@deriv/translations';
+import Chart from 'Components/chart';
+import ToolbarIcon from '../../bot-builder/toolbar/toolbar-icon';
+
+const ChartModal = ({ setEnabledModalChart }: { setEnabledModalChart: () => void }) => (
+    <div className='chart-modal-dialog'>
+        <div className='chart-modal-dialog__dialog'>
+            <div className='chart-modal-dialog__header-wrapper'>
+                <Text weight='bold' line_height='xxl'>
+                    <Localize i18n_default_text='Chart' />
+                </Text>
+                <div className='dc-dialog__header--close'>
+                    <ToolbarIcon
+                        popover_message={localize('Close')}
+                        icon='IcCross'
+                        icon_id='db-toolbar__sort-button'
+                        action={() => setEnabledModalChart()}
+                    />
+                </div>
+            </div>
+            <Chart show_digits_stats={false} />
+        </div>
+    </div>
+);
+
+export default ChartModal;

--- a/packages/bot-web-ui/src/components/dashboard/dashboard-component/chart-modal/index.ts
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard-component/chart-modal/index.ts
@@ -1,0 +1,4 @@
+import ChartModal from './chart-modal';
+import './chart-modal.scss';
+
+export default ChartModal;

--- a/packages/bot-web-ui/src/components/dashboard/dashboard-component/index.ts
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard-component/index.ts
@@ -1,3 +1,2 @@
-import DashboardComponent from './dashboard-component';
-
-export default DashboardComponent;
+export { default as ChartModal } from './chart-modal';
+export { default as DashboardComponent } from './dashboard-component';

--- a/packages/bot-web-ui/src/components/dashboard/dashboard.scss
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard.scss
@@ -10,16 +10,20 @@
     @include mobile {
         padding: 2rem;
     }
+
     .dc-dialog {
         position: relative;
+
         &__header-wrapper {
             margin: 0 0 2.4rem;
         }
+
         &__content {
             &__header {
                 display: flex;
                 justify-content: space-between;
                 margin: 0 0 2.4rem;
+
                 .dc-icon {
                     cursor: pointer;
                 }
@@ -29,10 +33,12 @@
         @include mobile {
             &__footer {
                 flex-wrap: unset;
+
                 .dc-dialog__button {
                     &:first-child {
                         margin-right: 1rem;
                     }
+
                     padding: 0;
                     width: 40%;
                     min-width: unset;
@@ -201,6 +207,17 @@
         &--expanded {
             width: calc(100vw - 39.8rem);
         }
+
+        &--modal {
+            // position: fixed !important;
+            z-index: 99999999 !important;
+            width: 400px !important;
+            height: 500px !important;
+            // top: 0;
+            // left: calc(100% - 80rem);
+            // position: absolute;
+            // dashboard_chart-wrapper
+        }
     }
 
     &__toolbox {
@@ -298,13 +315,16 @@
 
     .injectionDiv {
         height: calc(100vh - 20rem);
+
         .blocklyTrash {
             transition: all 0.4s;
+
             @include mobile {
                 display: none;
             }
         }
     }
+
     &--tour-active {
         .blocklyTrash {
             display: none;
@@ -376,6 +396,7 @@
 
     &__content {
         text-align: left;
+
         p {
             font-size: 1.4rem;
         }
@@ -390,10 +411,12 @@
 
 .joyride-content {
     font-size: 1.4rem;
+
     @media (max-height: 790px) {
         max-height: 46vh;
         overflow-y: auto;
     }
+
     &__left {
         text-align: left;
 
@@ -460,6 +483,7 @@
 
     &--tour-position {
         top: 0;
+
         .progress-bar-circle:first-child {
             display: none;
         }
@@ -711,6 +735,7 @@
 
     .dc-toast {
         width: 100%;
+
         &__message {
             background: var(--text-prominent);
             color: var(--general-main-1);

--- a/packages/bot-web-ui/src/components/dashboard/dashboard.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard.tsx
@@ -7,23 +7,33 @@ import { api_base } from '@deriv/bot-skeleton/src/services/api/api-base';
 import { DesktopWrapper, Dialog, MobileWrapper, Tabs } from '@deriv/components';
 import { isMobile } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
-import { localize } from '@deriv/translations';
+import { Localize } from '@deriv/translations';
 import Chart from 'Components/chart';
 import { DBOT_TABS, TAB_IDS } from 'Constants/bot-contents';
 import { useDBotStore } from 'Stores/useDBotStore';
+import Draggable from '../draggable';
 import RunPanel from '../run-panel';
 import RunStrategy from './dashboard-component/run-strategy';
 import { tour_list } from './dbot-tours/utils';
-import DashboardComponent from './dashboard-component';
+import { ChartModal, DashboardComponent } from './dashboard-component';
 import StrategyNotification from './strategy-notification';
 import Tutorial from './tutorial-tab';
 
 const Dashboard = observer(() => {
     const { dashboard, load_modal, run_panel, quick_strategy, summary_card } = useDBotStore();
-    const { active_tab, active_tour, setActiveTab, setWebSocketState, setActiveTour } = dashboard;
+    const {
+        active_tab,
+        active_tour,
+        is_enabled_modal_chart,
+        setEnabledModalChart,
+        setActiveTab,
+        setWebSocketState,
+        setActiveTour,
+    } = dashboard;
     const { onEntered, dashboard_strategies } = load_modal;
     const { is_dialog_open, is_drawer_open, dialog_options, onCancelButtonClick, onCloseDialog, onOkButtonClick } =
         run_panel;
+    const { cancel_button_text, ok_button_text, title, message } = dialog_options as { [key: string]: string };
     const { is_strategy_modal_open } = quick_strategy;
     const { clear } = summary_card;
     const { DASHBOARD, BOT_BUILDER } = DBOT_TABS;
@@ -127,14 +137,26 @@ const Dashboard = observer(() => {
                         onTabItemClick={handleTabChange}
                         top
                     >
-                        <div icon='IcDashboardComponentTab' label={localize('Dashboard')} id='id-dbot-dashboard'>
+                        <div
+                            icon='IcDashboardComponentTab'
+                            label={<Localize i18n_default_text='Dashboard' />}
+                            id='id-dbot-dashboard'
+                        >
                             <DashboardComponent handleTabChange={handleTabChange} />
                         </div>
-                        <div icon='IcBotBuilderTabIcon' label={localize('Bot Builder')} id='id-bot-builder' />
-                        <div icon='IcChartsTabDbot' label={localize('Charts')} id='id-charts'>
+                        <div
+                            icon='IcBotBuilderTabIcon'
+                            label={<Localize i18n_default_text='Bot Builder' />}
+                            id='id-bot-builder'
+                        />
+                        <div icon='IcChartsTabDbot' label={<Localize i18n_default_text='Charts' />} id='id-charts'>
                             <Chart />
                         </div>
-                        <div icon='IcTutorialsTabs' label={localize('Tutorials')} id='id-tutorials'>
+                        <div
+                            icon='IcTutorialsTabs'
+                            label={<Localize i18n_default_text='Tutorials' />}
+                            id='id-tutorials'
+                        >
                             <div className='tutorials-wrapper'>
                                 <Tutorial />
                             </div>
@@ -150,9 +172,9 @@ const Dashboard = observer(() => {
             </DesktopWrapper>
             <MobileWrapper>{!is_strategy_modal_open && <RunPanel />}</MobileWrapper>
             <Dialog
-                cancel_button_text={dialog_options.cancel_button_text || localize('Cancel')}
+                cancel_button_text={cancel_button_text || <Localize i18n_default_text='Cancel' />}
                 className={'dc-dialog__wrapper--fixed'}
-                confirm_button_text={dialog_options.ok_button_text || localize('OK')}
+                confirm_button_text={ok_button_text || <Localize i18n_default_text='OK' />}
                 has_close_icon
                 is_mobile_full_width={false}
                 is_visible={is_dialog_open}
@@ -160,10 +182,19 @@ const Dashboard = observer(() => {
                 onClose={onCloseDialog}
                 onConfirm={onOkButtonClick || onCloseDialog}
                 portal_element_id='modal_root'
-                title={dialog_options.title}
+                title={title}
             >
-                {dialog_options.message}
+                {message}
             </Dialog>
+            <Draggable
+                xaxis={window.innerWidth / 2}
+                yaxis={window.innerHeight / 2}
+                is_visible={is_enabled_modal_chart}
+                header_title=''
+                onCloseDraggable={setEnabledModalChart}
+            >
+                <ChartModal setEnabledModalChart={setEnabledModalChart} />
+            </Draggable>
             <StrategyNotification />
         </React.Fragment>
     );

--- a/packages/bot-web-ui/src/stores/dashboard-store.ts
+++ b/packages/bot-web-ui/src/stores/dashboard-store.ts
@@ -33,6 +33,7 @@ export interface IDashboardStore {
     showVideoDialog: (param: { [key: string]: string }) => void;
     strategy_save_type: string;
     toast_message: string;
+    is_enabled_modal_chart: boolean;
 }
 
 export default class DashboardStore implements IDashboardStore {
@@ -78,6 +79,7 @@ export default class DashboardStore implements IDashboardStore {
             toast_message: observable,
             setStrategySaveType: action.bound,
             setShowMobileTourDialog: action.bound,
+            is_enabled_modal_chart: observable,
         });
         this.root_store = root_store;
         const {
@@ -134,6 +136,7 @@ export default class DashboardStore implements IDashboardStore {
     strategy_save_type = 'unsaved';
     toast_message = '';
     is_web_socket_intialised = true;
+    is_enabled_modal_chart = false;
 
     get is_dark_mode() {
         const {
@@ -157,6 +160,10 @@ export default class DashboardStore implements IDashboardStore {
     setOpenSettings = (toast_message: string, show_toast = true) => {
         this.toast_message = toast_message;
         this.show_toast = show_toast;
+    };
+
+    setEnabledModalChart = () => {
+        this.is_enabled_modal_chart = !this.is_enabled_modal_chart;
     };
 
     setIsFileSupported = (is_file_supported: boolean) => {


### PR DESCRIPTION
## Changes:

Being able to see the charts while building a bot:
1.1 The chart view should be displayed as a pop up window with an active background 
1.2 The chart pop up window should be movable around the screen. User should not be allowed to resize the screen. 
1.3 Tab(text and icon) should be disabled when modal window with charts are active 
1.4 To be handled only for desktop
1.5 Make as per design, available buttons for desktop version on modal window should be different depends on full window on the tab charts 
1.6 Adjust and the market dropdown list in the chart modal window

<img width="1712" alt="Screenshot 2023-10-05 at 13 39 43" src="https://github.com/binary-com/deriv-app/assets/103181650/69d97b34-797e-489c-a888-cd3083526792"> 
<img width="1712" alt="Screenshot 2023-10-05 at 13 39 48" src="https://github.com/binary-com/deriv-app/assets/103181650/e3b9e6e3-87aa-4cc2-a8f1-441565bc2545">
<img width="1712" alt="Screenshot 2023-10-05 at 13 41 31" src="https://github.com/binary-com/deriv-app/assets/103181650/ce89244b-9d25-433c-978f-9b78a175bb1c">






### Screenshots:

Please provide some screenshots of the change.

