### PR TITLE
Nijil/ WALL-2575/ Notes section in Crypto Deposit is not left aligned

### DIFF
--- a/packages/wallets/src/features/cashier/modules/DepositCrypto/DepositCrypto.scss
+++ b/packages/wallets/src/features/cashier/modules/DepositCrypto/DepositCrypto.scss
@@ -8,6 +8,7 @@
         height: fit-content;
         flex-direction: column;
         gap: 1.6rem;
+        padding-bottom: 1.6rem;
     }
 
     &__main-content {
@@ -18,6 +19,7 @@
 
         @include mobile {
             padding: 0;
+            gap: 1.6rem;
         }
     }
 }

--- a/packages/wallets/src/features/cashier/modules/DepositCrypto/components/DepositCryptoDisclaimers/DepositCryptoDisclaimers.scss
+++ b/packages/wallets/src/features/cashier/modules/DepositCrypto/components/DepositCryptoDisclaimers/DepositCryptoDisclaimers.scss
@@ -30,6 +30,5 @@
         line-height: 1.8rem;
         text-align: center;
         display: flex;
-        justify-content: center;
     }
 }


### PR DESCRIPTION
## Changes:

- `Notes` section in Crypto Deposit should be left aligned.
- Gap between elements in Crypto Deposit for mobile screens should be 1.6rem.

### Screenshots:

![Screenshot 2023-11-13 at 15 59 17](https://github.com/binary-com/deriv-app/assets/62882794/e09b9313-adbb-4670-be3b-3f7beef8b21a)
![Screenshot 2023-11-13 at 15 59 39](https://github.com/binary-com/deriv-app/assets/62882794/245c078d-01aa-4247-ba1c-1806418c5878)
