### PR TITLE
fix: jurisdiction modal next button issue

### DIFF
--- a/packages/appstore/src/components/cfds-listing/cfds-listing.scss
+++ b/packages/appstore/src/components/cfds-listing/cfds-listing.scss
@@ -43,12 +43,9 @@
     }
     &__wrapper {
         @include desktop {
-            height: 69rem;
+            height: 76rem;
             perspective: 100rem;
             overflow: scroll;
-            &:has(.jurisdiction-modal__scrollable-content .cfd-jurisdiction-card--financial__wrapper) {
-                height: 76rem;
-            }
         }
     }
 

--- a/packages/appstore/src/components/cfds-listing/cfds-listing.scss
+++ b/packages/appstore/src/components/cfds-listing/cfds-listing.scss
@@ -1,4 +1,7 @@
 .jurisdiction-modal {
+    &__header ~ .dc-mobile-dialog__content {
+        height: 100%;
+    }
     &__title {
         display: flex;
         gap: 1.6rem;
@@ -14,44 +17,38 @@
     &__content-wrapper {
         display: flex;
         flex-direction: column;
-        @include desktop {
-            overflow: auto;
-        }
+        justify-content: space-between;
         width: 100%;
+        height: 100%;
         position: absolute;
         backface-visibility: hidden;
         transition: transform 0.6s ease;
         transform: rotateY(0deg);
     }
-    &__scrollable-content {
-        @include desktop {
-            overflow: auto;
-            height: 69rem;
-        }
-    }
+
     &__footer-content {
         background-color: var(--general-main-1);
         @include mobile {
             position: sticky;
-            bottom: 7.2rem;
+            bottom: 0;
         }
     }
     &__footer-button {
         background-color: var(--general-main-1);
         @include mobile {
-            height: 7.2rem;
             position: sticky;
             bottom: 0;
+            width: 100%;
         }
     }
-
     &__wrapper {
-        height: 76rem;
-        perspective: 100rem;
-        overflow: scroll;
-
-        @include mobile {
-            height: calc(100vh - 4rem);
+        @include desktop {
+            height: 69rem;
+            perspective: 100rem;
+            overflow: scroll;
+            &:has(.jurisdiction-modal__scrollable-content .cfd-jurisdiction-card--financial__wrapper) {
+                height: 76rem;
+            }
         }
     }
 
@@ -69,6 +66,10 @@
                 height: 70rem;
                 transform: rotateY(-180deg);
                 visibility: hidden;
+
+                @include mobile {
+                    height: 100%;
+                }
             }
         }
 
@@ -100,7 +101,7 @@
     }
 
     &__wrapper {
-        margin: 4rem 6rem 2rem;
+        margin: 3rem 5rem 1rem;
         display: flex;
         justify-content: center;
         gap: 1.6rem;
@@ -111,7 +112,7 @@
             flex-direction: column;
             align-items: center;
             overflow-y: scroll;
-            height: 60%;
+            height: 100%;
         }
     }
     &--selected {
@@ -181,14 +182,13 @@
         @include mobile {
             min-height: auto;
             width: 100%;
-            height: 100%;
         }
     }
 
     &__footnotes-container {
         display: flex;
         flex-direction: column;
-        justify-content: center;
+
         gap: 1rem;
         margin: 1rem;
         @include desktop {
@@ -217,6 +217,7 @@
         display: flex;
         justify-content: center;
         @include mobile {
+            margin-bottom: 1rem;
             padding: 0.8rem;
         }
     }
@@ -235,6 +236,16 @@
         & > p {
             font-size: 16px;
             text-align: center;
+        }
+    }
+}
+
+.cfd-jurisdiction-card--financial {
+    &__footnotes-container {
+        @include desktop {
+            gap: 1rem;
+            min-height: 7.6rem;
+            margin: 1rem;
         }
     }
 }
@@ -437,6 +448,7 @@
     &__maintenance {
         display: flex;
         padding-top: 1rem;
+        align-items: center;
 
         &-icon {
             padding-right: 0.5rem;
@@ -524,6 +536,7 @@
         &-description {
             display: flex;
             justify-content: center;
+            margin-top: 1.4rem;
         }
 
         &-app {
@@ -554,11 +567,6 @@
 
                     &:hover {
                         background-color: var(--button-secondary-hover);
-                    }
-                }
-                &-hide {
-                    @include mobile {
-                        display: none;
                     }
                 }
             }
@@ -648,11 +656,6 @@
                 align-items: center;
                 border: 1px solid var(--border-disabled);
                 border-radius: 5px;
-                &-hide {
-                    @include mobile {
-                        display: none;
-                    }
-                }
             }
         }
         &-text {
@@ -813,7 +816,7 @@
 
         @include mobile {
             grid-template-columns: 1fr;
-            margin: 0 6.5rem;
+            margin: 0 6.5rem 3rem;
         }
     }
 

--- a/packages/appstore/src/components/modals/account-type-modal/account-type-modal.scss
+++ b/packages/appstore/src/components/modals/account-type-modal/account-type-modal.scss
@@ -59,4 +59,13 @@
         justify-content: center;
         margin-bottom: 1rem;
     }
+
+    &__footer-button {
+        background-color: var(--general-main-1);
+        @include mobile {
+            position: sticky;
+            bottom: 0;
+            width: 100%;
+        }
+    }
 }

