### PR TITLE
[WALL] Nijil/ WALL-2526 / Wallet overlay content is not centre aligned anymore

### DIFF
--- a/packages/wallets/src/features/cashier/WalletCashier.scss
+++ b/packages/wallets/src/features/cashier/WalletCashier.scss
@@ -11,7 +11,6 @@
 .wallets-cashier-content {
     display: flex;
     position: relative;
-    align-items: center;
     justify-content: center;
     gap: 2.4rem;
     flex: 1;

--- a/packages/wallets/src/features/cashier/modules/DepositCrypto/components/DepositCryptoDisclaimers/DepositCryptoDisclaimers.scss
+++ b/packages/wallets/src/features/cashier/modules/DepositCrypto/components/DepositCryptoDisclaimers/DepositCryptoDisclaimers.scss
@@ -30,5 +30,10 @@
         line-height: 1.8rem;
         text-align: center;
         display: flex;
+        justify-content: center;
+
+        @include mobile {
+            justify-content: unset;
+        }
     }
 }


### PR DESCRIPTION
## Changes:

Wallet Overlay content is not centre aligned anymore until design files are updated.
Also `Notes` section should be
- Centre aligned in desktop
- Left aligned in responsive.

### Screenshots:

![Screenshot 2023-11-13 at 17 48 10](https://github.com/binary-com/deriv-app/assets/62882794/841c3200-3ad0-48ba-b7c4-779a52b87d5d)
![Screenshot 2023-11-13 at 17 48 31](https://github.com/binary-com/deriv-app/assets/62882794/85c39cd0-5347-4616-8a4f-c5f283bf63be)
