### PR TITLE
[Wallet] Aum / WALL-2245 / wallet-overlay-animation-onscroll

### DIFF
--- a/packages/wallets/src/AppContent.scss
+++ b/packages/wallets/src/AppContent.scss
@@ -6,7 +6,7 @@
     width: 100%;
     align-self: stretch;
     background: var(--system-light-7-secondary-background, #f2f3f4);
-    height: calc(100vh - 8.4rem); // 100vh - (4.8rem header + 3.6rem footer)
+    min-height: calc(100vh - 8.4rem); // 100vh - (4.8rem header + 3.6rem footer)
 
     @include mobile {
         overflow-y: auto;

--- a/packages/wallets/src/features/cashier/WalletCashier.scss
+++ b/packages/wallets/src/features/cashier/WalletCashier.scss
@@ -1,3 +1,9 @@
+.wallets-cashier {
+    display: flex;
+    flex-direction: column;
+    height: calc(100svh - 4rem);
+}
+
 .wallets-cashier-content {
     padding: 2.4rem 2.4rem 0px;
     display: flex;
@@ -5,6 +11,7 @@
     justify-content: center;
     flex: 1;
     background-color: #ffffff;
+    overflow: scroll;
 
     @include mobile {
         padding: 1.6rem;

--- a/packages/wallets/src/features/cashier/WalletCashier.tsx
+++ b/packages/wallets/src/features/cashier/WalletCashier.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useActiveWalletAccount } from '@deriv/api';
 import { WalletCashierContent, WalletCashierHeader } from './components';
 import './WalletCashier.scss';

--- a/packages/wallets/src/features/cashier/WalletCashier.tsx
+++ b/packages/wallets/src/features/cashier/WalletCashier.tsx
@@ -5,16 +5,22 @@ import './WalletCashier.scss';
 
 const WalletCashier = () => {
     const { isLoading } = useActiveWalletAccount();
+    const [is_content_scrolled, setIsContentScrolled] = useState(false);
+
+    const onContentScroll = (e: React.UIEvent<HTMLDivElement, UIEvent>) => {
+        const target = e.target as HTMLDivElement;
+        setIsContentScrolled(target.scrollTop > 0);
+    };
 
     if (isLoading) return <p>Loading...</p>;
 
     return (
-        <>
-            <WalletCashierHeader />
-            <div className='wallets-cashier-content'>
+        <div className='wallets-cashier'>
+            <WalletCashierHeader hide_wallet_details={is_content_scrolled} />
+            <div className='wallets-cashier-content' onScroll={onContentScroll}>
                 <WalletCashierContent />
             </div>
-        </>
+        </div>
     );
 };
 

--- a/packages/wallets/src/features/cashier/WalletCashier.tsx
+++ b/packages/wallets/src/features/cashier/WalletCashier.tsx
@@ -16,7 +16,7 @@ const WalletCashier = () => {
 
     return (
         <div className='wallets-cashier'>
-            <WalletCashierHeader hide_wallet_details={is_content_scrolled} />
+            <WalletCashierHeader hideWalletDetails={is_content_scrolled} />
             <div className='wallets-cashier-content' onScroll={onContentScroll}>
                 <WalletCashierContent />
             </div>

--- a/packages/wallets/src/features/cashier/WalletCashier.tsx
+++ b/packages/wallets/src/features/cashier/WalletCashier.tsx
@@ -5,7 +5,7 @@ import './WalletCashier.scss';
 
 const WalletCashier = () => {
     const { isLoading } = useActiveWalletAccount();
-    const [is_content_scrolled, setIsContentScrolled] = useState(false);
+    const [isContentScrolled, setIsContentScrolled] = useState(false);
 
     const onContentScroll = (e: React.UIEvent<HTMLDivElement, UIEvent>) => {
         const target = e.target as HTMLDivElement;
@@ -16,7 +16,7 @@ const WalletCashier = () => {
 
     return (
         <div className='wallets-cashier'>
-            <WalletCashierHeader hideWalletDetails={is_content_scrolled} />
+            <WalletCashierHeader hideWalletDetails={isContentScrolled} />
             <div className='wallets-cashier-content' onScroll={onContentScroll}>
                 <WalletCashierContent />
             </div>

--- a/packages/wallets/src/features/cashier/components/WalletCashierHeader/WalletCashierHeader.scss
+++ b/packages/wallets/src/features/cashier/components/WalletCashierHeader/WalletCashierHeader.scss
@@ -38,10 +38,10 @@
                 display: flex;
                 gap: 2.4rem;
                 align-items: center;
-                visibility: visible;
-                transition: visibility 0s, height 0.2s ease;
 
                 @include mobile {
+                    visibility: visible;
+                    transition: visibility 0s, height 0.2s ease;
                     height: 2rem;
                     gap: 0.8rem;
                 }
@@ -75,7 +75,9 @@
             }
 
             &__icon {
-                transition: visibility 0s, height 0.2s ease;
+                @include mobile {
+                    transition: visibility 0s, height 0.2s ease;
+                }
             }
         }
     }

--- a/packages/wallets/src/features/cashier/components/WalletCashierHeader/WalletCashierHeader.scss
+++ b/packages/wallets/src/features/cashier/components/WalletCashierHeader/WalletCashierHeader.scss
@@ -6,10 +6,12 @@
     display: flex;
     flex-direction: column;
     justify-content: space-between;
+    gap: 1.6rem;
 
     @include mobile {
-        padding-top: 1.6rem;
-        height: 12.2rem;
+        padding-top: 0rem;
+        transition: height 0.2s ease-in;
+        height: fit-content;
     }
 
     &__close-button {
@@ -24,7 +26,7 @@
         padding-inline: 2.4rem;
 
         @include mobile {
-            padding-inline: 1.6rem;
+            padding: 1.6rem 1.6rem 0rem;
         }
 
         &__top-left {
@@ -36,8 +38,11 @@
                 display: flex;
                 gap: 2.4rem;
                 align-items: center;
+                visibility: visible;
+                transition: visibility 0s, height 0.2s ease;
 
                 @include mobile {
+                    height: 2rem;
                     gap: 0.8rem;
                 }
 
@@ -67,6 +72,10 @@
 
             @include mobile {
                 gap: 0.8rem;
+            }
+
+            &__icon {
+                transition: visibility 0s, height 0.2s ease;
             }
         }
     }
@@ -113,4 +122,9 @@
             }
         }
     }
+}
+
+.wallets-hide-details {
+    height: 0;
+    visibility: hidden;
 }

--- a/packages/wallets/src/features/cashier/components/WalletCashierHeader/WalletCashierHeader.tsx
+++ b/packages/wallets/src/features/cashier/components/WalletCashierHeader/WalletCashierHeader.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
+import classNames from 'classnames';
 import { useActiveWalletAccount } from '@deriv/api';
 import { WalletCardIcon } from '../../../../components/WalletCardIcon';
 import { WalletGradientBackground } from '../../../../components/WalletGradientBackground';
@@ -11,7 +12,7 @@ import './WalletCashierHeader.scss';
 const realAccountTabs = ['deposit', 'withdraw', 'transfer', 'transactions'];
 const virtualAccountTabs = ['withdraw', 'transfer', 'transactions', 'reset-balance'];
 
-const WalletCashierHeader = () => {
+const WalletCashierHeader = ({ hide_wallet_details }: { hide_wallet_details: boolean }) => {
     const { data } = useActiveWalletAccount();
     const { isMobile } = useDevice();
     const history = useHistory();
@@ -32,7 +33,11 @@ const WalletCashierHeader = () => {
             <main className='wallets-cashier-header'>
                 <section className='wallets-cashier-header__info'>
                     <div className='wallets-cashier-header__info__top-left'>
-                        <div className='wallets-cashier-header__info__top-left__details'>
+                        <div
+                            className={classNames('wallets-cashier-header__info__top-left__details', {
+                                'wallets-hide-details': isMobile && hide_wallet_details,
+                            })}
+                        >
                             <h1 className='wallets-cashier-header__info__top-left__details__title'>
                                 {data?.currency} Wallet
                             </h1>
@@ -43,7 +48,15 @@ const WalletCashierHeader = () => {
                         <p className='wallets-cashier-header__info__top-left__balance'>{data?.display_balance}</p>
                     </div>
                     <div className='wallets-cashier-header__info__top-right'>
-                        {data?.wallet_currency_type && <WalletCardIcon size='xl' type={data?.wallet_currency_type} />}
+                        {data?.wallet_currency_type && (
+                            <div
+                                className={classNames('wallets-cashier-header__info__top-right__icon', {
+                                    'wallets-hide-details': isMobile && hide_wallet_details,
+                                })}
+                            >
+                                <WalletCardIcon size='xl' type={data?.wallet_currency_type} />
+                            </div>
+                        )}
                         <button
                             className='wallets-cashier-header__close-button'
                             onClick={() => history.push('/wallets')}

--- a/packages/wallets/src/features/cashier/components/WalletCashierHeader/WalletCashierHeader.tsx
+++ b/packages/wallets/src/features/cashier/components/WalletCashierHeader/WalletCashierHeader.tsx
@@ -12,7 +12,7 @@ import './WalletCashierHeader.scss';
 const realAccountTabs = ['deposit', 'withdraw', 'transfer', 'transactions'];
 const virtualAccountTabs = ['withdraw', 'transfer', 'transactions', 'reset-balance'];
 
-const WalletCashierHeader = ({ hide_wallet_details }: { hide_wallet_details: boolean }) => {
+const WalletCashierHeader = ({ hideWalletDetails }: { hideWalletDetails: boolean }) => {
     const { data } = useActiveWalletAccount();
     const { isMobile } = useDevice();
     const history = useHistory();
@@ -35,7 +35,7 @@ const WalletCashierHeader = ({ hide_wallet_details }: { hide_wallet_details: boo
                     <div className='wallets-cashier-header__info__top-left'>
                         <div
                             className={classNames('wallets-cashier-header__info__top-left__details', {
-                                'wallets-hide-details': isMobile && hide_wallet_details,
+                                'wallets-hide-details': isMobile && hideWalletDetails,
                             })}
                         >
                             <h1 className='wallets-cashier-header__info__top-left__details__title'>
@@ -51,7 +51,7 @@ const WalletCashierHeader = ({ hide_wallet_details }: { hide_wallet_details: boo
                         {data?.wallet_currency_type && (
                             <div
                                 className={classNames('wallets-cashier-header__info__top-right__icon', {
-                                    'wallets-hide-details': isMobile && hide_wallet_details,
+                                    'wallets-hide-details': isMobile && hideWalletDetails,
                                 })}
                             >
                                 <WalletCardIcon size='xl' type={data?.wallet_currency_type} />


### PR DESCRIPTION
## Changes:

Apply animation for hiding the wallet-name and wallet-icon when the user scrolls the wallet-cashier-content (given it is scrollable).

### Screenshots:

https://github.com/binary-com/deriv-app/assets/125039206/880f0b02-4313-4148-98f4-c87d2e55f7f2


Please provide some screenshots of the change.
