### PR TITLE
[Wallets] Rostislav / WALL-2445 / Fix `TransactionStatus` positioning in responsive crypto deposit

### DIFF
--- a/packages/wallets/src/features/cashier/modules/DepositCrypto/DepositCrypto.scss
+++ b/packages/wallets/src/features/cashier/modules/DepositCrypto/DepositCrypto.scss
@@ -9,7 +9,7 @@
         flex-direction: column;
         justify-content: start;
         gap: 1.6rem;
-        padding-top: 0rem;
+        padding-top: 0;
         padding-bottom: 2.4rem;
     }
 

--- a/packages/wallets/src/features/cashier/modules/DepositCrypto/DepositCrypto.scss
+++ b/packages/wallets/src/features/cashier/modules/DepositCrypto/DepositCrypto.scss
@@ -5,7 +5,12 @@
     justify-content: center;
 
     @include mobile {
+        height: fit-content;
         flex-direction: column;
+        justify-content: start;
+        gap: 1.6rem;
+        padding-top: 0rem;
+        padding-bottom: 2.4rem;
     }
 
     &__main-content {
@@ -18,12 +23,5 @@
         @include mobile {
             padding: 0;
         }
-    }
-
-    @include mobile {
-        width: 100%;
-        justify-content: start;
-        padding-top: 0rem;
-        gap: 1.6rem;
     }
 }

--- a/packages/wallets/src/features/cashier/modules/TransactionStatus/TransactionStatus.scss
+++ b/packages/wallets/src/features/cashier/modules/TransactionStatus/TransactionStatus.scss
@@ -1,9 +1,13 @@
 .wallets-transaction-status {
+    width: 100%;
+
     /* This positioning is temporary, ideally it should be determined by the parent component whenever we use `TransactionStatus` */
-    position: absolute;
-    top: 0;
-    right: 4rem;
-    width: 28.2rem;
+    @include desktop {
+        position: absolute;
+        top: 0;
+        right: 4rem;
+        max-width: 28.2rem;
+    }
 
     display: flex;
     align-self: stretch;


### PR DESCRIPTION
## Changes:

Fix `TransactionStatus` positioning in responsive crypto deposit

### Screenshots:


https://github.com/binary-com/deriv-app/assets/119863957/8a23afcc-4678-42b4-8c03-6d90740a6910

<img width="1422" alt="Screenshot 2023-11-03 at 17 38 32" src="https://github.com/binary-com/deriv-app/assets/119863957/32f59e87-0137-4dc4-8da3-1c96bf7e609b">

