### PR TITLE
[Wallets] Hamza/WALL-2608/Modifying useMutation in api package

### DIFF
--- a/packages/api/src/hooks/useTradingPlatformPasswordChange.ts
+++ b/packages/api/src/hooks/useTradingPlatformPasswordChange.ts
@@ -2,16 +2,21 @@ import { useCallback } from 'react';
 import useMutation from '../useMutation';
 
 type TPayload = Parameters<ReturnType<typeof useMutation<'trading_platform_password_change'>>['mutate']>[0]['payload'];
+type TPayloadAsync = Parameters<
+    ReturnType<typeof useMutation<'trading_platform_password_change'>>['mutateAsync']
+>[0]['payload'];
 
 /** A custom hook that change the Trading Platform Password. */
 const useTradingPlatformPasswordChange = () => {
-    const { mutate: _mutate, ...rest } = useMutation('trading_platform_password_change');
+    const { mutate: _mutate, mutateAsync: _mutateAsync, ...rest } = useMutation('trading_platform_password_change');
 
     const mutate = useCallback((payload: TPayload) => _mutate({ payload }), [_mutate]);
+    const mutateAsync = useCallback((payload: TPayloadAsync) => _mutateAsync({ payload }), [_mutateAsync]);
 
     return {
         /** The mutation function that accepts a payload and sends it to the server */
         mutate,
+        mutateAsync,
         ...rest,
     };
 };

--- a/packages/api/src/useMutation.ts
+++ b/packages/api/src/useMutation.ts
@@ -12,11 +12,11 @@ import type {
 
 const useMutation = <T extends TSocketEndpointNames>(name: T, options?: TSocketRequestMutationOptions<T>) => {
     const { send } = useAPI();
-    const { mutate: _mutate, ...rest } = _useMutation<
-        TSocketResponseData<T>,
-        TSocketError<T>,
-        TSocketAcceptableProps<T>
-    >(props => {
+    const {
+        mutate: _mutate,
+        mutateAsync: _mutateAsync,
+        ...rest
+    } = _useMutation<TSocketResponseData<T>, TSocketError<T>, TSocketAcceptableProps<T>>(props => {
         const prop = props?.[0];
         const payload = prop && 'payload' in prop ? (prop.payload as TSocketRequestPayload<T>) : undefined;
 
@@ -24,9 +24,11 @@ const useMutation = <T extends TSocketEndpointNames>(name: T, options?: TSocketR
     }, options);
 
     const mutate = useCallback((...payload: TSocketAcceptableProps<T>) => _mutate(payload), [_mutate]);
+    const mutateAsync = useCallback((...payload: TSocketAcceptableProps<T>) => _mutateAsync(payload), [_mutateAsync]);
 
     return {
         mutate,
+        mutateAsync,
         ...rest,
     };
 };

--- a/packages/hooks/src/__tests__/useDepositCryptoAddress.spec.tsx
+++ b/packages/hooks/src/__tests__/useDepositCryptoAddress.spec.tsx
@@ -8,7 +8,6 @@ jest.mock('@deriv/api', () => ({
     useRequest: jest.fn(() => ({ mutate: jest.fn() })),
 }));
 
-// @ts-expect-error need to come up with a way to mock the return type of useFetch
 const mockUseRequest = useRequest as jest.MockedFunction<typeof useRequest<'cashier'>>;
 
 describe('useDepositCryptoAddress', () => {

--- a/packages/hooks/src/__tests__/useWalletMigration.spec.tsx
+++ b/packages/hooks/src/__tests__/useWalletMigration.spec.tsx
@@ -11,7 +11,6 @@ jest.mock('@deriv/api', () => ({
 }));
 
 const mockUseFetch = useFetch as jest.MockedFunction<typeof useFetch<'wallet_migration'>>;
-// @ts-expect-error need to come up with a way to mock the return type of useRequest
 const mockUseRequest = useRequest as jest.MockedFunction<typeof useRequest<'wallet_migration'>>;
 
 describe('useWalletMigration', () => {


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
### Description:
#### Why this change is necessary?
The difference between mutate and mutateAsync is as follows:
- `mutate`: This is used to trigger the mutation without waiting for the result. It initiates the mutation, and any updates to the cache or UI are handled in the background.
- `mutateAsync`: This is used when you want to await the result of the mutation before proceeding. It is beneficial when actions or decisions need to be based on the outcome of the mutation.

We need to add the callback on the mutateAsync function so we can use `useTradingPlatformChange` and `useCreateMT5Account` websocket calls asynchronously.


Slack Discussion:
[Discussion](https://deriv-group.slack.com/archives/C05NSB1LPMX/p1699958017256429)

CU Card:
[Modifying useMutation in api package](https://app.clickup.com/t/20696747/WALL-2608)

### Screenshots:

Please provide some screenshots of the change.

#### useTradingPlatformChange
![image](https://github.com/binary-com/deriv-app/assets/120543468/4df5341a-1b04-4edb-94b9-9fc1fa40acc8)

#### useMutation:
![image](https://github.com/binary-com/deriv-app/assets/120543468/d554d056-1609-4ca0-8a50-a202a4f2e29c)
