### PR TITLE
[WALL] Fixed an issue where next button is disabled on selecting svg

### DIFF
--- a/packages/wallets/src/features/cfd/modals/JurisdictionModal/JurisdictionModal.tsx
+++ b/packages/wallets/src/features/cfd/modals/JurisdictionModal/JurisdictionModal.tsx
@@ -34,7 +34,7 @@ const JurisdictionModal = () => {
         ? undefined
         : () => (
               <WalletButton
-                  disabled={!selectedJurisdiction || !isCheckBoxChecked}
+                  disabled={!selectedJurisdiction || (selectedJurisdiction !== 'svg' && !isCheckBoxChecked)}
                   isFullWidth={isMobile}
                   onClick={() => show(<MT5PasswordModal marketType={marketType} platform={platform} />)}
                   text='Next'


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- Fixed a bug, where upon selecting SVG in jurisdiction modal, the Next button is disabled

https://github.com/binary-com/deriv-app/assets/103016120/6092694d-b18c-40e0-8ad1-6277cf92dd41



### Screenshots:

Please provide some screenshots of the change.
