### PR TITLE
Sergei / add isReady check for WS connection

### DIFF
--- a/packages/api/src/APIProvider.tsx
+++ b/packages/api/src/APIProvider.tsx
@@ -37,7 +37,10 @@ const getDerivAPIInstance = (): DerivAPIBasic => {
     }
 
     if (!window.DerivAPI?.[wss]) {
-        window.DerivAPI[wss] = new DerivAPIBasic({ connection: new WebSocket(wss) });
+        const DerivAPIBasicInstance = new DerivAPIBasic({ connection: new WebSocket(wss) });
+        window.DerivAPI[wss] = DerivAPIBasicInstance;
+        // add this to be consistent with socket_base
+        window.DerivAPI[wss].get = () => DerivAPIBasicInstance;
     }
 
     return window.DerivAPI?.[wss];

--- a/packages/api/src/__tests__/useMutation.spec.tsx
+++ b/packages/api/src/__tests__/useMutation.spec.tsx
@@ -3,6 +3,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import { TSocketResponse } from '../../types';
 import APIProvider from '../APIProvider';
 import useMutation from '../useMutation';
+import useAPI from '../useAPI';
 
 jest.mock('@deriv/shared', () => ({
     ...jest.requireActual('@deriv/shared'),
@@ -14,11 +15,13 @@ jest.mock('@deriv/shared', () => ({
                 echo_req: {},
             })
         ),
+        get: jest.fn(() => ({ connection: { readyState: 1 } })),
     }),
 }));
 
 describe('useMutation', () => {
     test('should call verify_email and get 1 in response', async () => {
+        useAPI;
         const wrapper = ({ children }: { children: JSX.Element }) => <APIProvider>{children}</APIProvider>;
 
         const { result, waitFor } = renderHook(() => useMutation('verify_email'), { wrapper });

--- a/packages/api/src/__tests__/usePaginatedFetch.spec.tsx
+++ b/packages/api/src/__tests__/usePaginatedFetch.spec.tsx
@@ -24,6 +24,7 @@ jest.mock('@deriv/shared', () => ({
                 req_id: 1,
             })
         ),
+        get: jest.fn(() => ({ connection: { readyState: 1 } })),
     }),
 }));
 

--- a/packages/api/src/__tests__/useQuery.spec.tsx
+++ b/packages/api/src/__tests__/useQuery.spec.tsx
@@ -15,6 +15,7 @@ jest.mock('@deriv/shared', () => ({
             })
         ),
         subscribe: jest.fn(),
+        get: jest.fn(() => ({ connection: { readyState: 1 } })),
     }),
 }));
 

--- a/packages/api/src/__tests__/useSubscription.spec.tsx
+++ b/packages/api/src/__tests__/useSubscription.spec.tsx
@@ -29,6 +29,7 @@ describe('useSubscription', () => {
                     },
                 };
             }),
+            get: jest.fn(() => ({ connection: { readyState: 1 } })),
         });
 
         const wrapper = ({ children }: { children: JSX.Element }) => <APIProvider>{children}</APIProvider>;

