### PR TITLE
feat: reduced appstore bundle size due to onfido

### DIFF
--- a/packages/account/src/Sections/Verification/ProofOfIdentity/onfido-sdk-view-container.tsx
+++ b/packages/account/src/Sections/Verification/ProofOfIdentity/onfido-sdk-view-container.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import countries from 'i18n-iso-countries';
-import { init, SdkHandle, SdkResponse, SupportedLanguages } from 'onfido-sdk-ui';
+import type { SdkHandle, SdkResponse, SupportedLanguages } from 'onfido-sdk-ui';
 import { CSSTransition } from 'react-transition-group';
 import { GetSettings, ResidenceList } from '@deriv/api-types';
 import { Loading, ThemedScrollbars } from '@deriv/components';
@@ -99,7 +99,9 @@ const OnfidoSdkViewContainer = ({
         async (service_token: string) => {
             if (!service_token) return;
             try {
-                onfido_init.current = await init({
+                const onfido = await import('onfido-sdk-ui');
+
+                onfido_init.current = await onfido.init({
                     containerId: 'onfido',
                     language: {
                         locale: (getLanguage().toLowerCase() as SupportedLanguages) || 'en',

--- a/packages/appstore/webpack.config.js
+++ b/packages/appstore/webpack.config.js
@@ -182,6 +182,33 @@ module.exports = function (env) {
                       new CssMinimizerPlugin(),
                   ]
                 : [],
+            splitChunks: {
+                chunks: 'all',
+                minChunks: 1,
+                cacheGroups: {
+                    default: {
+                        minChunks: 2,
+                        minSize: 102400,
+                        priority: -20,
+                        reuseExistingChunk: true,
+                    },
+                    account: {
+                        idHint: 'account',
+                        test: /[\\/]account\//,
+                        priority: -20,
+                    },
+                    onfido: {
+                        idHint: 'onfido',
+                        test: /[\\/]onfido\//,
+                        priority: -10,
+                    },
+                    defaultVendors: {
+                        idHint: 'vendors',
+                        test: /[\\/]node_modules[\\/]/,
+                        priority: -10,
+                    },
+                },
+            },
         },
         devtool: is_release ? 'source-map' : 'eval-cheap-module-source-map',
         externals: [


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- `onfido-sdk-ui` and `@onfido` when bundled with other dependencies has a size of 34MB, thus this dependency is bundled into a separate chunk in order to only load it during onfido verification process and reduce the size of each chunk in appstore and allow each chunk size to not exceed 25MB for Cloudflare deployment
<img width="1840" alt="Screenshot 2023-10-06 at 4 00 04 PM" src="https://github.com/binary-com/deriv-app/assets/103016120/3fbbba1b-5d38-47c4-82a9-422a6cd29876">
The dependency bundle which contains onfido is downloaded on first load in Trader's Hub:
<img width="1724" alt="Screenshot 2023-10-06 at 4 30 39 PM" src="https://github.com/binary-com/deriv-app/assets/103016120/56387785-9d30-4f5f-bc90-ac2d31c908ab">


#### After separating onfido and accounts into their own chunks:
<img width="1774" alt="Screenshot 2023-10-06 at 12 23 53 PM" src="https://github.com/binary-com/deriv-app/assets/103016120/d70f024f-35c2-43e7-bab9-c3e177a901c7">

<img width="1840" alt="Screenshot 2023-10-06 at 12 20 41 PM" src="https://github.com/binary-com/deriv-app/assets/103016120/6bd0b735-9809-4f91-81ab-6eac01f4ff8e">
The onfido bundle is only downloaded when required during the verification process:

https://github.com/binary-com/deriv-app/assets/103016120/c0a7cdce-abc0-46c7-acda-73c279da626e




### Screenshots:

Please provide some screenshots of the change.
