### PR TITLE
fix: added clients_country as dependency so as to avoid page load twice

### DIFF
--- a/packages/bot-web-ui/src/app/app-content.jsx
+++ b/packages/bot-web-ui/src/app/app-content.jsx
@@ -66,7 +66,7 @@ const AppContent = observer(() => {
     React.useEffect(() => {
         showDigitalOptionsMaltainvestError(client, common);
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [client.is_options_blocked, client.account_settings.country_code]);
+    }, [client.is_options_blocked, client.account_settings.country_code, client.clients_country]);
 
     const init = () => {
         GTM.init(combinedStore);


### PR DESCRIPTION
## Changes:
For Clients with EU ip bot page was loading twice. So added Clients country to dependency array when handling error.

### Screenshots:

Please provide some screenshots of the change.
