### PR TITLE
[WALL] Ameerul /WALL-1422 Noticing issue in Crypto Withdrawal transaction page

### DIFF
--- a/packages/cashier/src/pages/withdrawal/withdrawal-crypto-form/__tests__/withdrawal-crypto-form.spec.tsx
+++ b/packages/cashier/src/pages/withdrawal/withdrawal-crypto-form/__tests__/withdrawal-crypto-form.spec.tsx
@@ -38,7 +38,6 @@ describe('<WithdrawalCryptoForm />', () => {
                         requestWithdraw: jest.fn(),
                         setBlockchainAddress: jest.fn(),
                         setWithdrawPercentageSelectorResult: jest.fn(),
-                        resetWithdrawForm: jest.fn(),
                     },
                 },
             },

--- a/packages/cashier/src/pages/withdrawal/withdrawal-crypto-form/withdrawal-crypto-form.tsx
+++ b/packages/cashier/src/pages/withdrawal/withdrawal-crypto-form/withdrawal-crypto-form.tsx
@@ -66,7 +66,6 @@ const WithdrawalCryptoForm = observer(() => {
         setWithdrawPercentageSelectorResult,
         validateWithdrawFromAmount,
         validateWithdrawToAmount,
-        resetWithdrawForm,
     } = withdraw;
     const {
         converter_from_error,
@@ -83,7 +82,6 @@ const WithdrawalCryptoForm = observer(() => {
 
         return () => {
             percentageSelectorSelectionStatus(false);
-            resetWithdrawForm();
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);

--- a/packages/cashier/src/pages/withdrawal/withdrawal-crypto-receipt/__tests__/withdrawal-crypto-receipt.spec.tsx
+++ b/packages/cashier/src/pages/withdrawal/withdrawal-crypto-receipt/__tests__/withdrawal-crypto-receipt.spec.tsx
@@ -61,6 +61,10 @@ describe('<WithdrawalCryptoReceipt />', () => {
                     },
                 },
             },
+            ui: {
+                is_desktop: true,
+                is_mobile: false,
+            },
         });
     });
 

--- a/packages/cashier/src/pages/withdrawal/withdrawal-crypto-receipt/__tests__/withdrawal-crypto-receipt.spec.tsx
+++ b/packages/cashier/src/pages/withdrawal/withdrawal-crypto-receipt/__tests__/withdrawal-crypto-receipt.spec.tsx
@@ -4,6 +4,29 @@ import WithdrawalCryptoReceipt from '../withdrawal-crypto-receipt';
 import CashierProviders from '../../../../cashier-providers';
 import { mockStore } from '@deriv/stores';
 
