### PR TITLE
test: add test case for notify-item

### DIFF
--- a/packages/bot-web-ui/src/components/notify-item/__tests__/notify-item.spec.tsx
+++ b/packages/bot-web-ui/src/components/notify-item/__tests__/notify-item.spec.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { messageWithButton, messageWithImage, getIcon } from '../notify-item';
+import userEvent from '@testing-library/user-event';
+
+const messageWithButtonMockProps = {
+    unique_id: '123',
+    type: 'error',
+    message: 'sample text',
+    btn_text: 'ok',
+    onClick: jest.fn(),
+};
+
+describe('messageWithButtonMockProps', () => {
+    it('should render messageWithButton', () => {
+        const { container } = render(messageWithButton({ ...messageWithButtonMockProps }));
+        expect(container).toBeInTheDocument();
+        expect(screen.getByText('sample text')).toBeInTheDocument();
+    });
+
+    it('should call function of the button on click of the button', () => {
+        render(messageWithButton({ ...messageWithButtonMockProps }));
+        userEvent.click(screen.getByRole('button'));
+        expect(messageWithButtonMockProps.onClick).toHaveBeenCalled();
+    });
+
+    it('should get appropriate icon when getIcon is called', () => {
+        expect(getIcon('warn')).toEqual('IcAlertWarning');
+    });
+
+    it('should render messageWithImage', () => {
+        const { container } = render(messageWithImage('sample text', ''));
+        expect(container).toBeInTheDocument();
+        expect(screen.getByText('sample text')).toBeInTheDocument();
+        expect(screen.getByRole('img')).toBeInTheDocument();
+    });
+});

--- a/packages/bot-web-ui/src/components/notify-item/notify-item.jsx
+++ b/packages/bot-web-ui/src/components/notify-item/notify-item.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button, ExpansionPanel, Icon } from '@deriv/components';
 
-const getIcon = type => {
+export const getIcon = type => {
     switch (type) {
         case 'error':
             return 'IcAlertDanger';


### PR DESCRIPTION
## Changes:

Added test case for the component notify-item.jsx under src/components/notify-item folder.

### Screenshots:

Please provide some screenshots of the change.
