### PR TITLE
WEBREL-1574 / remove defaultChecked prop from checkbox

### DIFF
--- a/packages/components/src/components/checkbox/checkbox.tsx
+++ b/packages/components/src/components/checkbox/checkbox.tsx
@@ -72,7 +72,6 @@ const Checkbox = React.forwardRef<HTMLInputElement, TCheckBoxProps>(
                         ref={ref}
                         disabled={disabled}
                         onChange={onInputChange}
-                        defaultChecked={checked}
                         checked={checked}
                         {...otherProps}
                     />


### PR DESCRIPTION
## Changes:

This PR focuses on removing `defaultChecked` from the checkbox in components package to remove console error related to controlled & uncontrolled form. 
Having `checked` & `defaultChecked` prop at the same time creates an error by React.

### Screenshots:
<img width="1727" alt="Screenshot 2023-10-26 at 4 02 14 PM" src="https://github.com/binary-com/deriv-app/assets/129842155/01c3f7e5-cbdc-497e-aef2-ca5e40b58890">
