### PR TITLE
[FEQ] Add websocketurl to timeout

### DIFF
--- a/packages/core/src/Services/socket-general.js
+++ b/packages/core/src/Services/socket-general.js
@@ -12,11 +12,13 @@ let client_store, common_store, gtm_store;
 const BinarySocketGeneral = (() => {
     let session_duration_limit, session_start_time, session_timeout;
 
+    let responseTimeoutErrorTimer = null;
+
     const onDisconnect = () => {
+        clearTimeout(responseTimeoutErrorTimer);
         common_store.setIsSocketOpened(false);
     };
 
-    let responseTimeoutErrorTimer = null;
     const onOpen = is_ready => {
         responseTimeoutErrorTimer = setTimeout(() => {
             const error = new Error('deriv-api: no message received after 30s');

--- a/packages/core/src/Services/socket-general.js
+++ b/packages/core/src/Services/socket-general.js
@@ -21,13 +21,19 @@ const BinarySocketGeneral = (() => {
 
     const onOpen = is_ready => {
         responseTimeoutErrorTimer = setTimeout(() => {
+            const expectedResponseTypes = WS?.get?.()?.expect_response_types || {};
+            const pendingResponseTypes = Object.keys(expectedResponseTypes).filter(
+                key => expectedResponseTypes[key].state === 'pending'
+            );
+
             const error = new Error('deriv-api: no message received after 30s');
             error.userId = client_store?.loginid;
-            /* eslint-disable no-console */
+
             window.TrackJS?.console?.error({
                 message: error.message,
                 clientsCountry: client_store?.clients_country,
                 websocketUrl: getSocketURL(),
+                pendingResponseTypes,
             });
         }, 30000);
 

--- a/packages/core/src/Services/socket-general.js
+++ b/packages/core/src/Services/socket-general.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
 import { flow } from 'mobx';
-import { State, getActivePlatform, getPropertyValue, routes, getActionFromUrl } from '@deriv/shared';
+import { State, getSocketURL, getActivePlatform, getPropertyValue, routes, getActionFromUrl } from '@deriv/shared';
 import { localize } from '@deriv/translations';
 import ServerTime from '_common/base/server_time';
 import BinarySocket from '_common/base/socket_base';
@@ -22,7 +22,10 @@ const BinarySocketGeneral = (() => {
             const error = new Error('deriv-api: no message received after 30s');
             error.userId = client_store?.loginid;
             /* eslint-disable no-console */
-            console.error(error);
+            window.TrackJS?.console?.error({
+                message: error.message,
+                websocketUrl: getSocketURL(),
+            });
         }, 30000);
 
         if (is_ready) {

--- a/packages/core/src/Services/socket-general.js
+++ b/packages/core/src/Services/socket-general.js
@@ -24,6 +24,7 @@ const BinarySocketGeneral = (() => {
             /* eslint-disable no-console */
             window.TrackJS?.console?.error({
                 message: error.message,
+                clientsCountry: client_store?.clients_country,
                 websocketUrl: getSocketURL(),
             });
         }, 30000);


### PR DESCRIPTION
- Add the `websocketUrl` to the timeout error for trackjs.
- Add the `clientsCountry` to the timeout error for trackjs.
- Use the TrackJS error function as documented [here](https://docs.trackjs.com/browser-agent/sdk-reference/agent-methods/#consoleerror)