### PR TITLE
[BOT] Maryia/BOT-156/feat: add reverse d'alembert strategy config & XML

### DIFF
--- a/packages/bot-web-ui/src/components/quick-strategy/config.ts
+++ b/packages/bot-web-ui/src/components/quick-strategy/config.ts
@@ -188,4 +188,15 @@ export const STRATEGIES: TStrategies = {
             [LABEL_PROFIT, PROFIT, LABEL_LOSS, LOSS, CHECKBOX_MAX_STAKE, MAX_STAKE],
         ],
     },
+    REVERSE_D_ALEMBERT: {
+        name: 'reverse_dalembert',
+        label: localize('Reverse D’Alembert'),
+        description: localize(
+            "The Reverse D'Alembert strategy increases the stake after a successful trade and reduces the stake after a losing trade by the number of units that traders decide. One unit is equal to the amount of the initial stake. To manage risk, set the maximum stake for a single trade. The stake for the next trade will reset to the initial stake if it exceeds the maximum stake."
+        ),
+        fields: [
+            [SYMBOL, TRADETYPE, CONTRACT_TYPE, LABEL_STAKE, STAKE, LABEL_DURATION, DURATION_TYPE, DURATION],
+            [LABEL_PROFIT, PROFIT, LABEL_LOSS, LOSS, LABEL_DALEMBERT_UNIT, UNIT, CHECKBOX_MAX_STAKE, MAX_STAKE],
+        ],
+    },
 };

