### PR TITLE
chore: notify users that changes made wont affect running bot

### DIFF
--- a/packages/bot-web-ui/src/app/app.scss
+++ b/packages/bot-web-ui/src/app/app.scss
@@ -15,4 +15,5 @@
     --zindex-drawer: 5;
     --zindex-modal: 6;
     --zindex-draggable-modal: 7;
+    --zindex-snackbar: 8;
 }

--- a/packages/bot-web-ui/src/components/bot-snackbar/__tests__/bot-snackbar.spec.tsx
+++ b/packages/bot-web-ui/src/components/bot-snackbar/__tests__/bot-snackbar.spec.tsx
@@ -43,6 +43,8 @@ jest.useFakeTimers();
 describe('BotSnackbar', () => {
     let wrapper: ({ children }: { children: JSX.Element }) => JSX.Element, mock_DBot_store: RootStore | undefined;
     const mockHandleClose = jest.fn();
+    const test_message = <div>message test</div>;
+
     beforeAll(() => {
         const mock_store = mockStore({});
         mock_DBot_store = mockDBotStore(mock_store, mock_ws);
@@ -56,23 +58,21 @@ describe('BotSnackbar', () => {
         );
     });
     it('should render BotSnackbar with correct message', () => {
-        const test_message = 'message test';
         render(<BotSnackbar message={test_message} handleClose={mockHandleClose} is_open={true} />, {
             wrapper,
         });
-        expect(screen.getByText(test_message)).toBeInTheDocument();
+        expect(screen.getByText('message test')).toBeInTheDocument();
     });
 
     it('should not render BotSnackbar if snack bar is not opened', () => {
-        const test_message = 'message test';
         render(<BotSnackbar message={test_message} handleClose={mockHandleClose} is_open={false} />, {
             wrapper,
         });
-        expect(screen.queryByText(test_message)).not.toBeInTheDocument();
+        expect(screen.queryByText('message test')).not.toBeInTheDocument();
     });
 
     it('should render close button if snackbar is open', () => {
-        render(<BotSnackbar message='test' handleClose={mockHandleClose} is_open={true} />, {
+        render(<BotSnackbar message={test_message} handleClose={mockHandleClose} is_open={true} />, {
             wrapper,
         });
         const cls_btn = screen.getByTestId('bot-snackbar-notification-close');
@@ -80,7 +80,7 @@ describe('BotSnackbar', () => {
     });
 
     it('should hanlde close function on click close button', async () => {
-        render(<BotSnackbar message='test' handleClose={mockHandleClose} is_open={true} />, {
+        render(<BotSnackbar message={test_message} handleClose={mockHandleClose} is_open={true} />, {
             wrapper,
         });
         const cls_btn = screen.getByTestId('bot-snackbar-notification-close');
@@ -89,7 +89,7 @@ describe('BotSnackbar', () => {
     });
 
     it('should close snackbar after timeout is passed and mouse is not over the snackbar', async () => {
-        render(<BotSnackbar message='test' handleClose={mockHandleClose} is_open={true} timeout={4000} />, {
+        render(<BotSnackbar message={test_message} handleClose={mockHandleClose} is_open={true} timeout={4000} />, {
             wrapper,
         });
         const element = screen.getByTestId('bot-snackbar-notification-container');

--- a/packages/bot-web-ui/src/components/bot-snackbar/__tests__/bot-snackbar.spec.tsx
+++ b/packages/bot-web-ui/src/components/bot-snackbar/__tests__/bot-snackbar.spec.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { mockStore, StoreProvider } from '@deriv/stores';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { act, fireEvent, render, screen } from '@testing-library/react';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import userEvent from '@testing-library/user-event';
+import RootStore from '../../../stores/root-store';
+import { DBotStoreProvider, mockDBotStore } from '../../../stores/useDBotStore';
+import BotSnackbar from '../bot-snackbar';
+
+jest.mock('@deriv/shared', () => ({
+    ...jest.requireActual('@deriv/shared'),
+    isMobile: jest.fn(() => false),
+}));
+
+jest.mock('@deriv/bot-skeleton/src/scratch/blockly', () => jest.fn());
+jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => ({
+    saveRecentWorkspace: jest.fn(),
+    unHighlightAllBlocks: jest.fn(),
+}));
+jest.mock('@deriv/bot-skeleton/src/scratch/hooks/block_svg', () => jest.fn());
+jest.mock('@deriv/deriv-charts', () => ({
+    setSmartChartsPublicPath: jest.fn(),
+}));
+
+const mock_ws = {
+    authorized: {
+        subscribeProposalOpenContract: jest.fn(),
+        send: jest.fn(),
+    },
+    storage: {
+        send: jest.fn(),
+    },
+    contractUpdate: jest.fn(),
+    subscribeTicksHistory: jest.fn(),
+    forgetStream: jest.fn(),
+    activeSymbols: jest.fn(),
+    send: jest.fn(),
+};
+
+jest.useFakeTimers();
+
+describe('BotSnackbar', () => {
+    let wrapper: ({ children }: { children: JSX.Element }) => JSX.Element, mock_DBot_store: RootStore | undefined;
+    const mockHandleClose = jest.fn();
+    beforeAll(() => {
+        const mock_store = mockStore({});
+        mock_DBot_store = mockDBotStore(mock_store, mock_ws);
+
+        wrapper = ({ children }: { children: JSX.Element }) => (
+            <StoreProvider store={mock_store}>
+                <DBotStoreProvider ws={mock_ws} mock={mock_DBot_store}>
+                    {children}
+                </DBotStoreProvider>
+            </StoreProvider>
+        );
+    });
+    it('should render BotSnackbar with correct message', () => {
+        const test_message = 'message test';
+        render(<BotSnackbar message={test_message} handleClose={mockHandleClose} is_open={true} />, {
+            wrapper,
+        });
+        expect(screen.getByText(test_message)).toBeInTheDocument();
+    });
+
+    it('should not render BotSnackbar if snack bar is not opened', () => {
+        const test_message = 'message test';
+        render(<BotSnackbar message={test_message} handleClose={mockHandleClose} is_open={false} />, {
+            wrapper,
+        });
+        expect(screen.queryByText(test_message)).not.toBeInTheDocument();
+    });
+
+    it('should render close button if snackbar is open', () => {
+        render(<BotSnackbar message='test' handleClose={mockHandleClose} is_open={true} />, {
+            wrapper,
+        });
+        const cls_btn = screen.getByTestId('bot-snackbar-notification-close');
+        expect(cls_btn).toBeInTheDocument();
+    });
+
+    it('should hanlde close function on click close button', async () => {
+        render(<BotSnackbar message='test' handleClose={mockHandleClose} is_open={true} />, {
+            wrapper,
+        });
+        const cls_btn = screen.getByTestId('bot-snackbar-notification-close');
+        await userEvent.click(cls_btn);
+        expect(mockHandleClose).toBeCalled();
+    });
+
+    it('should close snackbar after timeout is passed and mouse is not over the snackbar', async () => {
+        render(<BotSnackbar message='test' handleClose={mockHandleClose} is_open={true} timeout={4000} />, {
+            wrapper,
+        });
+        const element = screen.getByTestId('bot-snackbar-notification-container');
+        act(() => {
+            fireEvent.mouseLeave(element);
+            jest.advanceTimersByTime(4100);
+        });
+        const cls_btn = screen.queryByTestId('bot-snackbar-notification-close');
+        expect(cls_btn).not.toBeInTheDocument();
+    });
+});

--- a/packages/bot-web-ui/src/components/bot-snackbar/bot-snackbar.scss
+++ b/packages/bot-web-ui/src/components/bot-snackbar/bot-snackbar.scss
@@ -1,0 +1,36 @@
+.bot-snackbar {
+    position: fixed;
+    z-index: var(--zindex-snackbar);
+    right: 38rem;
+    top: 12rem;
+
+    .dc-toast {
+        width: 100%;
+        &__message {
+            background: var(--text-prominent);
+            color: var(--general-main-1);
+            padding: 1rem 1.6rem;
+        }
+        &__message-content {
+            display: flex;
+
+            @include mobile {
+                align-items: center;
+            }
+        }
+    }
+
+    @include mobile {
+        top: unset;
+        left: 0;
+        right: 0;
+        bottom: 10.5rem;
+    }
+
+    .notification-close {
+        cursor: pointer;
+        filter: invert(1);
+        margin-left: 1rem;
+        margin-top: 0.1rem;
+    }
+}

--- a/packages/bot-web-ui/src/components/bot-snackbar/bot-snackbar.tsx
+++ b/packages/bot-web-ui/src/components/bot-snackbar/bot-snackbar.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { Icon, Toast } from '@deriv/components';
-import { Localize } from '@deriv/translations';
 
 type TBotSnackbar = {
     className?: string;
@@ -9,20 +8,10 @@ type TBotSnackbar = {
     handleClose: () => void;
     type?: 'error' | 'info' | 'notification';
     timeout?: number;
-    msg_localize_components?: JSX.Element[];
-    message: string;
+    message: JSX.Element;
 };
 
-const BotSnackbar = ({
-    message,
-    msg_localize_components = [],
-    timeout = 6000,
-    is_open,
-    onClick,
-    handleClose,
-    type,
-    className,
-}: TBotSnackbar) => {
+const BotSnackbar = ({ message, timeout = 6000, is_open, onClick, handleClose, type, className }: TBotSnackbar) => {
     const [notification_timer, setNotificationTimer] = useState(timeout);
 
     React.useEffect(() => {
@@ -43,7 +32,7 @@ const BotSnackbar = ({
             data-testid='bot-snackbar-notification-container'
         >
             <Toast is_open={is_open} type={type} timeout={notification_timer} onClick={onClick} onClose={handleClose}>
-                <div>{message && <Localize i18n_default_text={message} components={msg_localize_components} />}</div>
+                <div>{message}</div>
                 <Icon
                     icon='IcCross'
                     className={'notification-close'}

--- a/packages/bot-web-ui/src/components/bot-snackbar/bot-snackbar.tsx
+++ b/packages/bot-web-ui/src/components/bot-snackbar/bot-snackbar.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import { Icon, Toast } from '@deriv/components';
+import { Localize } from '@deriv/translations';
+
+type TBotSnackbar = {
+    className?: string;
+    is_open: boolean;
+    onClick?: React.MouseEventHandler<HTMLDivElement>;
+    handleClose: () => void;
+    type?: 'error' | 'info' | 'notification';
+    timeout?: number;
+    msg_localize_components?: JSX.Element[];
+    message: string;
+};
+
+const BotSnackbar = ({
+    message,
+    msg_localize_components = [],
+    timeout = 6000,
+    is_open,
+    onClick,
+    handleClose,
+    type,
+    className,
+}: TBotSnackbar) => {
+    const [notification_timer, setNotificationTimer] = useState(timeout);
+
+    React.useEffect(() => {
+        if (is_open) {
+            setNotificationTimer(timeout);
+        }
+    }, [is_open, timeout]);
+
+    return (
+        <div
+            onMouseOver={() => {
+                setNotificationTimer(0);
+            }}
+            onMouseLeave={() => {
+                setNotificationTimer(timeout);
+            }}
+            className={className ?? 'bot-snackbar'}
+            data-testid='bot-snackbar-notification-container'
+        >
+            <Toast is_open={is_open} type={type} timeout={notification_timer} onClick={onClick} onClose={handleClose}>
+                <div>{message && <Localize i18n_default_text={message} components={msg_localize_components} />}</div>
+                <Icon
+                    icon='IcCross'
+                    className={'notification-close'}
+                    data_testid={'bot-snackbar-notification-close'}
+                    onClick={handleClose}
+                />
+            </Toast>
+        </div>
+    );
+};
+export default BotSnackbar;

--- a/packages/bot-web-ui/src/components/bot-snackbar/index.tsx
+++ b/packages/bot-web-ui/src/components/bot-snackbar/index.tsx
@@ -1,0 +1,4 @@
+import BotSnackbar from './bot-snackbar';
+import './bot-snackbar.scss';
+
+export default BotSnackbar;

--- a/packages/bot-web-ui/src/components/dashboard/bot-builder/bot-builder.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/bot-builder/bot-builder.tsx
@@ -1,19 +1,21 @@
 import React from 'react';
 import classNames from 'classnames';
-
 import { observer } from '@deriv/stores';
-
+import { localize } from '@deriv/translations';
+import BotSnackbar from 'Components/bot-snackbar';
 import { useDBotStore } from '../../../stores/useDBotStore';
 import LoadModal from '../../load-modal';
 import SaveModal from '../dashboard-component/load-bot-preview/save-modal';
 import BotBuilderTourHandler from '../dbot-tours/bot-builder-tour';
 import QuickStrategy from '../quick-strategy';
-
 import WorkspaceWrapper from './workspace-wrapper';
 
 const BotBuilder = observer(() => {
-    const { dashboard, app } = useDBotStore();
+    const { dashboard, app, run_panel } = useDBotStore();
     const { active_tab, active_tour, is_preview_on_popup } = dashboard;
+    const { is_running } = run_panel;
+    const is_blockly_listener_registered = React.useRef(false);
+    const [show_snackbar, setShowSnackbar] = React.useState(false);
 
     const { onMount, onUnmount } = app;
     const el_ref = React.useRef<HTMLInputElement | null>(null);
@@ -23,8 +25,43 @@ const BotBuilder = observer(() => {
         return () => onUnmount();
     }, []);
 
+    const handleBlockChangeOnBotRun = (e: Event) => {
+        if (e.type !== 'ui') {
+            setShowSnackbar(true);
+            removeBlockChangeListener();
+        }
+    };
+
+    const removeBlockChangeListener = () => {
+        is_blockly_listener_registered.current = false;
+        window.Blockly?.derivWorkspace?.removeChangeListener(handleBlockChangeOnBotRun);
+    };
+
+    React.useEffect(() => {
+        const workspace = window.Blockly?.derivWorkspace;
+        if (workspace && is_running && !is_blockly_listener_registered.current) {
+            is_blockly_listener_registered.current = true;
+            workspace.addChangeListener(handleBlockChangeOnBotRun);
+        } else {
+            setShowSnackbar(false);
+            removeBlockChangeListener();
+        }
+
+        return () => {
+            if (workspace && is_blockly_listener_registered.current) {
+                removeBlockChangeListener();
+            }
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [is_running]);
+
     return (
         <>
+            <BotSnackbar
+                is_open={show_snackbar}
+                message={localize('Changes you make will not affect your running bot.')}
+                handleClose={() => setShowSnackbar(false)}
+            />
             <div
                 className={classNames('bot-builder', {
                     'bot-builder--active': active_tab === 1 && !is_preview_on_popup,

--- a/packages/bot-web-ui/src/components/dashboard/bot-builder/bot-builder.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/bot-builder/bot-builder.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import { observer } from '@deriv/stores';
-import { localize } from '@deriv/translations';
+import { Localize } from '@deriv/translations';
 import BotSnackbar from 'Components/bot-snackbar';
 import { useDBotStore } from '../../../stores/useDBotStore';
 import LoadModal from '../../load-modal';
@@ -59,7 +59,7 @@ const BotBuilder = observer(() => {
         <>
             <BotSnackbar
                 is_open={show_snackbar}
-                message={localize('Changes you make will not affect your running bot.')}
+                message={<Localize i18n_default_text='Changes you make will not affect your running bot.' />}
                 handleClose={() => setShowSnackbar(false)}
             />
             <div


### PR DESCRIPTION
## Changes:

- We need to show a snack bar message if the bot is running and the user tries to update the strategy
- A generic snack bar component is added
- On the bot builder component a workspace onChange listener is added if the bot is running and there is no active listener registered yet
- The snack bar message is shown to the user if there is any change received from the listener
- The listener is removed if the bot is not running or the user moves away from the component

Screenshot:
<img width="578" alt="Screenshot 2023-09-29 at 3 59 19 PM" src="https://github.com/binary-com/deriv-app/assets/129021108/5171e8f1-75c5-4561-a7d1-718a2a8fec8f">

