### PR TITLE
Farabi/bot-760/test case for route prompt dialog store

### DIFF
--- a/packages/bot-web-ui/src/stores/__tests__/route-prompt-store.spec.tsx
+++ b/packages/bot-web-ui/src/stores/__tests__/route-prompt-store.spec.tsx
@@ -1,0 +1,81 @@
+import RoutePromptDialogStore from '../route-prompt-dialog-store';
+
+const mockRouteTo = jest.fn();
+
+const mockCommonStore = {
+    common: {
+        routeTo: mockRouteTo,
+    },
+};
+describe('RoutePromptDialogStore', () => {
+    it('should set should_show to be false', () => {
+        const store = new RoutePromptDialogStore();
+        expect(store.should_show).toBe(false);
+    });
+
+    it('should set is_confirmed to be false', () => {
+        const store = new RoutePromptDialogStore();
+        expect(store.is_confirmed).toBe(false);
+    });
+
+    it('should set last_location to be null', () => {
+        const store = new RoutePromptDialogStore();
+        expect(store.last_location).toBe(null);
+    });
+
+    it('should update should_show', () => {
+        const store = new RoutePromptDialogStore();
+        store.setShoudShow(true);
+        expect(store.should_show).toBe(true);
+    });
+
+    it('should update should_show to false on onCancel', () => {
+        const store = new RoutePromptDialogStore();
+        store.onCancel();
+        expect(store.should_show).toBe(false);
+    });
+
+    it('should set should_show to false and is_confirmed to true on onConfirm', () => {
+        const store = new RoutePromptDialogStore();
+        store.onConfirm();
+        expect(store.should_show).toBe(false);
+        expect(store.is_confirmed).toBe(true);
+    });
+
+    it('should return false for shouldNavigateAfterPrompt if is_confirmed is false', () => {
+        const store = new RoutePromptDialogStore();
+        const next_location = '/bot';
+        store.shouldNavigateAfterPrompt(next_location);
+        expect(store.last_location).toEqual(next_location);
+    });
+
+    it('should return true for shouldNavigateAfterPrompt if is_confirmed is true', () => {
+        const store = new RoutePromptDialogStore();
+        store.onConfirm();
+        const next_location = { pathname: '/bot' };
+        expect(store.shouldNavigateAfterPrompt(next_location)).toBe(true);
+    });
+
+    it('should set should_show to true if location pathname not equal to bot', () => {
+        const store = new RoutePromptDialogStore();
+        store.setShoudShow(true);
+        let next_location = '';
+        store.shouldNavigateAfterPrompt(next_location);
+        expect(store.last_location).not.toEqual((next_location = '/bot'));
+        expect(store.should_show).toBe(true);
+    });
+
+    it('should not call common.routeTo when is_confirmed is false on continueRoute', () => {
+        const store = new RoutePromptDialogStore(null, mockCommonStore);
+        store.continueRoute();
+        expect(mockRouteTo).not.toHaveBeenCalled();
+    });
+
+    it('should call common.routeTo when is_confirmed is true on continueRoute', () => {
+        const store = new RoutePromptDialogStore(null, mockCommonStore);
+        store.last_location = { pathname: '/bot' };
+        store.onConfirm();
+        store.continueRoute();
+        expect(mockRouteTo).toHaveBeenCalled();
+    });
+});

