### PR TITLE
[DTRA] Maryia/WEBREL-1645/Hotfix: Vanilla Duration disappears when switching from unavailable duration

### DIFF
--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-wrapper.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/duration-wrapper.jsx
@@ -131,7 +131,7 @@ const DurationWrapper = observer(() => {
 
         assertDurationIsWithinBoundary(current_duration);
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+    }, [has_missing_duration_unit, simple_is_missing_duration_unit]);
 
     React.useEffect(() => {
         if (duration_unit === 'd') {


### PR DESCRIPTION
## Changes:

- to fix Vanilla Duration disappearing when switching from a Duration that is unavailable for Vanillas (e.g. Ticks/Minutes) on another trade type (e.g. Rise/Fall).