+let mock_last_transaction = {
+    address_hash: 'test_hash',
+    address_url: 'test_url',
+    amount: 0.2,
+    id: '1',
+    is_valid_to_cancel: 1,
+    status_code: 'LOCKED',
+    status_message: 'test_message',
+    submit_date: 1,
+    transaction_type: 'withdrawal',
+    is_deposit: false,
+    is_withdrawal: true,
+};
+
+jest.mock('@deriv/hooks', () => {
+    return {
+        ...jest.requireActual('@deriv/hooks'),
+        useCryptoTransactions: jest.fn(() => ({
+            last_transaction: mock_last_transaction,
+        })),
+    };
+});
+
 describe('<WithdrawalCryptoReceipt />', () => {
     let mockRootStore: ReturnType<typeof mockStore>;
     beforeEach(() => {
@@ -79,5 +102,35 @@ describe('<WithdrawalCryptoReceipt />', () => {
         const make_new_withdrawal_btn = screen.getByText('Make a new withdrawal');
         fireEvent.click(make_new_withdrawal_btn);
         expect(mockRootStore.modules.cashier.withdraw.setIsWithdrawConfirmed).toHaveBeenCalledTimes(1);
+    });
+
+    it('should show the status as "In process" if the transaction status is "PROCESSING"', () => {
+        mock_last_transaction = {
+            ...mock_last_transaction,
+            status_code: 'PROCESSING',
+        };
+        renderWithdrawalCryptoReceipt();
+
+        expect(screen.getByText('In process')).toBeInTheDocument();
+    });
+
+    it('should show the status as "Unsuccessful" if the transaction status is "ERROR"', () => {
+        mock_last_transaction = {
+            ...mock_last_transaction,
+            status_code: 'ERROR',
+        };
+        renderWithdrawalCryptoReceipt();
+
+        expect(screen.getByText('Unsuccessful')).toBeInTheDocument();
+    });
+
+    it('should show the status as "Successful" if the transaction status is "SENT"', () => {
+        mock_last_transaction = {
+            ...mock_last_transaction,
+            status_code: 'SENT',
+        };
+        renderWithdrawalCryptoReceipt();
+
+        expect(screen.getByText('Successful')).toBeInTheDocument();
     });
 });

--- a/packages/cashier/src/pages/withdrawal/withdrawal-crypto-receipt/withdrawal-crypto-receipt.tsx
+++ b/packages/cashier/src/pages/withdrawal/withdrawal-crypto-receipt/withdrawal-crypto-receipt.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Button, Clipboard, Icon, Text } from '@deriv/components';
 import { useCryptoTransactions } from '@deriv/hooks';
 import { TModifiedTransaction } from '@deriv/hooks/src/useCryptoTransactions';
-import { isMobile } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
 import { Localize, localize } from '@deriv/translations';
 import { useCashierStore } from 'Stores/useCashierStores';
@@ -14,6 +13,7 @@ import './withdrawal-crypto-receipt.scss';
 type TWalletInformationProps = {
     account: TAccount;
     blockchain_address: string;
+    is_mobile: boolean;
 };
 
 type TStatusProps = {
@@ -54,7 +54,7 @@ const Status = ({ last_transaction }: TStatusProps) => {
     );
 };
 
-const AccountInformation = ({ account }: { account: TAccount }) => {
+const AccountInformation = ({ account, is_mobile }: { account: TAccount; is_mobile: boolean }) => {
     return (
         <div className='withdrawal-crypto-receipt__account-info'>
             <div className='withdrawal-crypto-receipt__account-info-detail'>
@@ -62,7 +62,7 @@ const AccountInformation = ({ account }: { account: TAccount }) => {
                 <Text
                     color='prominent'
                     weight='bold'
-                    size={isMobile() ? 'xxs' : 's'}
+                    size={is_mobile ? 'xxs' : 's'}
                     align='center'
                     className='withdrawal-crypto-receipt__account-info-detail-text'
                 >
@@ -71,7 +71,7 @@ const AccountInformation = ({ account }: { account: TAccount }) => {
             </div>
             <Text
                 color='less-prominent'
-                size={isMobile() ? 'xs' : 's'}
+                size={is_mobile ? 'xs' : 's'}
                 align='center'
                 className='withdrawal-crypto-receipt__account-info-detail-text'
             >
@@ -81,7 +81,7 @@ const AccountInformation = ({ account }: { account: TAccount }) => {
     );
 };
 
-const WalletInformation = ({ account, blockchain_address }: TWalletInformationProps) => {
+const WalletInformation = ({ account, blockchain_address, is_mobile }: TWalletInformationProps) => {
     const text = getAccountText(account);
     return (
         <div className='withdrawal-crypto-receipt__account-info'>
@@ -105,7 +105,7 @@ const WalletInformation = ({ account, blockchain_address }: TWalletInformationPr
                 <Text
                     color='less-prominent'
                     as='p'
-                    size={isMobile() ? 'xxs' : 'xs'}
+                    size={is_mobile ? 'xxs' : 'xs'}
                     align='center'
                     className='withdrawal-crypto-receipt__account-info-detail-text'
                 >
@@ -113,10 +113,10 @@ const WalletInformation = ({ account, blockchain_address }: TWalletInformationPr
                 </Text>
                 <Clipboard
                     text_copy={blockchain_address}
-                    info_message={isMobile() ? '' : localize('copy')}
+                    info_message={is_mobile ? '' : localize('copy')}
                     icon='IcCashierClipboard'
                     success_message={localize('copied!')}
-                    popoverAlignment={isMobile() ? 'left' : 'bottom'}
+                    popoverAlignment={is_mobile ? 'left' : 'bottom'}
                 />
             </div>
         </div>
@@ -124,8 +124,9 @@ const WalletInformation = ({ account, blockchain_address }: TWalletInformationPr
 };
 
 const WithdrawalCryptoReceipt = observer(() => {
-    const { client } = useStore();
+    const { client, ui } = useStore();
     const { currency, is_switching } = client;
+    const { is_desktop, is_mobile } = ui;
     const { account_transfer, general_store, transaction_history, withdraw } = useCashierStore();
     const { selected_from: account } = account_transfer;
     const { cashier_route_tab_index: tab_index } = general_store;
@@ -155,13 +156,13 @@ const WithdrawalCryptoReceipt = observer(() => {
                 <Localize i18n_default_text='Your withdrawal will be processed within 24 hours' />
             </Text>
             <div className='withdrawal-crypto-receipt__detail'>
-                {!isMobile() && <Status last_transaction={last_transaction} />}
+                {is_desktop && <Status last_transaction={last_transaction} />}
                 <Text
                     as='p'
                     color='profit-success'
                     weight='bold'
                     align='center'
-                    size={isMobile() ? 'm' : 'l'}
+                    size={is_mobile ? 'm' : 'l'}
                     className='withdrawal-crypto-receipt__crypto'
                 >
                     <Localize
@@ -172,10 +173,10 @@ const WithdrawalCryptoReceipt = observer(() => {
                         }}
                     />
                 </Text>
-                {isMobile() && <Status last_transaction={last_transaction} />}
-                <AccountInformation account={account} />
+                {is_mobile && <Status last_transaction={last_transaction} />}
+                <AccountInformation account={account} is_mobile={is_mobile} />
                 <Icon className='withdrawal-crypto-receipt__icon' icon='IcArrowDown' size={30} />
-                <WalletInformation account={account} blockchain_address={blockchain_address} />
+                <WalletInformation account={account} blockchain_address={blockchain_address} is_mobile={is_mobile} />
             </div>
             <div className='withdrawal-crypto-receipt__button-wrapper'>
                 <Button

--- a/packages/hooks/src/useCryptoTransactions.ts
+++ b/packages/hooks/src/useCryptoTransactions.ts
@@ -13,7 +13,7 @@ type TWithdrawalStatus = Exclude<TStatus, TDepositStatus>;
 
 // Since BE sends the `status_code` for both `deposit` and `withdrawal` in the same field,
 // Here we modify the BE type to make `status_code` type more specific to the `transaction_type` field.
-type TModifiedTransaction = Omit<TTransaction, 'status_code' | 'transaction_type'> &
+export type TModifiedTransaction = Omit<TTransaction, 'status_code' | 'transaction_type'> &
     (
         | { transaction_type: 'deposit'; status_code: TDepositStatus }
         | { transaction_type: 'withdrawal'; status_code: TWithdrawalStatus }


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- Removed the resetWithdrawForm function when unMounting from withdrawl crypto form since it is already called when you request to withdraw in `requestWithdraw` function
- Removing the above helps to ensure the address is displayed and wont get reset if component unmounts
- Added proper transaction status changes if use decides to stay on the page using `last_transaction` from `useCryptoTransactions`, similar to how it is used in `TransactionsCryptoTransactionStatusSideNote`
- Updated test cases

### Screenshots:

Please provide some screenshots of the change.
<img width="446" alt="Screenshot 2023-11-02 at 11 42 46 AM" src="https://github.com/binary-com/deriv-app/assets/103412909/00bb1a90-8f6f-4bf7-b989-d838ffac3ab9">
<img width="451" alt="Screenshot 2023-11-02 at 11 43 07 AM" src="https://github.com/binary-com/deriv-app/assets/103412909/d196d97a-123f-407a-940f-46bba28864c5">
<img width="456" alt="Screenshot 2023-11-02 at 11 48 49 AM" src="https://github.com/binary-com/deriv-app/assets/103412909/003a2eea-4c83-4e04-94dd-7e4918e18a92">

