### PR TITLE
Ako/ reduce core bundle sizes

### DIFF
--- a/packages/core/build/webpack.config.js
+++ b/packages/core/build/webpack.config.js
@@ -35,19 +35,17 @@ module.exports = function (env) {
             minimize: IS_RELEASE,
             minimizer: MINIMIZERS,
             splitChunks: {
-                chunks: 'all',
-                minSize: 100000,
+                chunks: 'async',
+                minSize: 20000,
                 minSizeReduction: 102400,
                 minChunks: 1,
                 maxSize: 2500000,
                 maxAsyncRequests: 30,
                 maxInitialRequests: 30,
                 automaticNameDelimiter: '~',
-                enforceSizeThreshold: 500000,
                 cacheGroups: {
                     default: {
                         minChunks: 2,
-                        minSize: 102400,
                         priority: -20,
                         reuseExistingChunk: true,
                     },


### PR DESCRIPTION
## Changes:

We have an issue on core package that it has a bundle from p2p which is 34 MB. this is to fix that issue.
### before
<img width="514" alt="image" src="https://github.com/binary-com/deriv-app/assets/81898967/568e8e32-d947-4017-9824-65ae1dbd475a">

### After
<img width="1564" alt="image" src="https://github.com/binary-com/deriv-app/assets/81898967/db3cdb75-8fcd-4184-a41e-a31d980bce6b">

### Screenshots:

Please provide some screenshots of the change.
