### PR TITLE
Ameerul /P2PS-1726 Add the path /cashier/p2p/advertiser to apple-app-site-association file

### DIFF
--- a/packages/core/src/public/.well-known/apple-app-site-association
+++ b/packages/core/src/public/.well-known/apple-app-site-association
@@ -23,6 +23,7 @@
                 "appID": "36S5Q8S4V5.com.deriv.dp2p",
                 "paths": [
                     "/cashier/p2p",
+                    "/cashier/p2p/advertiser",
                     "/redirect/p2p"
                 ]
             }


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- Added path to `/cashier/p2p/advertiser` so mobile team can navigate to the advertiser page for share my ads

### Screenshots:

Please provide some screenshots of the change.

