### PR TITLE
Maryia/BOT-80/fix: the positioning of Next and Previous buttons  on the footer for onboarding tour on responsive

### DIFF
--- a/packages/bot-web-ui/src/components/dashboard/dashboard.scss
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard.scss
@@ -461,14 +461,15 @@
     flex-direction: column;
     align-items: center;
     position: fixed;
+
     left: 0;
     bottom: 0;
-    z-index: 1000;
-    background-color: var(--general-section-1);
     width: 100%;
-    border-top: solid 1px var(--border-normal);
     height: 100vh;
     padding: 1.6rem;
+    border-top: solid 1px var(--border-normal);
+    z-index: 1000;
+    background-color: var(--general-main-1);
 
     &--tour-position {
         top: 0;
@@ -509,18 +510,13 @@
     &__media {
         background: var(--general-section-1);
         text-align: center;
-        padding: 0.8rem;
         width: 100%;
-        height: 50%;
+        height: 65%;
         margin-bottom: 0.8rem;
     }
 
-    img {
-        height: 100%;
-    }
-
+    img,
     video {
-        width: 65%;
         height: 100%;
     }
 
@@ -565,7 +561,7 @@
     }
 
     &__bot-builder-tour {
-        height: unset;
+        height: 17rem;
         background: var(--general-section-1);
 
         .dbot-slider {
@@ -598,7 +594,6 @@
             }
 
             &__status {
-                height: 5rem;
                 display: flex;
                 @extend .position-center;
                 justify-content: flex-start;
@@ -610,6 +605,7 @@
                 @extend .position-center;
                 align-items: center;
                 justify-content: flex-start;
+                margin-left: 1rem;
 
                 .progress-bar-circle {
                     opacity: 0.16;

--- a/packages/bot-web-ui/src/components/dashboard/dashboard.scss
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard.scss
@@ -512,7 +512,7 @@
         text-align: center;
         width: 100%;
         height: 55%;
-        margin-bottom: 0.8rem;
+        margin-bottom: 1.6rem;
     }
 
     img {

--- a/packages/bot-web-ui/src/components/dashboard/dashboard.scss
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard.scss
@@ -10,16 +10,20 @@
     @include mobile {
         padding: 2rem;
     }
+
     .dc-dialog {
         position: relative;
+
         &__header-wrapper {
             margin: 0 0 2.4rem;
         }
+
         &__content {
             &__header {
                 display: flex;
                 justify-content: space-between;
                 margin: 0 0 2.4rem;
+
                 .dc-icon {
                     cursor: pointer;
                 }
@@ -29,10 +33,12 @@
         @include mobile {
             &__footer {
                 flex-wrap: unset;
+
                 .dc-dialog__button {
                     &:first-child {
                         margin-right: 1rem;
                     }
+
                     padding: 0;
                     width: 40%;
                     min-width: unset;
@@ -298,13 +304,16 @@
 
     .injectionDiv {
         height: calc(100vh - 20rem);
+
         .blocklyTrash {
             transition: all 0.4s;
+
             @include mobile {
                 display: none;
             }
         }
     }
+
     &--tour-active {
         .blocklyTrash {
             display: none;
@@ -376,6 +385,7 @@
 
     &__content {
         text-align: left;
+
         p {
             font-size: 1.4rem;
         }
@@ -390,10 +400,12 @@
 
 .joyride-content {
     font-size: 1.4rem;
+
     @media (max-height: 790px) {
         max-height: 46vh;
         overflow-y: auto;
     }
+
     &__left {
         text-align: left;
 
@@ -460,6 +472,7 @@
 
     &--tour-position {
         top: 0;
+
         .progress-bar-circle:first-child {
             display: none;
         }
@@ -467,6 +480,7 @@
 
     &--active {
         height: auto;
+        min-height: 17rem;
     }
 
     &__navbar {
@@ -516,7 +530,8 @@
 
     &__status {
         width: 100%;
-        margin-bottom: 1.6rem;
+        position: fixed;
+        bottom: 1.6rem;
     }
 
     &__button-group {
@@ -711,6 +726,7 @@
 
     .dc-toast {
         width: 100%;
+
         &__message {
             background: var(--text-prominent);
             color: var(--general-main-1);

--- a/packages/bot-web-ui/src/components/dashboard/dashboard.scss
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard.scss
@@ -511,7 +511,7 @@
         background: var(--general-section-1);
         text-align: center;
         width: 100%;
-        height: 60%;
+        height: 55%;
         margin-bottom: 0.8rem;
     }
 

--- a/packages/bot-web-ui/src/components/dashboard/dashboard.scss
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard.scss
@@ -511,7 +511,7 @@
         background: var(--general-section-1);
         text-align: center;
         width: 100%;
-        height: 65%;
+        height: 60%;
         margin-bottom: 0.8rem;
     }
 

--- a/packages/bot-web-ui/src/components/dashboard/dashboard.scss
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard.scss
@@ -515,9 +515,13 @@
         margin-bottom: 0.8rem;
     }
 
-    img,
+    img {
+        height: 100%;
+    }
+
     video {
         height: 100%;
+        width: 65%;
     }
 
     &__progress-bar {


### PR DESCRIPTION

## Changes:
1. fixed the positioning of the Next and Previous buttons  on the footer for **the onboarding tour** on responsive
2. fixed styles as per the design on responsive such as the size of the video, main background color, and size, and background color of the video container
3. fixed the positioning of the Next and Previous buttons on the footer for **bot builder guide tour** on responsive


### Screenshots:


https://github.com/binary-com/deriv-app/assets/103181650/907062be-3d87-4784-83b3-b25f6e4b5a2a


