### PR TITLE
fix: quick strategy duration issue

### DIFF
--- a/packages/bot-web-ui/src/components/quick-strategy/quick-strategy.tsx
+++ b/packages/bot-web-ui/src/components/quick-strategy/quick-strategy.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Form as FormikForm, Formik } from 'formik';
 import * as Yup from 'yup';
-import { ApiHelpers, config as qs_config } from '@deriv/bot-skeleton';
+import { config as qs_config } from '@deriv/bot-skeleton';
 import { MobileFullPageModal, Modal } from '@deriv/components';
 import { observer, useStore } from '@deriv/stores';
 import { localize } from '@deriv/translations';
@@ -10,7 +10,7 @@ import DesktopFormWrapper from './form-wrappers/desktop-form-wrapper';
 import MobileFormWrapper from './form-wrappers/mobile-form-wrapper';
 import { STRATEGIES } from './config';
 import Form from './form';
-import { TConfigItem, TDurationItemRaw, TFormData } from './types';
+import { TConfigItem, TFormData } from './types';
 import './quick-strategy.scss';
 
 type TFormikWrapper = {
@@ -33,8 +33,7 @@ const getErrorMessage = (dir: 'MIN' | 'MAX', value: number, type = 'DEFAULT') =>
 
 const FormikWrapper: React.FC<TFormikWrapper> = observer(({ children }) => {
     const { quick_strategy } = useDBotStore();
-    const [duration, setDuration] = React.useState<TDurationItemRaw | null>(null);
-    const { selected_strategy, form_data, onSubmit, setValue } = quick_strategy;
+    const { selected_strategy, form_data, onSubmit, setValue, current_duration_min_max } = quick_strategy;
     const config: TConfigItem[][] = STRATEGIES[selected_strategy]?.fields;
     const [dynamic_schema, setDynamicSchema] = useState(Yup.object().shape({}));
 
@@ -62,17 +61,6 @@ const FormikWrapper: React.FC<TFormikWrapper> = observer(({ children }) => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    React.useEffect(() => {
-        const getDurations = async () => {
-            const { contracts_for } = ApiHelpers.instance;
-            const durations = await contracts_for.getDurations(form_data.symbol, form_data.tradetype);
-            const d = durations.find((duration: TDurationItemRaw) => duration.unit === form_data.durationtype);
-            setDuration(d);
-        };
-        getDurations();
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [form_data.symbol, form_data.tradetype, form_data.durationtype]);
-
     const getErrors = (formikData: TFormData) => {
         const sub_schema: Record<string, any> = {};
         config.forEach(group => {
@@ -85,9 +73,9 @@ const FormikWrapper: React.FC<TFormikWrapper> = observer(({ children }) => {
                         let max = 10;
                         let min_error = getErrorMessage('MIN', min);
                         let max_error = getErrorMessage('MAX', max);
-                        if (field.name === 'duration' && duration) {
-                            min = duration.min;
-                            max = duration.max;
+                        if (field.name === 'duration' && current_duration_min_max) {
+                            min = current_duration_min_max.min;
+                            max = current_duration_min_max.max;
                             min_error = getErrorMessage('MIN', min, 'DURATION');
                             max_error = getErrorMessage('MAX', max, 'DURATION');
                         }

--- a/packages/bot-web-ui/src/components/quick-strategy/selects/duration-type.tsx
+++ b/packages/bot-web-ui/src/components/quick-strategy/selects/duration-type.tsx
@@ -22,7 +22,7 @@ type TDurationUnit = {
 const DurationUnit: React.FC<TDurationUnit> = ({ fullWidth = false, attached }) => {
     const [list, setList] = React.useState<TDurationUnitItem[]>([]);
     const { quick_strategy } = useDBotStore();
-    const { setValue } = quick_strategy;
+    const { setValue, setCurrentDurationMinMax } = quick_strategy;
     const { setFieldValue, validateForm, values } = useFormikContext<TFormData>();
     const { symbol, tradetype } = values;
     const selected = values?.durationtype;
@@ -46,10 +46,14 @@ const DurationUnit: React.FC<TDurationUnit> = ({ fullWidth = false, attached }) 
                         validateForm();
                     });
                     setValue('durationtype', durations?.[0]?.unit);
+                    setCurrentDurationMinMax(durations?.[0]?.min, durations?.[0]?.max);
                 } else {
                     const duration = duration_units?.find((duration: TDurationUnitItem) => duration.value === selected);
-                    setFieldValue?.('duration', duration?.min);
+                    setFieldValue?.('duration', duration?.min).then(() => {
+                        validateForm();
+                    });
                     setValue('duration', duration?.min);
+                    setCurrentDurationMinMax(duration?.min, duration?.max);
                 }
             };
             getDurationUnits();
@@ -78,9 +82,15 @@ const DurationUnit: React.FC<TDurationUnit> = ({ fullWidth = false, attached }) 
                             list_items={list}
                             onItemSelection={(item: TItem) => {
                                 if ((item as TDurationUnitItem)?.value) {
+                                    setCurrentDurationMinMax(
+                                        (item as TDurationUnitItem)?.min,
+                                        (item as TDurationUnitItem)?.max
+                                    );
                                     setFieldValue?.('durationtype', (item as TDurationUnitItem)?.value as string);
                                     setValue('durationtype', (item as TDurationUnitItem)?.value as string);
-                                    setFieldValue?.('duration', (item as TDurationUnitItem)?.min);
+                                    setFieldValue?.('duration', (item as TDurationUnitItem)?.min).then(() => {
+                                        validateForm();
+                                    });
                                     setValue('duration', (item as TDurationUnitItem)?.min);
                                 }
                             }}

--- a/packages/bot-web-ui/src/stores/quick-strategy-store.ts
+++ b/packages/bot-web-ui/src/stores/quick-strategy-store.ts
@@ -12,6 +12,10 @@ export type TActiveSymbol = {
 };
 
 interface IQuickStrategyStore {
+    current_duration_min_max: {
+        min: number;
+        max: number;
+    };
     root_store: RootStore;
     is_open: boolean;
     selected_strategy: string;
@@ -23,6 +27,7 @@ interface IQuickStrategyStore {
     setValue: (name: string, value: string) => void;
     onSubmit: (data: TFormData) => void;
     toggleStopBotDialog: () => void;
+    setCurrentDurationMinMax: (min: number, max: number) => void;
 }
 
 export default class QuickStrategyStore implements IQuickStrategyStore {
@@ -37,15 +42,21 @@ export default class QuickStrategyStore implements IQuickStrategyStore {
     };
     is_contract_dialog_open = false;
     is_stop_bot_dialog_open = false;
+    current_duration_min_max = {
+        min: 0,
+        max: 10,
+    };
 
     constructor(root_store: RootStore) {
         makeObservable(this, {
+            current_duration_min_max: observable,
             form_data: observable,
             is_contract_dialog_open: observable,
             is_open: observable,
             is_stop_bot_dialog_open: observable,
             selected_strategy: observable,
             onSubmit: action,
+            setCurrentDurationMinMax: action,
             setFormVisibility: action,
             setSelectedStrategy: action,
             setValue: action,
@@ -72,6 +83,13 @@ export default class QuickStrategyStore implements IQuickStrategyStore {
 
     setValue = (name: string, value: string | number | boolean) => {
         this.form_data[name as keyof TFormData] = value;
+    };
+
+    setCurrentDurationMinMax = (min = 0, max = 10) => {
+        this.current_duration_min_max = {
+            min,
+            max,
+        };
     };
 
     onSubmit = async (data: TFormData) => {


### PR DESCRIPTION
## Changes:

https://app.clickup.com/t/20696747/WEBREL-1687

- Duration field error schema is not updating based on the latest duration type selection
- Remove one `useEffect` from `quick-strategy.tsx` as we are only taking the latest min and max value from here which we can also collect from the `duration-type.tsx` file.
- Created one more observable in the store which will store the currently selected duration's min and max value