### PR TITLE
[wallets] thisyahlen/WALL-2300/chore: fix close icon and error handling for ctrader

### DIFF
--- a/packages/api/src/hooks/useCtraderAccountsList.ts
+++ b/packages/api/src/hooks/useCtraderAccountsList.ts
@@ -6,7 +6,7 @@ import useCtraderServiceToken from './useCtraderServiceToken';
 /** A custom hook that gets the list of created cTrader accounts. */
 const useCtraderAccountsList = () => {
     const { isSuccess } = useAuthorize();
-    const { data: ctrader_accounts } = useQuery('trading_platform_accounts', {
+    const { data: ctrader_accounts, ...rest } = useQuery('trading_platform_accounts', {
         payload: { platform: 'ctrader' },
         options: { enabled: isSuccess },
     });
@@ -28,6 +28,7 @@ const useCtraderAccountsList = () => {
     return {
         /** List of all created cTrader accounts */
         data: modified_ctrader_accounts,
+        ...rest,
     };
 };
 

--- a/packages/wallets/src/components/Base/ModalWrapper/ModalWrapper.scss
+++ b/packages/wallets/src/components/Base/ModalWrapper/ModalWrapper.scss
@@ -1,4 +1,4 @@
-.wallets-modal {
+.wallets-modal-wrapper {
     position: relative;
 
     &__close-icon {

--- a/packages/wallets/src/features/cfd/flows/CTrader/AvailableCTraderAccountsList/AvailableCTraderAccountsList.scss
+++ b/packages/wallets/src/features/cfd/flows/CTrader/AvailableCTraderAccountsList/AvailableCTraderAccountsList.scss
@@ -4,3 +4,9 @@
         flex-direction: column;
     }
 }
+
+.wallets-error-screen {
+    background: #fff;
+    border-radius: 1rem;
+    padding: 2rem;
+}

--- a/packages/wallets/src/features/cfd/flows/CTrader/AvailableCTraderAccountsList/AvailableCTraderAccountsList.tsx
+++ b/packages/wallets/src/features/cfd/flows/CTrader/AvailableCTraderAccountsList/AvailableCTraderAccountsList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useActiveWalletAccount, useCreateOtherCFDAccount, useCtraderAccountsList } from '@deriv/api';
-import { TradingAccountCard } from '../../../../../components';
+import { TradingAccountCard, WalletsErrorScreen } from '../../../../../components';
 import { ModalWrapper, WalletButton, WalletText } from '../../../../../components/Base';
 import { useModal } from '../../../../../components/ModalProvider';
 import CTrader from '../../../../../public/images/ctrader.svg';
@@ -36,8 +36,8 @@ const AvailableCTraderAccountsList: React.FC = () => {
     const onClickHandler = () => {
         onSubmit();
         show(
-            isSuccess && (
-                <ModalWrapper>
+            <ModalWrapper>
+                {isSuccess && (
                     <Success
                         description={`Transfer your virtual funds from your ${accountType} wallet to your ${ctraderMapper[0].title} ${accountType} account to practice trading.`}
                         displayBalance={cTraderAccounts?.find(account => account.login)?.display_balance}
@@ -46,8 +46,13 @@ const AvailableCTraderAccountsList: React.FC = () => {
                         renderButton={() => <WalletButton isFullWidth onClick={hide} size='lg' text='Continue' />}
                         title={`Your ${ctraderMapper[0].title} ${accountType} account is ready`}
                     />
-                </ModalWrapper>
-            )
+                )}
+                {!isSuccess && (
+                    <div className='wallets-error-screen'>
+                        <WalletsErrorScreen message='Sorry, an error occurred. Please try again later.' />
+                    </div>
+                )}
+            </ModalWrapper>
         );
     };
 

--- a/packages/wallets/src/features/cfd/modals/DxtradeEnterPasswordModal/DxtradeEnterPasswordModal.tsx
+++ b/packages/wallets/src/features/cfd/modals/DxtradeEnterPasswordModal/DxtradeEnterPasswordModal.tsx
@@ -10,7 +10,7 @@ import './DxtradeEnterPasswordModal.scss';
 const DxtradeEnterPasswordModal = () => {
     const history = useHistory();
     const [password, setPassword] = useState('');
-    const { isSuccess, mutate } = useCreateOtherCFDAccount();
+    const { isLoading, isSuccess, mutate } = useCreateOtherCFDAccount();
     const { data: dxtradeAccount, isSuccess: dxtradeAccountListSuccess } = useDxtradeAccountsList();
     const { data: activeWallet } = useActiveWalletAccount();
     const { hide } = useModal();
@@ -61,6 +61,7 @@ const DxtradeEnterPasswordModal = () => {
             {!isSuccess && (
                 <CreatePassword
                     icon={<DxTradePasswordIcon />}
+                    isLoading={isLoading}
                     onPasswordChange={e => setPassword(e.target.value)}
                     onPrimaryClick={onSubmit}
                     password={password}

--- a/packages/wallets/src/features/cfd/screens/CreatePassword/CreatePassword.tsx
+++ b/packages/wallets/src/features/cfd/screens/CreatePassword/CreatePassword.tsx
@@ -1,21 +1,29 @@
 import React from 'react';
+import { WalletButton } from '../../../../components/Base';
+import useDevice from '../../../../hooks/useDevice';
 import PasswordShowIcon from '../../../../public/images/ic-password-show.svg';
 import { TPlatforms } from '../../../../types';
 import { PlatformToTitleMapper } from '../../constants';
-import { WalletButton } from '../../../../components/Base';
-import useDevice from '../../../../hooks/useDevice';
 import './CreatePassword.scss';
 
 // TODO: Refactor the unnecessary props out once FlowProvider is integrated
 type TProps = {
     icon: React.ReactNode;
+    isLoading?: boolean;
     onPasswordChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
     onPrimaryClick: () => void;
     password: string;
     platform: TPlatforms.All;
 };
 
-const CreatePassword: React.FC<TProps> = ({ icon, onPasswordChange, onPrimaryClick, password, platform }) => {
+const CreatePassword: React.FC<TProps> = ({
+    icon,
+    isLoading,
+    onPasswordChange,
+    onPrimaryClick,
+    password,
+    platform,
+}) => {
     const { isMobile } = useDevice();
 
     const title = PlatformToTitleMapper[platform];
@@ -32,7 +40,7 @@ const CreatePassword: React.FC<TProps> = ({ icon, onPasswordChange, onPrimaryCli
             </div>
             {!isMobile && (
                 <WalletButton
-                    disabled={!password}
+                    disabled={!password || isLoading}
                     onClick={onPrimaryClick}
                     size='lg'
                     text={`Create ${title} password`}


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
1. Fix close icon for enter password modal
2. Throw error modal if error for ctrader 

### Screenshots:
<img width="1304" alt="Screenshot 2023-10-30 at 11 17 16 AM" src="https://github.com/binary-com/deriv-app/assets/104053934/9ee1d493-eef9-4cf9-b8db-f54b287d111c">
<img width="405" alt="Screenshot 2023-10-30 at 11 22 10 AM" src="https://github.com/binary-com/deriv-app/assets/104053934/aaffa3ad-21cd-4ff9-bd9d-a6f4bff07d5b">


