### PR TITLE
chore: Test for multiplier.js in utils

### DIFF
--- a/packages/bot-web-ui/src/utils/__tests__/multiplier.spec.ts
+++ b/packages/bot-web-ui/src/utils/__tests__/multiplier.spec.ts
@@ -1,0 +1,33 @@
+import { getBuyPrice, getContractUpdateConfig } from 'Utils/multiplier';
+
+describe('Multiplier Util', () => {
+    it('should return the buy price from contract_store', () => {
+        const contract_store = {
+            contract_info: {
+                buy_price: 100,
+            },
+        };
+        const buyPrice = getBuyPrice(contract_store);
+        expect(buyPrice).toBe(100);
+    });
+
+    it('should return contract update config with stop loss and take profit', () => {
+        const limit_order = {
+            stop_loss: { order_amount: 100 },
+            take_profit: { order_amount: 200 },
+        };
+        const config = getContractUpdateConfig({ limit_order });
+        expect(config.contract_update_stop_loss).toBe('100');
+        expect(config.contract_update_take_profit).toBe('200');
+        expect(config.has_contract_update_stop_loss).toBe(true);
+        expect(config.has_contract_update_take_profit).toBe(true);
+    });
+
+    it('should handle missing limit_order', () => {
+        const config = getContractUpdateConfig({ limit_order: undefined });
+        expect(config.contract_update_stop_loss).toBe('');
+        expect(config.contract_update_take_profit).toBe('');
+        expect(config.has_contract_update_stop_loss).toBe(false);
+        expect(config.has_contract_update_take_profit).toBe(false);
+    });
+});


### PR DESCRIPTION
## Changes:

Test case for multiplier.js in utils folder

- Test to check if `getBuyPrice()` return the correct `buy_price` retrieving it from the `contract_store`
- Test to check if `getContractUpdateConfig()` return the correct values for `contract_update_stop_loss`, `contract_update_take_profit `, `has_contract_update_stop_loss `, `has_contract_update_take_profit ` if the `limit_order` is present
- Test to check if `getContractUpdateConfig()` return the default values for `contract_update_stop_loss`, `contract_update_take_profit `, `has_contract_update_stop_loss `, `has_contract_update_take_profit ` if the `limit_order` is empty

<img width="1089" alt="Screenshot 2023-11-06 at 2 13 38 PM" src="https://github.com/binary-com/deriv-app/assets/129021108/39faf0ab-becf-404c-8d15-9a6b1aff9b12">
