### PR TITLE
[COJ]/likhith/[COJ-210]-incorporated API changes with backward compatibility

### DIFF
--- a/packages/api/src/hooks/useAccountStatus.ts
+++ b/packages/api/src/hooks/useAccountStatus.ts
@@ -93,9 +93,9 @@ const useAccountStatus = () => {
             /** the DF deposit will be blocked until the client gets age verified. */
             is_df_deposit_requires_poi: status.has('df_deposit_requires_poi'),
             /** the client has been fully authenticated by IDV. */
+            is_authenticated_with_idv: status.has('authenticated_with_idv'),
             // TODO: [account-status] Remove `authenticated_with_idv_photoid` check once we have the correct status from API
-            is_authenticated_with_idv:
-                status.has('authenticated_with_idv') || status.has('authenticated_with_idv_photoid'),
+            is_authenticated_with_idv_photo_id: status.has('authenticated_with_idv_photoid'),
             /** the client used to be fully authenticated by IDV but it was taken away due to compliance criteria. */
             is_idv_revoked: status.has('idv_revoked'),
         };

--- a/packages/api/src/hooks/useAccountStatus.ts
+++ b/packages/api/src/hooks/useAccountStatus.ts
@@ -93,7 +93,9 @@ const useAccountStatus = () => {
             /** the DF deposit will be blocked until the client gets age verified. */
             is_df_deposit_requires_poi: status.has('df_deposit_requires_poi'),
             /** the client has been fully authenticated by IDV. */
-            is_authenticated_with_idv_photoid: status.has('authenticated_with_idv_photoid'),
+            // TODO: [account-status] Remove `authenticated_with_idv_photoid` check once we have the correct status from API
+            is_authenticated_with_idv:
+                status.has('authenticated_with_idv') || status.has('authenticated_with_idv_photoid'),
             /** the client used to be fully authenticated by IDV but it was taken away due to compliance criteria. */
             is_idv_revoked: status.has('idv_revoked'),
         };

