### PR TITLE
chore: add user id to response timeout error

### DIFF
--- a/packages/core/src/Services/socket-general.js
+++ b/packages/core/src/Services/socket-general.js
@@ -23,7 +23,7 @@ const BinarySocketGeneral = (() => {
             error.userId = client_store.loginid;
             /* eslint-disable no-console */
             console.error({ error });
-        }, 100);
+        }, 30000);
 
         if (is_ready) {
             if (!client_store.is_valid_login) {

--- a/packages/core/src/Services/socket-general.js
+++ b/packages/core/src/Services/socket-general.js
@@ -22,7 +22,7 @@ const BinarySocketGeneral = (() => {
             const error = new Error('deriv-api: no message received after 30s');
             error.userId = client_store.loginid;
             /* eslint-disable no-console */
-            console.error({ error });
+            console.error(error);
         }, 30000);
 
         if (is_ready) {

--- a/packages/core/src/Services/socket-general.js
+++ b/packages/core/src/Services/socket-general.js
@@ -20,7 +20,7 @@ const BinarySocketGeneral = (() => {
     const onOpen = is_ready => {
         responseTimeoutErrorTimer = setTimeout(() => {
             const error = new Error('deriv-api: no message received after 30s');
-            error.userId = client_store.loginid;
+            error.userId = client_store?.loginid;
             /* eslint-disable no-console */
             console.error(error);
         }, 30000);

--- a/packages/core/src/Services/socket-general.js
+++ b/packages/core/src/Services/socket-general.js
@@ -16,11 +16,15 @@ const BinarySocketGeneral = (() => {
         common_store.setIsSocketOpened(false);
     };
 
-    const timer = setTimeout(() => {
-        /* eslint-disable no-console */
-        console.error('deriv-api: no message received after 30s');
-    }, 30000);
+    let responseTimeoutErrorTimer = null;
     const onOpen = is_ready => {
+        responseTimeoutErrorTimer = setTimeout(() => {
+            const error = new Error('deriv-api: no message received after 30s');
+            error.userId = client_store.loginid;
+            /* eslint-disable no-console */
+            console.error({ error });
+        }, 100);
+
         if (is_ready) {
             if (!client_store.is_valid_login) {
                 client_store.logout();
@@ -43,7 +47,7 @@ const BinarySocketGeneral = (() => {
     };
 
     const onMessage = response => {
-        clearTimeout(timer);
+        clearTimeout(responseTimeoutErrorTimer);
         handleError(response);
         // Header.hideNotification('CONNECTION_ERROR');
         switch (response.msg_type) {


### PR DESCRIPTION
Add the logged in user id to the error we are displaying, if no response happens after 30 seconds.

Also refactored:
- the `timer` variable to be more explicit
- moved the timeout start time to the onOpen event