### PR TITLE
[CFDS] Hamza/ chore: hide the reassembly notification and popup

### DIFF
--- a/packages/core/src/App/Containers/app-notification-messages.jsx
+++ b/packages/core/src/App/Containers/app-notification-messages.jsx
@@ -118,7 +118,6 @@ const AppNotificationMessages = ({
                   'trustpilot',
                   'unwelcome',
                   'additional_kyc_info',
-                  'mt5_notification',
               ].includes(message.key) || message.type === 'p2p_completed_order'
             : true;
 

--- a/packages/core/src/Stores/notification-store.js
+++ b/packages/core/src/Stores/notification-store.js
@@ -545,9 +545,6 @@ export default class NotificationStore extends BaseStore {
                     this.addNotificationMessage(this.client_notifications.svg_poi_expired);
                 }
             }
-            if (client && this.root_store.client.mt5_login_list.length > 0) {
-                this.addNotificationMessage(this.client_notifications.mt5_notification);
-            }
         }
 
         if (!is_eu && isMultiplierContract(selected_contract_type) && current_language === 'EN' && is_logged_in) {


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.

### Scope: 
We need to hide the Reassembly Notification from Notification tray and Toast Popup(Yellow Banner) from the whole Deriv-app.

### Acceptance Criteria:
- The Deriv MT5: Your action is needed notification has been hidden from the page and the notification inbox in both desktop and responsive

### Screenshots:

Please provide some screenshots of the change.

#### Before
![image](https://github.com/binary-com/deriv-app/assets/120543468/2959faa8-f55b-47e7-a8dc-5015ceb06127)

![image](https://github.com/binary-com/deriv-app/assets/120543468/84f15989-0e63-4d97-bf18-c60fc8a8170b)

#### After

<img width="1700" alt="image" src="https://github.com/binary-com/deriv-app/assets/120543468/7ac03056-380c-49eb-a74d-2aac9bef050e">

<img width="478" alt="image" src="https://github.com/binary-com/deriv-app/assets/120543468/51da1db9-5654-4a60-8eb5-ff5d2119901b">


