### PR TITLE
thisyahlen/WALL-2514/chore: on first login switch to the first wallet by default

### DIFF
--- a/packages/wallets/src/routes/WalletsListingRoute/WalletsListingRoute.tsx
+++ b/packages/wallets/src/routes/WalletsListingRoute/WalletsListingRoute.tsx
@@ -1,10 +1,23 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useActiveWalletAccount, useAuthorize, useWalletAccountsList } from '@deriv/api';
 import { DesktopWalletsList, WalletsAddMoreCarousel, WalletsCarousel, WalletTourGuide } from '../../components';
 import useDevice from '../../hooks/useDevice';
 import './WalletsListingRoute.scss';
 
 const WalletsListingRoute: React.FC = () => {
     const { isMobile } = useDevice();
+    const { data: walletAccounts } = useWalletAccountsList();
+    const { switchAccount } = useAuthorize();
+    const { data: activeWallet } = useActiveWalletAccount();
+
+    const firstLoginid = walletAccounts?.[0]?.loginid;
+
+    useEffect(() => {
+        if (!activeWallet && firstLoginid) {
+            switchAccount(firstLoginid);
+        }
+    }, [activeWallet, firstLoginid, switchAccount]);
+
     return (
         <div className='wallets-listing-route'>
             {isMobile ? <WalletsCarousel /> : <DesktopWalletsList />}


### PR DESCRIPTION
## Changes:
On first login, the first wallet should be expanded by default. Only applies to wallets which has linked_to trading account. 
If the wallet doesnt have linked_to trading account, the first wallet is expanded by default. 

### Cards
https://app.clickup.com/t/20696747/WALL-2514
