### PR TITLE
[Wallet] Aum / WALL-2291 / flow-and-content-change-for-demo-reset-balance

### DIFF
--- a/packages/wallets/src/features/cashier/modules/ResetBalance/ResetBalance.tsx
+++ b/packages/wallets/src/features/cashier/modules/ResetBalance/ResetBalance.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useHistory } from 'react-router-dom';
-import { useActiveWalletAccount, useMutation } from '@deriv/api';
+import { useMutation } from '@deriv/api';
 import WalletsActionScreen from '../../../../components/WalletsActionScreen/WalletsActionScreen';
 import IcResetDemoBalance from '../../../../public/images/ic-demo-reset-balance.svg';
 import IcResetDemoBalanceDone from '../../../../public/images/ic-demo-reset-balance-done.svg';
@@ -9,26 +9,22 @@ import './ResetBalance.scss';
 const ResetBalance = () => {
     const history = useHistory();
     const { isSuccess: isResetBalanceSuccess, mutate } = useMutation('topup_virtual');
-    const { data: activeWallet } = useActiveWalletAccount();
 
     const resetBalance = () => {
         mutate();
     };
-
-    const canReset = activeWallet?.balance !== 10000;
-
     return (
         <div className='wallets-reset-balance'>
             <WalletsActionScreen
-                actionText={canReset ? 'Reset balance' : 'Transfer funds'}
+                actionText={isResetBalanceSuccess ? 'Transfer funds' : 'Reset balance'}
                 description={
                     isResetBalanceSuccess
                         ? 'Your balance has been reset to 10,000.00 USD.'
-                        : 'Reset your virtual balance if it falls below 10,000.00 USD or exceeds 10,000.00 USD.'
+                        : 'Reset your virtual balance to 10,000.00 USD.'
                 }
                 icon={isResetBalanceSuccess ? <IcResetDemoBalanceDone /> : <IcResetDemoBalance />}
-                onAction={canReset ? resetBalance : () => history.push(`/wallets/cashier/transfer`)}
-                title={'Reset balance to 10,000.00 USD'}
+                onAction={isResetBalanceSuccess ? () => history.push(`/wallets/cashier/transfer`) : resetBalance}
+                title={isResetBalanceSuccess ? 'Reset balance to 10,000.00 USD' : 'Success'}
             />
         </div>
     );

--- a/packages/wallets/src/features/cashier/modules/ResetBalance/ResetBalance.tsx
+++ b/packages/wallets/src/features/cashier/modules/ResetBalance/ResetBalance.tsx
@@ -24,7 +24,7 @@ const ResetBalance = () => {
                 }
                 icon={isResetBalanceSuccess ? <IcResetDemoBalanceDone /> : <IcResetDemoBalance />}
                 onAction={isResetBalanceSuccess ? () => history.push(`/wallets/cashier/transfer`) : resetBalance}
-                title={isResetBalanceSuccess ? 'Reset balance to 10,000.00 USD' : 'Success'}
+                title={isResetBalanceSuccess ? 'Success' : 'Reset balance'}
             />
         </div>
     );


### PR DESCRIPTION
## Changes:

This PR changes the user-flow and the content of the demo reset balance according to this rule:
1. When the user opens the `Reset Balance` tab, show the reset balance screen (as shown below) and let the user click and reset their balance REGARDLESS of their current balance.
<img width="842" alt="image" src="https://github.com/binary-com/deriv-app/assets/125039206/6dc7b23c-3d11-450e-a342-abf8dad8e89a">

2. Once the user resets the balance, show the success screen (as shown below) with the CTA of `Transfer Funds` to redirect the user to the transfer tab.
<img width="884" alt="image" src="https://github.com/binary-com/deriv-app/assets/125039206/5269ae27-7ef0-4e53-b636-c5bb88ec0322">

#### Note: The flow will restart if the user comes to reset-balance tab from any other tab.
