### PR TITLE
[wallets] Farhan/WALL-2470/Accordion skeleton loader not showing on the first load (Desktop)

### DIFF
--- a/packages/wallets/src/components/DesktopWalletsList/DesktopWalletsList.scss
+++ b/packages/wallets/src/components/DesktopWalletsList/DesktopWalletsList.scss
@@ -1,5 +1,6 @@
 .wallets-desktop-wallets-list {
     max-width: 123.2rem;
+    width: 100%;
     height: max-content;
     display: flex;
     flex-direction: column;

--- a/packages/wallets/src/components/WalletsAccordion/WalletsAccordion.scss
+++ b/packages/wallets/src/components/WalletsAccordion/WalletsAccordion.scss
@@ -1,5 +1,5 @@
 .wallets-accordion {
-    width: 123.2rem;
+    max-width: 123.2rem;
     background: var(--system-light-8-primary-background, #fff);
     border-radius: 1.6rem;
     position: relative;


### PR DESCRIPTION
## Changes:

- Accordion loader not showing on the first load

### Screenshots:

## **Before**


https://github.com/binary-com/deriv-app/assets/125247833/49806e27-bd48-4f72-8a67-06a7c02e12ac

## **After**


https://github.com/binary-com/deriv-app/assets/125247833/0ffbeb4e-ba65-47eb-841f-55f4414e7d58

