### PR TITLE
[DTRA] / Kate / DTRA-518/ Profit/Loss in not shown when it is equal to zero

### DIFF
--- a/packages/components/src/components/contract-card/contract-card-items/__tests__/turbos-card-body.spec.tsx
+++ b/packages/components/src/components/contract-card/contract-card-items/__tests__/turbos-card-body.spec.tsx
@@ -38,7 +38,7 @@ describe('TurbosCardBody', () => {
         currency: 'USD',
         current_focus: null,
         error_message_alignment: 'left',
-        getCardLabels: mockCardLabels,
+        getCardLabels: mockCardLabels as React.ComponentProps<typeof TurbosCardBody>['getCardLabels'],
         getContractById: jest.fn(),
         is_sold: false,
         onMouseLeave: jest.fn(),
@@ -79,5 +79,13 @@ describe('TurbosCardBody', () => {
         expect(total_profit_loss_header).toBeInTheDocument();
         const total_profit_loss_amount = screen.getByText('50.00');
         expect(total_profit_loss_amount).toBeInTheDocument();
+    });
+    it('should render Total profit/loss even if profit === 0', () => {
+        const new_mocked_props = { ...mock_props };
+        new_mocked_props.contract_info.profit = 0;
+        render(<TurbosCardBody {...new_mocked_props} />);
+
+        expect(screen.getByText(mockCardLabels().TOTAL_PROFIT_LOSS)).toBeInTheDocument();
+        expect(screen.getByText('0.00')).toBeInTheDocument();
     });
 });

--- a/packages/components/src/components/contract-card/contract-card-items/turbos-card-body.tsx
+++ b/packages/components/src/components/contract-card/contract-card-items/turbos-card-body.tsx
@@ -101,25 +101,24 @@ const TurbosCardBody = ({
                     </div>
                 </MobileWrapper>
             </div>
-            {!!profit && (
-                <ContractCardItem
-                    className='dc-contract-card-item__total-profit-loss'
-                    header={TOTAL_PROFIT_LOSS}
-                    is_crypto={isCryptocurrency(currency)}
-                    is_loss={profit < 0}
-                    is_won={profit > 0}
+
+            <ContractCardItem
+                className='dc-contract-card-item__total-profit-loss'
+                header={TOTAL_PROFIT_LOSS}
+                is_crypto={isCryptocurrency(currency)}
+                is_loss={Number(profit) < 0}
+                is_won={Number(profit) > 0}
+            >
+                <Money amount={profit} currency={currency} />
+                <div
+                    className={classNames('dc-contract-card__indicative--movement', {
+                        'dc-contract-card__indicative--movement-complete': is_sold,
+                    })}
                 >
-                    <Money amount={profit} currency={currency} />
-                    <div
-                        className={classNames('dc-contract-card__indicative--movement', {
-                            'dc-contract-card__indicative--movement-complete': is_sold,
-                        })}
-                    >
-                        {status === 'profit' && <Icon icon='IcProfit' />}
-                        {status === 'loss' && <Icon icon='IcLoss' />}
-                    </div>
-                </ContractCardItem>
-            )}
+                    {status === 'profit' && <Icon icon='IcProfit' />}
+                    {status === 'loss' && <Icon icon='IcLoss' />}
+                </div>
+            </ContractCardItem>
         </React.Fragment>
     );
 };

