### PR TITLE
[Wallet] aum / WALL-2497 / fix-fiat-withdrawal-error-case

### DIFF
--- a/packages/wallets/src/features/cashier/flows/WalletWithdrawal/WalletWithdrawal.tsx
+++ b/packages/wallets/src/features/cashier/flows/WalletWithdrawal/WalletWithdrawal.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
-import { WithdrawalFiatModule } from '../../modules';
+import { WithdrawalFiatModule, WithdrawalVerificationModule } from '../../modules';
 
 const WalletWithdrawal = () => {
     //TODO: add withdrawal crypto module
-    return <WithdrawalFiatModule />;
+
+    if (sessionStorage.getItem('verification_code')) return <WithdrawalFiatModule />;
+
+    return <WithdrawalVerificationModule />;
 };
 
 export default WalletWithdrawal;

--- a/packages/wallets/src/features/cashier/modules/WithdrawalFiat/WithdrawalFiat.tsx
+++ b/packages/wallets/src/features/cashier/modules/WithdrawalFiat/WithdrawalFiat.tsx
@@ -42,7 +42,6 @@ const WithdrawalFiat = () => {
             )}
         </React.Fragment>
     );
-    // return null;
 };
 
 export default WithdrawalFiat;


### PR DESCRIPTION
## Changes:

1. Moved `WithdrawalVerificationModule` out of `WithdrawalFiatModule` inside the `WalletWithdrawal` flow.
2. Added error screen for `invalidToken` and other `generic` cashier errors using the `WalletsErrorScreen` (shown below).

<img width="1083" alt="image" src="https://github.com/binary-com/deriv-app/assets/125039206/0096b404-c634-4af1-a6b6-1758749294c5">