### PR TITLE
[COJ] shahzaib / idv poi not redirecting to onfido if failed in last attempt

### DIFF
--- a/packages/account/src/Sections/Verification/ProofOfIdentity/proof-of-identity-submission.jsx
+++ b/packages/account/src/Sections/Verification/ProofOfIdentity/proof-of-identity-submission.jsx
@@ -52,7 +52,7 @@ const POISubmission = observer(
 
                 if (is_idv_supported && Number(idv_submissions_left) > 0 && !is_idv_disallowed) {
                     setSubmissionService(service_code.idv);
-                } else if (onfido_submissions_left && is_onfido_supported) {
+                } else if (Number(onfido_submissions_left) > 0 && is_onfido_supported) {
                     setSubmissionService(service_code.onfido);
                 } else {
                     setSubmissionService(service_code.manual);
@@ -87,27 +87,25 @@ const POISubmission = observer(
             identity_last_attempt => {
                 const { service, country_code } = identity_last_attempt;
                 switch (service) {
-                    case service_code.idv: {
-                        if (Number(idv.submissions_left) < 1) {
-                            setSubmissionService(service_code.manual);
-                        }
-                        break;
-                    }
+                    case service_code.idv:
                     case service_code.onfido: {
-                        if (Number(onfido.submissions_left) < 1) {
+                        if (Number(idv.submissions_left) > 0 || Number(onfido.submissions_left) > 0) {
+                            setSubmissionStatus(submission_status_code.selecting);
+                        } else {
                             setSubmissionService(service_code.manual);
+                            setSubmissionStatus(submission_status_code.submitting);
                         }
                         break;
                     }
                     case service_code.manual: {
                         setSelectedCountry(getCountryFromResidence(country_code));
                         setSubmissionService(service_code.manual);
+                        setSubmissionStatus(submission_status_code.submitting);
                         break;
                     }
                     default:
                         break;
                 }
-                setSubmissionStatus(submission_status_code.submitting);
             },
             [
                 getCountryFromResidence,


### PR DESCRIPTION
## Changes:

This PR fixes the issue where if the IDV POI check fails 3 times, client is supposed to be redirected to onfido if there are submissions are available for the client, however, the flow is being redirected to manual. 
