### PR TITLE
[WALL] Nijil/WALL-2621/Adjust padding-top of transaction-status component

### DIFF
--- a/packages/wallets/src/features/cashier/modules/TransactionStatus/TransactionStatus.scss
+++ b/packages/wallets/src/features/cashier/modules/TransactionStatus/TransactionStatus.scss
@@ -4,7 +4,7 @@
     /* This positioning is temporary, ideally it should be determined by the parent component whenever we use `TransactionStatus` */
     @include desktop {
         position: absolute;
-        top: 0;
+        top: -2.4rem;
         right: 2.4rem;
         max-width: 28.2rem;
     }


### PR DESCRIPTION
## Changes:

Transaction Status component should be placed at 2.4rem from top. But since the padding of wallet-cashier-content is 4.8rem and position of transaction status is `absolute`, it should have a negative top of -2.4rem.

### Screenshots:

<img width="815" alt="Screenshot 2023-11-15 at 18 01 10" src="https://github.com/binary-com/deriv-app/assets/62882794/df5c73d1-3c40-4a0b-a6b7-00cf04d418fb">