--- a/packages/bot-web-ui/src/stores/__tests__/route-prompt-store.spec.tsx
+++ b/packages/bot-web-ui/src/stores/__tests__/route-prompt-store.spec.tsx
@@ -8,74 +8,68 @@ const mockCommonStore = {
     },
 };
 describe('RoutePromptDialogStore', () => {
+    let route_store: RoutePromptDialogStore;
+    beforeEach(() => {
+        route_store = new RoutePromptDialogStore(null, mockCommonStore);
+    });
+
     it('should set should_show to be false', () => {
-        const store = new RoutePromptDialogStore();
-        expect(store.should_show).toBe(false);
+        expect(route_store.should_show).toBe(false);
     });
 
     it('should set is_confirmed to be false', () => {
-        const store = new RoutePromptDialogStore();
-        expect(store.is_confirmed).toBe(false);
+        expect(route_store.is_confirmed).toBe(false);
     });
 
     it('should set last_location to be null', () => {
-        const store = new RoutePromptDialogStore();
-        expect(store.last_location).toBe(null);
+        expect(route_store.last_location).toBe(null);
     });
 
     it('should update should_show', () => {
-        const store = new RoutePromptDialogStore();
-        store.setShoudShow(true);
-        expect(store.should_show).toBe(true);
+        route_store.setShoudShow(true);
+        expect(route_store.should_show).toBe(true);
     });
 
     it('should update should_show to false on onCancel', () => {
-        const store = new RoutePromptDialogStore();
-        store.onCancel();
-        expect(store.should_show).toBe(false);
+        route_store.onCancel();
+        expect(route_store.should_show).toBe(false);
     });
 
     it('should set should_show to false and is_confirmed to true on onConfirm', () => {
-        const store = new RoutePromptDialogStore();
-        store.onConfirm();
-        expect(store.should_show).toBe(false);
-        expect(store.is_confirmed).toBe(true);
+        route_store.onConfirm();
+        expect(route_store.should_show).toBe(false);
+        expect(route_store.is_confirmed).toBe(true);
     });
 
     it('should return false for shouldNavigateAfterPrompt if is_confirmed is false', () => {
-        const store = new RoutePromptDialogStore();
         const next_location = '/bot';
-        store.shouldNavigateAfterPrompt(next_location);
-        expect(store.last_location).toEqual(next_location);
+        route_store.shouldNavigateAfterPrompt(next_location);
+        expect(route_store.last_location).toEqual(next_location);
     });
 
     it('should return true for shouldNavigateAfterPrompt if is_confirmed is true', () => {
-        const store = new RoutePromptDialogStore();
-        store.onConfirm();
+        route_store.onConfirm();
         const next_location = { pathname: '/bot' };
-        expect(store.shouldNavigateAfterPrompt(next_location)).toBe(true);
+        expect(route_store.shouldNavigateAfterPrompt(next_location)).toBe(true);
     });
 
     it('should set should_show to true if location pathname not equal to bot', () => {
-        const store = new RoutePromptDialogStore();
-        store.setShoudShow(true);
+        route_store.setShoudShow(true);
         let next_location = '';
-        store.shouldNavigateAfterPrompt(next_location);
-        expect(store.last_location).not.toEqual((next_location = '/bot'));
-        expect(store.should_show).toBe(true);
+        route_store.shouldNavigateAfterPrompt(next_location);
+        expect(route_store.last_location).not.toEqual((next_location = '/bot'));
+        expect(route_store.should_show).toBe(true);
     });
 
     it('should not call common.routeTo when is_confirmed is false on continueRoute', () => {
-        const store = new RoutePromptDialogStore(null, mockCommonStore);
-        store.continueRoute();
+        route_store.continueRoute();
         expect(mockRouteTo).not.toHaveBeenCalled();
     });
 
     it('should call common.routeTo when is_confirmed is true on continueRoute', () => {
-        const store = new RoutePromptDialogStore(null, mockCommonStore);
-        store.last_location = { pathname: '/bot' };
-        store.onConfirm();
-        store.continueRoute();
+        route_store.last_location = { pathname: '/bot' };
+        route_store.onConfirm();
+        route_store.continueRoute();
         expect(mockRouteTo).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## Changes:

- Added test case for route-prompt-dialog-store

### Screenshots:

<img width="1704" alt="Screenshot 2023-10-27 at 5 13 04 PM" src="https://github.com/binary-com/deriv-app/assets/102643568/edd8e9f1-0cbd-486d-bdbb-dec7c5bf5360">
