### PR TITLE
[BOT] Farabi/bot-985/remove survicate code snippet

### DIFF
--- a/packages/bot-web-ui/src/app/__tests__/app-main.spec.tsx
+++ b/packages/bot-web-ui/src/app/__tests__/app-main.spec.tsx
@@ -42,7 +42,7 @@ describe('App', () => {
         const { container } = render(
             <App
                 passthrough={{
-                    root_store: root_store as unknown as TStores,
+                    root_store: root_store as TStores,
                     WS: mock_ws,
                 }}
             />

--- a/packages/bot-web-ui/src/app/__tests__/app-main.spec.tsx
+++ b/packages/bot-web-ui/src/app/__tests__/app-main.spec.tsx
@@ -1,9 +1,8 @@
-import { initSurvicate, initSurvicateCalled } from '../../public-path';
 import React from 'react';
 import moment from 'moment';
 import { mockStore } from '@deriv/stores';
+import { TStores } from '@deriv/stores/types';
 import { render } from '@testing-library/react';
-import { TRootStore } from 'Types';
 import { mock_ws } from '../../utils/mock';
 import App from '../app-main';
 
@@ -29,15 +28,7 @@ jest.mock('@deriv/deriv-charts', () => ({
 
 jest.mock('@deriv/components', () => ({
     Loading: () => <div>Loading...</div>,
-    initSurvicate: () => <div>script...</div>,
 }));
-
-const mockDOM = `
-  <div id="dbot-survicate">
-    <div id="survicate-box" style="display: block;"></div>
-  </div>
-`;
-document.body.innerHTML = mockDOM;
 
 describe('App', () => {
     //mock for blockly
@@ -51,16 +42,11 @@ describe('App', () => {
         const { container } = render(
             <App
                 passthrough={{
-                    root_store: root_store as unknown as TRootStore,
+                    root_store: root_store as unknown as TStores,
                     WS: mock_ws,
                 }}
             />
         );
         expect(container).toBeInTheDocument();
-    });
-    it('check survicate script appended', () => {
-        initSurvicate();
-
-        expect(initSurvicateCalled).toBe(true);
     });
 });

--- a/packages/bot-web-ui/src/app/app-main.tsx
+++ b/packages/bot-web-ui/src/app/app-main.tsx
@@ -1,4 +1,3 @@
-import { initSurvicate } from '../public-path';
 import React from 'react';
 import { TStores } from '@deriv/stores/types';
 import type { TWebSocket } from 'Types';
@@ -17,13 +16,6 @@ const App = ({ passthrough }: TAppProps) => {
     const { root_store, WS } = passthrough;
     React.useEffect(() => {
         setInnerHeightToVariable();
-        initSurvicate();
-        return () => {
-            const survicate_box = document.getElementById('survicate-box') || undefined;
-            if (survicate_box) {
-                survicate_box.style.display = 'none';
-            }
-        };
     }, []);
 
     return (

--- a/packages/bot-web-ui/src/public-path.ts
+++ b/packages/bot-web-ui/src/public-path.ts
@@ -14,25 +14,4 @@ export function setBotPublicPath(path: string) {
 
 export const getImageLocation = (image_name: string) => getUrlBase(`/public/images/common/${image_name}`);
 
-// eslint-disable-next-line import/no-mutable-exports
-let initSurvicateCalled = false;
-const initSurvicate = () => {
-    initSurvicateCalled = true;
-    if (document.getElementById('dbot-survicate')) {
-        const survicate_box = document.getElementById('survicate-box') || undefined;
-        if (survicate_box) {
-            survicate_box.style.display = 'block';
-        }
-        return;
-    }
-
-    const script = document.createElement('script');
-    script.id = 'dbot-survicate';
-    script.async = true;
-    script.src = 'https://survey.survicate.com/workspaces/83b651f6b3eca1ab4551d95760fe5deb/web_surveys.js';
-    document.body.appendChild(script);
-};
-
-export { initSurvicate, initSurvicateCalled };
-
 setBotPublicPath(getUrlBase('/'));


### PR DESCRIPTION
## Changes:

- Removed survicate code snippet from app-main as we are no longer using survicate tool for tracking and will be replacing with hotjar tool
- Updated test file for app-main.spec to remove the test case for survicate
- Updated the deprecated TRootStore with TStores in app-main.spec
- Removed survicate code snippet from public-path
