### PR TITLE
chore: quick-strategy - fix breaking dbot

### DIFF
--- a/packages/bot-web-ui/src/components/dashboard/dashboard.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard.tsx
@@ -58,7 +58,7 @@ const Dashboard = observer(() => {
     }, []);
 
     React.useEffect(() => {
-        if (is_strategy_modal_open) {
+        if (is_open) {
             setTourDialogVisibility(false);
         }
 

--- a/packages/bot-web-ui/src/components/dashboard/dbot-tours/bot-builder-tour/bot-builder-tour-mobile.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dbot-tours/bot-builder-tour/bot-builder-tour-mobile.tsx
@@ -1,12 +1,9 @@
 import React from 'react';
-
 import { ProgressBarTracker } from '@deriv/components';
 import { observer } from '@deriv/stores';
 import { localize } from '@deriv/translations';
-
-import { useDBotStore } from 'Stores/useDBotStore';
 import { getSetting } from 'Utils/settings';
-
+import { useDBotStore } from 'Stores/useDBotStore';
 import Accordion from '../common/accordion';
 import TourButton from '../common/tour-button';
 import TourStartDialog from '../common/tour-start-dialog';
@@ -25,7 +22,7 @@ const BotBuilderTourMobile = observer(() => {
         setShowMobileTourDialog,
         setTourDialogVisibility,
     } = dashboard;
-    const { is_strategy_modal_open } = quick_strategy;
+    const { is_open } = quick_strategy;
     const [tour_step, setTourStep] = React.useState<number>(1);
     const content_data = BOT_BUILDER_MOBILE.find(({ tour_step_key }) => {
         return tour_step_key === tour_step;
@@ -40,7 +37,7 @@ const BotBuilderTourMobile = observer(() => {
         else toggleTourLoadModal(false);
         const token = getSetting('bot_builder_token');
         if (!token && active_tab === 1) {
-            if (is_strategy_modal_open) {
+            if (is_open) {
                 setTourDialogVisibility(false);
             } else {
                 setTourDialogVisibility(true);


### PR DESCRIPTION
## Changes:
Fixed breaking deriv-bot due to change of the variable name.
It was `is_strategy_dialog_open`
the new variable name is `is_open` and is being imported from the `quick_strategy` store
