### PR TITLE
WALL-2125 feat: refactored BEM a bit, added support for variants to InlineMessage [42069]

### DIFF
--- a/packages/wallets/src/components/Base/InlineMessage/InlineMessage.scss
+++ b/packages/wallets/src/components/Base/InlineMessage/InlineMessage.scss
@@ -7,7 +7,7 @@
     border-radius: 4px;
     height: min-content;
 
-    &__lg {
+    &--lg {
         @include tablet-up {
             padding: 16px;
             gap: 16px;
@@ -15,24 +15,24 @@
         }
     }
 
-    &__warning {
+    &--warning {
         background: rgba(255, 173, 58, 0.16);
     }
 
-    &__information {
+    &--information {
         background: rgba(55, 124, 252, 0.16);
     }
 
-    &__announcement {
+    &--announcement {
         background: rgba(75, 180, 179, 0.16);
     }
 
-    &__error {
+    &--error {
         background: rgba(236, 63, 63, 0.16);
     }
 
     &__icon {
-        &__sm {
+        &--sm {
             margin-top: 1px;
 
             @include mobile {
@@ -40,7 +40,7 @@
             }
         }
 
-        &__md {
+        &--md {
             margin-top: 2px;
 
             @include mobile {
@@ -48,7 +48,7 @@
             }
         }
 
-        &__lg {
+        &--lg {
             @include mobile {
                 margin-top: 1px;
             }
@@ -56,12 +56,12 @@
     }
 
     &__messages {
-        display: flex;
+        display: inline-flex;
+        align-self: center;
         flex-direction: column;
         flex: 1;
-        align-self: stretch;
 
-        &__xs {
+        &--xs {
             margin-top: 1px;
 
             @include mobile {
@@ -69,10 +69,35 @@
             }
         }
 
-        &__sm {
+        &--sm {
             @include mobile {
                 margin-top: 1px;
             }
         }
+    }
+
+    &--outlined {
+        background-color: transparent;
+        border: 1px solid;
+    }
+
+    &--outlined#{&}--warning {
+        color: rgba(255, 173, 58);
+        border-color: rgba(255, 173, 58);
+    }
+
+    &--outlined#{&}--information {
+        color: rgba(55, 124, 252);
+        border-color: rgba(55, 124, 252);
+    }
+
+    &--outlined#{&}--announcement {
+        color: rgba(75, 180, 179);
+        border-color: rgba(75, 180, 179);
+    }
+
+    &--outlined#{&}--error {
+        color: rgba(236, 63, 63);
+        border-color: rgba(236, 63, 63);
     }
 }

--- a/packages/wallets/src/components/Base/InlineMessage/InlineMessage.tsx
+++ b/packages/wallets/src/components/Base/InlineMessage/InlineMessage.tsx
@@ -16,9 +16,10 @@ const typeIconMapper = {
 type TProps = RequireAtLeastOne<{ children: React.ReactNode; message: React.ReactNode; title: React.ReactNode }> & {
     size?: 'lg' | 'md' | 'sm' | 'xs';
     type?: keyof typeof typeIconMapper;
+    variant?: 'contained' | 'outlined';
 };
 
-const InlineMessage: React.FC<TProps> = ({ children, message, size = 'xs', title, type = 'warning' }) => {
+const InlineMessage: React.FC<TProps> = ({ children, message, size = 'xs', title, type = 'warning', variant }) => {
     const { isMobile } = useDevice();
     const Icon = typeIconMapper[type];
     const iconSize = size === 'lg' && !isMobile ? 24 : 16;
@@ -36,9 +37,15 @@ const InlineMessage: React.FC<TProps> = ({ children, message, size = 'xs', title
     const fontSize = sizeToFontSizeMapper[size];
 
     return (
-        <div className={`wallets-inline-message wallets-inline-message__${type} wallets-inline-message__${size} `}>
-            <Icon className={`wallets-inline-message__icon__${size}`} height={iconSize} width={iconSize} />
-            <span className={`wallets-inline-message__messages inline-message__messages__${size}`} style={{ fontSize }}>
+        <div
+            className={`wallets-inline-message 
+                         wallets-inline-message--${type} 
+                         wallets-inline-message--${size} 
+                         wallets-inline-message--${variant} 
+                         `}
+        >
+            <Icon className={`wallets-inline-message__icon--${size}`} height={iconSize} width={iconSize} />
+            <span className={`wallets-inline-message__messages inline-message__messages--${size}`} style={{ fontSize }}>
                 {title && <strong>{title}</strong>}
                 {message && <span>{message}</span>}
                 {children}


### PR DESCRIPTION
## Changes:

https://app.clickup.com/t/20696747/WALL-2125

Added variant to InlineMessage in order to support account verification badge.
Updated BEM convention a bit, centered text vertically.
Original task was about implementing component for badge, but turned out, that there is already a component which does almost exactly what is needed, so only added variant to InlineMessage.

### Screenshots:
<img width="459" alt="Screenshot 2023-10-20 at 10 31 24" src="https://github.com/binary-com/deriv-app/assets/141034155/fc8f51ee-92ef-4f32-bc17-0dd233250612">

