### PR TITLE
[Wallets] Sergei / Wall 2476 / On pressing escape key success modal should be closed

### DIFF
--- a/packages/wallets/src/components/DerivAppsSection/DerivAppsGetAccount.tsx
+++ b/packages/wallets/src/components/DerivAppsSection/DerivAppsGetAccount.tsx
@@ -22,6 +22,7 @@ const DerivAppsGetAccount: React.FC = () => {
     const openSuccessModal = useCallback(() => {
         show(
             <ModalStepWrapper
+                closeOnEscape
                 renderFooter={isDesktop ? undefined : () => <DerivAppsSuccessFooter />}
                 shouldHideHeader={isDesktop}
             >


### PR DESCRIPTION
## Changes:

Add `closeOnEscape` property

### Card:

https://app.clickup.com/t/20696747/WALL-2476

### Video:

https://github.com/binary-com/deriv-app/assets/120570511/00fa3be5-f56e-403a-bd8a-67c139c6c9b8
