### PR TITLE
Arshad / Modal header border styling mt5 trade modal

### DIFF
--- a/packages/appstore/src/components/cfds-listing/cfds-listing.scss
+++ b/packages/appstore/src/components/cfds-listing/cfds-listing.scss
@@ -388,6 +388,12 @@
     display: none;
 }
 
+.dc-modal-header {
+    &--cfd-trade-modal {
+        border-bottom: 2px solid var(--general-section-5);
+    }
+}
+
 .cfd-trade-modal-container {
     width: inherit;
     overflow-y: scroll;

--- a/packages/cfd/src/Containers/mt5-trade-modal.tsx
+++ b/packages/cfd/src/Containers/mt5-trade-modal.tsx
@@ -65,7 +65,7 @@ const MT5TradeModal = observer(
                         is_open={is_open}
                         title={localize('Trade')}
                         toggleModal={toggleModal}
-                        should_header_stick_body={false}
+                        className='cfd-trade-modal'
                         width='600px'
                         exit_classname='cfd-modal--custom-exit'
                     >

--- a/packages/components/src/components/modal/modal.scss
+++ b/packages/components/src/components/modal/modal.scss
@@ -106,7 +106,7 @@
         align-items: center;
 
         &__border-bottom {
-            border-bottom: 2px solid var(--general-section-5) !important;
+            border-bottom: 2px solid var(--general-section-2) !important;
         }
 
         &__title {


### PR DESCRIPTION
## Changes:
Fixed the dark theme modal header border styling to be different for mt5 trade modal.

### Screenshots:
<img width="460" alt="image" src="https://github.com/binary-com/deriv-app/assets/135801848/30fcb264-7a18-4ce1-a6c7-b554781a7ac8">

