### PR TITLE
[WALL] removed idv_revoked dependency on usePOI

### DIFF
--- a/packages/api/src/hooks/usePOI.ts
+++ b/packages/api/src/hooks/usePOI.ts
@@ -75,7 +75,6 @@ const usePOI = () => {
         residence_list_data,
         authentication_data?.identity?.services,
         authentication_data?.is_idv_disallowed,
-        account_status_data?.is_idv_revoked,
     ]);
 
     const modified_verification_data = useMemo(() => {


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- `usePOI` no longer depends on `account_status.is_idv_revoked` as its only checked for `IDV` and `Labuan` cases on `useJurisdictionStatus` hook

### Screenshots:

Please provide some screenshots of the change.
