### PR TITLE
ako/ Split p2p chunks

### DIFF
--- a/packages/p2p/webpack.config.js
+++ b/packages/p2p/webpack.config.js
@@ -131,6 +131,27 @@ module.exports = function (env) {
                 : []),
         ],
         optimization: {
+            splitChunks: {
+                chunks: 'async',
+                minSize: 20000,
+                minRemainingSize: 0,
+                minChunks: 1,
+                maxAsyncRequests: 30,
+                maxInitialRequests: 30,
+                enforceSizeThreshold: 50000,
+                cacheGroups: {
+                    defaultVendors: {
+                        test: /[\\/]node_modules[\\/]/,
+                        priority: -10,
+                        reuseExistingChunk: true,
+                    },
+                    default: {
+                        minChunks: 2,
+                        priority: -20,
+                        reuseExistingChunk: true,
+                    },
+                },
+            },
             minimize: is_release,
             minimizer: is_release
                 ? [


### PR DESCRIPTION
## Changes:

As we didn't have split chunks configuration on p2p webpack config our bundles were more than 20MB.
This will fix that issue.

### Screenshots:

Please provide some screenshots of the change.
