### PR TITLE
Hamza/chore: removed token from other cfd accounts

### DIFF
--- a/packages/api/src/hooks/useCreateOtherCFDAccount.ts
+++ b/packages/api/src/hooks/useCreateOtherCFDAccount.ts
@@ -8,7 +8,6 @@ const useCreateOtherCFDAccount = () => {
     const { data, ...rest } = useMutation('trading_platform_new_account', {
         onSuccess: () => {
             invalidate('trading_platform_accounts');
-            invalidate('service_token');
         },
     });
 

--- a/packages/api/src/hooks/useCtraderAccountsList.ts
+++ b/packages/api/src/hooks/useCtraderAccountsList.ts
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 import useQuery from '../useQuery';
 import useAuthorize from './useAuthorize';
-import useCtraderServiceToken from './useCtraderServiceToken';
 
 /** A custom hook that gets the list of created cTrader accounts. */
 const useCtraderAccountsList = () => {
@@ -10,7 +9,6 @@ const useCtraderAccountsList = () => {
         payload: { platform: 'ctrader' },
         options: { enabled: isSuccess },
     });
-    const { data: token } = useCtraderServiceToken();
 
     /** Adding neccesary properties to cTrader accounts */
     const modified_ctrader_accounts = useMemo(
@@ -19,10 +17,8 @@ const useCtraderAccountsList = () => {
                 ...account,
                 /** The id of the cTrader account */
                 id: account.account_id,
-                /** The token of the cTrader account */
-                token,
             })),
-        [ctrader_accounts?.trading_platform_accounts, token]
+        [ctrader_accounts?.trading_platform_accounts]
     );
 
     return {

--- a/packages/api/src/hooks/useDxtradeAccountsList.ts
+++ b/packages/api/src/hooks/useDxtradeAccountsList.ts
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 import useQuery from '../useQuery';
 import useAuthorize from './useAuthorize';
-import useDxtradeServiceToken from './useDxtradeServiceToken';
 
 /** A custom hook that gets the list of created Deriv X accounts. */
 const useDxtradeAccountsList = () => {
@@ -10,8 +9,6 @@ const useDxtradeAccountsList = () => {
         payload: { platform: 'dxtrade' },
         options: { enabled: isSuccess },
     });
-
-    const { data: token } = useDxtradeServiceToken();
 
     /** Adding necessary properties to Deriv X accounts */
     const modified_dxtrade_accounts = useMemo(
@@ -24,10 +21,8 @@ const useDxtradeAccountsList = () => {
                     maximumFractionDigits: 2,
                     minimumIntegerDigits: 1,
                 }).format(account?.balance || 0)} ${account?.currency || 'USD'}`,
-                /** The token of the Deriv X account */
-                token,
             })),
-        [authorize_data?.preferred_language, dxtrade_accounts?.trading_platform_accounts, token]
+        [authorize_data?.preferred_language, dxtrade_accounts?.trading_platform_accounts]
     );
 
     return {


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
 Removed token from other cfd accounts because we need to request new token when we click the terminal button as the lifespan of this token is too short to be added in the Account List response. 
 
 Affected Platforms:
 cTrader
 Dxtrade
 

### Screenshots:

![image](https://github.com/binary-com/deriv-app/assets/120543468/ba5620b6-4404-4286-afa8-b2a14bcacf49)

Please provide some screenshots of the change.
