### PR TITLE
[Wallet] fix: aum/WALL-2435/fix-crypto-deposit-padding-alignment

### DIFF
--- a/packages/wallets/src/features/cashier/WalletCashier.scss
+++ b/packages/wallets/src/features/cashier/WalletCashier.scss
@@ -14,8 +14,13 @@
     justify-content: center;
     gap: 2.4rem;
     flex: 1;
+    padding: 4.8rem 1.6rem 0;
     background-color: #ffffff;
     overflow: scroll;
+
+    @include mobile {
+        padding: 2.4rem 1.6rem 0;
+    }
 
     &::-webkit-scrollbar {
         display: none;

--- a/packages/wallets/src/features/cashier/WalletCashier.scss
+++ b/packages/wallets/src/features/cashier/WalletCashier.scss
@@ -10,7 +10,6 @@
 
 .wallets-cashier-content {
     display: flex;
-    align-items: center;
     justify-content: center;
     gap: 2.4rem;
     flex: 1;

--- a/packages/wallets/src/features/cashier/modules/DepositCrypto/DepositCrypto.scss
+++ b/packages/wallets/src/features/cashier/modules/DepositCrypto/DepositCrypto.scss
@@ -1,10 +1,10 @@
 .wallets-deposit-crypto {
     position: relative;
     width: 100%;
-    height: 100%;
     display: flex;
     align-items: center;
     justify-content: center;
+    align-self: center;
     transform: translateY(-4.8rem);
 
     @include mobile {
@@ -13,7 +13,6 @@
         flex-direction: column;
         gap: 1.6rem;
         transform: translateY(-2.4rem);
-        align-self: center;
     }
 
     &__main-content {

--- a/packages/wallets/src/features/cashier/modules/DepositCrypto/DepositCrypto.scss
+++ b/packages/wallets/src/features/cashier/modules/DepositCrypto/DepositCrypto.scss
@@ -13,6 +13,7 @@
         flex-direction: column;
         gap: 1.6rem;
         transform: translateY(-2.4rem);
+        align-self: center;
     }
 
     &__main-content {

--- a/packages/wallets/src/features/cashier/modules/DepositCrypto/DepositCrypto.scss
+++ b/packages/wallets/src/features/cashier/modules/DepositCrypto/DepositCrypto.scss
@@ -12,6 +12,7 @@
         height: fit-content;
         flex-direction: column;
         gap: 1.6rem;
+        transform: translateY(-2.4rem);
     }
 
     &__main-content {

--- a/packages/wallets/src/features/cashier/modules/DepositCrypto/DepositCrypto.scss
+++ b/packages/wallets/src/features/cashier/modules/DepositCrypto/DepositCrypto.scss
@@ -5,6 +5,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    transform: translateY(-4.8rem);
 
     @include mobile {
         width: 100%;

--- a/packages/wallets/src/features/cashier/modules/DepositCrypto/DepositCrypto.scss
+++ b/packages/wallets/src/features/cashier/modules/DepositCrypto/DepositCrypto.scss
@@ -2,17 +2,16 @@
     position: relative;
     width: 100%;
     display: flex;
-    align-items: center;
     justify-content: center;
     align-self: center;
-    transform: translateY(-4.8rem);
+    transform: translateY(-2.4rem);
 
     @include mobile {
         width: 100%;
         height: fit-content;
         flex-direction: column;
         gap: 1.6rem;
-        transform: translateY(-2.4rem);
+        transform: translateY(-1.2rem);
     }
 
     &__main-content {

--- a/packages/wallets/src/features/cashier/modules/DepositCrypto/components/DepositCryptoDisclaimers/DepositCryptoDisclaimers.scss
+++ b/packages/wallets/src/features/cashier/modules/DepositCrypto/components/DepositCryptoDisclaimers/DepositCryptoDisclaimers.scss
@@ -13,11 +13,16 @@
         flex-direction: column;
         align-items: flex-start;
         line-height: 1.4rem;
+        gap: 1rem;
+
+        @include mobile {
+            gap: 0.8rem;
+        }
     }
 
     &__points {
         list-style: disc;
-        margin-left: 0.8rem;
+        margin-left: 1.4rem;
     }
 
     &__note {


### PR DESCRIPTION
## Changes:

1. Added padding for the `WalletCashierContent`:
    ```
     desktop: top=4.8rem inline=1.6rem
     responsive: top=2.4rem inline=1.6rem
    ```
2. Translate the `DepositCryptoModule` by `-2.4rem in desktop` and `-1.2rem in responsive` to account for the padding in `WalletCashierContent` and center it to the screen.
3. Fixed the `margin-left` for disclaimer list-items and gap between title and list-items.

<img height="400" alt="Screenshot 2023-11-09 at 11 56 16 AM" src="https://github.com/binary-com/deriv-app/assets/125039206/3abd9093-ecc0-4c59-b6cc-658bdd703574">
<img height="400" alt="Screenshot 2023-11-09 at 11 56 43 AM" src="https://github.com/binary-com/deriv-app/assets/125039206/ae0dbe4c-d4b9-4c58-aba4-69ec0546ec60">
