### PR TITLE
Kate / DTRA-438 / Add 'NEW!' label for Multipliers dropdown and widget

### DIFF
--- a/packages/components/src/components/dropdown/dropdown.scss
+++ b/packages/components/src/components/dropdown/dropdown.scss
@@ -118,6 +118,21 @@
     &__container {
         position: relative;
     }
+    &__label--new {
+        position: absolute;
+        right: 1rem;
+        top: calc(50% - 7px);
+        padding: 0.3rem 0.4rem;
+        border-radius: 16px;
+        font-size: 1rem;
+        font-weight: bold;
+        background-color: var(--text-loss-danger);
+        color: var(--status-colored-background);
+        @include mobile {
+            position: initial;
+            margin-bottom: 0;
+        }
+    }
     &__hint {
         margin-left: 1.2rem;
     }

--- a/packages/components/src/components/dropdown/dropdown.scss
+++ b/packages/components/src/components/dropdown/dropdown.scss
@@ -120,18 +120,12 @@
     }
     &__label--new {
         position: absolute;
-        right: 1rem;
+        right: 0.8rem;
         top: calc(50% - 7px);
-        padding: 0.3rem 0.4rem;
+        padding: 0 0.4rem;
         border-radius: 16px;
-        font-size: 1rem;
-        font-weight: bold;
         background-color: var(--text-loss-danger);
         color: var(--status-colored-background);
-        @include mobile {
-            position: initial;
-            margin-bottom: 0;
-        }
     }
     &__hint {
         margin-left: 1.2rem;

--- a/packages/components/src/components/dropdown/dropdown.scss
+++ b/packages/components/src/components/dropdown/dropdown.scss
@@ -123,7 +123,7 @@
         right: 0.8rem;
         top: calc(50% - 7px);
         padding: 0 0.4rem;
-        border-radius: 16px;
+        border-radius: $BORDER_RADIUS * 4;
         background-color: var(--text-loss-danger);
         color: var(--status-colored-background);
     }

