### PR TITLE
Ako/ pass the secrets to github env

### DIFF
--- a/.github/actions/build_and_push_docker_image/action.yml
+++ b/.github/actions/build_and_push_docker_image/action.yml
@@ -35,13 +35,13 @@ runs:
       uses: actions/checkout@v4
     - name: Setup Environment variables
       run: |
-        export NAMESPACE=${{ inputs.K8S_NAMESPACE }}
-        export KUBE_SERVER=${{ inputs.KUBE_SERVER }}
-        export SERVICEACCOUNT_TOKEN=${{ inputs.SERVICEACCOUNT_TOKEN }}
-        export DOCKERHUB_ORGANISATION=${{ inputs.DOCKERHUB_ORGANISATION }}
-        export CA_CRT=${{ inputs.CA_CRT }}
-        export APP_NAME="deriv-app"
-        export APP_VERSION=${{ inputs.APP_VERSION }}
+        echo "NAMESPACE=${{ inputs.K8S_NAMESPACE }}" >> "$GITHUB_ENV"
+        echo "KUBE_SERVER=${{ inputs.KUBE_SERVER }}" >> "$GITHUB_ENV"
+        echo "SERVICEACCOUNT_TOKEN=${{ inputs.SERVICEACCOUNT_TOKEN }}" >> "$GITHUB_ENV"
+        echo "DOCKERHUB_ORGANISATION=${{ inputs.DOCKERHUB_ORGANISATION }}" >> "$GITHUB_ENV"
+        echo "CA_CRT=${{ inputs.CA_CRT }}" >> "$GITHUB_ENV"
+        echo "APP_NAME=deriv-app" >> "$GITHUB_ENV"
+        echo "APP_VERSION=${{ inputs.APP_VERSION }}" >> "$GITHUB_ENV"
       shell: bash
     - name: Build docker image 🐳
       run: docker build -t ${DOCKERHUB_ORGANISATION}/${APP_NAME}:${APP_VERSION} -t ${DOCKERHUB_ORGANISATION}/${APP_NAME}:${{ github.ref_name }} .


### PR DESCRIPTION
## Changes:

Based on [this](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-writing-an-environment-variable-to-github_env) github document I altered the usage of `GITHUB_ENV` to fix the docker push action issue.

### Screenshots:

Please provide some screenshots of the change.
