### PR TITLE
Maryia/BOT-795/fix: snackbar close icon appearance on Safari doesn't match rest of the browsers

### DIFF
--- a/packages/bot-web-ui/src/components/trade-animation/trade-animation.scss
+++ b/packages/bot-web-ui/src/components/trade-animation/trade-animation.scss
@@ -2,6 +2,7 @@
     0% {
         width: 0%;
     }
+
     100% {
         width: 51%;
     }
@@ -11,6 +12,7 @@
     0% {
         width: 50%;
     }
+
     100% {
         width: 100%;
     }
@@ -20,9 +22,11 @@
     0% {
         transform: scale(0);
     }
+
     50% {
         transform: scale(1.5);
     }
+
     100% {
         transform: scale(0);
     }
@@ -32,6 +36,7 @@
     0% {
         transform: scale(0);
     }
+
     100% {
         transform: scale(1);
     }
@@ -41,9 +46,11 @@
     0% {
         transform: scale(0);
     }
+
     50% {
         transform: scale(1);
     }
+
     100% {
         transform: scale(0);
     }
@@ -59,10 +66,12 @@
         align-items: center;
         height: 40px;
     }
+
     &__overlay {
         border-top-left-radius: 0;
         border-bottom-right-radius: $BORDER_RADIUS;
     }
+
     // TODO: [fix-dc-bundle] Fix import issue with Deriv Component stylesheets (app should take precedence, and not repeat)
     &__button {
         width: fit-content;
@@ -70,6 +79,7 @@
         border-top-right-radius: 0 !important;
         border-bottom-right-radius: 0 !important;
     }
+
     &__container {
         width: 232px;
         height: 100%;
@@ -82,6 +92,7 @@
         border: solid 1px var(--border-normal);
         position: relative;
     }
+
     &__text {
         color: var(--text-general);
         font-size: 12px;
@@ -90,6 +101,7 @@
         margin-bottom: 5px;
         line-height: 18px;
     }
+
     &__progress {
         display: flex;
         justify-content: space-between;
@@ -110,6 +122,7 @@
                 align-self: center;
                 z-index: 1;
             }
+
             .dynamic-circle {
                 border-radius: 100%;
                 height: $dynamic-circle-diameter;
@@ -119,13 +132,16 @@
                 opacity: 0.32;
                 position: absolute;
             }
+
             &:nth-child(2) {
                 margin-left: 3px;
             }
+
             &:last-child {
                 margin-right: 3px;
             }
         }
+
         &-line {
             background-color: var(--border-normal);
             height: 100%;
@@ -133,25 +149,30 @@
             border-radius: $BORDER_RADIUS;
             position: absolute;
         }
+
         &-bar {
             background-color: var(--status-success);
             border-radius: $BORDER_RADIUS;
             width: 0;
             height: 100%;
         }
+
         &-3 {
             animation: animate-progress 0.5s 1;
             animation-fill-mode: forwards;
         }
+
         &-4 {
             width: 51%;
             border-radius: 5px 0 0 5px;
         }
+
         &-5 {
             animation: animate-progress-complete 0.5s 1;
             animation-fill-mode: forwards;
         }
     }
+
     &--running {
         #{$animation}__progress {
             .circular-wrapper {
@@ -161,6 +182,7 @@
                         background-color: $color-green-2;
                     }
                 }
+
                 &.active {
                     .dynamic-circle {
                         animation: animate-circle 0.8s infinite;
@@ -170,10 +192,12 @@
                         // z-index: 1;
                     }
                 }
+
                 .static-circle {
                     animation: animate-circle-appear 1s;
                     background-color: $COLOR_CORAL_RED;
                 }
+
                 .dynamic-circle {
                     animation: animate-circle 1s;
                     background-color: $COLOR_CORAL_RED;
@@ -198,11 +222,13 @@
 
     .dc-toast {
         width: 100%;
+
         &__message {
             background: var(--text-prominent);
             color: var(--general-main-1);
             padding: 1rem 1.6rem;
         }
+
         &__message-content {
             display: flex;
 
@@ -221,6 +247,8 @@
 
     .notification-close {
         cursor: pointer;
+        transform: translateZ(0);
+        -webkit-filter: invert(1);
         filter: invert(1);
         margin-left: 1rem;
         margin-top: 0.1rem;


### PR DESCRIPTION


## Changes:

fix: Snackbar **close icon** appearance on Safari doesn't match rest of the browsers:
* Do this for dark theme
* Do this for light theme

### Screenshots:


<img width="1700" alt="Screenshot 2023-10-12 at 17 22 31" src="https://github.com/binary-com/deriv-app/assets/103181650/7fa54f4a-0e44-4a7d-9c8c-05cdad82e507">



<img width="1700" alt="Screenshot 2023-10-12 at 17 19 50" src="https://github.com/binary-com/deriv-app/assets/103181650/f277e1f9-9e9e-4877-9cc6-ac8245db675b">