--- a/packages/components/src/components/dropdown/dropdown.tsx
+++ b/packages/components/src/components/dropdown/dropdown.tsx
@@ -508,9 +508,9 @@ const Dropdown = ({
                         value={value}
                     />
                     {should_show_new_label && (
-                        <span className='dc-dropdown__label--new'>
+                        <Text className='dc-dropdown__label--new' weight='bold' size='xxxs' line_height='s'>
                             <Localize i18n_default_text='NEW!' />
-                        </span>
+                        </Text>
                     )}
                 </div>
                 {!error && hint && (

--- a/packages/components/src/components/dropdown/dropdown.tsx
+++ b/packages/components/src/components/dropdown/dropdown.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import { CSSTransition } from 'react-transition-group';
 import { mobileOSDetect, getPosition } from '@deriv/shared';
 import { TList, findNextFocusableNode, findPreviousFocusableNode, TListItem } from './utility';
+import { Localize } from '@deriv/translations';
 import Items from './items';
 import DisplayText from './display-text';
 import Text from '../text/text';
@@ -43,6 +44,7 @@ type TDropdown = {
     onClick?: () => void;
     placeholder?: string;
     suffix_icon?: string;
+    should_show_new_label?: boolean;
     test_id?: string;
     value?: string | number;
     classNameIcon?: string;
@@ -260,6 +262,7 @@ const Dropdown = ({
     onClick,
     placeholder,
     suffix_icon,
+    should_show_new_label = false,
     test_id,
     value,
     classNameIcon,
@@ -504,6 +507,11 @@ const Dropdown = ({
                         suffix_icon={suffix_icon}
                         value={value}
                     />
+                    {should_show_new_label && (
+                        <span className='dc-dropdown__label--new'>
+                            <Localize i18n_default_text='NEW!' />
+                        </span>
+                    )}
                 </div>
                 {!error && hint && (
                     <Text

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/widgets.spec.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/widgets.spec.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 import { mockStore } from '@deriv/stores';
+import { AccumulatorOptionsWidget, MultiplierOptionsWidget } from '../widgets';
 import TraderProviders from '../../../../../../../trader-providers';
-import { AccumulatorOptionsWidget } from '../widgets';
 
-const default_mock_store = {
+const default_mock_store_accumulators = {
     modules: {
         trade: {
             growth_rate: 0.01,
@@ -14,6 +14,16 @@ const default_mock_store = {
         },
     },
 };
+const default_mock_store_multipliers = {
+    modules: {
+        trade: {
+            multiplier: 10,
+            symbol: '1HZ150V',
+        },
+    },
+    active_symbols: { active_symbols: [{ submarket_display_name: 'Continuous Indices', symbol: '1HZ150V' }] },
+};
+const new_label = 'NEW!';
 
 jest.mock('Modules/Trading/Containers/radio-group-options-modal', () =>
     jest.fn(prop => (
@@ -33,15 +43,13 @@ describe('AccumulatorOptionsWidget', () => {
     };
 
     it('should render component with extra tooltip', () => {
-        const mock_root_store = mockStore(default_mock_store);
-        render(mockAccumulatorOptionsWidget(mock_root_store));
+        render(mockAccumulatorOptionsWidget(mockStore(default_mock_store_accumulators)));
 
         expect(screen.getByText(/1%/i)).toBeInTheDocument();
         expect(screen.getByTestId(/dt_popover_wrapper/i)).toBeInTheDocument();
     });
     it('should render tooltip with text if user click on info icon, but should not open RadioGroupOptionsModal', () => {
-        const mock_root_store = mockStore(default_mock_store);
-        render(mockAccumulatorOptionsWidget(mock_root_store));
+        render(mockAccumulatorOptionsWidget(mockStore(default_mock_store_accumulators)));
 
         const info_icon = screen.getByTestId(/dt_popover_wrapper/i);
         userEvent.click(info_icon);
@@ -50,17 +58,55 @@ describe('AccumulatorOptionsWidget', () => {
         expect(screen.getByText(/RadioGroupOptionsModal/i)).toHaveAttribute('data-open', 'false');
     });
     it('if Accum contract is not open, user is able to open RadioGroupOptionsModal', () => {
-        const new_mock_store = { ...default_mock_store };
+        const new_mock_store = { ...default_mock_store_accumulators };
         new_mock_store.modules.trade = {
             growth_rate: 0.01,
             has_open_accu_contract: false,
             tick_size_barrier: 0,
         };
-        const mock_root_store = mockStore(new_mock_store);
-        render(mockAccumulatorOptionsWidget(mock_root_store));
+        render(mockAccumulatorOptionsWidget(mockStore(new_mock_store)));
 
         const toggle_button = screen.getByText(/RadioGroupOptionsModal/i);
         userEvent.click(toggle_button);
+
+        expect(screen.getByText(/RadioGroupOptionsModal/i)).toHaveAttribute('data-open', 'true');
+    });
+});
+
+describe('MultiplierOptionsWidget', () => {
+    const mockMultiplierOptionsWidget = mocked_store => {
+        return (
+            <TraderProviders store={mocked_store}>
+                <MultiplierOptionsWidget />
+            </TraderProviders>
+        );
+    };
+
+    it('should render component with multipliers value', () => {
+        render(mockMultiplierOptionsWidget(mockStore(default_mock_store_multipliers)));
+
+        expect(screen.getByText(/x10/i)).toBeInTheDocument();
+    });
+    it('should not render new! label if chosen symbol is not syntetic or is equal to Vol 150 (1 sec) or 250 (1 sec)', () => {
+        render(mockMultiplierOptionsWidget(mockStore(default_mock_store_multipliers)));
+
+        expect(screen.queryByText(new_label)).not.toBeInTheDocument();
+    });
+    it('should render new! label if chosen symbol is syntetic and is not equal to Vol 150 (1 sec) or 250 (1 sec)', () => {
+        const new_mock_store = { ...default_mock_store_multipliers };
+        new_mock_store.modules.trade.symbol = '1HZ100V';
+        new_mock_store.active_symbols = {
+            active_symbols: [{ submarket_display_name: 'Continuous Indices', symbol: '1HZ100V' }],
+        };
+        render(mockMultiplierOptionsWidget(mockStore(new_mock_store)));
+
+        expect(screen.getByText(new_label)).toBeInTheDocument();
+    });
+    it('shoul open RadioGroupOptionsModal if user clicked on Multiplier mobile widget', () => {
+        render(mockMultiplierOptionsWidget(mockStore(default_mock_store_multipliers)));
+
+        expect(screen.getByText(/RadioGroupOptionsModal/i)).toHaveAttribute('data-open', 'false');
+        userEvent.click(screen.getByText(/x10/i));
 
         expect(screen.getByText(/RadioGroupOptionsModal/i)).toHaveAttribute('data-open', 'true');
     });

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/widgets.spec.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/widgets.spec.jsx
@@ -21,7 +21,6 @@ const default_mock_store_multipliers = {
             symbol: '1HZ150V',
         },
     },
-    active_symbols: { active_symbols: [{ submarket_display_name: 'Continuous Indices', symbol: '1HZ150V' }] },
 };
 const new_label = 'NEW!';
 
@@ -95,9 +94,7 @@ describe('MultiplierOptionsWidget', () => {
     it('should render new! label if chosen symbol is syntetic and is not equal to Vol 150 (1 sec) or 250 (1 sec)', () => {
         const new_mock_store = { ...default_mock_store_multipliers };
         new_mock_store.modules.trade.symbol = '1HZ100V';
-        new_mock_store.active_symbols = {
-            active_symbols: [{ submarket_display_name: 'Continuous Indices', symbol: '1HZ100V' }],
-        };
+
         render(mockMultiplierOptionsWidget(mockStore(new_mock_store)));
 
         expect(screen.getByText(new_label)).toBeInTheDocument();

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/multiplier.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/multiplier.jsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import { Dropdown } from '@deriv/components';
 import { useTraderStore } from 'Stores/useTraderStores';
-import { observer } from '@deriv/stores';
+import { observer, useStore } from '@deriv/stores';
+import { showLabelForMultipliers } from '../../../../Helpers/contract-type';
 
 const Multiplier = observer(() => {
-    const { multiplier, multiplier_range_list, onChange } = useTraderStore();
+    const { multiplier, multiplier_range_list, onChange, symbol } = useTraderStore();
+    const {
+        active_symbols: { active_symbols },
+    } = useStore();
     return (
         <Dropdown
             id='multiplier'
@@ -16,6 +20,7 @@ const Multiplier = observer(() => {
             no_border={true}
             value={multiplier}
             onChange={onChange}
+            should_show_new_label={showLabelForMultipliers(symbol, active_symbols)}
         />
     );
 });

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/multiplier.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/multiplier.jsx
@@ -1,14 +1,11 @@
 import React from 'react';
 import { Dropdown } from '@deriv/components';
 import { useTraderStore } from 'Stores/useTraderStores';
-import { observer, useStore } from '@deriv/stores';
+import { observer } from '@deriv/stores';
 import { showLabelForMultipliers } from '../../../../Helpers/contract-type';
 
 const Multiplier = observer(() => {
     const { multiplier, multiplier_range_list, onChange, symbol } = useTraderStore();
-    const {
-        active_symbols: { active_symbols },
-    } = useStore();
     return (
         <Dropdown
             id='multiplier'
@@ -20,7 +17,7 @@ const Multiplier = observer(() => {
             no_border={true}
             value={multiplier}
             onChange={onChange}
-            should_show_new_label={showLabelForMultipliers(symbol, active_symbols)}
+            should_show_new_label={showLabelForMultipliers(symbol)}
         />
     );
 });

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/widgets.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/widgets.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { Money, Text, Popover } from '@deriv/components';
 import { useTraderStore } from 'Stores/useTraderStores';
-import { observer } from '@deriv/stores';
+import { observer, useStore } from '@deriv/stores';
 import MultiplierAmountModal from 'Modules/Trading/Containers/Multiplier/multiplier-amount-modal.jsx';
 import RadioGroupOptionsModal from 'Modules/Trading/Containers/radio-group-options-modal';
 import MultipliersExpiration from 'Modules/Trading/Components/Form/TradeParams/Multiplier/expiration.jsx';
@@ -10,6 +10,7 @@ import MultipliersExpirationModal from 'Modules/Trading/Components/Form/TradePar
 import MultipliersInfo from 'Modules/Trading/Components/Form/TradeParams/Multiplier/info.jsx';
 import { localize, Localize } from '@deriv/translations';
 import { getGrowthRatePercentage, getTickSizeBarrierPercentage } from '@deriv/shared';
+import { showLabelForMultipliers } from '../../../../Helpers/contract-type';
 
 const AmountWidget = ({ amount, currency, expiration, is_crypto_multiplier }) => {
     const [is_open, setIsOpen] = React.useState(false);
@@ -68,7 +69,13 @@ export const MultiplierAmountWidget = observer(() => {
     return <AmountWidget {...amount_widget_props} />;
 });
 
-const RadioGroupOptionsWidget = ({ displayed_trade_param, tooltip_message, is_disabled, modal_title }) => {
+const RadioGroupOptionsWidget = ({
+    displayed_trade_param,
+    tooltip_message,
+    is_disabled,
+    modal_title,
+    shoud_show_new_label,
+}) => {
     const [is_open, setIsOpen] = React.useState(false);
 
     const toggleModal = () => {
@@ -79,7 +86,13 @@ const RadioGroupOptionsWidget = ({ displayed_trade_param, tooltip_message, is_di
     return (
         <React.Fragment>
             <RadioGroupOptionsModal is_open={is_open} toggleModal={toggleModal} modal_title={modal_title} />
-            <div className='mobile-widget mobile-widget__multiplier-options' onClick={toggleModal}>
+            <div
+                className={classNames('mobile-widget mobile-widget__multiplier-options', {
+                    'mobile-widget__wide': tooltip_message || shoud_show_new_label,
+                    'mobile-widget__row': shoud_show_new_label,
+                })}
+                onClick={toggleModal}
+            >
                 <div
                     className={classNames('mobile-widget__item', {
                         'mobile-widget__item-disabled': is_disabled,
@@ -99,16 +112,30 @@ const RadioGroupOptionsWidget = ({ displayed_trade_param, tooltip_message, is_di
                         />
                     </span>
                 )}
+                {shoud_show_new_label && (
+                    <span className='dc-dropdown__label--new'>
+                        <Localize i18n_default_text='NEW!' />
+                    </span>
+                )}
             </div>
         </React.Fragment>
     );
 };
 
 export const MultiplierOptionsWidget = observer(() => {
-    const { multiplier } = useTraderStore();
+    const { multiplier, symbol } = useTraderStore();
+    const {
+        active_symbols: { active_symbols },
+    } = useStore();
     const displayed_trade_param = `x${multiplier}`;
     const modal_title = localize('Multiplier');
-    return <RadioGroupOptionsWidget displayed_trade_param={displayed_trade_param} modal_title={modal_title} />;
+    return (
+        <RadioGroupOptionsWidget
+            displayed_trade_param={displayed_trade_param}
+            modal_title={modal_title}
+            shoud_show_new_label={showLabelForMultipliers(symbol, active_symbols)}
+        />
+    );
 });
 
 export const AccumulatorOptionsWidget = observer(() => {

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/widgets.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/widgets.jsx
@@ -89,6 +89,7 @@ const RadioGroupOptionsWidget = ({
             <div
                 className={classNames('mobile-widget mobile-widget__multiplier-options', {
                     'mobile-widget__label': shoud_show_new_label,
+                    'mobile-widget__wide': !tooltip_message,
                 })}
                 onClick={toggleModal}
             >

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/widgets.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/widgets.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { Money, Text, Popover } from '@deriv/components';
 import { useTraderStore } from 'Stores/useTraderStores';
-import { observer, useStore } from '@deriv/stores';
+import { observer } from '@deriv/stores';
 import MultiplierAmountModal from 'Modules/Trading/Containers/Multiplier/multiplier-amount-modal.jsx';
 import RadioGroupOptionsModal from 'Modules/Trading/Containers/radio-group-options-modal';
 import MultipliersExpiration from 'Modules/Trading/Components/Form/TradeParams/Multiplier/expiration.jsx';
@@ -74,7 +74,7 @@ const RadioGroupOptionsWidget = ({
     tooltip_message,
     is_disabled,
     modal_title,
-    shoud_show_new_label,
+    should_show_new_label,
 }) => {
     const [is_open, setIsOpen] = React.useState(false);
 
@@ -88,7 +88,7 @@ const RadioGroupOptionsWidget = ({
             <RadioGroupOptionsModal is_open={is_open} toggleModal={toggleModal} modal_title={modal_title} />
             <div
                 className={classNames('mobile-widget mobile-widget__multiplier-options', {
-                    'mobile-widget__label': shoud_show_new_label,
+                    'mobile-widget__label': should_show_new_label,
                     'mobile-widget__wide': !tooltip_message,
                 })}
                 onClick={toggleModal}
@@ -112,7 +112,7 @@ const RadioGroupOptionsWidget = ({
                         />
                     </span>
                 )}
-                {shoud_show_new_label && (
+                {should_show_new_label && (
                     <Text className='dc-dropdown__label--new' weight='bold' size='xxxs' line_height='s'>
                         <Localize i18n_default_text='NEW!' />
                     </Text>
@@ -124,16 +124,13 @@ const RadioGroupOptionsWidget = ({
 
 export const MultiplierOptionsWidget = observer(() => {
     const { multiplier, symbol } = useTraderStore();
-    const {
-        active_symbols: { active_symbols },
-    } = useStore();
     const displayed_trade_param = `x${multiplier}`;
     const modal_title = localize('Multiplier');
     return (
         <RadioGroupOptionsWidget
             displayed_trade_param={displayed_trade_param}
             modal_title={modal_title}
-            shoud_show_new_label={showLabelForMultipliers(symbol, active_symbols)}
+            should_show_new_label={showLabelForMultipliers(symbol)}
         />
     );
 });

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/widgets.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/widgets.jsx
@@ -88,8 +88,7 @@ const RadioGroupOptionsWidget = ({
             <RadioGroupOptionsModal is_open={is_open} toggleModal={toggleModal} modal_title={modal_title} />
             <div
                 className={classNames('mobile-widget mobile-widget__multiplier-options', {
-                    'mobile-widget__wide': tooltip_message || shoud_show_new_label,
-                    'mobile-widget__row': shoud_show_new_label,
+                    'mobile-widget__label': shoud_show_new_label,
                 })}
                 onClick={toggleModal}
             >
@@ -113,9 +112,9 @@ const RadioGroupOptionsWidget = ({
                     </span>
                 )}
                 {shoud_show_new_label && (
-                    <span className='dc-dropdown__label--new'>
+                    <Text className='dc-dropdown__label--new' weight='bold' size='xxxs' line_height='s'>
                         <Localize i18n_default_text='NEW!' />
-                    </span>
+                    </Text>
                 )}
             </div>
         </React.Fragment>

--- a/packages/trader/src/Modules/Trading/Helpers/contract-type.tsx
+++ b/packages/trader/src/Modules/Trading/Helpers/contract-type.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { localize } from '@deriv/translations';
+import { ActiveSymbols } from '@deriv/api-types';
 import { TContractType, TContractCategory, TList } from '../Components/Form/ContractType/types';
 
 type TContractTypesList = {
@@ -42,6 +43,14 @@ export const getContractTypeCategoryIcons = () =>
  * @param {object} contract_types_list  - list of all contracts
  * @param {array}  unsupported_list - list of unsupported contract types
  */
+
+export const showLabelForMultipliers = (checked_symbol: string, active_symbols: ActiveSymbols) =>
+    active_symbols.some(
+        ({ submarket_display_name, symbol }) =>
+            /Continuous Indices/i.test(submarket_display_name) &&
+            checked_symbol === symbol &&
+            !/1HZ150V|1HZ250V/i.test(checked_symbol)
+    );
 
 export const getAvailableContractTypes = (contract_types_list: TContractTypesList, unsupported_list: string[]) => {
     return Object.keys(contract_types_list)

--- a/packages/trader/src/Modules/Trading/Helpers/contract-type.tsx
+++ b/packages/trader/src/Modules/Trading/Helpers/contract-type.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { localize } from '@deriv/translations';
-import { ActiveSymbols } from '@deriv/api-types';
 import { TContractType, TContractCategory, TList } from '../Components/Form/ContractType/types';
 
 type TContractTypesList = {
@@ -44,13 +43,8 @@ export const getContractTypeCategoryIcons = () =>
  * @param {array}  unsupported_list - list of unsupported contract types
  */
 
-export const showLabelForMultipliers = (checked_symbol: string, active_symbols: ActiveSymbols) =>
-    active_symbols.some(
-        ({ submarket_display_name, symbol }) =>
-            /Continuous Indices/i.test(submarket_display_name) &&
-            checked_symbol === symbol &&
-            !/1HZ150V|1HZ250V/i.test(checked_symbol)
-    );
+export const showLabelForMultipliers = (checked_symbol: string) =>
+    /R_|1HZ/i.test(checked_symbol) && !/1HZ150V|1HZ250V/i.test(checked_symbol);
 
 export const getAvailableContractTypes = (contract_types_list: TContractTypesList, unsupported_list: string[]) => {
     return Object.keys(contract_types_list)

--- a/packages/trader/src/sass/app/_common/mobile-widget.scss
+++ b/packages/trader/src/sass/app/_common/mobile-widget.scss
@@ -77,6 +77,9 @@
             margin-left: 0.8rem;
             justify-content: center;
             min-width: 8.8rem;
+            &:has(.mobile-widget__item-tooltip) {
+                min-width: 9.9rem;
+            }
 
             .mobile-widget__item-label {
                 color: var(--text-general);
@@ -134,12 +137,14 @@
             }
         }
     }
-    &__wide {
-        min-width: 9.9rem;
-    }
-    &__row {
-        flex-direction: row;
-        justify-content: space-between;
+    &__label {
+        min-width: 11.9rem;
+        padding: 0 0.8rem;
+        align-items: flex-start;
+
+        .mobile-widget__item {
+            margin-left: 2.4rem;
+        }
     }
     &__wrapper {
         display: flex;

--- a/packages/trader/src/sass/app/_common/mobile-widget.scss
+++ b/packages/trader/src/sass/app/_common/mobile-widget.scss
@@ -77,9 +77,6 @@
             margin-left: 0.8rem;
             justify-content: center;
             min-width: 8.8rem;
-            &:has(.mobile-widget__item-tooltip) {
-                min-width: 9.9rem;
-            }
 
             .mobile-widget__item-label {
                 color: var(--text-general);
@@ -136,6 +133,13 @@
                 }
             }
         }
+    }
+    &__wide {
+        min-width: 9.9rem;
+    }
+    &__row {
+        flex-direction: row;
+        justify-content: space-between;
     }
     &__wrapper {
         display: flex;

--- a/packages/trader/src/sass/app/_common/mobile-widget.scss
+++ b/packages/trader/src/sass/app/_common/mobile-widget.scss
@@ -137,11 +137,12 @@
             }
         }
     }
-    &__label {
+    &__wide {
         min-width: 11.9rem;
         padding: 0 0.8rem;
+    }
+    &__label {
         align-items: flex-start;
-
         .mobile-widget__item {
             margin-left: 2.4rem;
         }


### PR DESCRIPTION
## Changes:

- Add optional label NEW! to the `dropdown.tsx` and `widgets.jsx`.
- According to the card's requirements, this label should be shown for `Multipliers` with chosen `Volatility` symbol, **EXCEPT** `Vol 150 (1 sec)/ Vol 250 (2 sec)` , so I created a helper function for this purpose. As `NEW!` label is temporary, there is no need in flag from BE, it can be handled by FE powers.
- Add unit tests.

### Screenshots:

Please provide some screenshots of the change.
