### PR TITLE
shayan/feq-931/ fixed ts error for OrderedPlatformSections component

### DIFF
--- a/packages/appstore/src/modules/traders-hub/index.tsx
+++ b/packages/appstore/src/modules/traders-hub/index.tsx
@@ -62,7 +62,7 @@ const TradersHub = observer(() => {
     };
     if (!is_logged_in) return null;
 
-    const OrderedPlatformSections = (is_cfd_visible = true, is_options_and_multipliers_visible = true) => {
+    const OrderedPlatformSections = ({ is_cfd_visible = true, is_options_and_multipliers_visible = true }) => {
         return (
             <div
                 data-testid='dt_traders_hub'


### PR DESCRIPTION
we had an ts error for `<OrderedPlatformSections/>` 
![image](https://github.com/binary-com/deriv-app/assets/100833613/24af81eb-12b3-4e94-8734-9c63e2a679d3)
and to fix it I converted the components props into an object.