### PR TITLE
[Refactoring] shontzu/CFDS-1435/use-landing-company-hooks-for-cTrader-and-DxTrade

### DIFF
--- a/packages/api/src/hooks/index.ts
+++ b/packages/api/src/hooks/index.ts
@@ -11,6 +11,7 @@ export { default as useAllAvailableAccounts } from './useAllAvailableAccounts';
 export { default as useAllWalletAccounts } from './useAllWalletAccounts';
 export { default as useAuthentication } from './useAuthentication';
 export { default as useAuthorize } from './useAuthorize';
+export { default as useAccesiblePlatforms } from './useAccesiblePlatforms';
 export { default as useAvailableMT5Accounts } from './useAvailableMT5Accounts';
 export { default as useAvailableWallets } from './useAvailableWallets';
 export { default as useBalance } from './useBalance';

--- a/packages/api/src/hooks/useAccesiblePlatforms.ts
+++ b/packages/api/src/hooks/useAccesiblePlatforms.ts
@@ -1,7 +1,7 @@
 import useLandingCompany from './useLandingCompany';
 
 /**
- * A custom hook that returns a flag indicating whether ctrader and dxtrade are accessible for the current country of residence
+ * A custom hook that provides flags to determine the accessibility status of cTrader and Dxtrade based on the current country of residence.
  */
 const useAccesiblePlatforms = () => {
     const { data: landing_company } = useLandingCompany();

--- a/packages/api/src/hooks/useAccesiblePlatforms.ts
+++ b/packages/api/src/hooks/useAccesiblePlatforms.ts
@@ -1,21 +1,31 @@
+import { useMemo } from 'react';
 import useLandingCompany from './useLandingCompany';
 
 /**
  * A custom hook that provides flags to determine the accessibility status of cTrader and Dxtrade based on the current country of residence.
  */
 const useAccesiblePlatforms = () => {
-    const { data: landing_company } = useLandingCompany();
+    const { data: landing_company, ...rest } = useLandingCompany();
 
-    /** check if ctrader jurisdiction is offered in the landing_company response  */
-    const is_ctrader_available = landing_company?.ctrader?.all?.standard === 'svg';
-    /** check if dxtrade is in the landing_company response */
-    const is_dxtrade_available = landing_company?.dxtrade_all_company;
+    const modified_accesible_platform = useMemo(() => {
+        if (!landing_company) return;
+
+        /** check if ctrader jurisdiction is offered in the landing_company response  */
+        const is_ctrader_available = landing_company?.ctrader?.all?.standard === 'svg';
+        /** check if dxtrade is in the landing_company response */
+        const is_dxtrade_available = landing_company?.dxtrade_all_company;
+
+        return {
+            /** is ctrader accessible for this country of residence */
+            isCtraderAvailable: !!is_ctrader_available,
+            /** is dxtrade accessible for this country of residence */
+            isDxtradeAvailable: !!is_dxtrade_available,
+        };
+    }, [landing_company]);
 
     return {
-        /** is ctrader accessible for this country of residence */
-        isCtraderAvailable: !!is_ctrader_available,
-        /** is dxtrade accessible for this country of residence */
-        isDxtradeAvailable: !!is_dxtrade_available,
+        data: modified_accesible_platform,
+        ...rest,
     };
 };
 

--- a/packages/api/src/hooks/useAccesiblePlatforms.ts
+++ b/packages/api/src/hooks/useAccesiblePlatforms.ts
@@ -17,9 +17,9 @@ const useAccesiblePlatforms = () => {
 
         return {
             /** is ctrader accessible for this country of residence */
-            isCtraderAvailable: !!is_ctrader_available,
+            is_ctrader_available: !!is_ctrader_available,
             /** is dxtrade accessible for this country of residence */
-            isDxtradeAvailable: !!is_dxtrade_available,
+            is_dxtrade_available: !!is_dxtrade_available,
         };
     }, [landing_company]);
 

--- a/packages/api/src/hooks/useAccesiblePlatforms.ts
+++ b/packages/api/src/hooks/useAccesiblePlatforms.ts
@@ -1,0 +1,22 @@
+import useLandingCompany from './useLandingCompany';
+
+/**
+ * A custom hook that returns a flag indicating whether ctrader and dxtrade are accessible for the current country of residence
+ */
+const useAccesiblePlatforms = () => {
+    const { data: landing_company } = useLandingCompany();
+
+    /** check if ctrader jurisdiction is offered in the landing_company response  */
+    const is_ctrader_available = landing_company?.ctrader?.all?.standard === 'svg';
+    /** check if dxtrade is in the landing_company response */
+    const is_dxtrade_available = landing_company?.dxtrade_all_company;
+
+    return {
+        /** is ctrader accessible for this country of residence */
+        isCtraderAvailable: !!is_ctrader_available,
+        /** is dxtrade accessible for this country of residence */
+        isDxtradeAvailable: !!is_dxtrade_available,
+    };
+};
+
+export default useAccesiblePlatforms;


### PR DESCRIPTION
## create a hook using `landing_company` endpoint to get available cTrader and dxTrade accounts

### current behaviour 
- using flags like `CFDs_restricted_countries` and `financial_restricted_countries` to filter for available cTrader and dxTrade accounts:

<img src='https://github.com/binary-com/deriv-app/assets/108507236/2e203c59-5177-4f0e-8b16-3e4777ee3123' width="60%" />

### expected behaviour 
- using the `landing_company` hook to check if ctrader and dxtrade are allowed in client's country of residence 
- in the case of dxtrade, when it is available, `dxtrade_all_company` will be in the response, else, it is not in the response
- in the case of ctrader, when it is available, `ctrader` will be in the response and the jurisdiction will be svg. Else, `ctrader` will be in the response but the jurisdiction will be empty string (' ') or `undefined`

<img src='https://github.com/binary-com/deriv-app/assets/108507236/6415ae72-5d69-482c-998c-084ea31d7679' width="60%" />
