### PR TITLE
[WALL] yashim/refactor: api provider websocket instance to follow react lifecycle

### DIFF
--- a/packages/api/src/APIContext.ts
+++ b/packages/api/src/APIContext.ts
@@ -1,8 +1,0 @@
-import { createContext } from 'react';
-
-// Don't need to type `deriv_api` here, We will be using these methods inside
-// the `useQuery`, `useMutation` and `useSubscription` hook to make it type-safe.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const APIContext = createContext<Record<string, any> | null>(null);
-
-export default APIContext;

--- a/packages/api/src/APIProvider.tsx
+++ b/packages/api/src/APIProvider.tsx
@@ -45,12 +45,13 @@ const handleReconnection = (wss_url: string) => {
     }
 };
 
-const initializeWebSocket = (wss_url: string) => {
+const getWebsocketInstance = (wss_url: string) => {
     if (!window.WSConnections) {
         window.WSConnections = {};
     }
 
-    if (!window.WSConnections[wss_url] || !(window.WSConnections[wss_url] instanceof WebSocket)) {
+    const existingWebsocketInstance = window.WSConnections[wss_url];
+    if (!existingWebsocketInstance || !(existingWebsocketInstance instanceof WebSocket)) {
         window.WSConnections[wss_url] = new WebSocket(wss_url);
         window.WSConnections[wss_url].addEventListener('close', () => handleReconnection(wss_url));
     }
@@ -73,7 +74,7 @@ const initializeDerivAPI = (): DerivAPIBasic => {
     const language = localStorage.getItem('i18n_language');
     const brand = 'deriv';
     const wss_url = `wss://${endpoint}/websockets/v3?app_id=${app_id}&l=${language}&brand=${brand}`;
-    const websocketConnection = initializeWebSocket(wss_url);
+    const websocketConnection = getWebsocketInstance(wss_url);
 
     if (!window.DerivAPI?.[wss_url]) {
         window.DerivAPI[wss_url] = new DerivAPIBasic({ connection: websocketConnection });

--- a/packages/api/src/APIProvider.tsx
+++ b/packages/api/src/APIProvider.tsx
@@ -4,10 +4,11 @@ import DerivAPIBasic from '@deriv/deriv-api/dist/DerivAPIBasic';
 import { getAppId, getSocketURL, useWS } from '@deriv/shared';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
-// Don't need to type `deriv_api` here, We will be using these methods inside
-// the `useQuery`, `useMutation` and `useSubscription` hook to make it type-safe.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const APIContext = createContext<Record<string, any> | null>(null);
+type APIContextData = {
+    derivAPI: DerivAPIBasic | null;
+};
+
+const APIContext = createContext<APIContextData | null>(null);
 
 declare global {
     interface Window {
@@ -18,7 +19,6 @@ declare global {
 }
 
 // This is a temporary workaround to share a single `QueryClient` instance between all the packages.
-// Later once we have each package separated we won't need this anymore and can remove this.
 const getSharedQueryClientContext = (): QueryClient => {
     if (!window.ReactQueryClient) {
         window.ReactQueryClient = new QueryClient();
@@ -49,6 +49,11 @@ const handleReconnection = (wss_url: string) => {
     }
 };
 
+/**
+ * Retrieves or initializes a WebSocket instance based on the provided URL.
+ * @param {string} wss_url - The WebSocket URL.
+ * @returns {WebSocket} The WebSocket instance associated with the provided URL.
+ */
 const getWebsocketInstance = (wss_url: string) => {
     if (!window.WSConnections) {
         window.WSConnections = {};

--- a/packages/api/src/APIProvider.tsx
+++ b/packages/api/src/APIProvider.tsx
@@ -36,12 +36,16 @@ let timer_id: NodeJS.Timer;
  */
 const handleReconnection = (wss_url: string) => {
     if (!window.WSConnections) return;
-    const currentWebsocket = window.WSConnections[wss_url];
-    if (currentWebsocket instanceof WebSocket && [2, 3].includes(currentWebsocket.readyState)) {
+    const existingWebsocketInstance = window.WSConnections[wss_url];
+    if (
+        !existingWebsocketInstance ||
+        !(existingWebsocketInstance instanceof WebSocket) ||
+        [2, 3].includes(existingWebsocketInstance.readyState)
+    ) {
         clearTimeout(timer_id);
         timer_id = setTimeout(() => {
             initializeDerivAPI();
-        }, 500);
+        }, 1000);
     }
 };
 
@@ -51,7 +55,11 @@ const getWebsocketInstance = (wss_url: string) => {
     }
 
     const existingWebsocketInstance = window.WSConnections[wss_url];
-    if (!existingWebsocketInstance || !(existingWebsocketInstance instanceof WebSocket)) {
+    if (
+        !existingWebsocketInstance ||
+        !(existingWebsocketInstance instanceof WebSocket) ||
+        [2, 3].includes(existingWebsocketInstance.readyState)
+    ) {
         window.WSConnections[wss_url] = new WebSocket(wss_url);
         window.WSConnections[wss_url].addEventListener('close', () => handleReconnection(wss_url));
     }

--- a/packages/api/src/useAPI.ts
+++ b/packages/api/src/useAPI.ts
@@ -1,4 +1,4 @@
-import { useCallback, useContext } from 'react';
+import { useCallback } from 'react';
 
 import type {
     TSocketEndpointNames,
@@ -7,18 +7,17 @@ import type {
     TSocketResponseData,
     TSocketSubscribableEndpointNames,
 } from '../types';
-
-import APIContext from './APIContext';
+import { useAPIContext } from './APIProvider';
 
 const useAPI = () => {
-    const api = useContext(APIContext);
+    const { derivAPI } = useAPIContext();
 
     const send = useCallback(
         async <T extends TSocketEndpointNames | TSocketPaginateableEndpointNames = TSocketEndpointNames>(
             name: T,
             payload?: TSocketRequestPayload<T>
         ): Promise<TSocketResponseData<T>> => {
-            const response = await api?.send({ [name]: 1, ...(payload || {}) });
+            const response = await derivAPI?.send({ [name]: 1, ...(payload || {}) });
 
             if (response.error) {
                 throw response.error;
@@ -26,7 +25,7 @@ const useAPI = () => {
 
             return response;
         },
-        [api]
+        [derivAPI]
     );
 
     const subscribe = useCallback(
@@ -42,8 +41,8 @@ const useAPI = () => {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 onError: (response: any) => void
             ) => { unsubscribe?: VoidFunction };
-        } => api?.subscribe({ [name]: 1, subscribe: 1, ...(payload || {}) }),
-        [api]
+        } => derivAPI?.subscribe({ [name]: 1, subscribe: 1, ...(payload || {}) }),
+        [derivAPI]
     );
 
     return {


### PR DESCRIPTION
## Changes:
- Wrapped DerivAPI instance around refs without breaking current functionality
- Added initial support for WebSocket language settings by reading 'i18n_language' local storage item
- Fixed reconnection failing for certain scenarios
