### PR TITLE
[BOT] chore: fix quick strategy max stake disable error issue

### DIFF
--- a/packages/bot-web-ui/src/components/quick-strategy/inputs/qs-checkbox.tsx
+++ b/packages/bot-web-ui/src/components/quick-strategy/inputs/qs-checkbox.tsx
@@ -21,8 +21,9 @@ const QSCheckbox: React.FC<TQSCheckbox> = observer(
         const { values, setFieldValue, validateForm } = useFormikContext<TFormData>();
 
         const handleChange = () => {
-            setFieldValue(name, !values?.[name]);
-            validateForm();
+            setFieldValue(name, !values?.[name]).finally(() => {
+                validateForm();
+            });
         };
 
         return (
@@ -47,7 +48,7 @@ const QSCheckbox: React.FC<TQSCheckbox> = observer(
                                         <Popover
                                             message={description}
                                             zIndex='9999'
-                                            alignment={is_mobile ? 'bottom' : 'right'}
+                                            alignment={is_mobile ? 'top' : 'right'}
                                             icon='info'
                                         />
                                     </span>

--- a/packages/bot-web-ui/src/components/quick-strategy/inputs/qs-input-label.tsx
+++ b/packages/bot-web-ui/src/components/quick-strategy/inputs/qs-input-label.tsx
@@ -21,12 +21,7 @@ const QSInputLabel: React.FC<TQSInputLabel> = observer(({ label, description, fu
                     {label}
                 </Text>
                 <span>
-                    <Popover
-                        message={description}
-                        zIndex='9999'
-                        alignment={is_mobile ? 'bottom' : 'right'}
-                        icon='info'
-                    />
+                    <Popover message={description} zIndex='9999' alignment={is_mobile ? 'top' : 'right'} icon='info' />
                 </span>
             </div>
         </div>

--- a/packages/bot-web-ui/src/components/quick-strategy/inputs/qs-input.tsx
+++ b/packages/bot-web-ui/src/components/quick-strategy/inputs/qs-input.tsx
@@ -26,8 +26,8 @@ const QSInput: React.FC<TQSInput> = observer(
         return (
             <Field name={name} key={name} id={name}>
                 {({ field, meta }: FieldProps) => {
-                    const { error, touched } = meta;
-                    const has_error = error && touched;
+                    const { error } = meta;
+                    const has_error = error;
                     return (
                         <div
                             className={classNames('qs__form__field', {
@@ -40,7 +40,7 @@ const QSInput: React.FC<TQSInput> = observer(
                                 <Popover
                                     alignment='bottom'
                                     message={error}
-                                    is_open={!!(error && touched && has_focus)}
+                                    is_open={!!(error && has_focus)}
                                     zIndex='9999'
                                     classNameBubble='qs__warning-bubble'
                                     has_error

--- a/packages/bot-web-ui/src/components/quick-strategy/quick-strategy.tsx
+++ b/packages/bot-web-ui/src/components/quick-strategy/quick-strategy.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Form as FormikForm, Formik } from 'formik';
 import * as Yup from 'yup';
 import { ApiHelpers, config as qs_config } from '@deriv/bot-skeleton';
@@ -36,6 +36,7 @@ const FormikWrapper: React.FC<TFormikWrapper> = observer(({ children }) => {
     const [duration, setDuration] = React.useState<TDurationItemRaw | null>(null);
     const { selected_strategy, form_data, onSubmit, setValue } = quick_strategy;
     const config: TConfigItem[][] = STRATEGIES[selected_strategy]?.fields;
+    const [dynamic_schema, setDynamicSchema] = useState(Yup.object().shape({}));
 
     const initial_value: TFormData = {
         symbol: qs_config.QUICK_STRATEGY.DEFAULT.symbol,
@@ -72,7 +73,7 @@ const FormikWrapper: React.FC<TFormikWrapper> = observer(({ children }) => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [form_data.symbol, form_data.tradetype, form_data.durationtype]);
 
-    const getErrors = () => {
+    const getErrors = (formikData: TFormData) => {
         const sub_schema: Record<string, any> = {};
         config.forEach(group => {
             if (!group?.length) return null;
@@ -90,49 +91,56 @@ const FormikWrapper: React.FC<TFormikWrapper> = observer(({ children }) => {
                             min_error = getErrorMessage('MIN', min, 'DURATION');
                             max_error = getErrorMessage('MAX', max, 'DURATION');
                         }
-                        if (field.name === 'max_stake') {
+                        const should_validate = field.should_have
+                            ? field.should_have?.every(item => {
+                                  return formikData?.[item.key] === item.value;
+                              })
+                            : true;
+                        if (should_validate && field.name === 'max_stake') {
                             min = +form_data?.stake;
                             if (isNaN(min)) {
                                 min = +initial_value.stake;
                             }
                             min_error = getErrorMessage('MIN', min);
                         }
-                        field.validation.forEach(validation => {
-                            if (typeof validation === 'string') {
-                                switch (validation) {
-                                    case 'required':
-                                        schema = schema.required(localize('Field cannot be empty'));
-                                        break;
-                                    case 'min':
-                                        schema = schema.min(min, min_error);
-                                        break;
-                                    case 'max':
-                                        schema = schema.max(max, max_error);
-                                        break;
-                                    case 'ceil':
-                                        schema = schema.round('ceil');
-                                        break;
-                                    case 'floor':
-                                        schema = schema.round('floor');
-                                        break;
-                                    default:
-                                        break;
+                        if (should_validate) {
+                            field.validation.forEach(validation => {
+                                if (typeof validation === 'string') {
+                                    switch (validation) {
+                                        case 'required':
+                                            schema = schema.required(localize('Field cannot be empty'));
+                                            break;
+                                        case 'min':
+                                            schema = schema.min(min, min_error);
+                                            break;
+                                        case 'max':
+                                            schema = schema.max(max, max_error);
+                                            break;
+                                        case 'ceil':
+                                            schema = schema.round('ceil');
+                                            break;
+                                        case 'floor':
+                                            schema = schema.round('floor');
+                                            break;
+                                        default:
+                                            break;
+                                    }
+                                } else if (typeof validation === 'object') {
+                                    if (validation?.type) {
+                                        schema = schema[validation.type](
+                                            validation.value,
+                                            localize(validation.getMessage(validation.value))
+                                        );
+                                    }
                                 }
-                            } else if (typeof validation === 'object') {
-                                if (validation?.type) {
-                                    schema = schema[validation.type](
-                                        validation.value,
-                                        localize(validation.getMessage(validation.value))
-                                    );
-                                }
-                            }
-                        });
+                            });
+                        }
                         sub_schema[field.name] = schema;
                     }
                 }
             });
         });
-        return Yup.object().shape(sub_schema);
+        setDynamicSchema(Yup.object().shape(sub_schema));
     };
 
     const handleSubmit = (form_data: TFormData) => {
@@ -141,7 +149,15 @@ const FormikWrapper: React.FC<TFormikWrapper> = observer(({ children }) => {
     };
 
     return (
-        <Formik initialValues={initial_value} validationSchema={getErrors()} onSubmit={handleSubmit} validateOnBlur>
+        <Formik
+            initialValues={initial_value}
+            validationSchema={dynamic_schema}
+            onSubmit={handleSubmit}
+            validate={values => getErrors(values)}
+            validateOnBlur
+            validateOnChange
+            validateOnMount
+        >
             {children}
         </Formik>
     );


### PR DESCRIPTION
## Changes:

- CU https://app.clickup.com/t/20696747/BOT-1001
- Put the popover to show at the top for mobile devices 
- Change showing error on popover logic. Now it will show a red border whenever an error occurs and on hover it will show the error messages in the popover 
- Validation logic is updated and dynamically taken from the config file if any field is dependent upon any other field
- Perform validation checks on `validateOnBlur` `validateOnChange` `validateOnMount`


https://github.com/binary-com/deriv-app/assets/129021108/afcce7e9-fb60-4110-853b-da371afe5c2c
