### PR TITLE
[Wallets] Rostislav / WALL-2443 / Align `TransactionStatus` header font size with Figma

### DIFF
--- a/packages/wallets/src/features/cashier/modules/TransactionStatus/TransactionStatus.tsx
+++ b/packages/wallets/src/features/cashier/modules/TransactionStatus/TransactionStatus.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useActiveWalletAccount, useCryptoTransactions } from '@deriv/api';
-import { Divider, WalletText } from '../../../../components/Base';
 import { WalletsTransactionStatusLoader } from '../../../../components';
+import { Divider, WalletText } from '../../../../components/Base';
 import Warning from '../../../../public/images/warning.svg';
 import { THooks } from '../../../../types';
 import { TransactionStatusError } from './components/TransactionStatusError';
@@ -33,15 +33,9 @@ const TransactionStatus: React.FC<TTransactionStatus> = ({ transactionType }) =>
         return () => unsubscribe();
     }, [subscribe, transactionType, unsubscribe]);
 
-    const isLoading = useMemo(
-        () => isTransactionsLoading || isActiveWalletAccountLoading,
-        [isTransactionsLoading, isActiveWalletAccountLoading]
-    );
-
-    const isError = useMemo(
-        () => !!activeWalletAccountError || !!recentTransactionsError,
-        [activeWalletAccountError, recentTransactionsError]
-    );
+    const isLoading = isTransactionsLoading || isActiveWalletAccountLoading;
+    const isError = !!activeWalletAccountError || !!recentTransactionsError;
+    const isTransactionStatusSuccessVisible = !isLoading && !isError && wallet;
 
     const refresh = useCallback(() => {
         unsubscribe();
@@ -62,7 +56,7 @@ const TransactionStatus: React.FC<TTransactionStatus> = ({ transactionType }) =>
             <div className='wallets-transaction-status__body'>
                 {!isError && isLoading && <WalletsTransactionStatusLoader />}
                 {isError && <TransactionStatusError refresh={refresh} />}
-                {!isLoading && !isError && wallet && (
+                {isTransactionStatusSuccessVisible && (
                     <TransactionStatusSuccess
                         transactionType={transactionType}
                         transactions={transactions || []}

--- a/packages/wallets/src/features/cashier/modules/TransactionStatus/TransactionStatus.tsx
+++ b/packages/wallets/src/features/cashier/modules/TransactionStatus/TransactionStatus.tsx
@@ -62,10 +62,10 @@ const TransactionStatus: React.FC<TTransactionStatus> = ({ transactionType }) =>
             <div className='wallets-transaction-status__body'>
                 {!isError && isLoading && <WalletsTransactionStatusLoader />}
                 {isError && <TransactionStatusError refresh={refresh} />}
-                {!isLoading && !isError && wallet && transactions && (
+                {!isLoading && !isError && wallet && (
                     <TransactionStatusSuccess
                         transactionType={transactionType}
-                        transactions={transactions}
+                        transactions={transactions || []}
                         wallet={wallet}
                     />
                 )}

--- a/packages/wallets/src/features/cashier/modules/TransactionStatus/TransactionStatus.tsx
+++ b/packages/wallets/src/features/cashier/modules/TransactionStatus/TransactionStatus.tsx
@@ -53,7 +53,9 @@ const TransactionStatus: React.FC<TTransactionStatus> = ({ transactionType }) =>
     return (
         <div className='wallets-transaction-status'>
             <div className='wallets-transaction-status__header'>
-                <WalletText weight='bold'>Transaction status</WalletText>
+                <WalletText size='sm' weight='bold'>
+                    Transaction status
+                </WalletText>
                 {isError && <Warning />}
             </div>
             <Divider color='#d6dadb' /> {/* --color-grey-5 */}

--- a/packages/wallets/src/features/cashier/modules/TransactionStatus/components/TransactionStatusSuccess/TransactionStatusSuccess.tsx
+++ b/packages/wallets/src/features/cashier/modules/TransactionStatus/components/TransactionStatusSuccess/TransactionStatusSuccess.tsx
@@ -49,7 +49,7 @@ const TransactionStatusSuccess: React.FC<TTransactionStatusSuccess> = ({ transac
                 </React.Fragment>
             ) : (
                 <React.Fragment>
-                    <WalletText size='xs'>No recent transactions.</WalletText>
+                    <WalletText size='sm'>No recent transactions.</WalletText>
                     <Divider color='#d6dadb' /> {/* --color-grey-5 */}
                 </React.Fragment>
             )}


### PR DESCRIPTION
## Changes:

Align `TransactionStatus` font sizes with Figma and fix "No recent transactions." display.

### Screenshots:

<img width="723" alt="Screenshot 2023-11-03 at 15 37 59" src="https://github.com/binary-com/deriv-app/assets/119863957/e843a8ff-6c90-4785-a033-1213360719ab">


