### PR TITLE
Ako/ remove nx access token as its expired

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -4,7 +4,6 @@
     "default": {
       "runner": "@nrwl/nx-cloud",
       "options": {
-        "accessToken": "ZTMzMDk4MmEtNjMyOC00ZjFiLWI5MTktYTc1ODhiOTI0OTJifHJlYWQ=",
         "cacheableOperations": [
           "build",
           "test",


### PR DESCRIPTION
## Changes:
Since the NX access token is expired it needs to be removed. 
Later on if we enable nx back we can simply commit the readonly token again.