### PR TITLE
chore: Test case for session-storage.js

### DIFF
--- a/packages/bot-web-ui/src/utils/__tests__/session-storage.spec.ts
+++ b/packages/bot-web-ui/src/utils/__tests__/session-storage.spec.ts
@@ -1,0 +1,35 @@
+import { getStoredItemsByKey, getStoredItemsByUser, setStoredItemsByKey } from 'Utils/session-storage';
+
+describe('Session Storage Util', () => {
+    const storageKey = 'example_key';
+    const defaultValue = 'default_value';
+    const storedItems = { example: 'data' };
+
+    it('should return default value when storage is empty', () => {
+        const result = getStoredItemsByKey(storageKey, defaultValue);
+        expect(result).toBe(defaultValue);
+    });
+
+    it('should return default value when loginid is falsy', () => {
+        const loginid = '123';
+        const result = getStoredItemsByUser(storageKey, loginid, defaultValue);
+        expect(result).toBe(defaultValue);
+    });
+
+    it('should set stored items', () => {
+        setStoredItemsByKey(storageKey, storedItems);
+        const result = getStoredItemsByKey(storageKey, defaultValue);
+        expect(result).toStrictEqual(storedItems);
+    });
+
+    it('should throw error if invalid object is passed to store', () => {
+        const consoleWarnMock = jest.fn();
+        global.console.warn = consoleWarnMock;
+        const circularObject = {
+            circularReference: {},
+        };
+        circularObject.circularReference = circularObject;
+        setStoredItemsByKey('example_key', circularObject);
+        expect(consoleWarnMock).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Changes:

This PR covers the test case for session-storage.js
- Tested `getStoredItemsByKey()` to check if the default value is returned if the storage is empty
- Tested `getStoredItemsByUser()` to check if the default value is returned if the storage is empty
- Tested `setStoredItemsByKey()` to check if the value that is set is returned 
- Tested `setStoredItemsByKey()` to check if the set value is an invalid object then it's throwing an error

<img width="1322" alt="Screenshot 2023-11-06 at 1 08 56 PM" src="https://github.com/binary-com/deriv-app/assets/129021108/483eb69d-3cc3-4256-ac84-b6a53d85b8df">