### PR TITLE
Maryia/DTRA-480/fix: Console warning about bad state in DurationWrapper component

### DIFF
--- a/packages/stores/src/mockStore.ts
+++ b/packages/stores/src/mockStore.ts
@@ -307,11 +307,14 @@ const mock = (): TStores & { is_mock: boolean } => {
         },
         ui: {
             advanced_duration_unit: 't',
+            advanced_expiry_type: 'duration',
             account_switcher_disabled_message: '',
             app_contents_scroll_ref: {
                 current: null,
             },
             current_focus: null,
+            duration_t: 5,
+            getDurationFromUnit: jest.fn(),
             is_account_settings_visible: false,
             is_advanced_duration: false,
             is_loading: false,
@@ -410,6 +413,7 @@ const mock = (): TStores & { is_mock: boolean } => {
             vanilla_trade_type: 'VANILLALONGCALL',
             is_chart_countdown_visible: false,
             is_additional_kyc_info_modal_open: false,
+            simple_duration_unit: 't',
             toggleAdditionalKycInfoModal: jest.fn(),
             is_kyc_information_submitted_modal_open: false,
             toggleKycInformationSubmittedModal: jest.fn(),

--- a/packages/stores/types.ts
+++ b/packages/stores/types.ts
@@ -558,12 +558,15 @@ type TCommonStore = {
 
 type TUiStore = {
     advanced_duration_unit: string;
+    advanced_expiry_type: string;
     addToast: (toast_config: TAddToastProps) => void;
     account_switcher_disabled_message: string;
     app_contents_scroll_ref: React.MutableRefObject<null | HTMLDivElement>;
     current_focus: string | null;
     disableApp: () => void;
+    duration_t: number;
     enableApp: () => void;
+    getDurationFromUnit: (unit: string) => number;
     has_only_forward_starting_contracts: boolean;
     has_real_account_signup_ended: boolean;
     header_extension: JSX.Element | null;
@@ -620,6 +623,7 @@ type TUiStore = {
     setIsClosingCreateRealAccountModal: (value: boolean) => void;
     setRealAccountSignupEnd: (status: boolean) => void;
     setPurchaseState: (index: number) => void;
+    simple_duration_unit: string;
     sub_section_index: number;
     setPromptHandler: (
         condition: boolean,

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/__tests__/duration-wrapper.spec.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/__tests__/duration-wrapper.spec.tsx
@@ -72,7 +72,7 @@ describe('<DurationWrapper />', () => {
                 onChangeUiStore: jest.fn(),
                 simple_duration_unit: 't',
             },
-        };
+        } as unknown as ReturnType<typeof mockStore>;
     });
     const mockDurationWrapper = (mocked_store: TCoreStores) => {
         return (

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/__tests__/duration-wrapper.spec.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/__tests__/duration-wrapper.spec.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { TCoreStores } from '@deriv/stores/types';
+import { mockStore } from '@deriv/stores';
+import userEvent from '@testing-library/user-event';
+import DurationWrapper from '../duration-wrapper';
+import TraderProviders from '../../../../../../../trader-providers';
+
+describe('<DurationWrapper />', () => {
+    let default_mock_store: ReturnType<typeof mockStore>;
+    beforeEach(() => {
+        default_mock_store = {
+            modules: {
+                trade: {
+                    contract_expiry_type: 'intraday',
+                    contract_type: 'rise_fall',
+                    duration: 3,
+                    duration_unit: 'm',
+                    duration_units_list: [
+                        {
+                            text: 'Ticks',
+                            value: 't',
+                        },
+                        {
+                            text: 'Seconds',
+                            value: 's',
+                        },
+                        {
+                            text: 'Minutes',
+                            value: 'm',
+                        },
+                        {
+                            text: 'Hours',
+                            value: 'h',
+                        },
+                        {
+                            text: 'Days',
+                            value: 'd',
+                        },
+                    ],
+                    duration_min_max: {
+                        daily: {
+                            min: 86400,
+                            max: 31536000,
+                        },
+                        intraday: {
+                            min: 15,
+                            max: 86400,
+                        },
+                        tick: {
+                            min: 1,
+                            max: 10,
+                        },
+                    },
+                    expiry_type: 'duration',
+                    expiry_date: null,
+                    expiry_epoch: '',
+                    expiry_time: null,
+                    onChange: jest.fn(),
+                    onChangeMultiple: jest.fn(),
+                    start_date: 0,
+                    market_open_times: [],
+                    validation_errors: { duration: [] },
+                },
+            },
+            ui: {
+                advanced_expiry_type: 'duration',
+                advanced_duration_unit: 'm',
+                duration_t: 5,
+                getDurationFromUnit: jest.fn(() => 3),
+                is_advanced_duration: true,
+                onChangeUiStore: jest.fn(),
+                simple_duration_unit: 't',
+            },
+        };
+    });
+    const mockDurationWrapper = (mocked_store: TCoreStores) => {
+        return (
+            <TraderProviders store={mocked_store}>
+                <DurationWrapper />
+            </TraderProviders>
+        );
+    };
+    it('should render Duration, End time, and 3 Minutes duration', () => {
+        render(mockDurationWrapper(default_mock_store));
+        expect(screen.getByText(/Duration/i)).toBeInTheDocument();
+        expect(screen.getByText(/End time/i)).toBeInTheDocument();
+        expect(screen.getByDisplayValue(/3/i)).toBeInTheDocument();
+        expect(screen.getByText(/Minutes/i)).toBeInTheDocument();
+    });
+    it('should render 15 Seconds duration', () => {
+        default_mock_store.modules.trade.duration = 15;
+        default_mock_store.modules.trade.duration_unit = 's';
+        default_mock_store.ui.advanced_duration_unit = 's';
+        default_mock_store.ui.getDurationFromUnit = jest.fn(() => 15);
+        render(mockDurationWrapper(default_mock_store));
+        expect(screen.getByText(/Seconds/i)).toBeInTheDocument();
+        expect(screen.getByDisplayValue(/15/i)).toBeInTheDocument();
+    });
+    it('should execute onChange & onChangeUiStore when a user types a new value', () => {
+        default_mock_store.modules.trade.duration = 2;
+        default_mock_store.ui.getDurationFromUnit = jest.fn(() => 2);
+        render(mockDurationWrapper(default_mock_store));
+        const duration_input = screen.getByDisplayValue(/2/i);
+        userEvent.type(duration_input, '5');
+        expect(default_mock_store.modules.trade.onChange).toHaveBeenCalledWith({
+            target: { name: 'duration', value: 25 },
+        });
+        expect(default_mock_store.ui.onChangeUiStore).toHaveBeenCalledWith({ name: 'duration_m', value: 25 });
+        expect(default_mock_store.modules.trade.onChangeMultiple).toHaveBeenCalledTimes(0);
+    });
+});

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-wrapper.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-wrapper.jsx
@@ -66,21 +66,11 @@ const DurationWrapper = observer(() => {
         return duration_list.some(du => du.value === duration_type);
     };
 
-    const setDurationUnit = () => {
-        if (duration_units_list?.length > 0) {
-            const new_duration_unit = duration_units_list[0].value;
-            const new_duration_value = getDurationFromUnit(new_duration_unit);
-
-            onChangeUiStore({
-                name: `${is_advanced_duration ? 'advanced' : 'simple'}_duration_unit`,
-                value: new_duration_unit,
-            });
-            onChangeMultiple({
-                duration_unit: new_duration_unit,
-                duration: +new_duration_value,
-            });
-        }
-    };
+    const current_duration_unit = is_advanced_duration ? advanced_duration_unit : simple_duration_unit;
+    const has_missing_duration_unit = !hasDurationUnit(current_duration_unit, is_advanced_duration);
+    const simple_is_missing_duration_unit =
+        !is_advanced_duration && simple_duration_unit === 'd' && duration_units_list.length === 4;
+    const [min_value, max_value] = getDurationMinMaxValues(duration_min_max, contract_expiry_type, duration_unit);
 
     const handleEndTime = () => {
         const symbol_has_endtime = duration_units_list.length > 1 || is_advanced_duration;
@@ -117,27 +107,24 @@ const DurationWrapper = observer(() => {
     );
 
     React.useEffect(() => {
-        if (duration_unit === 'd') {
-            onChangeUiStore({
-                name: 'is_advanced_duration',
-                value: true,
-            });
-        }
-    }, [duration_unit, onChangeUiStore]);
-
-    React.useEffect(() => {
         const current_unit = is_advanced_duration ? advanced_duration_unit : simple_duration_unit;
         const current_duration = getDurationFromUnit(current_unit);
+        let unit = duration_unit;
+        let duration_value = duration;
 
-        if (duration_unit !== current_unit) {
-            onChangeUiStore({
-                name: `${is_advanced_duration ? 'advanced' : 'simple'}_duration_unit`,
-                value: duration_unit,
-            });
+        if (duration_units_list?.length > 0 && (has_missing_duration_unit || simple_is_missing_duration_unit)) {
+            unit = duration_units_list[0].value;
+            duration_value = getDurationFromUnit(unit);
+            onChangeMultiple({ duration_unit: unit, duration: +duration_value });
         }
 
-        if (+duration !== +current_duration) {
-            onChangeUiStore({ name: `duration_${duration_unit}`, value: duration });
+        if (unit !== current_unit) {
+            onChangeUiStore({ name: 'advanced_duration_unit', value: unit });
+            onChangeUiStore({ name: 'simple_duration_unit', value: unit });
+        }
+
+        if (+duration_value !== +current_duration) {
+            onChangeUiStore({ name: `duration_${unit}`, value: duration_value });
         }
 
         if (expiry_type === 'endtime') handleEndTime();
@@ -145,6 +132,12 @@ const DurationWrapper = observer(() => {
         assertDurationIsWithinBoundary(current_duration);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
+
+    React.useEffect(() => {
+        if (duration_unit === 'd') {
+            onChangeUiStore({ name: 'is_advanced_duration', value: true });
+        }
+    }, [duration_unit, onChangeUiStore]);
 
     React.useEffect(() => {
         if (is_advanced_duration && expiry_type !== advanced_expiry_type) {
@@ -177,16 +170,6 @@ const DurationWrapper = observer(() => {
         onChangeUiStore,
         getDurationFromUnit,
     ]);
-
-    const current_duration_unit = is_advanced_duration ? advanced_duration_unit : simple_duration_unit;
-    const has_missing_duration_unit = !hasDurationUnit(current_duration_unit, is_advanced_duration);
-    const simple_is_missing_duration_unit =
-        !is_advanced_duration && simple_duration_unit === 'd' && duration_units_list.length === 4;
-    const [min_value, max_value] = getDurationMinMaxValues(duration_min_max, contract_expiry_type, duration_unit);
-
-    if (has_missing_duration_unit || simple_is_missing_duration_unit) {
-        setDurationUnit();
-    }
 
     return (
         <Duration hasDurationUnit={hasDurationUnit} max_value={max_value} min_value={min_value} {...duration_props} />


### PR DESCRIPTION
## Changes:

- to fix a console warning about bad state in `DurationWrapper` component saying: '_Cannot update a component (`c`) while rendering a different component (`c`)_' - by ensuring that all state updates upon the initial render of `DurationWrapper` component happen inside `useEffect`.

