### PR TITLE
[Wallets] Aizad / chore: Re-add large button into WalletButton scss mapper

### DIFF
--- a/packages/wallets/src/components/Base/WalletButton/WalletButton.scss
+++ b/packages/wallets/src/components/Base/WalletButton/WalletButton.scss
@@ -27,6 +27,10 @@ $size-map: (
         height: 3.2rem,
         padding: 0.6rem 1.6rem,
     ),
+    'lg': (
+        height: 4rem,
+        padding: 1rem 1.6rem,
+    ),
 );
 
 .wallets-button {


### PR DESCRIPTION
## Changes:
Re-add buttonSize = `lg`
<img width="310" alt="Screenshot 2023-10-25 at 12 07 45 PM" src="https://github.com/binary-com/deriv-app/assets/103104395/164fd07a-a81a-4083-82a3-d0866a1ac377">

