### PR TITLE
[Wallets] Rostislav / WALL-2348 / Implement Loader on initial render, Loader on scroll and fix double scroll

### DIFF
--- a/packages/api/src/hooks/useTransactions.ts
+++ b/packages/api/src/hooks/useTransactions.ts
@@ -11,7 +11,7 @@ const useTransactions = () => {
     const { isFetching, isSuccess } = useAuthorize();
     const [filter, setFilter] = useState<TFilter>();
     const invalidate = useInvalidateQuery();
-    const { data, fetchNextPage, ...rest } = useInfiniteQuery('statement', {
+    const { data, fetchNextPage, remove, ...rest } = useInfiniteQuery('statement', {
         options: {
             enabled: !isFetching && isSuccess,
             getNextPageParam: (lastPage, pages) => {
@@ -28,6 +28,12 @@ const useTransactions = () => {
     useEffect(() => {
         invalidate('statement');
     }, [filter, invalidate]);
+
+    useEffect(() => {
+        return () => {
+            remove();
+        };
+    }, [remove]);
 
     // Flatten the data array.
     const flatten_data = useMemo(() => {

--- a/packages/wallets/src/features/cashier/WalletCashier.scss
+++ b/packages/wallets/src/features/cashier/WalletCashier.scss
@@ -9,7 +9,7 @@
 }
 
 .wallets-cashier-content {
-    padding: 2.4rem 2.4rem 0px;
+    padding-top: 2.4rem;
     display: flex;
     gap: 2.4rem;
     justify-content: center;

--- a/packages/wallets/src/features/cashier/modules/TransactionStatus/TransactionStatus.scss
+++ b/packages/wallets/src/features/cashier/modules/TransactionStatus/TransactionStatus.scss
@@ -2,7 +2,7 @@
     /* This positioning is temporary, ideally it should be determined by the parent component whenever we use `TransactionStatus` */
     position: absolute;
     top: 0;
-    right: 0;
+    right: 4rem;
     width: 28.2rem;
 
     display: flex;

--- a/packages/wallets/src/features/cashier/modules/Transactions/Transactions.scss
+++ b/packages/wallets/src/features/cashier/modules/Transactions/Transactions.scss
@@ -1,7 +1,12 @@
 .wallets-transactions {
-    width: 70vw;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 
     &__header {
+        width: 100%;
+        max-width: 80rem;
         display: flex;
         gap: 16px;
         justify-content: flex-end;

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompleted/TransactionsCompleted.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompleted/TransactionsCompleted.tsx
@@ -36,28 +36,24 @@ const TransactionsCompleted: React.FC<TProps> = ({ filter }) => {
     if (!data) return <TransactionsNoDataState />;
 
     return (
-        <div>
-            <TransactionsTable
-                columns={[
-                    {
-                        accessorFn: row =>
-                            row.transaction_time && moment.unix(row.transaction_time).format('DD MMM YYYY'),
-                        accessorKey: 'date',
-                        header: 'Date',
-                    },
-                ]}
-                data={data}
-                fetchMore={fetchMoreOnBottomReached}
-                groupBy={['date']}
-                rowGroupRender={transaction => (
-                    <p className='wallets-transactions-completed__group-title'>
-                        {transaction.transaction_time &&
-                            moment.unix(transaction.transaction_time).format('DD MMM YYYY')}
-                    </p>
-                )}
-                rowRender={transaction => <TransactionsCompletedRow transaction={transaction} />}
-            />
-        </div>
+        <TransactionsTable
+            columns={[
+                {
+                    accessorFn: row => row.transaction_time && moment.unix(row.transaction_time).format('DD MMM YYYY'),
+                    accessorKey: 'date',
+                    header: 'Date',
+                },
+            ]}
+            data={data}
+            fetchMore={fetchMoreOnBottomReached}
+            groupBy={['date']}
+            rowGroupRender={transaction => (
+                <p className='wallets-transactions-completed__group-title'>
+                    {transaction.transaction_time && moment.unix(transaction.transaction_time).format('DD MMM YYYY')}
+                </p>
+            )}
+            rowRender={transaction => <TransactionsCompletedRow transaction={transaction} />}
+        />
     );
 };
 

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompleted/TransactionsCompleted.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompleted/TransactionsCompleted.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import moment from 'moment';
 import { useTransactions } from '@deriv/api';
 import { TSocketRequestPayload } from '@deriv/api/types';
@@ -16,7 +16,6 @@ type TProps = {
 
 const TransactionsCompleted: React.FC<TProps> = ({ filter }) => {
     const { data: transactions, fetchNextPage, isFetching, isLoading, setFilter } = useTransactions();
-    const [shouldShowLoader, setShouldShowLoader] = useState(true);
 
     const fetchMoreOnBottomReached = useCallback(
         (containerRefElement?: HTMLDivElement | null) => {
@@ -33,16 +32,9 @@ const TransactionsCompleted: React.FC<TProps> = ({ filter }) => {
 
     useEffect(() => {
         setFilter(filter);
-        setShouldShowLoader(true);
     }, [filter]); // eslint-disable-line react-hooks/exhaustive-deps
 
-    useEffect(() => {
-        if (!isFetching && !isLoading) {
-            setShouldShowLoader(false);
-        }
-    }, [transactions, isFetching, isLoading]);
-
-    if (shouldShowLoader) return <Loader />;
+    if (!transactions && (isFetching || isLoading)) return <Loader />;
 
     if (!transactions) return <TransactionsNoDataState />;
 

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompleted/TransactionsCompleted.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompleted/TransactionsCompleted.tsx
@@ -1,7 +1,8 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import moment from 'moment';
 import { useTransactions } from '@deriv/api';
 import { TSocketRequestPayload } from '@deriv/api/types';
+import { Loader } from '../../../../../../components';
 import { TransactionsCompletedRow } from '../TransactionsCompletedRow';
 import { TransactionsNoDataState } from '../TransactionsNoDataState';
 import { TransactionsTable } from '../TransactionsTable';
@@ -14,7 +15,8 @@ type TProps = {
 };
 
 const TransactionsCompleted: React.FC<TProps> = ({ filter }) => {
-    const { data, fetchNextPage, isFetching, setFilter } = useTransactions();
+    const { data: transactions, fetchNextPage, isFetching, isLoading, setFilter } = useTransactions();
+    const [shouldShowLoader, setShouldShowLoader] = useState(true);
 
     const fetchMoreOnBottomReached = useCallback(
         (containerRefElement?: HTMLDivElement | null) => {
@@ -31,9 +33,18 @@ const TransactionsCompleted: React.FC<TProps> = ({ filter }) => {
 
     useEffect(() => {
         setFilter(filter);
+        setShouldShowLoader(true);
     }, [filter]); // eslint-disable-line react-hooks/exhaustive-deps
 
-    if (!data) return <TransactionsNoDataState />;
+    useEffect(() => {
+        if (!isFetching && !isLoading) {
+            setShouldShowLoader(false);
+        }
+    }, [transactions, isFetching, isLoading]);
+
+    if (shouldShowLoader) return <Loader />;
+
+    if (!transactions) return <TransactionsNoDataState />;
 
     return (
         <TransactionsTable
@@ -44,7 +55,7 @@ const TransactionsCompleted: React.FC<TProps> = ({ filter }) => {
                     header: 'Date',
                 },
             ]}
-            data={data}
+            data={transactions}
             fetchMore={fetchMoreOnBottomReached}
             groupBy={['date']}
             rowGroupRender={transaction => (

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsPending/TransactionsPending.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsPending/TransactionsPending.tsx
@@ -14,7 +14,7 @@ type TProps = {
 };
 
 const TransactionsPending: React.FC<TProps> = ({ filter = 'all' }) => {
-    const { data: transactions, isLoading, resetData, subscribe, unsubscribe } = useCryptoTransactions();
+    const { data: transactions, isLoading, isSubscribed, resetData, subscribe, unsubscribe } = useCryptoTransactions();
 
     useEffect(() => {
         resetData();
@@ -23,7 +23,7 @@ const TransactionsPending: React.FC<TProps> = ({ filter = 'all' }) => {
         return () => unsubscribe();
     }, [filter, resetData, subscribe, unsubscribe]);
 
-    if (!transactions && isLoading) return <Loader />;
+    if (!isSubscribed || isLoading) return <Loader />;
 
     if (!transactions) return <TransactionsNoDataState />;
 

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsPending/TransactionsPending.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsPending/TransactionsPending.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import moment from 'moment';
 import { useCryptoTransactions } from '@deriv/api';
 import { Loader } from '../../../../../../components';
@@ -14,24 +14,16 @@ type TProps = {
 };
 
 const TransactionsPending: React.FC<TProps> = ({ filter = 'all' }) => {
-    const { data: transactions, isLoading, isSubscribed, resetData, subscribe, unsubscribe } = useCryptoTransactions();
-    const [shouldShowLoader, setShouldShowLoader] = useState(true);
+    const { data: transactions, isLoading, resetData, subscribe, unsubscribe } = useCryptoTransactions();
 
     useEffect(() => {
-        setShouldShowLoader(true);
         resetData();
         subscribe({ payload: { transaction_type: filter } });
 
         return () => unsubscribe();
     }, [filter, resetData, subscribe, unsubscribe]);
 
-    useEffect(() => {
-        if (isSubscribed && !isLoading) {
-            setShouldShowLoader(false);
-        }
-    }, [isLoading, isSubscribed]);
-
-    if (shouldShowLoader) return <Loader />;
+    if (!transactions && isLoading) return <Loader />;
 
     if (!transactions) return <TransactionsNoDataState />;
 

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsTable/TransactionsTable.scss
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsTable/TransactionsTable.scss
@@ -1,13 +1,22 @@
 .wallets-transactions-table {
-    padding-block: 0.8rem;
+    width: 100%;
     display: flex;
     flex-direction: column;
-    gap: 1.6rem;
+    align-items: center;
+    padding-block: 0 0.8rem;
     height: 65vh;
     overflow: auto;
 
     @include mobile {
         height: 75vh;
+    }
+
+    &-content {
+        width: 100%;
+        max-width: 80rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1.6rem;
     }
 
     &-row {

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsTable/TransactionsTable.scss
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsTable/TransactionsTable.scss
@@ -11,7 +11,7 @@
         height: 75vh;
     }
 
-    &-content {
+    &__content {
         width: 100%;
         max-width: 80rem;
         display: flex;
@@ -19,7 +19,7 @@
         gap: 1.6rem;
     }
 
-    &-row {
+    &__row {
         display: flex;
         flex-direction: column;
         gap: 0.8rem;

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsTable/TransactionsTable.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsTable/TransactionsTable.tsx
@@ -27,9 +27,9 @@ const TransactionsTable = <T,>({ columns, data, fetchMore, groupBy, rowGroupRend
             onScroll={e => (fetchMore ? fetchMore(e.target as HTMLDivElement) : null)}
             ref={tableContainerRef}
         >
-            <div className='wallets-transactions-table-content'>
+            <div className='wallets-transactions-table__content'>
                 {table.getRowModel().rows.map(rowGroup => (
-                    <div className='wallets-transactions-table-row' key={rowGroup.id}>
+                    <div className='wallets-transactions-table__row' key={rowGroup.id}>
                         {rowGroupRender(rowGroup.original)}
                         {rowGroup.subRows.map(row => (
                             <div key={row.id}>{rowRender(row.original)}</div>

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsTable/TransactionsTable.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsTable/TransactionsTable.tsx
@@ -27,14 +27,16 @@ const TransactionsTable = <T,>({ columns, data, fetchMore, groupBy, rowGroupRend
             onScroll={e => (fetchMore ? fetchMore(e.target as HTMLDivElement) : null)}
             ref={tableContainerRef}
         >
-            {table.getRowModel().rows.map(rowGroup => (
-                <div className='wallets-transactions-table-row' key={rowGroup.id}>
-                    {rowGroupRender(rowGroup.original)}
-                    {rowGroup.subRows.map(row => (
-                        <div key={row.id}>{rowRender(row.original)}</div>
-                    ))}
-                </div>
-            ))}
+            <div className='wallets-transactions-table-content'>
+                {table.getRowModel().rows.map(rowGroup => (
+                    <div className='wallets-transactions-table-row' key={rowGroup.id}>
+                        {rowGroupRender(rowGroup.original)}
+                        {rowGroup.subRows.map(row => (
+                            <div key={row.id}>{rowRender(row.original)}</div>
+                        ))}
+                    </div>
+                ))}
+            </div>
         </div>
     );
 };


### PR DESCRIPTION
## Changes:

- [x] fix double scroll & layout issues on desktop
- [x] add loaders when switching and waiting for data 
- [x] fix a bug of previous transactions details appearing for a split second after switching to other wallet

### Screenshots:

https://github.com/binary-com/deriv-app/assets/119863957/837e23eb-3e89-4664-92e8-a8e2176cd79b
