### PR TITLE
[Wallets] Sergei / wall - 2478 / Texts in Options and multipliers looks too small in responsive

### DIFF
--- a/packages/wallets/src/components/DerivAppsSection/DerivAppsGetAccount.tsx
+++ b/packages/wallets/src/components/DerivAppsSection/DerivAppsGetAccount.tsx
@@ -61,7 +61,7 @@ const DerivAppsGetAccount: React.FC = () => {
                 <WalletText size='sm' weight='bold'>
                     Deriv Apps
                 </WalletText>
-                <WalletText lineHeight='2xs' size='2xs'>
+                <WalletText lineHeight='2xs' size='xs'>
                     {activeWallet?.is_malta_wallet
                         ? 'Get a Deriv Apps trading account regulated by MFSA to trade multipliers on Deriv Trader.'
                         : 'Get a Deriv Apps trading account to trade options and multipliers on these apps.'}

--- a/packages/wallets/src/components/OptionsAndMultipliersListing/OptionsAndMultipliersListing.scss
+++ b/packages/wallets/src/components/OptionsAndMultipliersListing/OptionsAndMultipliersListing.scss
@@ -38,6 +38,11 @@
             font-size: 1.6rem;
             line-height: 2.4rem;
 
+            @include mobile {
+                font-size: 1.2rem;
+                line-height: 1.8rem;
+            }
+
             &__link {
                 color: var(--brand-coral, #ff444f);
             }

--- a/packages/wallets/src/components/OptionsAndMultipliersListing/OptionsAndMultipliersListing.scss
+++ b/packages/wallets/src/components/OptionsAndMultipliersListing/OptionsAndMultipliersListing.scss
@@ -35,14 +35,6 @@
         }
 
         &-subtitle {
-            font-size: 1.6rem;
-            line-height: 2.4rem;
-
-            @include mobile {
-                font-size: 1.2rem;
-                line-height: 1.8rem;
-            }
-
             &__link {
                 color: var(--brand-coral, #ff444f);
             }

--- a/packages/wallets/src/components/OptionsAndMultipliersListing/OptionsAndMultipliersListing.tsx
+++ b/packages/wallets/src/components/OptionsAndMultipliersListing/OptionsAndMultipliersListing.tsx
@@ -93,8 +93,8 @@ const OptionsAndMultipliersListing: React.FC<TOptionsAndMultipliersListingProps>
                             Options & Multipliers
                         </WalletText>
                     )}
-                    <div className='wallets-options-and-multipliers-listing__header-subtitle'>
-                        <h1>
+                    <div>
+                        <WalletText size={isMobile ? 'sm' : 'md'}>
                             Earn a range of payouts by correctly predicting market price movements with{' '}
                             <a
                                 className='wallets-options-and-multipliers-listing__header-subtitle__link'
@@ -116,7 +116,7 @@ const OptionsAndMultipliersListing: React.FC<TOptionsAndMultipliersListingProps>
                                 multipliers
                             </a>
                             .
-                        </h1>
+                        </WalletText>
                     </div>
                 </div>
                 <DerivAppsSection />


### PR DESCRIPTION
## Changes:

- Decrease Options and Multipliers subtitle font size in responsive
- Increase Deriv Apps description font size

## Card:

https://app.clickup.com/t/20696747/WALL-2478

### Screenshots:

![image](https://github.com/binary-com/deriv-app/assets/120570511/d2381e5a-23f1-45c0-8d28-73d5e0bb3253)
