### PR TITLE
shontzu/PRODQA-1335/Swap-free-jurisdiction-modal-has-extra-spaces-and-Next-button-not-visible-on-mobile-2

### DIFF
--- a/packages/appstore/src/components/cfds-listing/cfds-listing.scss
+++ b/packages/appstore/src/components/cfds-listing/cfds-listing.scss
@@ -43,9 +43,12 @@
     }
     &__wrapper {
         @include desktop {
-            height: 76rem;
+            height: 69rem;
             perspective: 100rem;
             overflow: scroll;
+            &:has(.jurisdiction-modal__scrollable-content .cfd-jurisdiction-card--financial__wrapper) {
+                height: 76rem;
+            }
         }
     }
 
@@ -185,7 +188,7 @@
     &__footnotes-container {
         display: flex;
         flex-direction: column;
-        justify-content: center;
+
         gap: 1rem;
         margin: 1rem;
         @include desktop {
@@ -233,6 +236,16 @@
         & > p {
             font-size: 16px;
             text-align: center;
+        }
+    }
+}
+
+.cfd-jurisdiction-card--financial {
+    &__footnotes-container {
+        @include desktop {
+            gap: 1rem;
+            min-height: 7.6rem;
+            margin: 1rem;
         }
     }
 }

--- a/packages/appstore/src/components/cfds-listing/cfds-listing.scss
+++ b/packages/appstore/src/components/cfds-listing/cfds-listing.scss
@@ -43,12 +43,8 @@
     }
     &__wrapper {
         @include desktop {
-            height: 69rem;
+            height: 76rem;
             perspective: 100rem;
-            overflow: scroll;
-            &:has(.jurisdiction-modal__scrollable-content .cfd-jurisdiction-card--financial__wrapper) {
-                height: 76rem;
-            }
         }
     }
 
@@ -190,7 +186,7 @@
         flex-direction: column;
 
         gap: 1rem;
-        margin: 1rem;
+        margin: 1rem 1rem 7rem;
         @include desktop {
             min-height: 7.6rem;
         }


### PR DESCRIPTION
- [CU](https://app.clickup.com/t/20696747/CFDS-1322)

before: URL bar on top of screen and navigation bar on bottom screen causing many small issues like:
- "Next" button not visible in mobile with navigation bar
- A lot of extra space when "Next" button is visible
- gap in footer between checkbox and "Next" button 
- double scrollers in tablet view causing glitchy experience

<img src='https://github.com/binary-com/deriv-app/assets/108507236/3b20329c-39d0-4481-b074-9e86cdc2f4b1' width="25%" />
<img src='https://github.com/binary-com/deriv-app/assets/108507236/31cdc778-2135-42e5-9e11-db89ad8a1d81' width="25%" />
<img src='https://github.com/binary-com/deriv-app/assets/108507236/a7fa6cb3-e7aa-448b-8e40-842e6c54b9a9' width="25%" />
<img src='https://github.com/binary-com/deriv-app/assets/108507236/2a5220a5-7bf0-4459-b049-5abbf4b3dfa9' width="15%" />

after: 
- "Next" button stays at bottom of screen without needing to scroll and doesn't get hidden by navigation bar
- double scrollers fixed and scrolling on tablet is smooth not glitchy
- the fix does not break desktop or tablet view and works in both MF and CR accounts

https://github.com/binary-com/deriv-app/assets/108507236/b540ee33-7832-4c4e-a7e8-f771bea49872

https://github.com/binary-com/deriv-app/assets/108507236/a0d3c138-c445-48b0-a016-62c749c7af9f