--- a/packages/cfd/src/Containers/cfd-financial-stp-real-account-signup.tsx
+++ b/packages/cfd/src/Containers/cfd-financial-stp-real-account-signup.tsx
@@ -86,8 +86,10 @@ const CFDFinancialStpRealAccountSignup = observer(({ onFinish }: TCFDFinancialSt
     let is_mounted = React.useRef(true).current;
 
     const { need_poi_for_maltainvest, need_poi_for_bvi_labuan_vanuatu } = getAuthenticationStatusInfo(account_status);
-
-    const is_authenticated_with_idv_photoid = useIsAccountStatusPresent('authenticated_with_idv_photoid');
+    // TODO: [account-status] Remove `authenticated_with_idv_photoid` check once we have the correct status from API
+    const is_authenticated_with_idv =
+        useIsAccountStatusPresent('authenticated_with_idv') ||
+        useIsAccountStatusPresent('authenticated_with_idv_photoid');
 
     const poi_config: TItemsState<typeof passthroughProps> = {
         body: CFDPOI,
@@ -130,7 +132,7 @@ const CFDFinancialStpRealAccountSignup = observer(({ onFinish }: TCFDFinancialSt
     };
 
     const shouldShowPOA = () => {
-        if (JURISDICTION.LABUAN === jurisdiction_selected_shortcode && is_authenticated_with_idv_photoid) {
+        if (JURISDICTION.LABUAN === jurisdiction_selected_shortcode && is_authenticated_with_idv) {
             return true;
         }
         return !['pending', 'verified'].includes(authentication_status.document_status);
@@ -195,7 +197,7 @@ const CFDFinancialStpRealAccountSignup = observer(({ onFinish }: TCFDFinancialSt
     const form_value = getCurrent('form_value');
 
     const passthrough: Partial<TCFDFinancialStpRealAccountSignupProps> & {
-        is_authenticated_with_idv_photoid?: boolean;
+        is_authenticated_with_idv?: boolean;
     } = ((getCurrent('forwarded_props') || []) as TItemsState<typeof passthroughProps>['forwarded_props']).reduce(
         (forwarded_prop, item) => {
             return Object.assign(forwarded_prop, {
@@ -206,7 +208,7 @@ const CFDFinancialStpRealAccountSignup = observer(({ onFinish }: TCFDFinancialSt
     );
 
     if (shouldShowPOA()) {
-        passthrough.is_authenticated_with_idv_photoid = is_authenticated_with_idv_photoid;
+        passthrough.is_authenticated_with_idv = is_authenticated_with_idv;
     }
 
     return (

--- a/packages/cfd/src/Containers/cfd-financial-stp-real-account-signup.tsx
+++ b/packages/cfd/src/Containers/cfd-financial-stp-real-account-signup.tsx
@@ -86,10 +86,9 @@ const CFDFinancialStpRealAccountSignup = observer(({ onFinish }: TCFDFinancialSt
     let is_mounted = React.useRef(true).current;
 
     const { need_poi_for_maltainvest, need_poi_for_bvi_labuan_vanuatu } = getAuthenticationStatusInfo(account_status);
+    const is_authenticated_with_idv = useIsAccountStatusPresent('authenticated_with_idv');
     // TODO: [account-status] Remove `authenticated_with_idv_photoid` check once we have the correct status from API
-    const is_authenticated_with_idv =
-        useIsAccountStatusPresent('authenticated_with_idv') ||
-        useIsAccountStatusPresent('authenticated_with_idv_photoid');
+    const is_authenticated_with_idv_photoid = useIsAccountStatusPresent('authenticated_with_idv_photoid');
 
     const poi_config: TItemsState<typeof passthroughProps> = {
         body: CFDPOI,
@@ -132,7 +131,11 @@ const CFDFinancialStpRealAccountSignup = observer(({ onFinish }: TCFDFinancialSt
     };
 
     const shouldShowPOA = () => {
-        if (JURISDICTION.LABUAN === jurisdiction_selected_shortcode && is_authenticated_with_idv) {
+        // TODO: [account-status] Remove `is_authenticated_with_idv_photoid` check once we have the correct status from API
+        if (
+            JURISDICTION.LABUAN === jurisdiction_selected_shortcode &&
+            (!is_authenticated_with_idv || is_authenticated_with_idv_photoid)
+        ) {
             return true;
         }
         return !['pending', 'verified'].includes(authentication_status.document_status);
@@ -196,20 +199,13 @@ const CFDFinancialStpRealAccountSignup = observer(({ onFinish }: TCFDFinancialSt
 
     const form_value = getCurrent('form_value');
 
-    const passthrough: Partial<TCFDFinancialStpRealAccountSignupProps> & {
-        is_authenticated_with_idv?: boolean;
-    } = ((getCurrent('forwarded_props') || []) as TItemsState<typeof passthroughProps>['forwarded_props']).reduce(
-        (forwarded_prop, item) => {
-            return Object.assign(forwarded_prop, {
-                [item]: passthroughProps[item],
-            });
-        },
-        {}
-    );
-
-    if (shouldShowPOA()) {
-        passthrough.is_authenticated_with_idv = is_authenticated_with_idv;
-    }
+    const passthrough: Partial<TCFDFinancialStpRealAccountSignupProps> = (
+        (getCurrent('forwarded_props') || []) as TItemsState<typeof passthroughProps>['forwarded_props']
+    ).reduce((forwarded_prop, item) => {
+        return Object.assign(forwarded_prop, {
+            [item]: passthroughProps[item],
+        });
+    }, {});
 
     return (
         <Div100vhContainer

--- a/packages/hooks/src/useIsAccountStatusPresent.ts
+++ b/packages/hooks/src/useIsAccountStatusPresent.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useStore } from '@deriv/stores';
 
+// TODO: [account-status] Remove `authenticated_with_idv_photoid` check once we have the correct status from API
 const AccountStatusList = [
     'address_verified',
     'age_verification',
@@ -8,6 +9,7 @@ const AccountStatusList = [
     'allow_poa_resubmission',
     'allow_poi_resubmission',
     'authenticated',
+    'authenticated_with_idv',
     'authenticated_with_idv_photoid',
     'cashier_locked',
     'crs_tin_information',

--- a/packages/shared/src/utils/cfd/cfd.ts
+++ b/packages/shared/src/utils/cfd/cfd.ts
@@ -357,11 +357,11 @@ export const getAuthenticationStatusInfo = (account_status: GetAccountStatus): T
         manual: { status: manual_status } = {},
     } = services;
 
-    /** Check if User was authenticated by IDV process */
     // TODO: [account-status] Remove `authenticated_with_idv_photoid` check once we have the correct status from API
-    const is_authenticated_with_idv = account_status?.status?.some(status =>
-        ['authenticated_with_idv', 'authenticated_with_idv_photoid'].includes(status)
-    );
+    const is_authenticated_with_idv_photoid = account_status?.status?.includes('authenticated_with_idv_photoid');
+    /** Check if User was authenticated by IDV process */
+    const is_authenticated_with_idv = account_status?.status?.includes('authenticated_with_idv_photoid');
+
     const is_idv_revoked = account_status?.status?.includes('idv_revoked');
 
     const acknowledged_status: string[] = ['pending', 'verified'];
@@ -431,7 +431,8 @@ export const getAuthenticationStatusInfo = (account_status: GetAccountStatus): T
         !poi_verified_for_bvi_labuan_vanuatu;
 
     const poi_poa_verified_for_bvi_labuan_vanuatu: boolean = poi_verified_for_bvi_labuan_vanuatu && poa_verified;
-    const poa_resubmit_for_labuan = is_authenticated_with_idv;
+    // TODO: [account-status] Remove `is_authenticated_with_idv_photoid` check once we have the correct status from API
+    const poa_resubmit_for_labuan = !is_authenticated_with_idv || is_authenticated_with_idv_photoid;
 
     return {
         poa_status,

--- a/packages/shared/src/utils/cfd/cfd.ts
+++ b/packages/shared/src/utils/cfd/cfd.ts
@@ -360,7 +360,7 @@ export const getAuthenticationStatusInfo = (account_status: GetAccountStatus): T
     // TODO: [account-status] Remove `authenticated_with_idv_photoid` check once we have the correct status from API
     const is_authenticated_with_idv_photoid = account_status?.status?.includes('authenticated_with_idv_photoid');
     /** Check if User was authenticated by IDV process */
-    const is_authenticated_with_idv = account_status?.status?.includes('authenticated_with_idv_photoid');
+    const is_authenticated_with_idv = account_status?.status?.includes('authenticated_with_idv');
 
     const is_idv_revoked = account_status?.status?.includes('idv_revoked');
 

--- a/packages/shared/src/utils/cfd/cfd.ts
+++ b/packages/shared/src/utils/cfd/cfd.ts
@@ -357,7 +357,11 @@ export const getAuthenticationStatusInfo = (account_status: GetAccountStatus): T
         manual: { status: manual_status } = {},
     } = services;
 
-    const is_authenticated_with_idv_photoid = account_status?.status?.includes('authenticated_with_idv_photoid');
+    /** Check if User was authenticated by IDV process */
+    // TODO: [account-status] Remove `authenticated_with_idv_photoid` check once we have the correct status from API
+    const is_authenticated_with_idv = account_status?.status?.some(status =>
+        ['authenticated_with_idv', 'authenticated_with_idv_photoid'].includes(status)
+    );
     const is_idv_revoked = account_status?.status?.includes('idv_revoked');
 
     const acknowledged_status: string[] = ['pending', 'verified'];
@@ -427,7 +431,7 @@ export const getAuthenticationStatusInfo = (account_status: GetAccountStatus): T
         !poi_verified_for_bvi_labuan_vanuatu;
 
     const poi_poa_verified_for_bvi_labuan_vanuatu: boolean = poi_verified_for_bvi_labuan_vanuatu && poa_verified;
-    const poa_resubmit_for_labuan = is_authenticated_with_idv_photoid;
+    const poa_resubmit_for_labuan = is_authenticated_with_idv;
 
     return {
         poa_status,


### PR DESCRIPTION
## Changes:

Rename `authenticated_with_idv_photoid` status flag used in code to `authenticated_with_idv` to support other IDV verification status for MT5 account creation in future

## Note:
Once API returns correct status, incorporate `TODO: [account-status]` tasks
