### PR TITLE
Ameerul /P2PS-1433 Enhancement for My Ads message

### DIFF
--- a/packages/p2p/src/pages/buy-sell/no-ads/__tests__/no-ads.spec.jsx
+++ b/packages/p2p/src/pages/buy-sell/no-ads/__tests__/no-ads.spec.jsx
@@ -44,9 +44,9 @@ describe('<NoAds/>', () => {
             screen.getByText('Looking to buy or sell USD? You can post your own ad for others to respond.')
         ).toBeInTheDocument();
     });
-    it('should display "You have no ads" when is_ads_page is true', () => {
+    it('should display "You have no ads. 😞" when is_ads_page is true', () => {
         render(<NoAds {...mock_props} is_ads_page />);
-        expect(screen.getByText('You have no ads.')).toBeInTheDocument();
+        expect(screen.getByText('You have no ads. 😞')).toBeInTheDocument();
         expect(screen.getByText('Create new ad')).toBeInTheDocument();
     });
     it('should handle onclick of create ad button', () => {

--- a/packages/p2p/src/pages/buy-sell/no-ads/no-ads.jsx
+++ b/packages/p2p/src/pages/buy-sell/no-ads/no-ads.jsx
@@ -33,7 +33,7 @@ const NoAds = ({ is_ads_page = false }) => {
                 <React.Fragment>
                     <Text align='center' className='no-ads__title' weight='bold'>
                         {is_ads_page ? (
-                            <Localize i18n_default_text='You have no ads.' />
+                            <Localize i18n_default_text='You have no ads. 😞' />
                         ) : (
                             <Localize i18n_default_text='No ads for this currency 😞' />
                         )}


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- Updated the message in My Ads page when the user has no ads from `You have no ads.` to `You have no ads. 😞`

### Screenshots:

Please provide some screenshots of the change.

### Old message
<img width="704" alt="Screenshot 2023-11-08 at 10 49 03 AM" src="https://github.com/binary-com/deriv-app/assets/103412909/62fef592-44d3-4afe-b969-c9933b86d2dc">

### New message
<img width="674" alt="Screenshot 2023-11-08 at 10 49 51 AM" src="https://github.com/binary-com/deriv-app/assets/103412909/620e30fb-715a-40f4-bf07-feb9aa80e59d">