--- a/packages/bot-web-ui/src/xml/reverse_dalembert.xml
+++ b/packages/bot-web-ui/src/xml/reverse_dalembert.xml
@@ -1,0 +1,765 @@
+<xml xmlns="http://www.w3.org/1999/xhtml" is_dbot="true" collection="false">
+  <variables>
+    <variable type="" id="LbJ%gBkQn8lHX-LuY;OE" islocal="false" iscloud="false">rdalembert:resultIsWin</variable>
+    <variable type="" id="p:YOw{BN8)4wTUEgW?f;" islocal="false" iscloud="false">rdalembert:profit</variable>
+    <variable type="" id="Kb@{Vb{+5IqV=d~y*dcr" islocal="false" iscloud="false">rdalembert:totalProfit</variable>
+    <variable type="" id="6G^6o^Ic@rjF|sHv*m.6" islocal="false" iscloud="false">rdalembert:tradeAgain</variable>
+    <variable type="" id="*p5|Lkk9Q^ZuPBQ-48g2" islocal="false" iscloud="false">rdalembert:profitThreshold</variable>
+    <variable type="" id="ipD5?_dQ1Zkvf%v|[?DQ" islocal="false" iscloud="false">rdalembert:unit</variable>
+    <variable type="" id="[$B]vBH,~wrN`PUt5m/f" islocal="false" iscloud="false">dalembert:initialStake</variable>
+    <variable type="" id="a1BTYNHC?_yR4sfvNJ7N" islocal="false" iscloud="false">rdalembert:lossThreshold</variable>
+    <variable type="" id="_(;)ob:l.sc|#L7kv7Z6" islocal="false" iscloud="false">won</variable>
+    <variable type="" id="p#@Pr/Y.sKueWX#oRSPl" islocal="false" iscloud="false">Notification:totalProfit</variable>
+    <variable type="" id="5SwcMzq.f)VNUzjbKfrw" islocal="false" iscloud="false">Notification:lossThresholdReached</variable>
+    <variable type="" id="g-j|c!)nK2VN`qwryRs]" islocal="false" iscloud="false">loss</variable>
+    <variable type="" id="I--KAm(C+#{d?~ip*23e" islocal="false" iscloud="false">Notification:profitThresholdReached</variable>
+    <variable type="" id="FRbI:RhI/`[lrO`o;=P," islocal="false" iscloud="false">rdalembert:multiplier</variable>
+    <variable type="" id="uC{c9eog8*^P1i,w44!$" islocal="false" iscloud="false">item</variable>
+    <variable type="" id="Nh^CEvzF8vy6S=Av+EK*" islocal="false" iscloud="false">rdalembert:winningstreaklimit</variable>
+    <variable type="" id="a7IYQ8sCrkwg52uC)3Jr" islocal="false" iscloud="false">maxStake</variable>
+    <variable type="" id="ZHj$;|RdAjiZ|O2=_4[%" islocal="false" iscloud="false">useMaxStake?</variable>
+    <variable type="" id="KsvT3)s83kK`UK6wBw!x" islocal="false" iscloud="false">Notification:currentStake</variable>
+  </variables>
+  <block type="trade_definition" id="i]`fLRZ]?mshi{9kS+fg" deletable="false" x="0" y="0">
+    <statement name="TRADE_OPTIONS">
+      <block type="trade_definition_market" id="w2tV#|N1PqTM)~5-6|An" deletable="false" movable="false">
+        <field name="MARKET_LIST">synthetic_index</field>
+        <field name="SUBMARKET_LIST">random_index</field>
+        <field name="SYMBOL_LIST">1HZ10V</field>
+        <next>
+          <block type="trade_definition_tradetype" id="4BIa?F@i2*Mlrd:{G,SF" deletable="false" movable="false">
+            <field name="TRADETYPECAT_LIST">callput</field>
+            <field name="TRADETYPE_LIST">callput</field>
+            <next>
+              <block type="trade_definition_contracttype" id="kujUv]]-mtF@Na3q/.(g" deletable="false" movable="false">
+                <field name="TYPE_LIST">both</field>
+                <next>
+                  <block type="trade_definition_candleinterval" id="[DsSG;O7*n`fK%ed;aj5" deletable="false" movable="false">
+                    <field name="CANDLEINTERVAL_LIST">60</field>
+                    <next>
+                      <block type="trade_definition_restartbuysell" id="]RX]Y0mfW-(HKGjkY]ly" deletable="false" movable="false">
+                        <field name="TIME_MACHINE_ENABLED">FALSE</field>
+                        <next>
+                          <block type="trade_definition_restartonerror" id="il/#yt1#I,KbD:6BQx?#" deletable="false" movable="false">
+                            <field name="RESTARTONERROR">TRUE</field>
+                          </block>
+                        </next>
+                      </block>
+                    </next>
+                  </block>
+                </next>
+              </block>
+            </next>
+          </block>
+        </next>
+      </block>
+    </statement>
+    <statement name="INITIALIZATION">
+      <block type="variables_set" id="Du{sRSk*=/e?L(x]-?i)">
+        <field name="VAR" id="ZHj$;|RdAjiZ|O2=_4[%" variabletype="">useMaxStake?</field>
+        <value name="VALUE" strategy_value="boolean_max_stake">
+          <block type="logic_boolean" id="P_*YEiIi(iR34Wk);uj}">
+            <field name="BOOL">TRUE</field>
+          </block>
+        </value>
+        <next>
+          <block type="variables_set" id="LUYU6FrN.u6_%mg@vU#h">
+            <field name="VAR" id="a7IYQ8sCrkwg52uC)3Jr" variabletype="">maxStake</field>
+            <value name="VALUE" strategy_value="max_stake">
+              <shadow type="math_number" id="A{/Vi,3YgR0DG]Sk$B1;">
+                <field name="NUM">1000</field>
+              </shadow>
+            </value>
+          </block>
+        </next>
+      </block>
+    </statement>
+    <statement name="SUBMARKET">
+      <block type="trade_definition_tradeoptions" id="8=uN{72G(CSbw2LN=h?0">
+        <mutation has_first_barrier="false" has_second_barrier="false" has_prediction="false"></mutation>
+        <field name="DURATIONTYPE_LIST">t</field>
+        <value name="DURATION" strategy_value="duration">
+          <shadow type="math_number" id="hSDuZ!{4g^QMknCA-O|d">
+            <field name="NUM">1</field>
+          </shadow>
+        </value>
+        <value name="AMOUNT">
+          <shadow type="math_number">
+            <field name="NUM">1</field>
+          </shadow>
+          <block type="procedures_callreturn" id="JKIgKdNnmR8J;^];~[kp">
+            <mutation name="Reverse D'Alembert Trade Amount"></mutation>
+            <data>CI@IiTlr,.O=:m#QLq`M</data>
+          </block>
+        </value>
+      </block>
+    </statement>
+  </block>
+  <block type="after_purchase" id="cb%w4#L|)A]1F1+)uk_u" x="865" y="0">
+    <statement name="AFTERPURCHASE_STACK">
+      <block type="controls_if" id="Y7vVfZ`@dP+KBKXW6C|a">
+        <value name="IF0">
+          <block type="procedures_callreturn" id="_ES]wQc*K9uQmJ1a:MA,">
+            <mutation name="Reverse D'Alembert Trade Again After Purchase">
+              <arg name="rdalembert:profit"></arg>
+              <arg name="rdalembert:resultIsWin"></arg>
+            </mutation>
+            <data>-9(QN`Sc2$IvQPr6M9QP</data>
+            <value name="ARG0">
+              <block type="read_details" id="6~ERQr:ogkONG,..Ooj+">
+                <field name="DETAIL_INDEX">4</field>
+              </block>
+            </value>
+            <value name="ARG1">
+              <block type="contract_check_result" id="N85;,Dl!TJMa_U[tgj6#">
+                <field name="CHECK_RESULT">win</field>
+              </block>
+            </value>
+          </block>
+        </value>
+        <statement name="DO0">
+          <block type="trade_again" id="(T~B6mBGK5D2unsjU25_"></block>
+        </statement>
+      </block>
+    </statement>
+  </block>
+  <block type="before_purchase" id="Z])37`R^9KsrX4I7bAqP" deletable="false" x="0" y="648">
+    <statement name="BEFOREPURCHASE_STACK">
+      <block type="purchase" id="?QH{0D:/t^fpgu}4sb`x">
+        <field name="PURCHASE_LIST">CALL</field>
+      </block>
+    </statement>
+  </block>
+  <block type="procedures_defnoreturn" id="s`u(+vlS44fI;pul:nfW" collapsed="true" x="0" y="832">
+    <mutation>
+      <arg name="rdalembert:resultIsWin" varid="x]b3MHpbtR?cJQDP@,eG"></arg>
+    </mutation>
+    <field name="NAME">Reverse D'Alembert Core Functionality</field>
+    <statement name="STACK">
+      <block type="text_join" id="zYEF.argiFI:vv)yakZ9">
+        <field name="VARIABLE" id="KsvT3)s83kK`UK6wBw!x" variabletype="">Notification:currentStake</field>
+        <statement name="STACK">
+          <block type="text_statement" id="5v[zJ^ugi$=k?wll^MD{">
+            <value name="TEXT">
+              <shadow type="text" id="ziIJnUr8=c,u_buxu%DE">
+                <field name="TEXT">Current stake:</field>
+              </shadow>
+            </value>
+            <next>
+              <block type="text_statement" id=".b-0t$c%EYY91mKvM2$S">
+                <value name="TEXT">
+                  <shadow type="text" id="8AsEFzdnOu_DrOJM(hZ3">
+                    <field name="TEXT"></field>
+                  </shadow>
+                  <block type="procedures_callreturn" id="n^Y?)=QK[3=XCs74!@?s">
+                    <mutation name="Reverse D'Alembert Trade Amount"></mutation>
+                    <data>CI@IiTlr,.O=:m#QLq`M</data>
+                  </block>
+                </value>
+              </block>
+            </next>
+          </block>
+        </statement>
+        <next>
+          <block type="notify" id="hI3|A(GK3OLS={}dKkJk">
+            <field name="NOTIFICATION_TYPE">warn</field>
+            <field name="NOTIFICATION_SOUND">silent</field>
+            <value name="MESSAGE">
+              <shadow type="text" id="8Z7@GsYOR#$lF(X8s6vh">
+                <field name="TEXT">abc</field>
+              </shadow>
+              <block type="variables_get" id="!}bL5F4uJ#%r3AS4ogSm">
+                <field name="VAR" id="KsvT3)s83kK`UK6wBw!x" variabletype="">Notification:currentStake</field>
+              </block>
+            </value>
+            <next>
+              <block type="controls_if" id="B-,mWt$U5Ox.^T5l[AU)">
+                <mutation else="1"></mutation>
+                <value name="IF0">
+                  <block type="variables_get" id="LKMXXjt~M8@Xs?F,2_mg">
+                    <field name="VAR" id="x]b3MHpbtR?cJQDP@,eG" variabletype="">rdalembert:resultIsWin</field>
+                  </block>
+                </value>
+                <statement name="DO0">
+                  <block type="variables_set" id="!|A-Hf9?rM7mY*)z~nK8">
+                    <field name="VAR" id="FRbI:RhI/`[lrO`o;=P," variabletype="">rdalembert:multiplier</field>
+                    <value name="VALUE">
+                      <block type="math_arithmetic" id="qN47IB5UuHC!6nve8cj.">
+                        <field name="OP">MULTIPLY</field>
+                        <value name="A">
+                          <shadow type="math_number" id="xr9_kcyW9m=RnAK$xAdh">
+                            <field name="NUM">1</field>
+                          </shadow>
+                          <block type="variables_get" id="|]`,UJwsyW$1OQ*uN%KI">
+                            <field name="VAR" id="FRbI:RhI/`[lrO`o;=P," variabletype="">rdalembert:multiplier</field>
+                          </block>
+                        </value>
+                        <value name="B">
+                          <shadow type="math_number" id="h$n/~8a9%h~-RCs3DI_]">
+                            <field name="NUM">1</field>
+                          </shadow>
+                          <block type="variables_get" id="~;`^8J(h2Yx@ZG2U.N0U">
+                            <field name="VAR" id="ipD5?_dQ1Zkvf%v|[?DQ" variabletype="">rdalembert:unit</field>
+                          </block>
+                        </value>
+                      </block>
+                    </value>
+                    <next>
+                      <block type="controls_if" id="~1XAP0xxC~6a8KNel~K1">
+                        <value name="IF0">
+                          <block type="logic_compare" id="}}Pt7%4EVntK)R(z=)T^">
+                            <field name="OP">GT</field>
+                            <value name="A">
+                              <block type="logic_operation" id="pI!Rs.lT`cm$.Ktfbw:f">
+                                <field name="OP">AND</field>
+                                <value name="A">
+                                  <block type="variables_get" id="5$E6}vdo2Pg6HYb_K1fF">
+                                    <field name="VAR" id="ZHj$;|RdAjiZ|O2=_4[%" variabletype="">useMaxStake?</field>
+                                  </block>
+                                </value>
+                                <value name="B">
+                                  <block type="procedures_callreturn" id="7:%(tuqcj:gvlJ,^XOIK">
+                                    <mutation name="Reverse D'Alembert Trade Amount"></mutation>
+                                    <data>CI@IiTlr,.O=:m#QLq`M</data>
+                                  </block>
+                                </value>
+                              </block>
+                            </value>
+                            <value name="B">
+                              <block type="variables_get" id="6n6xh[n}yKF@{ZgH#1{$">
+                                <field name="VAR" id="a7IYQ8sCrkwg52uC)3Jr" variabletype="">maxStake</field>
+                              </block>
+                            </value>
+                          </block>
+                        </value>
+                        <statement name="DO0">
+                          <block type="variables_set" id="*cArguDIC+~yz5:,tt*G">
+                            <field name="VAR" id="FRbI:RhI/`[lrO`o;=P," variabletype="">rdalembert:multiplier</field>
+                            <value name="VALUE">
+                              <shadow type="math_number" id="-*o6L}5@V/$-SoI%1qCC">
+                                <field name="NUM">1</field>
+                              </shadow>
+                            </value>
+                            <next>
+                              <block type="notify" id="t,C`*f{H{ML(`w(?Dp[I">
+                                <field name="NOTIFICATION_TYPE">error</field>
+                                <field name="NOTIFICATION_SOUND">silent</field>
+                                <value name="MESSAGE">
+                                  <shadow type="text" id="f;YsY_xH](Za:*Z9oIJd">
+                                    <field name="TEXT">Stake resets for the next trade (reason: exceeds max stake amount)</field>
+                                  </shadow>
+                                </value>
+                              </block>
+                            </next>
+                          </block>
+                        </statement>
+                      </block>
+                    </next>
+                  </block>
+                </statement>
+                <statement name="ELSE">
+                  <block type="variables_set" id="wj3775x9=0gF~p`wl];k">
+                    <field name="VAR" id="FRbI:RhI/`[lrO`o;=P," variabletype="">rdalembert:multiplier</field>
+                    <value name="VALUE">
+                      <shadow type="math_number" id="#{5k!r3Zgo@m8VSv[fPn">
+                        <field name="NUM">1</field>
+                      </shadow>
+                    </value>
+                  </block>
+                </statement>
+              </block>
+            </next>
+          </block>
+        </next>
+      </block>
+    </statement>
+  </block>
+  <block type="procedures_defreturn" id="x3TA)`V~gtD7?rqNj[.9" collapsed="true" x="0" y="928">
+    <field name="NAME">Reverse D'Alembert Trade Amount</field>
+    <statement name="STACK">
+      <block type="controls_if" id="m|NvCXT=!Z{`Uz`r:m|$">
+        <value name="IF0">
+          <block type="logic_compare" id="PeeDP94E)V=#S~69%:Hk">
+            <field name="OP">EQ</field>
+            <value name="A">
+              <block type="variables_get" id="f.km2[vh(%]*F2SuNU%G">
+                <field name="VAR" id="*p5|Lkk9Q^ZuPBQ-48g2" variabletype="">rdalembert:profitThreshold</field>
+              </block>
+            </value>
+            <value name="B">
+              <block type="logic_null" id="[R@rhEZMD*U(Q~m#KCMh"></block>
+            </value>
+          </block>
+        </value>
+        <statement name="DO0">
+          <block type="variables_set" id="{}-XA:3=]2W.Aq|zIiP(">
+            <field name="VAR" id="*p5|Lkk9Q^ZuPBQ-48g2" variabletype="">rdalembert:profitThreshold</field>
+            <value name="VALUE" strategy_value="profit">
+              <shadow type="math_number" id=")LH%,ON4KG6!Tgj)[Zkk">
+                <field name="NUM">5000</field>
+              </shadow>
+            </value>
+          </block>
+        </statement>
+        <next>
+          <block type="controls_if" id="Usu?ety_d{DdqDPFw78m">
+            <value name="IF0">
+              <block type="logic_compare" id="e8qk^*j@H6ng{H8}Vv3R">
+                <field name="OP">EQ</field>
+                <value name="A">
+                  <block type="variables_get" id="EzMg)v,zllQlN8mb?5{h">
+                    <field name="VAR" id="a1BTYNHC?_yR4sfvNJ7N" variabletype="">rdalembert:lossThreshold</field>
+                  </block>
+                </value>
+                <value name="B">
+                  <block type="logic_null" id=")k{fUEt[/)H?^NgdHT*+"></block>
+                </value>
+              </block>
+            </value>
+            <statement name="DO0">
+              <block type="variables_set" id=":OS%IuonU;AkRO!H-SEF">
+                <field name="VAR" id="a1BTYNHC?_yR4sfvNJ7N" variabletype="">rdalembert:lossThreshold</field>
+                <value name="VALUE" strategy_value="loss">
+                  <shadow type="math_number" id="yD}(.wdC*ybVT:xmROY[">
+                    <field name="NUM">3000</field>
+                  </shadow>
+                </value>
+              </block>
+            </statement>
+            <next>
+              <block type="controls_if" id="-XkmG`TcfQ120.%uPetQ">
+                <value name="IF0">
+                  <block type="logic_compare" id="N_[iwyYPZsj8rKmV:GTj">
+                    <field name="OP">EQ</field>
+                    <value name="A">
+                      <block type="variables_get" id="{:C[v0vezVot0F{#8z#C">
+                        <field name="VAR" id="[$B]vBH,~wrN`PUt5m/f" variabletype="">rdalembert:initialStake</field>
+                      </block>
+                    </value>
+                    <value name="B">
+                      <block type="logic_null" id="n{-TB11IDQw5O(9-=zIr"></block>
+                    </value>
+                  </block>
+                </value>
+                <statement name="DO0">
+                  <block type="variables_set" id="BEp45H17VcN)bNjaC13X">
+                    <field name="VAR" id="[$B]vBH,~wrN`PUt5m/f" variabletype="">rdalembert:initialStake</field>
+                    <value name="VALUE" strategy_value="stake">
+                      <shadow type="math_number" id=",Q|hF0TEfT$Sel0hjM^9">
+                        <field name="NUM">100</field>
+                      </shadow>
+                    </value>
+                  </block>
+                </statement>
+                <next>
+                  <block type="controls_if" id="!_^Y3:=rFtL6aF0#~DFT">
+                    <value name="IF0">
+                      <block type="logic_compare" id="cmU^7GLDMN~++3mP^+$n">
+                        <field name="OP">EQ</field>
+                        <value name="A">
+                          <block type="variables_get" id="?:}:mXzQgsbYRfm~0C*H">
+                            <field name="VAR" id="ipD5?_dQ1Zkvf%v|[?DQ" variabletype="">rdalembert:unit</field>
+                          </block>
+                        </value>
+                        <value name="B">
+                          <block type="logic_null" id="$fhp;`t^Ie,SzUO{y4qg"></block>
+                        </value>
+                      </block>
+                    </value>
+                    <statement name="DO0">
+                      <block type="variables_set" id="-93lGY=!6I#8sh)~z`3Z">
+                        <field name="VAR" id="ipD5?_dQ1Zkvf%v|[?DQ" variabletype="">rdalembert:unit</field>
+                        <value name="VALUE" strategy_value="unit">
+                          <shadow type="math_number" id="g[L0,]t@d`pq?4f%}}1O">
+                            <field name="NUM">2</field>
+                          </shadow>
+                        </value>
+                      </block>
+                    </statement>
+                    <next>
+                      <block type="controls_if" id="D?v;;-QQ=]k/%a8XK/RQ">
+                        <value name="IF0">
+                          <block type="logic_compare" id="@LNL@pA9b#8SJGe$4zur">
+                            <field name="OP">EQ</field>
+                            <value name="A">
+                              <block type="variables_get" id="Wc7riq/+8b5q+,f9@uR6">
+                                <field name="VAR" id="FRbI:RhI/`[lrO`o;=P," variabletype="">rdalembert:multiplier</field>
+                              </block>
+                            </value>
+                            <value name="B">
+                              <block type="logic_null" id="g^$2zUmo/#v.0SthN[lG"></block>
+                            </value>
+                          </block>
+                        </value>
+                        <statement name="DO0">
+                          <block type="variables_set" id="ZA0SX,/mZR=Q@Qs{0-nM">
+                            <field name="VAR" id="FRbI:RhI/`[lrO`o;=P," variabletype="">rdalembert:multiplier</field>
+                            <value name="VALUE">
+                              <shadow type="math_number" id="y^=8[fZs0weMPlUMzJ0v">
+                                <field name="NUM">1</field>
+                              </shadow>
+                            </value>
+                          </block>
+                        </statement>
+                        <next>
+                          <block type="controls_if" id="$8xAQGgiV1U|3nDiZ0:X">
+                            <value name="IF0">
+                              <block type="logic_compare" id="]TOR9VFmHAS3vC~A20mf">
+                                <field name="OP">EQ</field>
+                                <value name="A">
+                                  <block type="variables_get" id="]esY#,FN9C}bbgG:As`K">
+                                    <field name="VAR" id="Kb@{Vb{+5IqV=d~y*dcr" variabletype="">rdalembert:totalProfit</field>
+                                  </block>
+                                </value>
+                                <value name="B">
+                                  <block type="logic_null" id="0NIH0U%Bk-4w*SgA+dX|"></block>
+                                </value>
+                              </block>
+                            </value>
+                            <statement name="DO0">
+                              <block type="variables_set" id="2s+YXTZv%VGRY=?APf^h">
+                                <field name="VAR" id="Kb@{Vb{+5IqV=d~y*dcr" variabletype="">rdalembert:totalProfit</field>
+                                <value name="VALUE">
+                                  <shadow type="math_number" id="%JgI()#r0Zu#ruzKLXpj">
+                                    <field name="NUM">0</field>
+                                  </shadow>
+                                </value>
+                              </block>
+                            </statement>
+                          </block>
+                        </next>
+                      </block>
+                    </next>
+                  </block>
+                </next>
+              </block>
+            </next>
+          </block>
+        </next>
+      </block>
+    </statement>
+    <value name="RETURN">
+      <block type="math_arithmetic" id="MR,#W3HBlh/CZGh.TF:m">
+        <field name="OP">MULTIPLY</field>
+        <value name="A">
+          <shadow type="math_number">
+            <field name="NUM">1</field>
+          </shadow>
+          <block type="variables_get" id="IBo=7;I!m0Bv(.Zn7^/3">
+            <field name="VAR" id="FRbI:RhI/`[lrO`o;=P," variabletype="">rdalembert:multiplier</field>
+          </block>
+        </value>
+        <value name="B">
+          <shadow type="math_number">
+            <field name="NUM">1</field>
+          </shadow>
+          <block type="variables_get" id="w$Dd.MXXRvJmyJuC~XUu">
+            <field name="VAR" id="[$B]vBH,~wrN`PUt5m/f" variabletype="">rdalembert:initialStake</field>
+          </block>
+        </value>
+      </block>
+    </value>
+  </block>
+  <block type="procedures_defreturn" id="N,_%hZ47`]!eOyc7%u8]" collapsed="true" x="0" y="1024">
+    <mutation>
+      <arg name="rdalembert:profit" varid="[M$5RsD`g|8-P;C+mbf4"></arg>
+      <arg name="rdalembert:resultIsWin" varid="x]b3MHpbtR?cJQDP@,eG"></arg>
+    </mutation>
+    <field name="NAME">Reverse D'Alembert Trade Again After Purchase</field>
+    <statement name="STACK">
+      <block type="math_change" id="G)p)~Q+g*Hsak%Mg_PMd">
+        <field name="VAR" id="Kb@{Vb{+5IqV=d~y*dcr" variabletype="">rdalembert:totalProfit</field>
+        <value name="DELTA">
+          <shadow type="math_number">
+            <field name="NUM">1</field>
+          </shadow>
+          <block type="variables_get" id="|xO6#sg$RRE9Ub8W6Oq=">
+            <field name="VAR" id="[M$5RsD`g|8-P;C+mbf4" variabletype="">rdalembert:profit</field>
+          </block>
+        </value>
+        <next>
+          <block type="variables_set" id="p?gdu**|cGlmOTw^G_D@">
+            <field name="VAR" id="Kb@{Vb{+5IqV=d~y*dcr" variabletype="">rdalembert:totalProfit</field>
+            <value name="VALUE">
+              <block type="math_arithmetic" id="lSSFZC-1xm}v~a9_Xw3@">
+                <field name="OP">DIVIDE</field>
+                <value name="A">
+                  <shadow type="math_number">
+                    <field name="NUM">1</field>
+                  </shadow>
+                  <block type="math_round" id="qe@`Q7,j_0|sTdj`,F|B">
+                    <field name="OP">ROUND</field>
+                    <value name="NUM">
+                      <shadow type="math_number">
+                        <field name="NUM">3.1</field>
+                      </shadow>
+                      <block type="math_arithmetic" id="9b({-h28~_/qs:s!*WkN">
+                        <field name="OP">MULTIPLY</field>
+                        <value name="A">
+                          <shadow type="math_number">
+                            <field name="NUM">1</field>
+                          </shadow>
+                          <block type="variables_get" id="`n%c*E0(V,0.I[D%,s!j">
+                            <field name="VAR" id="Kb@{Vb{+5IqV=d~y*dcr" variabletype="">rdalembert:totalProfit</field>
+                          </block>
+                        </value>
+                        <value name="B">
+                          <shadow type="math_number" id="9_(K(Vo5-U%*h=jJ]+oF">
+                            <field name="NUM">100</field>
+                          </shadow>
+                        </value>
+                      </block>
+                    </value>
+                  </block>
+                </value>
+                <value name="B">
+                  <shadow type="math_number" id="bRV]-C*:i*}p+`XB_rv7">
+                    <field name="NUM">100</field>
+                  </shadow>
+                </value>
+              </block>
+            </value>
+            <next>
+              <block type="procedures_callnoreturn" id=".HOK{2j(GR=qlV..gc}o">
+                <mutation name="Reverse D'Alembert Core Functionality">
+                  <arg name="rdalembert:resultIsWin"></arg>
+                </mutation>
+                <data>y?vDuuwfiR,*DqC],*C:</data>
+                <value name="ARG0">
+                  <block type="variables_get" id="pgjZvSeFe;B(ZL|$v(!:">
+                    <field name="VAR" id="x]b3MHpbtR?cJQDP@,eG" variabletype="">rdalembert:resultIsWin</field>
+                  </block>
+                </value>
+                <next>
+                  <block type="text_join" id="jW!]JTxnzDnsTxu^+gT!">
+                    <field name="VARIABLE" id="p#@Pr/Y.sKueWX#oRSPl" variabletype="">Notification:totalProfit</field>
+                    <statement name="STACK">
+                      <block type="text_statement" id="Y3$$Wh@Fr:}*_(hMrtvA">
+                        <value name="TEXT">
+                          <shadow type="text" id="Hm%lX3B[OAyV1OrSBqCn">
+                            <field name="TEXT">Total Profit:</field>
+                          </shadow>
+                        </value>
+                        <next>
+                          <block type="text_statement" id="[(J[NV?+P0O}]:cG4cP}">
+                            <value name="TEXT">
+                              <shadow type="text">
+                                <field name="TEXT"></field>
+                              </shadow>
+                              <block type="variables_get" id="FUazlkQi-clh,Vt%{Z2@">
+                                <field name="VAR" id="Kb@{Vb{+5IqV=d~y*dcr" variabletype="">rdalembert:totalProfit</field>
+                              </block>
+                            </value>
+                          </block>
+                        </next>
+                      </block>
+                    </statement>
+                    <next>
+                      <block type="notify" id="e$Pci.r)?[2i9=/L]hI{">
+                        <field name="NOTIFICATION_TYPE">info</field>
+                        <field name="NOTIFICATION_SOUND">silent</field>
+                        <value name="MESSAGE">
+                          <shadow type="text">
+                            <field name="TEXT">abc</field>
+                          </shadow>
+                          <block type="variables_get" id="!EEfy=FF,cmavRcMOd`9">
+                            <field name="VAR" id="p#@Pr/Y.sKueWX#oRSPl" variabletype="">Notification:totalProfit</field>
+                          </block>
+                        </value>
+                        <next>
+                          <block type="variables_set" id="TPOGTMEqW41Wa{D|?]`V">
+                            <field name="VAR" id="6G^6o^Ic@rjF|sHv*m.6" variabletype="">rdalembert:tradeAgain</field>
+                            <value name="VALUE">
+                              <block type="logic_boolean" id="WK=zt|fDEnw}@@bsZ+%v">
+                                <field name="BOOL">FALSE</field>
+                              </block>
+                            </value>
+                            <next>
+                              <block type="controls_if" id="KTuC8HMyaDp6Q3xId0@A">
+                                <mutation else="1"></mutation>
+                                <value name="IF0">
+                                  <block type="logic_compare" id="7[;$pQigi:R:T3}s(G6^">
+                                    <field name="OP">LT</field>
+                                    <value name="A">
+                                      <block type="variables_get" id="{T)uCW@]IoOpTp7;JdSO">
+                                        <field name="VAR" id="Kb@{Vb{+5IqV=d~y*dcr" variabletype="">rdalembert:totalProfit</field>
+                                      </block>
+                                    </value>
+                                    <value name="B">
+                                      <block type="variables_get" id="5m`a=f+P*-wT*3b-Acg=">
+                                        <field name="VAR" id="*p5|Lkk9Q^ZuPBQ-48g2" variabletype="">rdalembert:profitThreshold</field>
+                                      </block>
+                                    </value>
+                                  </block>
+                                </value>
+                                <statement name="DO0">
+                                  <block type="controls_if" id=".O}[W@YXqN#zGd%ewXJ*">
+                                    <mutation else="1"></mutation>
+                                    <value name="IF0">
+                                      <block type="logic_compare" id="%XaSru*P96b@:s~*f6/b">
+                                        <field name="OP">GT</field>
+                                        <value name="A">
+                                          <block type="variables_get" id=".j^jS`B22${#0xP~J7;S">
+                                            <field name="VAR" id="Kb@{Vb{+5IqV=d~y*dcr" variabletype="">rdalembert:totalProfit</field>
+                                          </block>
+                                        </value>
+                                        <value name="B">
+                                          <block type="math_single" id="K9$ftop.bUpkoibNkVQL">
+                                            <field name="OP">NEG</field>
+                                            <value name="NUM">
+                                              <shadow type="math_number">
+                                                <field name="NUM">9</field>
+                                              </shadow>
+                                              <block type="variables_get" id="`nfV$q=C}%gf{r$Jyt-#">
+                                                <field name="VAR" id="a1BTYNHC?_yR4sfvNJ7N" variabletype="">rdalembert:lossThreshold</field>
+                                              </block>
+                                            </value>
+                                          </block>
+                                        </value>
+                                      </block>
+                                    </value>
+                                    <statement name="DO0">
+                                      <block type="variables_set" id="b_=Q.Dj-VBXKcWz33ioo">
+                                        <field name="VAR" id="6G^6o^Ic@rjF|sHv*m.6" variabletype="">rdalembert:tradeAgain</field>
+                                        <value name="VALUE">
+                                          <block type="logic_boolean" id="v}*;H=73;[WKn2R,+.0P">
+                                            <field name="BOOL">TRUE</field>
+                                          </block>
+                                        </value>
+                                      </block>
+                                    </statement>
+                                    <statement name="ELSE">
+                                      <block type="text_join" id="0Q-B~fTe|,QnY@(c,h@*">
+                                        <field name="VARIABLE" id="5SwcMzq.f)VNUzjbKfrw" variabletype="">Notification:lossThresholdReached</field>
+                                        <statement name="STACK">
+                                          <block type="text_statement" id="db1K?]^sdr=ocll68sJz">
+                                            <value name="TEXT">
+                                              <shadow type="text" id="{lVc8F}w58h0szOx[bg;">
+                                                <field name="TEXT">Loss threshold triggered. Total Loss:</field>
+                                              </shadow>
+                                            </value>
+                                            <next>
+                                              <block type="text_statement" id="Wf^WII2`tL|r}@bNbN[o">
+                                                <value name="TEXT">
+                                                  <shadow type="text">
+                                                    <field name="TEXT"></field>
+                                                  </shadow>
+                                                  <block type="math_single" id="`6,2Jm!UJarPK~GWrlBz">
+                                                    <field name="OP">NEG</field>
+                                                    <value name="NUM">
+                                                      <shadow type="math_number">
+                                                        <field name="NUM">9</field>
+                                                      </shadow>
+                                                      <block type="variables_get" id="1(j3)T@W,~*yuT=FOi%.">
+                                                        <field name="VAR" id="Kb@{Vb{+5IqV=d~y*dcr" variabletype="">rdalembert:totalProfit</field>
+                                                      </block>
+                                                    </value>
+                                                  </block>
+                                                </value>
+                                              </block>
+                                            </next>
+                                          </block>
+                                        </statement>
+                                        <next>
+                                          <block type="notify" id="q.sr[qd;.DUw+ZC?)UV.">
+                                            <field name="NOTIFICATION_TYPE">error</field>
+                                            <field name="NOTIFICATION_SOUND">silent</field>
+                                            <value name="MESSAGE">
+                                              <shadow type="text" id="]H*2?o+looqEo1$JWuK:">
+                                                <field name="TEXT">abc</field>
+                                              </shadow>
+                                              <block type="variables_get" id="#-JX,G#Ut/%m]*XWkTY^">
+                                                <field name="VAR" id="5SwcMzq.f)VNUzjbKfrw" variabletype="">Notification:lossThresholdReached</field>
+                                              </block>
+                                            </value>
+                                            <next>
+                                              <block type="text_print" id="7Hu/[~lR.t.}-Yj{1)Uz">
+                                                <value name="TEXT">
+                                                  <shadow type="text">
+                                                    <field name="TEXT">abc</field>
+                                                  </shadow>
+                                                  <block type="variables_get" id="FovJWy:zEzG5q}JWeVtB">
+                                                    <field name="VAR" id="5SwcMzq.f)VNUzjbKfrw" variabletype="">Notification:lossThresholdReached</field>
+                                                  </block>
+                                                </value>
+                                              </block>
+                                            </next>
+                                          </block>
+                                        </next>
+                                      </block>
+                                    </statement>
+                                  </block>
+                                </statement>
+                                <statement name="ELSE">
+                                  <block type="text_join" id="[A$i5JA+{nps8EN,kgnS">
+                                    <field name="VARIABLE" id="I--KAm(C+#{d?~ip*23e" variabletype="">Notification:profitThresholdReached</field>
+                                    <statement name="STACK">
+                                      <block type="text_statement" id="*d%K,c1?SW4n,rFX.*li">
+                                        <value name="TEXT">
+                                          <shadow type="text" id="weGes?KSjTg7EPpK}{.2">
+                                            <field name="TEXT">Profit threshold triggered. Total Profit:</field>
+                                          </shadow>
+                                        </value>
+                                        <next>
+                                          <block type="text_statement" id="-:.y|:f5RYmLM+7|FWbi">
+                                            <value name="TEXT">
+                                              <shadow type="text">
+                                                <field name="TEXT"></field>
+                                              </shadow>
+                                              <block type="variables_get" id="vkzm7ZsfkqpuUv[-mVlL">
+                                                <field name="VAR" id="Kb@{Vb{+5IqV=d~y*dcr" variabletype="">rdalembert:totalProfit</field>
+                                              </block>
+                                            </value>
+                                          </block>
+                                        </next>
+                                      </block>
+                                    </statement>
+                                    <next>
+                                      <block type="notify" id="*Fvg4A^b~Hi^8P)7xZAo">
+                                        <field name="NOTIFICATION_TYPE">success</field>
+                                        <field name="NOTIFICATION_SOUND">silent</field>
+                                        <value name="MESSAGE">
+                                          <shadow type="text" id="L:%knJ;0;s+$BZEb+n]f">
+                                            <field name="TEXT">abc</field>
+                                          </shadow>
+                                          <block type="variables_get" id="laosKK4d:6Qx+TogN*0s">
+                                            <field name="VAR" id="I--KAm(C+#{d?~ip*23e" variabletype="">Notification:profitThresholdReached</field>
+                                          </block>
+                                        </value>
+                                        <next>
+                                          <block type="text_print" id="(3se7`318IM+E4L`y]h*">
+                                            <value name="TEXT">
+                                              <shadow type="text">
+                                                <field name="TEXT">abc</field>
+                                              </shadow>
+                                              <block type="variables_get" id="fec1s;/PX|TlCC@)Yf{F">
+                                                <field name="VAR" id="I--KAm(C+#{d?~ip*23e" variabletype="">Notification:profitThresholdReached</field>
+                                              </block>
+                                            </value>
+                                          </block>
+                                        </next>
+                                      </block>
+                                    </next>
+                                  </block>
+                                </statement>
+                              </block>
+                            </next>
+                          </block>
+                        </next>
+                      </block>
+                    </next>
+                  </block>
+                </next>
+              </block>
+            </next>
+          </block>
+        </next>
+      </block>
+    </statement>
+    <value name="RETURN">
+      <block type="variables_get" id="j?CldGzC$5jEF4LPS]9j">
+        <field name="VAR" id="6G^6o^Ic@rjF|sHv*m.6" variabletype="">rdalembert:tradeAgain</field>
+      </block>
+    </value>
+  </block>
+</xml>


### PR DESCRIPTION
## Changes:

1. add `Reverse D'alembert` strategy for quick strategies
2. added the required fields for `Reverse D'alembert` to the quick strategy config
3. added the `Reverse D'alembert` xml with updated fields

### Screenshots:

Please provide some screenshots of the change.
