### PR TITLE
[DTRA] Maryia/DTRA-494/fix: console error about preventDefault inside passive event listener

### DIFF
--- a/packages/components/src/hooks/__tests__/use-onlongpress.spec.tsx
+++ b/packages/components/src/hooks/__tests__/use-onlongpress.spec.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { useLongPress } from '../use-onlongpress';
+import { act } from '@testing-library/react';
+
+describe('useLongPress', () => {
+    let preventDefault: () => void, stopPropagation: () => void;
+    let event = {} as React.MouseEvent & React.TouchEvent;
+    beforeEach(() => {
+        preventDefault = jest.fn();
+        stopPropagation = jest.fn();
+        event = {
+            ...event,
+            preventDefault,
+            stopPropagation,
+        };
+    });
+    it('should return event handlers', () => {
+        const { result } = renderHook(() => useLongPress(jest.fn(), 300));
+        expect(result.current).toHaveProperty('onMouseDown');
+        expect(result.current).toHaveProperty('onMouseUp');
+        expect(result.current).toHaveProperty('onMouseLeave');
+        expect(result.current).toHaveProperty('onTouchStart');
+        expect(result.current).toHaveProperty('onTouchEnd');
+    });
+    it('should call preventDefault() and stopPropagation() when onMouseDown is triggered', () => {
+        const { result } = renderHook(() => useLongPress(jest.fn(), 300));
+        act(() => {
+            result.current.onMouseDown(event);
+        });
+        expect(preventDefault).toBeCalledTimes(1);
+        expect(stopPropagation).toBeCalledTimes(1);
+    });
+    it('should not call preventDefault() or stopPropagation() when onMouseUp is triggered', () => {
+        const { result } = renderHook(() => useLongPress(jest.fn(), 300));
+        act(() => {
+            result.current.onMouseUp();
+        });
+        expect(preventDefault).not.toBeCalled();
+        expect(stopPropagation).not.toBeCalled();
+    });
+    it('should not call preventDefault() or stopPropagation() when onMouseLeave is triggered', () => {
+        const { result } = renderHook(() => useLongPress(jest.fn(), 300));
+        act(() => {
+            result.current.onMouseLeave();
+        });
+        expect(preventDefault).not.toBeCalled();
+        expect(stopPropagation).not.toBeCalled();
+    });
+    it('should not call preventDefault() or stopPropagation() when onTouchStart is triggered', () => {
+        const { result } = renderHook(() => useLongPress(jest.fn(), 300));
+        act(() => {
+            result.current.onTouchStart();
+        });
+        expect(preventDefault).not.toBeCalled();
+        expect(stopPropagation).not.toBeCalled();
+    });
+    it('should not call preventDefault() or stopPropagation() when onTouchEnd is triggered', () => {
+        const { result } = renderHook(() => useLongPress(jest.fn(), 300));
+        act(() => {
+            result.current.onTouchEnd();
+        });
+        expect(preventDefault).not.toBeCalled();
+        expect(stopPropagation).not.toBeCalled();
+    });
+});

--- a/packages/components/src/hooks/use-onlongpress.ts
+++ b/packages/components/src/hooks/use-onlongpress.ts
@@ -34,10 +34,7 @@ export const useLongPress = (
         },
         onMouseUp: () => setStartLongPress(false),
         onMouseLeave: () => setStartLongPress(false),
-        onTouchStart: (e: React.TouchEvent) => {
-            preventDefaults(e);
-            setStartLongPress(true);
-        },
+        onTouchStart: () => setStartLongPress(true),
         onTouchEnd: () => setStartLongPress(false),
     };
 };


### PR DESCRIPTION
## Changes:

- to fix a console error: '_Unable to preventDefault inside passive event listener invocation_'.

### Screenshots:

Test coverage of the `useLongPress` hook:
<img width="1728" alt="Screenshot 2023-11-15 at 8 40 36 PM" src="https://github.com/binary-com/deriv-app/assets/103177211/b2eb892b-1b9c-4dd6-8eb2-1387b26d09ba">
