### PR TITLE
[P2PS]-fix: file uploads not working in sendbird

### DIFF
--- a/packages/p2p/src/stores/sendbird-store.ts
+++ b/packages/p2p/src/stores/sendbird-store.ts
@@ -9,6 +9,7 @@ import { BaseMessage, FileMessage, MessageType, MessageTypeFilter, UserMessage }
 
 import BaseStore from 'Stores/base_store';
 import ChatMessage, { convertFromChannelMessage } from 'Utils/chat-message';
+import { renameFile } from 'Utils/file-uploader';
 import { requestWS } from 'Utils/websocket';
 
 type TChatInfo = { app_id: string; user_id: string; token?: string };
@@ -403,9 +404,10 @@ export default class SendbirdStore extends BaseStore {
     sendFile(file: File) {
         if (!file) return;
 
+        const updated_file = renameFile(file);
         this.active_chat_channel
             ?.sendFileMessage({
-                file,
+                file: updated_file,
                 fileName: file.name,
                 fileSize: file.size,
                 mimeType: file.type,

--- a/packages/p2p/src/utils/file-uploader.js
+++ b/packages/p2p/src/utils/file-uploader.js
@@ -17,3 +17,15 @@ export const getErrorMessage = files =>
     isFileTooLarge(files) && isFileSupported(files)
         ? localize('Cannot upload a file over 5MB')
         : localize('File uploaded is not supported');
+
+/**
+ * The function renames the files by removing any non ISO-8859-1 code point from filename and returns a new blob object with the updated file name.
+ * @param {File} file
+ * @returns {Blob}
+ */
+export const renameFile = file => {
+    const new_file = new Blob([file], { type: file.type });
+    // eslint-disable-next-line no-control-regex
+    new_file.name = file.name.replace(/[^\x00-\x7F]+/g, '');
+    return new_file;
+};


### PR DESCRIPTION
## Changes:

This pr is to solve the issue where some files were not getting uploaded in the sendbird chat. It happened for random files. The issue was because of the file name. When uploading screenshots, few file names had non ascii characters and it resulted in an internal server error from sendbird. Solved the issue by formatting the filename before uploading.

### Screenshots:

Please provide some screenshots of the change.
![Screenshot 2023-11-10 at 11 15 09 AM](https://github.com/binary-com/deriv-app/assets/122768621/52a67674-0144-4cd6-aa70-d6bb25ef1c1b)
