### PR TITLE
Maryia/BOT-846/fix: avoid showing "Lets build a bot" when user opens quick strategy in dbot

### DIFF
--- a/packages/bot-web-ui/src/components/dashboard/dashboard.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard.tsx
@@ -24,7 +24,8 @@ import Tutorial from './tutorial-tab';
 
 const Dashboard = observer(() => {
     const { dashboard, load_modal, run_panel, quick_strategy, summary_card } = useDBotStore();
-    const { active_tab, active_tour, setActiveTab, setWebSocketState, setActiveTour } = dashboard;
+    const { active_tab, active_tour, setActiveTab, setWebSocketState, setActiveTour, setTourDialogVisibility } =
+        dashboard;
     const { onEntered, dashboard_strategies } = load_modal;
     const { is_dialog_open, is_drawer_open, dialog_options, onCancelButtonClick, onCloseDialog, onOkButtonClick } =
         run_panel;
@@ -61,6 +62,10 @@ const Dashboard = observer(() => {
     }, []);
 
     React.useEffect(() => {
+        if (is_strategy_modal_open) {
+            setTourDialogVisibility(false);
+        }
+
         if (init_render.current) {
             setActiveTab(Number(active_hash_tab));
             if (is_mobile) handleTabChange(Number(active_hash_tab));

--- a/packages/bot-web-ui/src/components/dashboard/dbot-tours/bot-builder-tour/bot-builder-tour-mobile.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dbot-tours/bot-builder-tour/bot-builder-tour-mobile.tsx
@@ -14,7 +14,7 @@ import { BOT_BUILDER_MOBILE } from '../config';
 import { highlightLoadModalButton } from '../utils';
 
 const BotBuilderTourMobile = observer(() => {
-    const { dashboard, load_modal } = useDBotStore();
+    const { dashboard, load_modal, quick_strategy } = useDBotStore();
     const { toggleTourLoadModal } = load_modal;
     const {
         onTourEnd,
@@ -25,6 +25,7 @@ const BotBuilderTourMobile = observer(() => {
         setShowMobileTourDialog,
         setTourDialogVisibility,
     } = dashboard;
+    const { is_strategy_modal_open } = quick_strategy;
     const [tour_step, setTourStep] = React.useState<number>(1);
     const content_data = BOT_BUILDER_MOBILE.find(({ tour_step_key }) => {
         return tour_step_key === tour_step;
@@ -39,8 +40,12 @@ const BotBuilderTourMobile = observer(() => {
         else toggleTourLoadModal(false);
         const token = getSetting('bot_builder_token');
         if (!token && active_tab === 1) {
+            if (is_strategy_modal_open) {
+                setTourDialogVisibility(false);
+            } else {
+                setTourDialogVisibility(true);
+            }
             setShowMobileTourDialog(true);
-            setTourDialogVisibility(true);
         }
     }, [tour_step, show_mobile_tour_dialog]);
 


### PR DESCRIPTION
## Changes:

* Avoid showing "Lets build a bot" when user opens quick strategy in dbot
* Bot builder tour "Bot Builder guides" shouldn't come for the mobile version when the quick strategy is opened

### Screenshots:


https://github.com/binary-com/deriv-app/assets/103181650/40b7ceda-d478-44db-ab4a-08d52d5ea227



https://github.com/binary-com/deriv-app/assets/103181650/0cf40711-260f-4825-8cef-5934d322c75a






