### PR TITLE
Ako/fix chunks split config

### DIFF
--- a/packages/core/build/webpack.config.js
+++ b/packages/core/build/webpack.config.js
@@ -36,10 +36,11 @@ module.exports = function (env) {
             minimizer: MINIMIZERS,
             splitChunks: {
                 chunks: 'all',
-                minSize: 102400,
+                minSize: 100000,
                 minSizeReduction: 102400,
                 minChunks: 1,
-                maxAsyncRequests: 5,
+                maxSize: 2500000,
+                maxAsyncRequests: 30,
                 maxInitialRequests: 3,
                 automaticNameDelimiter: '~',
                 enforceSizeThreshold: 500000,

--- a/packages/p2p/webpack.config.js
+++ b/packages/p2p/webpack.config.js
@@ -138,7 +138,7 @@ module.exports = function (env) {
                 minChunks: 1,
                 maxAsyncRequests: 30,
                 maxInitialRequests: 30,
-                enforceSizeThreshold: 50000,
+                maxSize: 2500000,
                 cacheGroups: {
                     defaultVendors: {
                         test: /[\\/]node_modules[\\/]/,

--- a/packages/wallets/webpack.config.js
+++ b/packages/wallets/webpack.config.js
@@ -152,7 +152,7 @@ module.exports = function (env) {
                 minSize: 102400,
                 minSizeReduction: 102400,
                 minChunks: 1,
-                maxAsyncRequests: 5,
+                maxAsyncRequests: 30,
                 maxInitialRequests: 3,
                 automaticNameDelimiter: '~',
                 enforceSizeThreshold: 500000,


### PR DESCRIPTION
## Changes:

* add MaxSize to split the chunks.
* Use 30 as maxAsyncRequests as its webpack recommendation.