### PR TITLE
Create smoketests.yml

### DIFF
--- a/.github/workflows/smoketests.yml
+++ b/.github/workflows/smoketests.yml
@@ -14,7 +14,7 @@ on:
         
 jobs:
   cypress-run:
-    runs-on: ubuntu-latest
+    runs-on: Runner_16cores_Deriv-app
     strategy:
       fail-fast: false 
       matrix:

--- a/.github/workflows/smoketests.yml
+++ b/.github/workflows/smoketests.yml
@@ -1,0 +1,80 @@
+name: Run Smoke Tests - Deriv app
+
+permissions:
+    actions: write
+    checks: write
+    contents: write
+    deployments: write
+    pull-requests: write
+    statuses: write
+
+on: 
+    issue_comment:
+        types: [edited]
+        
+jobs:
+  cypress-run:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false 
+      matrix:
+        containers: [1,2]
+
+    steps:
+    - name: Capture Vercel preview URL
+      id: vercel_preview_url
+      uses: binary-com/vercel-preview-url-action@v1.0.5
+      with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
+    - name: Checkout external repository with Cypress tests
+      uses: actions/checkout@v4
+      with:
+        repository: deriv-com/e2e-deriv-app
+        #repository: deriv-experiments/Cypress-demo
+
+    - name: Cypress run
+      # Uses the official Cypress GitHub action https://github.com/cypress-io/github-action
+      uses: cypress-io/github-action@v6
+      with:
+        # Records to Cypress Cloud 
+        # https://docs.cypress.io/guides/cloud/projects#Set-up-a-project-to-record
+        record: true
+        parallel: true # Runs test in parallel using settings above
+        spec: cypress/e2e/smoke/*.js
+        group: 'Smoke Tests'
+        
+      env:
+        # For recording and parallelization to work you must set your CYPRESS_RECORD_KEY
+        # in GitHub repo → Settings → Secrets → Actions
+        CYPRESS_RECORD_KEY: ${{ secrets.E2E_CYPRESS_RECORD_KEY }}
+        # Creating a token https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
+        GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        # Set Base Url from client_payload.
+        CYPRESS_BASE_URL: ${{ steps.vercel_preview_url.outputs.vercel_preview_url }}
+        # Send PR details to Cypress test run
+        COMMIT_INFO_MESSAGE: PR "${{ github.event.issue.number }}" in Repo "${{ github.repository }}"
+        # Set login env variables
+        E2E_OAUTH_URL: ${{ secrets.E2E_OAUTH_URL }}
+        E2E_CONFIG_APPID: ${{ secrets.E2E_CONFIG_APPID }}
+        E2E_CONFIG_SERVER: ${{ secrets.E2E_CONFIG_SERVER }}
+
+    - name: Set comments message
+      id: set_msg 
+      if: always()
+      run: |
+        # Using shell script to conditionally set the message
+        if [[ "${{ job.status }}" == "success" ]]; then
+          echo "msg=:rocket: Smoke test run (${{ matrix.containers }}) passed successfully!" >> $GITHUB_OUTPUT
+        else
+          echo "msg=:x: Smoke test run (${{ matrix.containers }}) failed. See logs for details: [Visit Action](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}})" >> $GITHUB_OUTPUT
+        fi
+        
+    - name: Leave comment
+      if: always()
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        header: Smoke tests status update
+        number: ${{ github.event.issue.number }}
+        message: "${{ steps.set_msg.outputs.msg }}"
+        recreate: true

--- a/.github/workflows/smoketests.yml
+++ b/.github/workflows/smoketests.yml
@@ -40,7 +40,7 @@ jobs:
         # https://docs.cypress.io/guides/cloud/projects#Set-up-a-project-to-record
         record: true
         parallel: true # Runs test in parallel using settings above
-        spec: cypress/e2e/smoke/*.js
+        spec: cypress/e2e/smoke/t*.js
         group: 'Smoke Tests'
         
       env:

--- a/.github/workflows/smoketests.yml
+++ b/.github/workflows/smoketests.yml
@@ -31,7 +31,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: deriv-com/e2e-deriv-app
-        #repository: deriv-experiments/Cypress-demo
 
     - name: Cypress run
       # Uses the official Cypress GitHub action https://github.com/cypress-io/github-action


### PR DESCRIPTION
Create yml that will run e2e smoke tests after PR comment has been edited (e.g. by Vercel update). This yml is based on the smoketest.yml that is already up and running in Deriv-com, with which @balakrishna-deriv has had some visibility.

The current test that this will run is a very simple. i.e. Login and test app-trader account switcher. We will add to the tests gradually so as to bed the process in gently.

NB. I have run this past @ali-hosseini-deriv and see https://app.clickup.com/t/20696747/FEQ-873, if other approvers require further info. And I have added the requisite E2E_ secrets as defined in the Cypress env variable section.

## Changes:

Please provide a summary of the change.

### Screenshots:

Please provide some screenshots of the change.
