### PR TITLE
Remove t* filter for smoke tests

### DIFF
--- a/.github/workflows/smoketests.yml
+++ b/.github/workflows/smoketests.yml
@@ -40,7 +40,7 @@ jobs:
         # https://docs.cypress.io/guides/cloud/projects#Set-up-a-project-to-record
         record: true
         parallel: true # Runs test in parallel using settings above
-        spec: cypress/e2e/smoke/t*.js
+        spec: cypress/e2e/smoke/*.js
         group: 'Smoke Tests'
         
       env:


### PR DESCRIPTION
We should be able to run everything in the smoke test folder now.

## Changes:

Removed the t in the spec file filter. At the moment it will only run traders hub tests and we want to run others in that folder now.

### Screenshots:

<img width="229" alt="image" src="https://github.com/binary-com/deriv-app/assets/144238191/771fec24-0b22-4073-9d43-551e8be64bcd">