--- a/packages/appstore/src/components/modals/account-type-modal/account-type-modal.tsx
+++ b/packages/appstore/src/components/modals/account-type-modal/account-type-modal.tsx
@@ -177,7 +177,7 @@ const MT5AccountTypeModal = () => {
                             is_synthetic_available={is_synthetic_available}
                             is_swapfree_available={is_swapfree_available}
                         />
-                        <Modal.Footer has_separator>
+                        <Modal.Footer className='account-type-card__footer-button' has_separator>
                             <Button
                                 style={{ width: '100%' }}
                                 disabled={!account_type_card}

--- a/packages/cfd/src/Containers/jurisdiction-modal/__test__/jurisdiction-modal-checkbox.spec.tsx
+++ b/packages/cfd/src/Containers/jurisdiction-modal/__test__/jurisdiction-modal-checkbox.spec.tsx
@@ -1,56 +1,66 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import JurisdictionModalCheckbox from '../jurisdiction-modal-checkbox';
-import RootStore from 'Stores/index';
-import { Jurisdiction } from '@deriv/shared';
+import { StoreProvider, mockStore } from '@deriv/stores';
+import { JURISDICTION } from '../../../Helpers/cfd-config';
 
 describe('JurisdictionModalCheckbox', () => {
-    const mock_store = {
-        client: {},
-        common: {},
-        ui: {},
-    };
-    const mockRootStore = new RootStore(mock_store);
+    const mock_store = mockStore({
+        ui: { is_mobile: false },
+    });
 
     const mock_props = {
         class_name: '',
         is_checked: false,
         jurisdiction_selected_shortcode: '',
         onCheck: jest.fn(),
-        context: mockRootStore,
         should_restrict_bvi_account_creation: false,
         should_restrict_vanuatu_account_creation: false,
     };
 
+    const wrapper = ({ children }: { children: JSX.Element }) => (
+        <StoreProvider store={mock_store}>{children}</StoreProvider>
+    );
+
     it('should not render JurisdictionModalCheckbox when jurisdiction is not selected', () => {
-        render(<JurisdictionModalCheckbox {...mock_props} />);
+        render(<JurisdictionModalCheckbox {...mock_props} />, { wrapper });
         expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
     });
 
     it('should render labuan account and displays checkbox', () => {
-        render(<JurisdictionModalCheckbox {...mock_props} jurisdiction_selected_shortcode={Jurisdiction.LABUAN} />);
+        render(<JurisdictionModalCheckbox {...mock_props} jurisdiction_selected_shortcode={JURISDICTION.LABUAN} />, {
+            wrapper,
+        });
         expect(screen.queryByRole('checkbox')).toBeInTheDocument();
     });
 
     it('should render function onCheck when checkbox is clicked for labuan account', () => {
-        render(<JurisdictionModalCheckbox {...mock_props} jurisdiction_selected_shortcode={Jurisdiction.LABUAN} />);
+        render(<JurisdictionModalCheckbox {...mock_props} jurisdiction_selected_shortcode={JURISDICTION.LABUAN} />, {
+            wrapper,
+        });
         const checkbox = screen.getByRole('checkbox');
         fireEvent.click(checkbox);
         expect(mock_props.onCheck).toHaveBeenCalled();
     });
 
     it('should render svg account without displaying checkbox', () => {
-        render(<JurisdictionModalCheckbox {...mock_props} jurisdiction_selected_shortcode={Jurisdiction.SVG} />);
+        render(<JurisdictionModalCheckbox {...mock_props} jurisdiction_selected_shortcode={JURISDICTION.SVG} />, {
+            wrapper,
+        });
         expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
     });
 
     it('should render bvi account without restriction and displays checkbox', () => {
-        render(<JurisdictionModalCheckbox {...mock_props} jurisdiction_selected_shortcode={Jurisdiction.BVI} />);
+        render(<JurisdictionModalCheckbox {...mock_props} jurisdiction_selected_shortcode={JURISDICTION.BVI} />, {
+            wrapper,
+        });
         expect(screen.queryByRole('checkbox')).toBeInTheDocument();
     });
 
     it('should render function onCheck when checkbox is clicked for bvi account without restriction', () => {
-        render(<JurisdictionModalCheckbox {...mock_props} jurisdiction_selected_shortcode={Jurisdiction.BVI} />);
+        render(<JurisdictionModalCheckbox {...mock_props} jurisdiction_selected_shortcode={JURISDICTION.BVI} />, {
+            wrapper,
+        });
         const checkbox = screen.getByRole('checkbox');
         fireEvent.click(checkbox);
         expect(mock_props.onCheck).toHaveBeenCalled();
@@ -60,20 +70,25 @@ describe('JurisdictionModalCheckbox', () => {
         render(
             <JurisdictionModalCheckbox
                 {...mock_props}
-                jurisdiction_selected_shortcode={Jurisdiction.BVI}
+                jurisdiction_selected_shortcode={JURISDICTION.BVI}
                 should_restrict_bvi_account_creation
-            />
+            />,
+            { wrapper }
         );
         expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
     });
 
     it('should render vanuatu account without restriction and displays checkbox', () => {
-        render(<JurisdictionModalCheckbox {...mock_props} jurisdiction_selected_shortcode={Jurisdiction.VANUATU} />);
+        render(<JurisdictionModalCheckbox {...mock_props} jurisdiction_selected_shortcode={JURISDICTION.VANUATU} />, {
+            wrapper,
+        });
         expect(screen.queryByRole('checkbox')).toBeInTheDocument();
     });
 
     it('should render function onCheck when checkbox is clicked for vanuatu account without restriction', () => {
-        render(<JurisdictionModalCheckbox {...mock_props} jurisdiction_selected_shortcode={Jurisdiction.VANUATU} />);
+        render(<JurisdictionModalCheckbox {...mock_props} jurisdiction_selected_shortcode={JURISDICTION.VANUATU} />, {
+            wrapper,
+        });
         const checkbox = screen.getByRole('checkbox');
         fireEvent.click(checkbox);
         expect(mock_props.onCheck).toHaveBeenCalled();
@@ -83,9 +98,10 @@ describe('JurisdictionModalCheckbox', () => {
         render(
             <JurisdictionModalCheckbox
                 {...mock_props}
-                jurisdiction_selected_shortcode={Jurisdiction.VANUATU}
+                jurisdiction_selected_shortcode={JURISDICTION.VANUATU}
                 should_restrict_vanuatu_account_creation
-            />
+            />,
+            { wrapper }
         );
         expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
     });

--- a/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal-checkbox.tsx
+++ b/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal-checkbox.tsx
@@ -35,7 +35,7 @@ const JurisdictionCheckBox = ({
     };
 
     const getCheckboxLabel = () => (
-        <Text as='p' align='center' size={isMobile() ? 'xxs' : 'xs'} line_height='xs'>
+        <Text as='p' size={isMobile() ? 'xxs' : 'xs'} line_height='xs'>
             <Localize
                 i18n_default_text="I confirm and accept {{company}} 's <0>Terms and Conditions</0>"
                 values={{ company: dbvi_company_names[jurisdiction_selected_shortcode].name }}

--- a/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal-checkbox.tsx
+++ b/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal-checkbox.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Checkbox, StaticUrl, Text } from '@deriv/components';
-import { isMobile, Jurisdiction } from '@deriv/shared';
+import { is_mobile, Jurisdiction } from '@deriv/shared';
 import { Localize } from '@deriv/translations';
 import { TJurisdictionCheckBoxProps } from '../props.types';
 
@@ -35,7 +35,7 @@ const JurisdictionCheckBox = ({
     };
 
     const getCheckboxLabel = () => (
-        <Text as='p' size={isMobile() ? 'xxs' : 'xs'} line_height='xs'>
+        <Text as='p' size={is_mobile ? 'xxs' : 'xs'} line_height='xs'>
             <Localize
                 i18n_default_text="I confirm and accept {{company}} 's <0>Terms and Conditions</0>"
                 values={{ company: dbvi_company_names[jurisdiction_selected_shortcode].name }}

--- a/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal-checkbox.tsx
+++ b/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal-checkbox.tsx
@@ -1,72 +1,74 @@
 import React from 'react';
 import { Checkbox, StaticUrl, Text } from '@deriv/components';
-import { useStore } from '@deriv/stores';
-import { Jurisdiction } from '@deriv/shared';
+import { useStore, observer } from '@deriv/stores';
 import { Localize } from '@deriv/translations';
 import { TJurisdictionCheckBoxProps } from '../props.types';
+import { JURISDICTION } from '../../Helpers/cfd-config';
 
-const JurisdictionCheckBox = ({
-    class_name,
-    is_checked,
-    jurisdiction_selected_shortcode,
-    onCheck,
-    should_restrict_bvi_account_creation,
-    should_restrict_vanuatu_account_creation,
-}: TJurisdictionCheckBoxProps) => {
-    const { ui } = useStore();
-    const { is_mobile } = ui;
+const JurisdictionCheckBox = observer(
+    ({
+        class_name,
+        is_checked,
+        jurisdiction_selected_shortcode,
+        onCheck,
+        should_restrict_bvi_account_creation,
+        should_restrict_vanuatu_account_creation,
+    }: TJurisdictionCheckBoxProps) => {
+        const { ui } = useStore();
+        const { is_mobile } = ui;
 
-    const shouldShowCheckBox = () => {
-        if (
-            !jurisdiction_selected_shortcode ||
-            jurisdiction_selected_shortcode === Jurisdiction.SVG ||
-            (jurisdiction_selected_shortcode === Jurisdiction.BVI && should_restrict_bvi_account_creation) ||
-            (jurisdiction_selected_shortcode === Jurisdiction.VANUATU && should_restrict_vanuatu_account_creation)
-        ) {
-            return false;
-        }
-        return true;
-    };
+        const shouldShowCheckBox = () => {
+            if (
+                !jurisdiction_selected_shortcode ||
+                jurisdiction_selected_shortcode === JURISDICTION.SVG ||
+                (jurisdiction_selected_shortcode === JURISDICTION.BVI && should_restrict_bvi_account_creation) ||
+                (jurisdiction_selected_shortcode === JURISDICTION.VANUATU && should_restrict_vanuatu_account_creation)
+            ) {
+                return false;
+            }
+            return true;
+        };
 
-    const dbvi_company_names: { [key: string]: { [key: string]: string } } = {
-        bvi: { name: 'Deriv (BVI) Ltd', tnc_url: 'tnc/deriv-(bvi)-ltd.pdf' },
-        labuan: { name: 'Deriv (FX) Ltd', tnc_url: 'tnc/deriv-(fx)-ltd.pdf' },
-        maltainvest: {
-            name: 'Deriv Investments (Europe) Limited',
-            tnc_url: 'tnc/deriv-investments-(europe)-limited.pdf',
-        },
-        vanuatu: { name: 'Deriv (V) Ltd', tnc_url: 'tnc/general-terms.pdf' },
-    };
+        const dbvi_company_names: { [key: string]: { [key: string]: string } } = {
+            bvi: { name: 'Deriv (BVI) Ltd', tnc_url: 'tnc/deriv-(bvi)-ltd.pdf' },
+            labuan: { name: 'Deriv (FX) Ltd', tnc_url: 'tnc/deriv-(fx)-ltd.pdf' },
+            maltainvest: {
+                name: 'Deriv Investments (Europe) Limited',
+                tnc_url: 'tnc/deriv-investments-(europe)-limited.pdf',
+            },
+            vanuatu: { name: 'Deriv (V) Ltd', tnc_url: 'tnc/general-terms.pdf' },
+        };
 
-    const getCheckboxLabel = () => (
-        <Text as='p' size={is_mobile ? 'xxs' : 'xs'} line_height='xs'>
-            <Localize
-                i18n_default_text="I confirm and accept {{company}} 's <0>Terms and Conditions</0>"
-                values={{ company: dbvi_company_names[jurisdiction_selected_shortcode].name }}
-                components={[
-                    <StaticUrl
-                        key={0}
-                        className='link--no-bold'
-                        href={dbvi_company_names[jurisdiction_selected_shortcode].tnc_url}
-                    />,
-                ]}
-            />
-        </Text>
-    );
-    return (
-        <React.Fragment>
-            {shouldShowCheckBox() && (
-                <div className={class_name}>
-                    <Checkbox
-                        value={is_checked}
-                        onChange={onCheck}
-                        label={getCheckboxLabel()}
-                        defaultChecked={!!is_checked}
-                    />
-                </div>
-            )}
-        </React.Fragment>
-    );
-};
+        const getCheckboxLabel = () => (
+            <Text as='p' size={is_mobile ? 'xxs' : 'xs'} line_height='xs'>
+                <Localize
+                    i18n_default_text="I confirm and accept {{company}} 's <0>Terms and Conditions</0>"
+                    values={{ company: dbvi_company_names[jurisdiction_selected_shortcode].name }}
+                    components={[
+                        <StaticUrl
+                            key={0}
+                            className='link--no-bold'
+                            href={dbvi_company_names[jurisdiction_selected_shortcode].tnc_url}
+                        />,
+                    ]}
+                />
+            </Text>
+        );
+        return (
+            <React.Fragment>
+                {shouldShowCheckBox() && (
+                    <div className={class_name}>
+                        <Checkbox
+                            value={is_checked}
+                            onChange={onCheck}
+                            label={getCheckboxLabel()}
+                            defaultChecked={!!is_checked}
+                        />
+                    </div>
+                )}
+            </React.Fragment>
+        );
+    }
+);
 
 export default JurisdictionCheckBox;

--- a/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal-checkbox.tsx
+++ b/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal-checkbox.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Checkbox, StaticUrl, Text } from '@deriv/components';
-import { is_mobile, Jurisdiction } from '@deriv/shared';
+import { useStore } from '@deriv/stores';
+import { Jurisdiction } from '@deriv/shared';
 import { Localize } from '@deriv/translations';
 import { TJurisdictionCheckBoxProps } from '../props.types';
 
@@ -12,6 +13,9 @@ const JurisdictionCheckBox = ({
     should_restrict_bvi_account_creation,
     should_restrict_vanuatu_account_creation,
 }: TJurisdictionCheckBoxProps) => {
+    const { ui } = useStore();
+    const { is_mobile } = ui;
+
     const shouldShowCheckBox = () => {
         if (
             !jurisdiction_selected_shortcode ||

--- a/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal-content-wrapper.tsx
+++ b/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal-content-wrapper.tsx
@@ -1,15 +1,14 @@
 import classNames from 'classnames';
 import React from 'react';
 import { Button, Modal } from '@deriv/components';
-import { getAuthenticationStatusInfo, isMobile } from '@deriv/shared';
-import { useStore, observer } from '@deriv/stores';
+import { getAuthenticationStatusInfo, isMobile, Jurisdiction } from '@deriv/shared';
 import { localize } from '@deriv/translations';
 import { TJurisdictionModalContentWrapperProps } from '../props.types';
 import JurisdictionModalContent from './jurisdiction-modal-content';
 import JurisdictionCheckBox from './jurisdiction-modal-checkbox';
 import JurisdictionModalFootNote from './jurisdiction-modal-foot-note';
+import { useStore, observer } from '@deriv/stores';
 import { useCfdStore } from '../../Stores/Modules/CFD/Helpers/useCfdStores';
-import { MARKET_TYPE, JURISDICTION } from '../../Helpers/cfd-config';
 
 const JurisdictionModalContentWrapper = observer(({ openPasswordModal }: TJurisdictionModalContentWrapperProps) => {
     const { client, traders_hub } = useStore();
@@ -71,29 +70,29 @@ const JurisdictionModalContentWrapper = observer(({ openPasswordModal }: TJurisd
 
     const financial_available_accounts = trading_platform_available_accounts.filter(
         available_account =>
-            available_account.market_type === MARKET_TYPE.FINANCIAL &&
+            available_account.market_type === 'financial' &&
             (show_eu_related_content
-                ? available_account.shortcode === JURISDICTION.MALTA_INVEST
-                : available_account.shortcode !== JURISDICTION.MALTA_INVEST)
+                ? available_account.shortcode === 'maltainvest'
+                : available_account.shortcode !== 'maltainvest')
     );
 
     const synthetic_available_accounts = trading_platform_available_accounts.filter(
         available_account =>
-            available_account.market_type === MARKET_TYPE.GAMING &&
+            available_account.market_type === 'gaming' &&
             (show_eu_related_content
-                ? available_account.shortcode === JURISDICTION.MALTA_INVEST
-                : available_account.shortcode !== JURISDICTION.MALTA_INVEST)
+                ? available_account.shortcode === 'maltainvest'
+                : available_account.shortcode !== 'maltainvest')
     );
 
     const all_market_type_available_accounts = trading_platform_available_accounts?.filter(
-        available_account => available_account.market_type === MARKET_TYPE.ALL
+        available_account => available_account.market_type === 'all'
     );
 
-    const is_svg_selected = jurisdiction_selected_shortcode === JURISDICTION.SVG;
-    const is_bvi_selected = jurisdiction_selected_shortcode === JURISDICTION.BVI;
-    const is_vanuatu_selected = jurisdiction_selected_shortcode === JURISDICTION.VANUATU;
-    const is_labuan_selected = jurisdiction_selected_shortcode === JURISDICTION.LABUAN;
-    const is_maltainvest_selected = jurisdiction_selected_shortcode === JURISDICTION.MALTA_INVEST;
+    const is_svg_selected = jurisdiction_selected_shortcode === Jurisdiction.SVG;
+    const is_bvi_selected = jurisdiction_selected_shortcode === Jurisdiction.BVI;
+    const is_vanuatu_selected = jurisdiction_selected_shortcode === Jurisdiction.VANUATU;
+    const is_labuan_selected = jurisdiction_selected_shortcode === Jurisdiction.LABUAN;
+    const is_maltainvest_selected = jurisdiction_selected_shortcode === Jurisdiction.MALTA_INVEST;
 
     const is_idv_country =
         residence_list.find(elem => elem?.value === residence)?.identity?.services?.idv?.is_country_supported === 1;
@@ -102,20 +101,20 @@ const JurisdictionModalContentWrapper = observer(({ openPasswordModal }: TJurisd
 
     const swapfree_available_accounts = trading_platform_available_accounts.filter(
         available_account =>
-            available_account.market_type === MARKET_TYPE.ALL &&
+            available_account.market_type === 'all' &&
             (show_eu_related_content
-                ? available_account.shortcode === JURISDICTION.MALTA_INVEST
-                : available_account.shortcode !== JURISDICTION.MALTA_INVEST)
+                ? available_account.shortcode === 'maltainvest'
+                : available_account.shortcode !== 'maltainvest')
     );
 
     const isNextButtonDisabled = () => {
         if (jurisdiction_selected_shortcode) {
             let is_account_created;
-            if (account_type.type === MARKET_TYPE.SYNTHETIC) {
+            if (account_type.type === 'synthetic') {
                 is_account_created = real_synthetic_accounts_existing_data?.some(
                     account => account.landing_company_short === jurisdiction_selected_shortcode
                 );
-            } else if (account_type.type === MARKET_TYPE.ALL) {
+            } else if (account_type.type === 'all') {
                 is_account_created = real_swapfree_accounts_existing_data?.some(
                     account => account.landing_company_short === jurisdiction_selected_shortcode
                 );
@@ -209,45 +208,40 @@ const JurisdictionModalContentWrapper = observer(({ openPasswordModal }: TJurisd
                     synthetic_available_accounts={synthetic_available_accounts}
                     all_market_type_available_accounts={all_market_type_available_accounts}
                 />
-                <div
-                    className={classNames(
-                        'jurisdiction-modal__footer-content',
-                        `cfd-jurisdiction-card--${account_type.type}__footer-wrapper`
-                    )}
-                >
-                    <div className={`cfd-jurisdiction-card--${account_type.type}__footnotes-container`}>
-                        <JurisdictionModalFootNote
-                            account_status={account_status}
-                            account_type={account_type.type}
-                            card_classname={`cfd-jurisdiction-card--${account_type.type}`}
-                            jurisdiction_selected_shortcode={jurisdiction_selected_shortcode}
-                            should_restrict_bvi_account_creation={should_restrict_bvi_account_creation}
-                            should_restrict_vanuatu_account_creation={should_restrict_vanuatu_account_creation}
-                        />
-                        <JurisdictionCheckBox
-                            is_checked={checked}
-                            onCheck={() => setChecked(!checked)}
-                            class_name={`cfd-jurisdiction-card--${account_type.type}__jurisdiction-checkbox`}
-                            jurisdiction_selected_shortcode={jurisdiction_selected_shortcode}
-                            should_restrict_bvi_account_creation={should_restrict_bvi_account_creation}
-                            should_restrict_vanuatu_account_creation={should_restrict_vanuatu_account_creation}
-                        />
-                    </div>
-                </div>
             </div>
-            <Modal.Footer className='jurisdiction-modal__footer-button' has_separator>
-                <Button
-                    disabled={isNextButtonDisabled()}
-                    primary
-                    style={{ width: isMobile() ? '100%' : 'unset' }}
-                    onClick={() => {
-                        toggleJurisdictionModal();
-                        onSelectRealAccount();
-                    }}
-                >
-                    {localize('Next')}
-                </Button>
-            </Modal.Footer>
+            <div className={classNames('jurisdiction-modal__footer-content', `cfd-jurisdiction-card__footer-wrapper`)}>
+                <div className={`cfd-jurisdiction-card--${account_type.type}__footnotes-container`}>
+                    <JurisdictionModalFootNote
+                        account_status={account_status}
+                        account_type={account_type.type}
+                        card_classname={`cfd-jurisdiction-card--${account_type.type}`}
+                        jurisdiction_selected_shortcode={jurisdiction_selected_shortcode}
+                        should_restrict_bvi_account_creation={should_restrict_bvi_account_creation}
+                        should_restrict_vanuatu_account_creation={should_restrict_vanuatu_account_creation}
+                    />
+                    <JurisdictionCheckBox
+                        is_checked={checked}
+                        onCheck={() => setChecked(!checked)}
+                        class_name={`cfd-jurisdiction-card--${account_type.type}__jurisdiction-checkbox`}
+                        jurisdiction_selected_shortcode={jurisdiction_selected_shortcode}
+                        should_restrict_bvi_account_creation={should_restrict_bvi_account_creation}
+                        should_restrict_vanuatu_account_creation={should_restrict_vanuatu_account_creation}
+                    />
+                </div>
+                <Modal.Footer className='jurisdiction-modal__footer-button' has_separator>
+                    <Button
+                        disabled={isNextButtonDisabled()}
+                        primary
+                        style={{ width: isMobile() ? '100%' : 'unset' }}
+                        onClick={() => {
+                            toggleJurisdictionModal();
+                            onSelectRealAccount();
+                        }}
+                    >
+                        {localize('Next')}
+                    </Button>
+                </Modal.Footer>
+            </div>
         </div>
     );
 });

--- a/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal-content-wrapper.tsx
+++ b/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal-content-wrapper.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import React from 'react';
 import { Button, Modal } from '@deriv/components';
-import { getAuthenticationStatusInfo, is_mobile } from '@deriv/shared';
+import { getAuthenticationStatusInfo } from '@deriv/shared';
 import { localize } from '@deriv/translations';
 import { TJurisdictionModalContentWrapperProps } from '../props.types';
 import JurisdictionModalContent from './jurisdiction-modal-content';
@@ -12,9 +12,10 @@ import { useCfdStore } from '../../Stores/Modules/CFD/Helpers/useCfdStores';
 import { MARKET_TYPE, JURISDICTION } from '../../Helpers/cfd-config';
 
 const JurisdictionModalContentWrapper = observer(({ openPasswordModal }: TJurisdictionModalContentWrapperProps) => {
-    const { client, traders_hub } = useStore();
+    const { client, traders_hub, ui } = useStore();
 
     const { show_eu_related_content } = traders_hub;
+    const { is_mobile } = ui;
 
     const {
         trading_platform_available_accounts,

--- a/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal-content-wrapper.tsx
+++ b/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal-content-wrapper.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import React from 'react';
 import { Button, Modal } from '@deriv/components';
-import { getAuthenticationStatusInfo, isMobile, Jurisdiction } from '@deriv/shared';
+import { getAuthenticationStatusInfo, is_mobile } from '@deriv/shared';
 import { localize } from '@deriv/translations';
 import { TJurisdictionModalContentWrapperProps } from '../props.types';
 import JurisdictionModalContent from './jurisdiction-modal-content';
@@ -9,6 +9,7 @@ import JurisdictionCheckBox from './jurisdiction-modal-checkbox';
 import JurisdictionModalFootNote from './jurisdiction-modal-foot-note';
 import { useStore, observer } from '@deriv/stores';
 import { useCfdStore } from '../../Stores/Modules/CFD/Helpers/useCfdStores';
+import { MARKET_TYPE, JURISDICTION } from '../../Helpers/cfd-config';
 
 const JurisdictionModalContentWrapper = observer(({ openPasswordModal }: TJurisdictionModalContentWrapperProps) => {
     const { client, traders_hub } = useStore();
@@ -70,29 +71,29 @@ const JurisdictionModalContentWrapper = observer(({ openPasswordModal }: TJurisd
 
     const financial_available_accounts = trading_platform_available_accounts.filter(
         available_account =>
-            available_account.market_type === 'financial' &&
+            available_account.market_type === MARKET_TYPE.FINANCIAL &&
             (show_eu_related_content
-                ? available_account.shortcode === 'maltainvest'
-                : available_account.shortcode !== 'maltainvest')
+                ? available_account.shortcode === JURISDICTION.MALTA_INVEST
+                : available_account.shortcode !== JURISDICTION.MALTA_INVEST)
     );
 
     const synthetic_available_accounts = trading_platform_available_accounts.filter(
         available_account =>
-            available_account.market_type === 'gaming' &&
+            available_account.market_type === MARKET_TYPE.GAMING &&
             (show_eu_related_content
-                ? available_account.shortcode === 'maltainvest'
-                : available_account.shortcode !== 'maltainvest')
+                ? available_account.shortcode === JURISDICTION.MALTA_INVEST
+                : available_account.shortcode !== JURISDICTION.MALTA_INVEST)
     );
 
     const all_market_type_available_accounts = trading_platform_available_accounts?.filter(
-        available_account => available_account.market_type === 'all'
+        available_account => available_account.market_type === MARKET_TYPE.ALL
     );
 
-    const is_svg_selected = jurisdiction_selected_shortcode === Jurisdiction.SVG;
-    const is_bvi_selected = jurisdiction_selected_shortcode === Jurisdiction.BVI;
-    const is_vanuatu_selected = jurisdiction_selected_shortcode === Jurisdiction.VANUATU;
-    const is_labuan_selected = jurisdiction_selected_shortcode === Jurisdiction.LABUAN;
-    const is_maltainvest_selected = jurisdiction_selected_shortcode === Jurisdiction.MALTA_INVEST;
+    const is_svg_selected = jurisdiction_selected_shortcode === JURISDICTION.SVG;
+    const is_bvi_selected = jurisdiction_selected_shortcode === JURISDICTION.BVI;
+    const is_vanuatu_selected = jurisdiction_selected_shortcode === JURISDICTION.VANUATU;
+    const is_labuan_selected = jurisdiction_selected_shortcode === JURISDICTION.LABUAN;
+    const is_maltainvest_selected = jurisdiction_selected_shortcode === JURISDICTION.MALTA_INVEST;
 
     const is_idv_country =
         residence_list.find(elem => elem?.value === residence)?.identity?.services?.idv?.is_country_supported === 1;
@@ -101,20 +102,20 @@ const JurisdictionModalContentWrapper = observer(({ openPasswordModal }: TJurisd
 
     const swapfree_available_accounts = trading_platform_available_accounts.filter(
         available_account =>
-            available_account.market_type === 'all' &&
+            available_account.market_type === MARKET_TYPE.ALL &&
             (show_eu_related_content
-                ? available_account.shortcode === 'maltainvest'
-                : available_account.shortcode !== 'maltainvest')
+                ? available_account.shortcode === JURISDICTION.MALTA_INVEST
+                : available_account.shortcode !== JURISDICTION.MALTA_INVEST)
     );
 
     const isNextButtonDisabled = () => {
         if (jurisdiction_selected_shortcode) {
             let is_account_created;
-            if (account_type.type === 'synthetic') {
+            if (account_type.type === MARKET_TYPE.SYNTHETIC) {
                 is_account_created = real_synthetic_accounts_existing_data?.some(
                     account => account.landing_company_short === jurisdiction_selected_shortcode
                 );
-            } else if (account_type.type === 'all') {
+            } else if (account_type.type === MARKET_TYPE.ALL) {
                 is_account_created = real_swapfree_accounts_existing_data?.some(
                     account => account.landing_company_short === jurisdiction_selected_shortcode
                 );
@@ -232,7 +233,7 @@ const JurisdictionModalContentWrapper = observer(({ openPasswordModal }: TJurisd
                     <Button
                         disabled={isNextButtonDisabled()}
                         primary
-                        style={{ width: isMobile() ? '100%' : 'unset' }}
+                        style={{ width: is_mobile ? '100%' : 'unset' }}
                         onClick={() => {
                             toggleJurisdictionModal();
                             onSelectRealAccount();

--- a/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal.tsx
+++ b/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal.tsx
@@ -8,14 +8,14 @@ import { DynamicLeverageContext } from '../dynamic-leverage/dynamic-leverage-con
 import DynamicLeverageModalContent from '../dynamic-leverage/dynamic-leverage-modal-content';
 import JurisdictionModalContentWrapper from './jurisdiction-modal-content-wrapper';
 import JurisdictionModalTitle from './jurisdiction-modal-title';
-import { MARKET_TYPE } from '../../Helpers/cfd-config';
 
 const JurisdictionModal = observer(({ openPasswordModal }: TJurisdictionModalProps) => {
-    const { traders_hub, ui, common } = useStore();
+    const { traders_hub, ui, common, client } = useStore();
 
     const { show_eu_related_content } = traders_hub;
     const { disableApp, enableApp } = ui;
     const { platform } = common;
+    const { is_eu } = client;
 
     const { account_type, is_jurisdiction_modal_visible, toggleJurisdictionModal } = useCfdStore();
 
@@ -39,7 +39,7 @@ const JurisdictionModal = observer(({ openPasswordModal }: TJurisdictionModalPro
             })}
         >
             <JurisdictionModalContentWrapper openPasswordModal={openPasswordModal} />
-            <DynamicLeverageModalContent />
+            {account_type.type === 'financial' && !is_eu && <DynamicLeverageModalContent />}
         </div>
     );
 
@@ -56,7 +56,7 @@ const JurisdictionModal = observer(({ openPasswordModal }: TJurisdictionModalPro
                             is_open={is_jurisdiction_modal_visible}
                             toggleModal={onJurisdictionModalToggle}
                             type='button'
-                            width={account_type.type === MARKET_TYPE.FINANCIAL ? '1200px' : '1040px'}
+                            width={account_type.type === 'financial' ? '1200px' : '1040px'}
                             has_close_icon={!is_dynamic_leverage_visible}
                             title={
                                 <JurisdictionModalTitle
@@ -75,6 +75,7 @@ const JurisdictionModal = observer(({ openPasswordModal }: TJurisdictionModalPro
                             visible={is_jurisdiction_modal_visible}
                             onClose={onJurisdictionModalToggle}
                             has_close_icon={!is_dynamic_leverage_visible}
+                            header_classname='jurisdiction-modal__header'
                             title={
                                 <JurisdictionModalTitle
                                     show_eu_related_content={show_eu_related_content}

--- a/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal.tsx
+++ b/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal.tsx
@@ -8,7 +8,7 @@ import { DynamicLeverageContext } from '../dynamic-leverage/dynamic-leverage-con
 import DynamicLeverageModalContent from '../dynamic-leverage/dynamic-leverage-modal-content';
 import JurisdictionModalContentWrapper from './jurisdiction-modal-content-wrapper';
 import JurisdictionModalTitle from './jurisdiction-modal-title';
-import { MARKET_TYPE } from 'src/Helpers/cfd-config';
+import { MARKET_TYPE } from '../../Helpers/cfd-config';
 
 const JurisdictionModal = observer(({ openPasswordModal }: TJurisdictionModalProps) => {
     const { traders_hub, ui, common, client } = useStore();

--- a/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal.tsx
+++ b/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal.tsx
@@ -8,6 +8,7 @@ import { DynamicLeverageContext } from '../dynamic-leverage/dynamic-leverage-con
 import DynamicLeverageModalContent from '../dynamic-leverage/dynamic-leverage-modal-content';
 import JurisdictionModalContentWrapper from './jurisdiction-modal-content-wrapper';
 import JurisdictionModalTitle from './jurisdiction-modal-title';
+import { MARKET_TYPE } from 'src/Helpers/cfd-config';
 
 const JurisdictionModal = observer(({ openPasswordModal }: TJurisdictionModalProps) => {
     const { traders_hub, ui, common, client } = useStore();
@@ -39,7 +40,7 @@ const JurisdictionModal = observer(({ openPasswordModal }: TJurisdictionModalPro
             })}
         >
             <JurisdictionModalContentWrapper openPasswordModal={openPasswordModal} />
-            {account_type.type === 'financial' && !is_eu && <DynamicLeverageModalContent />}
+            {account_type.type === MARKET_TYPE.FINANCIAL && !is_eu && <DynamicLeverageModalContent />}
         </div>
     );
 
@@ -56,7 +57,7 @@ const JurisdictionModal = observer(({ openPasswordModal }: TJurisdictionModalPro
                             is_open={is_jurisdiction_modal_visible}
                             toggleModal={onJurisdictionModalToggle}
                             type='button'
-                            width={account_type.type === 'financial' ? '1200px' : '1040px'}
+                            width={account_type.type === MARKET_TYPE.FINANCIAL ? '1200px' : '1040px'}
                             has_close_icon={!is_dynamic_leverage_visible}
                             title={
                                 <JurisdictionModalTitle


### PR DESCRIPTION
A new PR [CFDS-1324](https://app.clickup.com/t/20696747/CFDS-1324) for the reverted card [CFDS-1209 / PRODQA-1335](https://app.clickup.com/t/20696747/PRODQA-1335)


### Before: 
- "Next" button not visible in mobile with navigation bar
- A lot of extra space when "Next" button is visible
- gap in footer between checkbox and "Next" button 
- double scrollers in tablet view causing glitchy experience

<img src='https://github.com/binary-com/deriv-app/assets/108507236/3b20329c-39d0-4481-b074-9e86cdc2f4b1' width="25%" />
<img src='https://github.com/binary-com/deriv-app/assets/108507236/31cdc778-2135-42e5-9e11-db89ad8a1d81' width="25%" />
<img src='https://github.com/binary-com/deriv-app/assets/108507236/a7fa6cb3-e7aa-448b-8e40-842e6c54b9a9' width="25%" />
<img src='https://github.com/binary-com/deriv-app/assets/108507236/2a5220a5-7bf0-4459-b049-5abbf4b3dfa9' width="15%" />
<!-- <img src='https://github.com/binary-com/deriv-app/assets/108507236/64b5cae0-9c56-4fd3-aa5d-d445626a8dde' /> -->


### After:
- checking for issue in desktop, tablet, and mobile, using CR and MF account
- [figma](https://www.figma.com/file/8jC3I58t0WCAyI6pGDAIVl/Release---Deriv-MT5-accounts?type=design&node-id=17000-286959&mode=design&t=SwmSXVOGgM1Y1FlU-4)

https://github.com/binary-com/deriv-app/assets/108507236/cd4fbb0b-afc3-4396-a4f1-b307d5a6047d


