### PR TITLE
[WALL] Sergei / fix PR for useAvailableWallets hook

### DIFF
--- a/packages/wallets/src/components/WalletTourGuide/WalletMobileTourGuide.tsx
+++ b/packages/wallets/src/components/WalletTourGuide/WalletMobileTourGuide.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useLocalStorage, useReadLocalStorage } from 'usehooks-ts';
-import { useActiveWalletAccount, useAuthorize, useAvailableWallets, useWalletAccountsList } from '@deriv/api';
+import { useActiveWalletAccount, useAllWalletAccounts, useAuthorize, useWalletAccountsList } from '@deriv/api';
 import Joyride, { ACTIONS, CallBackProps, EVENTS, STATUS } from '@deriv/react-joyride';
 import useDevice from '../../hooks/useDevice';
 import { useTabs } from '../Base/Tabs/Tabs';
@@ -27,7 +27,7 @@ const WalletMobileTourGuide = ({ isMT5PlatformListLoaded = true, isOptionsAndMul
     const { isFetching, isLoading, isSuccess, switchAccount } = useAuthorize();
     const { data: wallets } = useWalletAccountsList();
     const { data: activeWallet } = useActiveWalletAccount();
-    const { data: availableWallets } = useAvailableWallets();
+    const { data: availableWallets } = useAllWalletAccounts();
 
     const fiatWalletLoginId = wallets?.[0]?.loginid;
     const activeWalletLoginId = activeWallet?.loginid;

--- a/packages/wallets/src/components/WalletTourGuide/WalletTourGuide.tsx
+++ b/packages/wallets/src/components/WalletTourGuide/WalletTourGuide.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { useLocalStorage, useReadLocalStorage } from 'usehooks-ts';
-import { useActiveWalletAccount, useAuthorize, useAllWalletAccounts, useWalletAccountsList } from '@deriv/api';
+import { useActiveWalletAccount, useAllWalletAccounts, useAuthorize, useWalletAccountsList } from '@deriv/api';
 import Joyride, { ACTIONS, CallBackProps } from '@deriv/react-joyride';
 import useDevice from '../../hooks/useDevice';
 import {


### PR DESCRIPTION
## Description:

All PRs fail because `useAvailableWallets` was changed, but `WalletMobileTourGuide` component used this hook. Need to change it to `useAllWalletAccounts` hook

## Changes:

- change `useAvailableWallets` to `useAllWalletAccounts`

## Card:

https://app.clickup.com/t/20696747/WALL-2600
