### PR TITLE
Ako/ Disable import sort order auto-fix temporarily

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,5 +1,5 @@
 {
     "*.{js,jsx,ts,tsx,md,html,css,scss}": "prettier --write",
-    "*.{js,jsx,ts,tsx}": "eslint --fix --config .eslintrc.js",
+    "*.{js,jsx,ts,tsx}": "eslint --fix --config .eslintrc.js --rule 'simple-import-sort/imports: 0'",
     "*.{css,scss}": "npx stylelint --fix"
 }


### PR DESCRIPTION
## Changes:

This is causing lots of issues, Disabling the rule temporarily to fix in the next step.
