### PR TITLE
Maryia/Bot-682/test: add test case for flyout-text.jsx

### DIFF
--- a/packages/bot-web-ui/src/components/flyout/__tests__/flyout-text.spec.tsx
+++ b/packages/bot-web-ui/src/components/flyout/__tests__/flyout-text.spec.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import FlyoutText from '../help-contents/flyout-text';
+
+describe('FlyoutText', () => {
+    const sampleText = 'Sample text for testing';
+
+    beforeEach(() => {
+        render(<FlyoutText text={sampleText} />);
+    });
+
+    it('renders the provided text', () => {
+        const renderedText = screen.getByText(sampleText);
+
+        expect(renderedText).toBeInTheDocument();
+    });
+
+    it('renders with the correct styles', () => {
+        const renderedText = screen.getByText(sampleText);
+
+        expect(renderedText).toHaveStyle('lineHeight: 1.3em');
+    });
+});

--- a/packages/bot-web-ui/src/components/flyout/help-contents/flyout-help-base.jsx
+++ b/packages/bot-web-ui/src/components/flyout/help-contents/flyout-help-base.jsx
@@ -6,7 +6,7 @@ import { help_content_config, help_content_types } from 'Utils/help-content/help
 import { useDBotStore } from 'Stores/useDBotStore';
 import FlyoutBlock from '../flyout-block.jsx';
 import FlyoutImage from './flyout-img.jsx';
-import FlyoutText from './flyout-text.jsx';
+import FlyoutText from './flyout-text';
 import FlyoutVideo from './flyout-video.jsx';
 
 const HelpBase = observer(() => {

--- a/packages/bot-web-ui/src/components/flyout/help-contents/flyout-text.tsx
+++ b/packages/bot-web-ui/src/components/flyout/help-contents/flyout-text.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { PropTypes } from 'prop-types';
 import { Text } from '@deriv/components';
 
-const FlyoutText = props => {
+const FlyoutText = (props: { text: string }) => {
     const { text } = props;
 
     return (
@@ -10,10 +9,6 @@ const FlyoutText = props => {
             {text}
         </Text>
     );
-};
-
-FlyoutText.propTypes = {
-    text: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
 };
 
 export default FlyoutText;


### PR DESCRIPTION
## Changes:

1. add test case for flyout-text.jsx
2. convert flyout-text **.jsx** to **.tsx**

### Screenshots:

<img width="1725" alt="Screenshot 2023-10-09 at 12 27 12" src="https://github.com/binary-com/deriv-app/assets/103181650/88884d47-1e1c-4b3f-a211-c9590acee21f">