--- a/packages/api/src/useAPI.ts
+++ b/packages/api/src/useAPI.ts
@@ -1,4 +1,4 @@
-import { useCallback, useContext } from 'react';
+import { useCallback, useContext, useEffect, useState } from 'react';
 
 import type {
     TSocketEndpointNames,
@@ -12,6 +12,13 @@ import APIContext from './APIContext';
 
 const useAPI = () => {
     const api = useContext(APIContext);
+    const [isReady, setIsReady] = useState<boolean>(api?.get()?.connection?.readyState === 1);
+
+    useEffect(() => {
+        if ((api?.get()?.connection?.readyState === 1) !== isReady) {
+            setIsReady(api?.get()?.connection?.readyState === 1);
+        }
+    }, [api, isReady]);
 
     const send = useCallback(
         async <T extends TSocketEndpointNames | TSocketPaginateableEndpointNames = TSocketEndpointNames>(
@@ -49,6 +56,7 @@ const useAPI = () => {
     return {
         send,
         subscribe,
+        isReady,
     };
 };
 

--- a/packages/api/src/useAPI.ts
+++ b/packages/api/src/useAPI.ts
@@ -12,10 +12,10 @@ import APIContext from './APIContext';
 
 const useAPI = () => {
     const api = useContext(APIContext);
-    const [isReady, setIsReady] = useState<boolean>(api?.get()?.connection?.readyState === 1);
+    const [isReady, setIsReady] = useState<boolean>(api?.get()?.connection?.readyState === WebSocket.OPEN);
 
     useEffect(() => {
-        if ((api?.get()?.connection?.readyState === 1) !== isReady) {
+        if ((api?.get()?.connection?.readyState === WebSocket.OPEN) !== isReady) {
             setIsReady(api?.get()?.connection?.readyState === 1);
         }
     }, [api, isReady]);

--- a/packages/api/src/useAPI.ts
+++ b/packages/api/src/useAPI.ts
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useState } from 'react';
+import { useCallback, useContext } from 'react';
 
 import type {
     TSocketEndpointNames,
@@ -12,14 +12,6 @@ import APIContext from './APIContext';
 
 const useAPI = () => {
     const api = useContext(APIContext);
-    const readyState = api?.get()?.connection?.readyState;
-    const [isReady, setIsReady] = useState<boolean>(readyState === WebSocket.OPEN);
-
-    useEffect(() => {
-        if ((readyState === WebSocket.OPEN) !== isReady) {
-            setIsReady(readyState === WebSocket.OPEN);
-        }
-    }, [isReady, readyState]);
 
     const send = useCallback(
         async <T extends TSocketEndpointNames | TSocketPaginateableEndpointNames = TSocketEndpointNames>(
@@ -57,7 +49,7 @@ const useAPI = () => {
     return {
         send,
         subscribe,
-        isReady,
+        isReady: api?.get()?.connection?.readyState === WebSocket.OPEN,
     };
 };
 

--- a/packages/api/src/useAPI.ts
+++ b/packages/api/src/useAPI.ts
@@ -12,13 +12,14 @@ import APIContext from './APIContext';
 
 const useAPI = () => {
     const api = useContext(APIContext);
-    const [isReady, setIsReady] = useState<boolean>(api?.get()?.connection?.readyState === WebSocket.OPEN);
+    const readyState = api?.get()?.connection?.readyState;
+    const [isReady, setIsReady] = useState<boolean>(readyState === WebSocket.OPEN);
 
     useEffect(() => {
-        if ((api?.get()?.connection?.readyState === WebSocket.OPEN) !== isReady) {
-            setIsReady(api?.get()?.connection?.readyState === 1);
+        if ((readyState === WebSocket.OPEN) !== isReady) {
+            setIsReady(readyState === WebSocket.OPEN);
         }
-    }, [api, isReady]);
+    }, [isReady, readyState]);
 
     const send = useCallback(
         async <T extends TSocketEndpointNames | TSocketPaginateableEndpointNames = TSocketEndpointNames>(

--- a/packages/api/src/useQuery.ts
+++ b/packages/api/src/useQuery.ts
@@ -15,9 +15,12 @@ const useQuery = <T extends TSocketEndpointNames>(name: T, ...props: TSocketAcce
     const prop = props?.[0];
     const payload = prop && 'payload' in prop ? (prop.payload as TSocketRequestPayload<T>) : undefined;
     const options = prop && 'options' in prop ? (prop.options as TSocketRequestQueryOptions<T>) : undefined;
-    const { send } = useAPI();
+    const { send, isReady } = useAPI();
 
-    return _useQuery<TSocketResponseData<T>, unknown>(getQueryKeys(name, payload), () => send(name, payload), options);
+    return _useQuery<TSocketResponseData<T>, unknown>(getQueryKeys(name, payload), () => send(name, payload), {
+        ...options,
+        enabled: isReady && (options?.enabled ?? true),
+    });
 };
 
 export default useQuery;

--- a/packages/appstore/src/modules/wallets/wallets.tsx
+++ b/packages/appstore/src/modules/wallets/wallets.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { observer, useStore } from '@deriv/stores';
-import { ThemedScrollbars, Loading } from '@deriv/components';
+import { ThemedScrollbars } from '@deriv/components';
 import { useActiveWallet, useWalletsList } from '@deriv/hooks';
 import AddMoreWallets from 'Components/add-more-wallets';
 import ModalManager from 'Components/modals/modal-manager';
@@ -11,18 +11,16 @@ import './wallets.scss';
 
 const Wallets = observer(() => {
     const { client, ui } = useStore();
-    const { switchAccount, is_authorize } = client;
+    const { switchAccount } = client;
     const { is_mobile } = ui;
     const { data } = useWalletsList();
     const active_wallet = useActiveWallet();
 
     useEffect(() => {
-        if (!active_wallet && data && data?.length) {
+        if (!active_wallet && data?.[0]?.loginid) {
             switchAccount(data[0].loginid);
         }
     }, [active_wallet, data, switchAccount]);
-
-    if (!is_authorize) return <Loading is_fullscreen />;
 
     return (
         <ThemedScrollbars className='wallets-module' is_scrollbar_hidden>

--- a/packages/core/src/App/Components/Layout/Header/__tests__/menu-link.spec.tsx
+++ b/packages/core/src/App/Components/Layout/Header/__tests__/menu-link.spec.tsx
@@ -67,7 +67,7 @@ describe('MenuLink', () => {
 
         renderCheck();
         const link = screen.getByTestId('dt_menu_link');
-        expect(link.getAttribute('href')).toBeFalsy();
+        expect(link.onclick).toBeFalsy();
     });
 
     it('should render menu link if deriv_static_url', () => {

--- a/packages/core/src/App/Components/Layout/Header/__tests__/menu-link.spec.tsx
+++ b/packages/core/src/App/Components/Layout/Header/__tests__/menu-link.spec.tsx
@@ -67,7 +67,7 @@ describe('MenuLink', () => {
 
         renderCheck();
         const link = screen.getByTestId('dt_menu_link');
-        expect(link.onclick).toBeFalsy();
+        expect(link.getAttribute('href')).toBeFalsy();
     });
 
     it('should render menu link if deriv_static_url', () => {

--- a/packages/core/src/App/Components/Layout/Header/__tests__/menu-link.spec.tsx
+++ b/packages/core/src/App/Components/Layout/Header/__tests__/menu-link.spec.tsx
@@ -62,12 +62,13 @@ describe('MenuLink', () => {
         });
     };
 
-    it('should render no links with icon and text without passing link_to', () => {
+    it('should render proper class if as_disabled', () => {
+        mock_props.as_disabled = true;
         renderComponent();
 
         renderCheck();
         const link = screen.getByTestId('dt_menu_link');
-        expect(link.onclick).toBeFalsy();
+        expect(link).toHaveClass('dc-mobile-drawer__submenu-toggle--disabled');
     });
 
     it('should render menu link if deriv_static_url', () => {

--- a/packages/hooks/src/useAuthorize.ts
+++ b/packages/hooks/src/useAuthorize.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useQuery } from '@deriv/api';
+import { useFetch } from '@deriv/api';
 import { getActiveAuthTokenIDFromLocalStorage } from '@deriv/utils';
 
 /** A custom hook that authorize the user with the given token. If no token is given,
@@ -8,9 +8,13 @@ import { getActiveAuthTokenIDFromLocalStorage } from '@deriv/utils';
 const useAuthorize = () => {
     const current_token = getActiveAuthTokenIDFromLocalStorage();
 
-    const { data, ...rest } = useQuery('authorize', {
+    const { data, ...rest } = useFetch('authorize', {
         payload: { authorize: current_token || '' },
-        options: { enabled: Boolean(current_token), staleTime: Infinity, keepPreviousData: true },
+        options: {
+            enabled: Boolean(current_token),
+            /** infinite cache. Invalidate it when the user creates new wallet or new DTrader account */
+            staleTime: Infinity,
+        },
     });
 
     // Add additional information to the authorize response.

--- a/packages/hooks/src/useAuthorize.ts
+++ b/packages/hooks/src/useAuthorize.ts
@@ -1,15 +1,16 @@
 import { useMemo } from 'react';
-import { useFetch } from '@deriv/api';
+import { useQuery } from '@deriv/api';
 import { getActiveAuthTokenIDFromLocalStorage } from '@deriv/utils';
 
-/** A custom hook that authorize the user with the given token. If no token is given, it will use the current token. */
-const useAuthorize = (token?: string) => {
+/** A custom hook that authorize the user with the given token. If no token is given,
+ * it will use the current token from localStorage.
+ */
+const useAuthorize = () => {
     const current_token = getActiveAuthTokenIDFromLocalStorage();
-    const auth_token = token || current_token || '';
 
-    const { data, ...rest } = useFetch('authorize', {
-        payload: { authorize: auth_token },
-        options: { enabled: Boolean(auth_token) },
+    const { data, ...rest } = useQuery('authorize', {
+        payload: { authorize: current_token || '' },
+        options: { enabled: Boolean(current_token), staleTime: Infinity, keepPreviousData: true },
     });
 
     // Add additional information to the authorize response.

--- a/packages/hooks/src/useAuthorize.ts
+++ b/packages/hooks/src/useAuthorize.ts
@@ -14,6 +14,9 @@ const useAuthorize = () => {
             enabled: Boolean(current_token),
             /** infinite cache. Invalidate it when the user creates new wallet or new DTrader account */
             staleTime: Infinity,
+            /** need this to prevent loading when the user switches between wallets */
+            /** TODO: move this property to hook which will use account_list endpoint */
+            keepPreviousData: true,
         },
     });
 

--- a/packages/hooks/src/useWalletMigration.ts
+++ b/packages/hooks/src/useWalletMigration.ts
@@ -1,15 +1,9 @@
 import { useCallback } from 'react';
-import { useAuthorize, useFetch, useInvalidateQuery, useRequest } from '@deriv/api';
-import { useStore } from '@deriv/stores';
+import { useFetch, useInvalidateQuery, useRequest } from '@deriv/api';
+import useAuthorize from './useAuthorize';
 
 /** A custom hook to get the status of wallet_migration API and to start/reset the migration process */
 const useWalletMigration = () => {
-    // TODO: delete it later, it's a temporary solution
-    // because we have to check for authorize from client store before doing API call
-    // This hook will be refactored later for subscribe when BE is ready
-    const { client } = useStore();
-    const { is_authorize } = client;
-
     const invalidate = useInvalidateQuery();
 
     /** Make a request to wallet_migration API and onSuccess it will invalidate the cached data  */
@@ -23,7 +17,7 @@ const useWalletMigration = () => {
         options: {
             refetchInterval: response => (response?.wallet_migration?.state === 'in_progress' ? 500 : false),
             // delete it later
-            enabled: is_authorize && isSuccess,
+            enabled: isSuccess,
         },
     });
 

--- a/packages/hooks/src/useWalletsList.ts
+++ b/packages/hooks/src/useWalletsList.ts
@@ -5,6 +5,7 @@ import { useStore } from '@deriv/stores';
 
 import useAuthorize from './useAuthorize';
 import useCurrencyConfig from './useCurrencyConfig';
+import useBalance from './useBalance';
 
 const currency_to_icon_mapper: Record<string, Record<'light' | 'dark', string>> = {
     Demo: {
@@ -64,16 +65,12 @@ const currency_to_icon_mapper: Record<string, Record<'light' | 'dark', string>> 
 /** A custom hook to get the list of wallets for the current user. */
 /** @deprecated Use `useWalletAccountsList` instead. */
 const useWalletsList = () => {
-    const { ui, client } = useStore();
+    const { ui } = useStore();
     const { is_dark_mode_on } = ui;
-    const { is_authorize } = client;
     const { getConfig } = useCurrencyConfig();
 
-    const { data: authorize_data, isSuccess, ...rest } = useAuthorize();
-    const { data: balance_data } = useFetch('balance', {
-        payload: { account: 'all' },
-        options: { enabled: is_authorize && isSuccess },
-    });
+    const { data: authorize_data, ...rest } = useAuthorize();
+    const { data: balance_data } = useBalance();
 
     // Filter out non-wallet accounts.
     const wallets = useMemo(
@@ -87,9 +84,9 @@ const useWalletsList = () => {
             wallets?.map(wallet => ({
                 ...wallet,
                 /** Wallet balance */
-                balance: balance_data?.balance?.accounts?.[wallet.loginid || '']?.balance || 0,
+                balance: balance_data?.accounts?.[wallet.loginid || '']?.balance || 0,
             })),
-        [balance_data?.balance?.accounts, wallets]
+        [balance_data?.accounts, wallets]
     );
 
     // Add additional information to each wallet.


### PR DESCRIPTION
## Changes:

QA29 | 1011

- Add isReady check to useAPI
- Check WS is open before make API request by useQuery
- Delete loading screen when user switches between wallets