--- a/packages/reports/src/Constants/data-table-constants.tsx
+++ b/packages/reports/src/Constants/data-table-constants.tsx
@@ -228,11 +228,11 @@ export const getOpenPositionsColumnsTemplate = (currency: string) => [
         title: localize('Indicative profit/loss'),
         col_index: 'profit',
         renderCellContent: ({ row_obj }: TCellContentProps) => {
+            const { profit_loss, contract_info } = row_obj ?? {};
             if (
-                !row_obj.profit_loss &&
-                row_obj.profit_loss !== 0 &&
-                !row_obj.contract_info?.profit &&
-                row_obj.contract_info?.profit !== 0
+                !profit_loss &&
+                profit_loss !== 0 &&
+                (!contract_info || (!contract_info?.profit && contract_info?.profit !== 0))
             )
                 return;
             const profit = row_obj.profit_loss ?? row_obj.contract_info.profit;

--- a/packages/reports/src/Constants/data-table-constants.tsx
+++ b/packages/reports/src/Constants/data-table-constants.tsx
@@ -228,7 +228,12 @@ export const getOpenPositionsColumnsTemplate = (currency: string) => [
         title: localize('Indicative profit/loss'),
         col_index: 'profit',
         renderCellContent: ({ row_obj }: TCellContentProps) => {
-            if (!row_obj.profit_loss && (!row_obj.contract_info || !row_obj.contract_info.profit)) return;
+            if (
+                !row_obj.profit_loss &&
+                row_obj.profit_loss !== 0 &&
+                (!row_obj.contract_info || !row_obj.contract_info.profit)
+            )
+                return;
             const profit = row_obj.profit_loss || row_obj.contract_info.profit;
             // eslint-disable-next-line consistent-return
             return (

--- a/packages/reports/src/Constants/data-table-constants.tsx
+++ b/packages/reports/src/Constants/data-table-constants.tsx
@@ -229,12 +229,7 @@ export const getOpenPositionsColumnsTemplate = (currency: string) => [
         col_index: 'profit',
         renderCellContent: ({ row_obj }: TCellContentProps) => {
             const { profit_loss, contract_info } = row_obj ?? {};
-            if (
-                !profit_loss &&
-                profit_loss !== 0 &&
-                (!contract_info || (!contract_info?.profit && contract_info?.profit !== 0))
-            )
-                return;
+            if (!profit_loss && profit_loss !== 0 && !contract_info?.profit && contract_info?.profit !== 0) return;
             const profit = profit_loss ?? contract_info.profit;
             // eslint-disable-next-line consistent-return
             return (

--- a/packages/reports/src/Constants/data-table-constants.tsx
+++ b/packages/reports/src/Constants/data-table-constants.tsx
@@ -231,7 +231,7 @@ export const getOpenPositionsColumnsTemplate = (currency: string) => [
             if (
                 !row_obj.profit_loss &&
                 row_obj.profit_loss !== 0 &&
-                (!row_obj.contract_info || !row_obj.contract_info.profit)
+                (!row_obj.contract_info || (!row_obj.contract_info.profit && row_obj.contract_info.profit !== 0))
             )
                 return;
             const profit = row_obj.profit_loss ?? row_obj.contract_info.profit;

--- a/packages/reports/src/Constants/data-table-constants.tsx
+++ b/packages/reports/src/Constants/data-table-constants.tsx
@@ -235,7 +235,7 @@ export const getOpenPositionsColumnsTemplate = (currency: string) => [
                 (!contract_info || (!contract_info?.profit && contract_info?.profit !== 0))
             )
                 return;
-            const profit = row_obj.profit_loss ?? row_obj.contract_info.profit;
+            const profit = profit_loss ?? contract_info.profit;
             // eslint-disable-next-line consistent-return
             return (
                 <div

--- a/packages/reports/src/Constants/data-table-constants.tsx
+++ b/packages/reports/src/Constants/data-table-constants.tsx
@@ -234,7 +234,7 @@ export const getOpenPositionsColumnsTemplate = (currency: string) => [
                 (!row_obj.contract_info || !row_obj.contract_info.profit)
             )
                 return;
-            const profit = row_obj.profit_loss || row_obj.contract_info.profit;
+            const profit = row_obj.profit_loss ?? row_obj.contract_info.profit;
             // eslint-disable-next-line consistent-return
             return (
                 <div

--- a/packages/reports/src/Constants/data-table-constants.tsx
+++ b/packages/reports/src/Constants/data-table-constants.tsx
@@ -231,7 +231,8 @@ export const getOpenPositionsColumnsTemplate = (currency: string) => [
             if (
                 !row_obj.profit_loss &&
                 row_obj.profit_loss !== 0 &&
-                (!row_obj.contract_info || (!row_obj.contract_info.profit && row_obj.contract_info.profit !== 0))
+                !row_obj.contract_info?.profit &&
+                row_obj.contract_info?.profit !== 0
             )
                 return;
             const profit = row_obj.profit_loss ?? row_obj.contract_info.profit;

--- a/packages/trader/src/App/Components/Elements/PositionsDrawer/__tests__/position-modal-card.spec.tsx
+++ b/packages/trader/src/App/Components/Elements/PositionsDrawer/__tests__/position-modal-card.spec.tsx
@@ -141,9 +141,8 @@ describe('<PositionsModalCard />', () => {
         expect(screen.getByText(/Contract value:/i)).toBeInTheDocument();
         expect(screen.getByText(/2,517.00/i)).toBeInTheDocument();
         expect(screen.getByText(/Entry spot:/i)).toBeInTheDocument();
-        expect(screen.getByText(/0.00/i)).toBeInTheDocument();
         expect(screen.getByText(/Take profit:/i)).toBeInTheDocument();
-        expect(screen.getByText(/-/i)).toBeInTheDocument();
+        expect(screen.getAllByText(/0.00/i)).toHaveLength(2);
         expect(screen.getByText(/Barrier:/i)).toBeInTheDocument();
         expect(screen.getByText(/2,650/i)).toBeInTheDocument();
     });


### PR DESCRIPTION
## Changes:
- In current implementation of` <TurbosCardBody />` `Total Profit/Loss` was not shown if profit was === 0 because of `!!profit` && check. File was refactored together with tests. Confirmed by PO, that we shouldn't show any color indication for such cases.
- Add additional check for zero-values in Reports -> Open Contracts (_packages/reports/src/Constants/data-table-constants.tsx_), because previously PNL was not shown if it was zero. Applied to all contracts.

### Screenshots:

<img width="1413" alt="Screenshot 2023-11-17 at 10 46 31" src="https://github.com/binary-com/deriv-app/assets/121025168/b3b6db40-99ab-4f9f-80a6-5b4abb866174">
<img width="1413" alt="Screenshot 2023-11-17 at 10 46 44" src="https://github.com/binary-com/deriv-app/assets/121025168/70623677-8287-4470-acc8-00bd7d8c519c">
