### PR TITLE
fix: renamed payload props for file upload

### DIFF
--- a/packages/account/src/Components/poi/status/unsupported/detail-component.tsx
+++ b/packages/account/src/Components/poi/status/unsupported/detail-component.tsx
@@ -63,11 +63,11 @@ const DetailComponent = ({
                 const expiration_date =
                     typeof data.expiry_date?.format === 'function' ? data.expiry_date.format('YYYY-MM-DD') : undefined;
                 uploadFile(file, WS.getSocket, {
-                    documentType: document_type,
-                    pageType,
-                    expirationDate: expiration_date,
-                    documentId: data.document_id || '',
-                    lifetimeValid: +(lifetime_valid && !expiration_date),
+                    document_type,
+                    page_type: pageType,
+                    expiration_date,
+                    document_id: data.document_id || '',
+                    lifetime_valid: +(lifetime_valid && !expiration_date),
                     document_issuing_country: country_code_key,
                 })
                     .then(response => {


### PR DESCRIPTION
## Changes:

- Incorrect request payload cause the document to be uploaded under wrong category. Changed Request payload to match the API

