### PR TITLE
[Wallets] Sergei / Suggestion to avoid loading when the user switches between wallets

### DIFF
--- a/packages/api/src/hooks/useAuthorize.ts
+++ b/packages/api/src/hooks/useAuthorize.ts
@@ -12,7 +12,7 @@ const useAuthorize = () => {
 
     const { data, ...rest } = useQuery('authorize', {
         payload: { authorize: current_token || '' },
-        options: { enabled: Boolean(current_token) },
+        options: { enabled: Boolean(current_token), keepPreviousData: true },
     });
 
     // Add additional information to the authorize response.


### PR DESCRIPTION
## Changes:

Add `keepPreviousData` to `useAuthorize` hook. When the endpoint `accounts_list` will be created and separated from `authorize` request then we can move `keepPreviousData` property to the new hook. 

You can read about keepPreviousData property [here](https://tanstack.com/query/v4/docs/react/guides/paginated-queries#better-paginated-queries-with-keeppreviousdata)

### Video:
[Desktop]

How it was:

https://github.com/binary-com/deriv-app/assets/120570511/0c8586bd-5e50-4022-a50b-c6da199ab08b

How it now:

https://github.com/binary-com/deriv-app/assets/120570511/09753f46-a226-4c19-91ff-9f6e1341abbe

[Responsive]

How it was:

https://github.com/binary-com/deriv-app/assets/120570511/27ee7c83-9f35-4c64-a155-3247134e4997

How it now:

https://github.com/binary-com/deriv-app/assets/120570511/cfceaccc-cb8e-46af-8d7b-c2dfd893c1e7