### PR TITLE
Shafin/bot 685/chore  filter dialog test case

### DIFF
--- a/packages/bot-web-ui/src/components/journal/journal-components/__tests__/filter-dialog.spec.tsx
+++ b/packages/bot-web-ui/src/components/journal/journal-components/__tests__/filter-dialog.spec.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { mockStore, StoreProvider } from '@deriv/stores';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { act, render, screen, waitFor } from '@testing-library/react';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import userEvent from '@testing-library/user-event';
+import { mock_ws } from 'Utils/mock';
+import RootStore from 'Stores/index';
+import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
+import FilterDialog from '../filter-dialog';
+
+jest.mock('@deriv/shared', () => ({
+    ...jest.requireActual('@deriv/shared'),
+    isMobile: () => false,
+}));
+
+jest.mock('@deriv/bot-skeleton/src/scratch/blockly', () => jest.fn());
+jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => ({
+    saveRecentWorkspace: jest.fn(),
+    unHighlightAllBlocks: jest.fn(),
+}));
+jest.mock('@deriv/bot-skeleton/src/scratch/hooks/block_svg', () => jest.fn());
+jest.mock('@deriv/deriv-charts', () => ({
+    setSmartChartsPublicPath: jest.fn(),
+}));
+
+const mockProps = {
+    toggle_ref: { current: null },
+    checked_filters: [],
+    filters: [
+        { id: 'error', label: 'Errors' },
+        { id: 'notify', label: 'Notifications' },
+        { id: 'success', label: 'System' },
+    ],
+    is_filter_dialog_visible: true,
+    filterMessage: jest.fn(),
+    toggleFilterDialog: jest.fn(),
+};
+describe('Draggable', () => {
+    let wrapper: ({ children }: { children: JSX.Element }) => JSX.Element, mock_DBot_store: RootStore | undefined;
+
+    beforeEach(() => {
+        jest.resetModules();
+        const mock_store = mockStore({});
+        mock_DBot_store = mockDBotStore(mock_store, mock_ws);
+
+        wrapper = ({ children }: { children: JSX.Element }) => (
+            <StoreProvider store={mock_store}>
+                <DBotStoreProvider ws={mock_ws} mock={mock_DBot_store}>
+                    {children}
+                </DBotStoreProvider>
+            </StoreProvider>
+        );
+    });
+
+    test('should renders FilterDialog', () => {
+        const { container } = render(<FilterDialog {...mockProps} />, {
+            wrapper,
+        });
+        expect(container).toBeInTheDocument();
+    });
+
+    test('should render FilterDialog with filters', () => {
+        render(<FilterDialog {...mockProps} />, {
+            wrapper,
+        });
+        const filterMessageElement = screen.getByText('Errors');
+        expect(filterMessageElement).toBeInTheDocument();
+    });
+
+    test('should call toggleFilterDialog when clicking outside the dialog', async () => {
+        const { container } = render(<FilterDialog {...mockProps} />, { wrapper });
+        act(() => {
+            userEvent.click(container);
+        });
+        await waitFor(() => expect(mockProps.toggleFilterDialog).toHaveBeenCalled());
+    });
+});

--- a/packages/bot-web-ui/src/components/journal/journal-components/__tests__/filter-dialog.spec.tsx
+++ b/packages/bot-web-ui/src/components/journal/journal-components/__tests__/filter-dialog.spec.tsx
@@ -9,11 +9,6 @@ import RootStore from 'Stores/index';
 import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
 import FilterDialog from '../filter-dialog';
 
-jest.mock('@deriv/shared', () => ({
-    ...jest.requireActual('@deriv/shared'),
-    isMobile: () => false,
-}));
-
 jest.mock('@deriv/bot-skeleton/src/scratch/blockly', () => jest.fn());
 jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => ({
     saveRecentWorkspace: jest.fn(),
@@ -36,11 +31,11 @@ const mockProps = {
     filterMessage: jest.fn(),
     toggleFilterDialog: jest.fn(),
 };
+
 describe('Draggable', () => {
     let wrapper: ({ children }: { children: JSX.Element }) => JSX.Element, mock_DBot_store: RootStore | undefined;
 
-    beforeEach(() => {
-        jest.resetModules();
+    beforeAll(() => {
         const mock_store = mockStore({});
         mock_DBot_store = mockDBotStore(mock_store, mock_ws);
 

--- a/packages/bot-web-ui/src/components/journal/journal-components/__tests__/filter-dialog.spec.tsx
+++ b/packages/bot-web-ui/src/components/journal/journal-components/__tests__/filter-dialog.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mockStore, StoreProvider } from '@deriv/stores';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import userEvent from '@testing-library/user-event';
 import { mock_ws } from 'Utils/mock';

--- a/packages/bot-web-ui/src/components/journal/journal-components/__tests__/filter-dialog.spec.tsx
+++ b/packages/bot-web-ui/src/components/journal/journal-components/__tests__/filter-dialog.spec.tsx
@@ -63,11 +63,9 @@ describe('Draggable', () => {
         expect(filterMessageElement).toBeInTheDocument();
     });
 
-    test('should call toggleFilterDialog when clicking outside the dialog', async () => {
+    test('should call toggleFilterDialog when clicking outside the dialog', () => {
         const { container } = render(<FilterDialog {...mockProps} />, { wrapper });
-        act(() => {
-            userEvent.click(container);
-        });
-        await waitFor(() => expect(mockProps.toggleFilterDialog).toHaveBeenCalled());
+        userEvent.click(container);
+        expect(mockProps.toggleFilterDialog).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## Changes:

Test case for the journal filter dialog component

- Test if the FilterDialog component renders properly
- Test if the FilterDialog shows the filters in the UI that are passed to it
- Test if toggleFilterDialog which is to toggle the pop-up (open/close state) gets called if the user clicks outside of the pop-up
