### PR TITLE
fix: make setCurrentFocus optional

### DIFF
--- a/packages/components/src/components/input-field/input.tsx
+++ b/packages/components/src/components/input-field/input.tsx
@@ -36,7 +36,7 @@ type TInputProps = {
     onKeyPressed: React.KeyboardEventHandler<HTMLInputElement>;
     placeholder?: string;
     required?: boolean;
-    setCurrentFocus: (name: string | null) => void;
+    setCurrentFocus?: (name: string | null) => void;
     type: string;
     value?: number | string;
 };
@@ -80,12 +80,10 @@ const Input = ({
     }, [current_focus, name]);
 
     const onBlurHandler = (e: React.FocusEvent<HTMLInputElement>) => {
-        setCurrentFocus(null);
-        if (onBlur) {
-            onBlur(e);
-        }
+        setCurrentFocus?.(null);
+        onBlur?.(e);
     };
-    const onFocus = () => setCurrentFocus(name);
+    const onFocus = () => setCurrentFocus?.(name);
 
     const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         /**


### PR DESCRIPTION
Fix a trackjs error when `setCurrentFocus` is not passed in