### PR TITLE
[COJ]/WALL_1460/Amina/fix: reset balance notification

### DIFF
--- a/packages/core/src/Stores/notification-store.js
+++ b/packages/core/src/Stores/notification-store.js
@@ -16,7 +16,6 @@ import {
     isMobile,
     isMultiplierContract,
     LocalStore,
-    platform_name,
     routes,
     unique,
 } from '@deriv/shared';
@@ -1093,7 +1092,6 @@ export default class NotificationStore extends BaseStore {
                 type: 'info',
                 is_persistent: true,
                 should_show_again: true,
-                platform: [platform_name.DTrader],
                 is_disposable: true,
                 action: {
                     text: localize('Reset balance'),


### PR DESCRIPTION
## Changes:
Notification for reset demo account balance is not shown in traders_hub . It was because the notification had a config that it should be shown only in dtrader. Removing the platform restriction in this PR

### Screenshots:

Please provide some screenshots of the change.
