### PR TITLE
[DTRA] / Kate / WEBREL-75 / Test coverage + Refactoring: Multiplier trade params in Trader package

### DIFF
--- a/packages/components/src/components/button/button.scss
+++ b/packages/components/src/components/button/button.scss
@@ -207,6 +207,10 @@
             font-size: 1.4rem;
         }
     }
+    &__wide {
+        width: 100%;
+        height: 4rem;
+    }
     &__effect:focus:not(:active):after {
         content: '';
         position: absolute;

--- a/packages/components/src/components/modal/modal.scss
+++ b/packages/components/src/components/modal/modal.scss
@@ -181,6 +181,11 @@
         line-height: 1.43;
         color: var(--text-prominent);
 
+        &__expiration {
+            min-height: 12rem;
+            padding: 1.6rem;
+        }
+
         @include mobile {
             font-size: 1.2rem;
             padding: 0.8rem 2.4rem;

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/cancel-deal.spec.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/cancel-deal.spec.tsx
@@ -21,7 +21,7 @@ jest.mock('@deriv/components', () => ({
     Dropdown: jest.fn(props => (
         <div>
             {dropdown}
-            <button onClick={props.onChange}>OnChange</button>
+            <button onClick={props.onChange}>DropdownList</button>
         </div>
     )),
 }));
@@ -85,7 +85,7 @@ describe('<CancelDeal />', () => {
     it('should call onChangeCancellationDuration if user clicked on dropdown', () => {
         render(mockTakeProfit());
 
-        userEvent.click(screen.getByText('OnChange'));
+        userEvent.click(screen.getByText('DropdownList'));
 
         expect(onChangeCancellationDuration).toBeCalled();
     });

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/cancel-deal.spec.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/cancel-deal.spec.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
+import { mockStore } from '@deriv/stores';
+import { onChangeCancellationDuration, onToggleCancellation } from 'Stores/Modules/Trading/Helpers/multiplier';
+import CancelDeal from '../cancel-deal';
+import TraderProviders from '../../../../../../../trader-providers';
+
+const dropdown = 'Dropdown';
+const deal_cancellation = 'Deal cancellation';
+const popover = 'dt_popover_wrapper';
+
+jest.mock('Stores/Modules/Trading/Helpers/multiplier', () => ({
+    ...jest.requireActual('Stores/Modules/Trading/Helpers/multiplier'),
+    onChangeCancellationDuration: jest.fn(),
+    onToggleCancellation: jest.fn(),
+}));
+
+jest.mock('@deriv/components', () => ({
+    ...jest.requireActual('@deriv/components'),
+    Dropdown: jest.fn(props => (
+        <div>
+            {dropdown}
+            <button onClick={props.onChange}>OnChange</button>
+        </div>
+    )),
+}));
+
+describe('<CancelDeal />', () => {
+    let default_mocked_store: ReturnType<typeof mockStore>;
+
+    beforeEach(() => {
+        default_mocked_store = {
+            ...mockStore({}),
+            modules: {
+                trade: {
+                    cancellation_range_list: [{ text: 'mocked text', value: 'mocked value' }],
+                    cancellation_duration: '10',
+                    has_cancellation: true,
+                    has_stop_loss: true,
+                    has_take_profit: true,
+                    onChangeMultiple: jest.fn(),
+                },
+            },
+        };
+    });
+
+    const mockTakeProfit = () => {
+        return (
+            <TraderProviders store={default_mocked_store}>
+                <CancelDeal />
+            </TraderProviders>
+        );
+    };
+
+    it('should not render component if cancellation_range_list is empty ', () => {
+        default_mocked_store.modules.trade.cancellation_range_list = [];
+        const { container } = render(mockTakeProfit());
+
+        expect(container).toBeEmptyDOMElement();
+    });
+    it('should render Deal cancellation checkbox, popover and dropdown if has_cancellation, has_stop_loss and has_take_profit are equal to true', () => {
+        render(mockTakeProfit());
+
+        expect(screen.getByText(deal_cancellation)).toBeInTheDocument();
+        expect(screen.getByRole('checkbox')).toBeInTheDocument();
+        expect(screen.getByTestId(popover)).toBeInTheDocument();
+        expect(screen.getByText(dropdown)).toBeInTheDocument();
+    });
+    it('should not render dropdown if has_cancellation is false', () => {
+        default_mocked_store.modules.trade.has_cancellation = false;
+        render(mockTakeProfit());
+
+        expect(screen.getByText(deal_cancellation)).toBeInTheDocument();
+        expect(screen.getByRole('checkbox')).toBeInTheDocument();
+        expect(screen.queryByText(dropdown)).not.toBeInTheDocument();
+    });
+    it('should render extra popover (as a result there will be 2 popovers) with notification if should_show_cancellation_warning from ui store is true', () => {
+        default_mocked_store.modules.trade.has_take_profit = false;
+        default_mocked_store.ui.should_show_cancellation_warning = true;
+        render(mockTakeProfit());
+
+        expect(screen.getAllByTestId(popover)).toHaveLength(2);
+    });
+    it('should call onChangeCancellationDuration if user clicked on dropdown', () => {
+        render(mockTakeProfit());
+
+        userEvent.click(screen.getByText('OnChange'));
+
+        expect(onChangeCancellationDuration).toBeCalled();
+    });
+    it('should call onToggleCancellation if user clicked on checkbox', () => {
+        render(mockTakeProfit());
+
+        userEvent.click(screen.getByRole('checkbox'));
+
+        expect(onToggleCancellation).toBeCalled();
+    });
+    it('after user hover on extra popover, text with checkbox should be shown and user will be able to checked; on unhover toggleCancellationWarning should be called', () => {
+        default_mocked_store.modules.trade.has_take_profit = false;
+        default_mocked_store.ui.should_show_cancellation_warning = true;
+        const { rerender } = render(mockTakeProfit());
+
+        expect(screen.queryByText(/Don't show this again/i)).not.toBeInTheDocument();
+        expect(screen.getByRole('checkbox')).toBeInTheDocument();
+        userEvent.hover(screen.getAllByTestId(popover)[0]);
+        expect(screen.getByText(/Don't show this again/i)).toBeInTheDocument();
+        expect(screen.getAllByRole('checkbox')).toHaveLength(2);
+
+        userEvent.click(screen.getAllByRole('checkbox')[0]);
+        expect(screen.getAllByRole('checkbox')[0]).toBeChecked();
+
+        rerender(mockTakeProfit());
+
+        userEvent.unhover(screen.getByText(/Take profit and\/or/i));
+        expect(default_mocked_store.ui.toggleCancellationWarning).toBeCalled();
+    });
+});

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/expiration-modal.spec.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/expiration-modal.spec.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MultipliersExpirationModal from '../expiration-modal';
+
+const mocked_props = {
+    is_open: true,
+    toggleModal: jest.fn(),
+};
+
+jest.mock('@deriv/components', () => ({
+    ...jest.requireActual('@deriv/components'),
+    Div100vhContainer: jest.fn(({ children }) => <div>{children}</div>),
+}));
+jest.mock('../expiration', () => jest.fn(() => 'Expiration Component'));
+
+describe('<MultipliersExpirationModal />', () => {
+    beforeAll(() => {
+        (ReactDOM.createPortal as jest.Mock) = jest.fn(component => {
+            return component;
+        });
+    });
+
+    afterAll(() => {
+        (ReactDOM.createPortal as jest.Mock).mockClear();
+    });
+
+    it('should render modal with a proper text', () => {
+        render(<MultipliersExpirationModal {...mocked_props} />);
+
+        expect(screen.getByText('Expiration')).toBeInTheDocument();
+        expect(screen.getByText(/your contract will be closed automatically at the/i)).toBeInTheDocument();
+        expect(screen.getByText('OK')).toBeInTheDocument();
+    });
+    it('should call toggleModal if user clicked on OK button', () => {
+        render(<MultipliersExpirationModal {...mocked_props} />);
+
+        userEvent.click(screen.getByText('OK'));
+
+        expect(mocked_props.toggleModal).toBeCalled();
+    });
+});

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/expiration.spec.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/expiration.spec.tsx
@@ -7,6 +7,11 @@ import TraderProviders from '../../../../../../../trader-providers';
 
 const expiry_date = '28 Nov 2023 at 11:04';
 
+jest.mock('@deriv/shared', () => ({
+    ...jest.requireActual('@deriv/shared'),
+    getDateFromNow: jest.fn(() => '28 Nov 2023'),
+}));
+
 describe('<Expiration />', () => {
     let default_mocked_store: ReturnType<typeof mockStore>,
         default_mocked_props: React.ComponentProps<typeof Expiration>;

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/expiration.spec.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/expiration.spec.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import moment from 'moment';
+import { render, screen } from '@testing-library/react';
+import { mockStore } from '@deriv/stores';
+import Expiration from '../expiration';
+import TraderProviders from '../../../../../../../trader-providers';
+
+const expiry_date = '28 Nov 2023 at 11:04';
+
+describe('<Expiration />', () => {
+    let default_mocked_store: ReturnType<typeof mockStore>,
+        default_mocked_props: React.ComponentProps<typeof Expiration>;
+
+    beforeEach(() => {
+        default_mocked_store = {
+            ...mockStore({}),
+            modules: {
+                trade: {
+                    expiration: 1701215999,
+                },
+            },
+            common: {
+                ...mockStore({}).common,
+                server_time: moment('2023-11-21T12:55:10.488Z'),
+            },
+        };
+        default_mocked_props = { is_text_only: true, text_size: '14' };
+    });
+
+    const mockExpiration = () => {
+        return (
+            <TraderProviders store={default_mocked_store}>
+                <Expiration {...default_mocked_props} />
+            </TraderProviders>
+        );
+    };
+
+    it('should render only text about date of expiry if is_text_only === true', () => {
+        render(mockExpiration());
+
+        expect(screen.getByText(expiry_date)).toBeInTheDocument();
+        expect(screen.queryByText('Expires on')).not.toBeInTheDocument();
+    });
+    it('should render dash instead of date of expiry if is_text_only === true and expiration is falsy', () => {
+        default_mocked_store.modules.trade.expiration = undefined;
+        render(mockExpiration());
+
+        expect(screen.getByText('-')).toBeInTheDocument();
+        expect(screen.queryByText(expiry_date)).not.toBeInTheDocument();
+    });
+    it('should render fieldset component with date of expiry if is_text_only === false', () => {
+        default_mocked_props.is_text_only = false;
+        render(mockExpiration());
+
+        expect(screen.getByText('Expires on')).toBeInTheDocument();
+        expect(screen.getByText(expiry_date)).toBeInTheDocument();
+    });
+    it('should render fieldset component with dash if is_text_only === false and expiration is falsy', () => {
+        default_mocked_props.is_text_only = false;
+        default_mocked_store.modules.trade.expiration = undefined;
+        render(mockExpiration());
+
+        expect(screen.getByText('Expires on')).toBeInTheDocument();
+        expect(screen.getByText('-')).toBeInTheDocument();
+        expect(screen.queryByText(expiry_date)).not.toBeInTheDocument();
+    });
+});

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/info.spec.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/info.spec.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
+import { mockStore } from '@deriv/stores';
+import MultipliersInfo from '../info';
+import TraderProviders from '../../../../../../../trader-providers';
+
+const commission = 'Commission';
+const stop_out = 'Stop out';
+const commission_tooltip_text = /0.0440%/i;
+const stop_out_tooltip_text = /your contract will be closed automatically when your loss reaches/i;
+
+describe('<MultipliersInfo />', () => {
+    let default_mocked_store: ReturnType<typeof mockStore>,
+        default_mocked_props: React.ComponentProps<typeof MultipliersInfo>;
+
+    beforeEach(() => {
+        default_mocked_store = {
+            ...mockStore({}),
+            modules: {
+                trade: {
+                    currency: 'USD',
+                    has_stop_loss: false,
+                    multiplier: 10,
+                    amount: 100,
+                    commission: 0.44,
+                    stop_out: 5,
+                },
+            },
+        };
+        default_mocked_props = {
+            amount: 100,
+            className: 'mocked_classname',
+            commission_text_size: '14',
+            commission: 0.44,
+            is_tooltip_relative: true,
+            multiplier: 10,
+            should_show_tooltip: true,
+            stop_out_text_size: '14',
+            stop_out: 5,
+        };
+    });
+
+    const mockMultipliersInfo = () => {
+        return (
+            <TraderProviders store={default_mocked_store}>
+                <MultipliersInfo {...default_mocked_props} />
+            </TraderProviders>
+        );
+    };
+
+    it('should render commission text with popover and stop out text with popover', () => {
+        render(mockMultipliersInfo());
+
+        expect(screen.getAllByTestId('dt_popover_wrapper')).toHaveLength(2);
+
+        const commission_block = screen.getByText(commission);
+        expect(commission_block).toBeInTheDocument();
+        expect(screen.getByText(/0.44 USD/i)).toBeInTheDocument();
+
+        expect(screen.queryByText(commission_tooltip_text)).not.toBeInTheDocument();
+        userEvent.hover(commission_block);
+        expect(screen.getByText(commission_tooltip_text)).toBeInTheDocument();
+
+        const stop_out_block = screen.getByText(stop_out);
+        expect(stop_out_block).toBeInTheDocument();
+        expect(screen.getByText(/5.00 USD/i)).toBeInTheDocument();
+
+        expect(screen.queryByText(stop_out_tooltip_text)).not.toBeInTheDocument();
+        userEvent.hover(stop_out_block);
+        expect(screen.getByText(stop_out_tooltip_text)).toBeInTheDocument();
+    });
+    it('should not render stop out text with popover if has_stop_loss === true', () => {
+        default_mocked_store.modules.trade.has_stop_loss = true;
+        render(mockMultipliersInfo());
+
+        expect(screen.queryByText(stop_out)).not.toBeInTheDocument();
+        expect(screen.queryByText(/5.00 USD/i)).not.toBeInTheDocument();
+    });
+    it('should not render tooltips if should_show_tooltip === false', () => {
+        default_mocked_props.should_show_tooltip = false;
+        render(mockMultipliersInfo());
+
+        expect(screen.queryByTestId('dt_popover_wrapper')).not.toBeInTheDocument();
+    });
+    it('should render commission text and stop out text even if they were not passed in props (fallback from store should work)', () => {
+        default_mocked_props = { className: 'mocked_classname' };
+        render(mockMultipliersInfo());
+
+        expect(screen.getByText(commission)).toBeInTheDocument();
+        expect(screen.getByText(/0.44 USD/i)).toBeInTheDocument();
+
+        expect(screen.getByText(stop_out)).toBeInTheDocument();
+        expect(screen.getByText(/5.00 USD/i)).toBeInTheDocument();
+    });
+    it('should render zero values for commission text and stop out text if they were not passed in props and fallback is falsy', () => {
+        default_mocked_props = { className: 'mocked_classname' };
+        default_mocked_store.modules.trade = {};
+        render(mockMultipliersInfo());
+
+        expect(screen.getByText(commission)).toBeInTheDocument();
+        expect(screen.getByText(stop_out)).toBeInTheDocument();
+        expect(screen.getAllByText(/0.00 USD/i)).toHaveLength(2);
+    });
+});

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/multiplier.spec.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/multiplier.spec.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { mockStore } from '@deriv/stores';
+import Multiplier from '../multiplier';
+import TraderProviders from '../../../../../../../trader-providers';
+
+const mocked_props = {
+    modules: {
+        trade: {
+            multiplier: 10,
+            multiplier_range_list: [],
+            onChange: jest.fn(),
+            symbol: '1HZ100V',
+        },
+    },
+};
+describe('<Multiplier/>', () => {
+    const mockMultiplier = () => {
+        return (
+            <TraderProviders store={mockStore(mocked_props)}>
+                <Multiplier />
+            </TraderProviders>
+        );
+    };
+
+    it('should render component', () => {
+        render(mockMultiplier());
+
+        expect(screen.getByTestId('multiplier')).toBeInTheDocument();
+        expect(screen.getByText('NEW!')).toBeInTheDocument();
+    });
+});

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/stop-loss.spec.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/stop-loss.spec.tsx
@@ -15,7 +15,7 @@ describe('<StopLoss />', () => {
                 trade: {
                     amount: 10,
                     currency: 'USD',
-                    validation_errors: { take_profit__error: ['mocked_error', 'mocked_error'] },
+                    validation_errors: { take_profit_error: ['mocked_error', 'mocked_error'] },
                     stop_loss: '10',
                     has_stop_loss: true,
                     onChangeMultiple: jest.fn(),
@@ -29,7 +29,7 @@ describe('<StopLoss />', () => {
             onChange: jest.fn(),
             onChangeMultiple: jest.fn(),
             stop_loss: '10',
-            validation_errors: { take_profit__error: ['mocked_error', 'mocked_error'] },
+            validation_errors: { take_profit_error: ['mocked_error', 'mocked_error'] },
         };
     });
 

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/stop-loss.spec.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/stop-loss.spec.tsx
@@ -62,7 +62,7 @@ describe('<StopLoss />', () => {
 
         expect(default_mocked_props.onChange).toBeCalled();
     });
-    it('should should render functioning Stop Loss input with checkbox if props were not passed (backup should work)', () => {
+    it('should render functioning Stop Loss input with checkbox if props were not passed (backup should work)', () => {
         default_mocked_props = {};
         render(mockStopLoss());
 

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/stop-loss.spec.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/stop-loss.spec.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
+import { mockStore } from '@deriv/stores';
+import StopLoss from '../stop-loss';
+import TraderProviders from '../../../../../../../trader-providers';
+
+describe('<StopLoss />', () => {
+    let default_mocked_store: ReturnType<typeof mockStore>, default_mocked_props: React.ComponentProps<typeof StopLoss>;
+
+    beforeEach(() => {
+        default_mocked_store = {
+            ...mockStore({}),
+            modules: {
+                trade: {
+                    amount: 10,
+                    currency: 'USD',
+                    validation_errors: { take_profit__error: ['mocked_error', 'mocked_error'] },
+                    stop_loss: '10',
+                    has_stop_loss: true,
+                    onChangeMultiple: jest.fn(),
+                    onChange: jest.fn(),
+                },
+            },
+        };
+
+        default_mocked_props = {
+            has_stop_loss: true,
+            onChange: jest.fn(),
+            onChangeMultiple: jest.fn(),
+            stop_loss: '10',
+            validation_errors: { take_profit__error: ['mocked_error', 'mocked_error'] },
+        };
+    });
+
+    const mockExpiration = () => {
+        return (
+            <TraderProviders store={default_mocked_store}>
+                <StopLoss {...default_mocked_props} />
+            </TraderProviders>
+        );
+    };
+
+    it('should render Stop Loss input with checkbox', () => {
+        render(mockExpiration());
+
+        expect(screen.getByText('Stop loss')).toBeInTheDocument();
+        expect(screen.getByRole('checkbox')).toBeInTheDocument();
+        expect(screen.getByRole('textbox')).toBeInTheDocument();
+    });
+    it('should call onChangeMultiple if user clicked on checkbox', () => {
+        render(mockExpiration());
+
+        userEvent.click(screen.getByRole('checkbox'));
+
+        expect(default_mocked_props.onChangeMultiple).toBeCalled();
+    });
+    it('should call onChange if user changed value in input', () => {
+        render(mockExpiration());
+
+        userEvent.type(screen.getByRole('textbox'), '20');
+
+        expect(default_mocked_props.onChange).toBeCalled();
+    });
+    it('should should render functioning Stop Loss input with checkbox if props were not passed (backup should work)', () => {
+        default_mocked_props = {};
+        render(mockExpiration());
+
+        const check_box = screen.getByRole('checkbox');
+        const input = screen.getByRole('textbox');
+
+        expect(screen.getByText('Stop loss')).toBeInTheDocument();
+        expect(check_box).toBeInTheDocument();
+        expect(input).toBeInTheDocument();
+
+        userEvent.click(check_box);
+        expect(default_mocked_store.modules.trade.onChangeMultiple).toBeCalled();
+
+        userEvent.type(input, '20');
+        expect(default_mocked_store.modules.trade.onChange).toBeCalled();
+    });
+});

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/stop-loss.spec.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/stop-loss.spec.tsx
@@ -33,7 +33,7 @@ describe('<StopLoss />', () => {
         };
     });
 
-    const mockExpiration = () => {
+    const mockStopLoss = () => {
         return (
             <TraderProviders store={default_mocked_store}>
                 <StopLoss {...default_mocked_props} />
@@ -42,21 +42,21 @@ describe('<StopLoss />', () => {
     };
 
     it('should render Stop Loss input with checkbox', () => {
-        render(mockExpiration());
+        render(mockStopLoss());
 
         expect(screen.getByText('Stop loss')).toBeInTheDocument();
         expect(screen.getByRole('checkbox')).toBeInTheDocument();
         expect(screen.getByRole('textbox')).toBeInTheDocument();
     });
     it('should call onChangeMultiple if user clicked on checkbox', () => {
-        render(mockExpiration());
+        render(mockStopLoss());
 
         userEvent.click(screen.getByRole('checkbox'));
 
         expect(default_mocked_props.onChangeMultiple).toBeCalled();
     });
     it('should call onChange if user changed value in input', () => {
-        render(mockExpiration());
+        render(mockStopLoss());
 
         userEvent.type(screen.getByRole('textbox'), '20');
 
@@ -64,7 +64,7 @@ describe('<StopLoss />', () => {
     });
     it('should should render functioning Stop Loss input with checkbox if props were not passed (backup should work)', () => {
         default_mocked_props = {};
-        render(mockExpiration());
+        render(mockStopLoss());
 
         const check_box = screen.getByRole('checkbox');
         const input = screen.getByRole('textbox');

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/take-profit.spec.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/take-profit.spec.tsx
@@ -65,7 +65,7 @@ describe('<TakeProfit />', () => {
 
         expect(default_mocked_props.onChange).toBeCalled();
     });
-    it('should should render functioning Take profits input with checkbox if props were not passed (backup should work)', () => {
+    it('should render functioning Take profits input with checkbox if props were not passed (backup should work)', () => {
         default_mocked_props = {};
         render(mockTakeProfit());
 

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/take-profit.spec.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/take-profit.spec.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
+import { mockStore } from '@deriv/stores';
+import TakeProfit from '../take-profit';
+import TraderProviders from '../../../../../../../trader-providers';
+
+describe('<TakeProfit />', () => {
+    let default_mocked_store: ReturnType<typeof mockStore>,
+        default_mocked_props: React.ComponentProps<typeof TakeProfit>;
+
+    beforeEach(() => {
+        default_mocked_store = {
+            ...mockStore({}),
+            modules: {
+                trade: {
+                    is_accumulator: false,
+                    is_multiplier: true,
+                    has_open_accu_contract: false,
+                    amount: 10,
+                    validation_errors: { stop_loss_error: ['mocked_error', 'mocked_error'] },
+                    take_profit: '10',
+                    has_take_profit: true,
+                    onChangeMultiple: jest.fn(),
+                    onChange: jest.fn(),
+                },
+            },
+        };
+
+        default_mocked_props = {
+            has_take_profit: true,
+            onChange: jest.fn(),
+            onChangeMultiple: jest.fn(),
+            take_profit: '10',
+            validation_errors: { stop_loss_error: ['mocked_error', 'mocked_error'] },
+        };
+    });
+
+    const mockTakeProfit = () => {
+        return (
+            <TraderProviders store={default_mocked_store}>
+                <TakeProfit {...default_mocked_props} />
+            </TraderProviders>
+        );
+    };
+
+    it('should render Take profit input with checkbox', () => {
+        render(mockTakeProfit());
+
+        expect(screen.getByText('Take profit')).toBeInTheDocument();
+        expect(screen.getByRole('checkbox')).toBeInTheDocument();
+        expect(screen.getByRole('textbox')).toBeInTheDocument();
+    });
+    it('should call onChangeMultiple if user clicked on checkbox', () => {
+        render(mockTakeProfit());
+
+        userEvent.click(screen.getByRole('checkbox'));
+
+        expect(default_mocked_props.onChangeMultiple).toBeCalled();
+    });
+    it('should call onChange if user changed value in input', () => {
+        render(mockTakeProfit());
+
+        userEvent.type(screen.getByRole('textbox'), '20');
+
+        expect(default_mocked_props.onChange).toBeCalled();
+    });
+    it('should should render functioning Take profits input with checkbox if props were not passed (backup should work)', () => {
+        default_mocked_props = {};
+        render(mockTakeProfit());
+
+        const check_box = screen.getByRole('checkbox');
+        const input = screen.getByRole('textbox');
+
+        expect(screen.getByText('Take profit')).toBeInTheDocument();
+        expect(check_box).toBeInTheDocument();
+        expect(input).toBeInTheDocument();
+
+        userEvent.click(check_box);
+        expect(default_mocked_store.modules.trade.onChangeMultiple).toBeCalled();
+
+        userEvent.type(input, '20');
+        expect(default_mocked_store.modules.trade.onChange).toBeCalled();
+    });
+    it('should render correct text of the tooltip for Multipliers', () => {
+        render(mockTakeProfit());
+
+        expect(screen.queryByText(/When your profit reaches/i)).not.toBeInTheDocument();
+        userEvent.hover(screen.getByTestId('dt_popover_wrapper'));
+
+        expect(screen.getByText(/When your profit reaches/i)).toBeInTheDocument();
+    });
+    it('should render correct text of the tooltip for Accumulators', () => {
+        default_mocked_store.modules.trade.is_accumulator = true;
+        default_mocked_store.modules.trade.is_multiplier = false;
+        render(mockTakeProfit());
+
+        expect(screen.queryByText(/Your contract will be closed/i)).not.toBeInTheDocument();
+        userEvent.hover(screen.getByTestId('dt_popover_wrapper'));
+
+        expect(screen.getByText(/Your contract will be closed/i)).toBeInTheDocument();
+    });
+});

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/widgets.spec.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/widgets.spec.tsx
@@ -3,8 +3,8 @@ import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 import { mockStore } from '@deriv/stores';
 import { AccumulatorOptionsWidget, MultiplierOptionsWidget } from '../widgets';
-import TraderProviders from '../../../../../../../trader-providers';
 import { TCoreStores } from '@deriv/stores/types';
+import TraderProviders from '../../../../../../../trader-providers';
 
 const default_mock_store_accumulators = {
     modules: {

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/widgets.spec.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/widgets.spec.tsx
@@ -154,7 +154,7 @@ describe('<MultiplierAmountWidget />', () => {
         );
     };
 
-    it('should render only amount of money and Multipliers Info if it is not crypro', () => {
+    it('should render only amount of money and Multipliers Info if it is not crypto', () => {
         render(mockMultiplierAmountWidget());
 
         expect(screen.getByText(/10.00 USD/i)).toBeInTheDocument();
@@ -172,7 +172,7 @@ describe('<MultiplierAmountWidget />', () => {
 
         expect(screen.getByText(multiplier_amount_modal)).toBeInTheDocument();
     });
-    it('should render amount of money, Multipliers Info, Multipliers Expiration if it is crypro', () => {
+    it('should render amount of money, Multipliers Info, Multipliers Expiration if it is crypto', () => {
         default_mocked_store.modules.trade.is_crypto_multiplier = true;
         render(mockMultiplierAmountWidget());
 
@@ -180,7 +180,7 @@ describe('<MultiplierAmountWidget />', () => {
         expect(screen.getByText(multipliers_info)).toBeInTheDocument();
         expect(screen.getByText(multipliers_expiration)).toBeInTheDocument();
     });
-    it('should render Multipliers Expiration Modal if it is crypro and user clicked on Expiration button', () => {
+    it('should render Multipliers Expiration Modal if it is crypto and user clicked on Expiration button', () => {
         default_mocked_store.modules.trade.is_crypto_multiplier = true;
         render(mockMultiplierAmountWidget());
 

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/widgets.spec.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/__tests__/widgets.spec.tsx
@@ -2,29 +2,15 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 import { mockStore } from '@deriv/stores';
-import { AccumulatorOptionsWidget, MultiplierOptionsWidget } from '../widgets';
-import { TCoreStores } from '@deriv/stores/types';
+import { AccumulatorOptionsWidget, MultiplierOptionsWidget, MultiplierAmountWidget } from '../widgets';
 import TraderProviders from '../../../../../../../trader-providers';
 
-const default_mock_store_accumulators = {
-    modules: {
-        trade: {
-            growth_rate: 0.01,
-            has_open_accu_contract: true,
-            tick_size_barrier: 0,
-        },
-    },
-};
-const default_mock_store_multipliers = {
-    modules: {
-        trade: {
-            multiplier: 10,
-            symbol: '1HZ150V',
-        },
-    },
-};
 const new_label = 'NEW!';
 const radio_group_options_modal = 'RadioGroupOptionsModal';
+const multiplier_amount_modal = 'Multiplier Amount Modal';
+const multipliers_info = 'Multipliers Info';
+const multipliers_expiration = 'Multipliers Expiration';
+const multipliers_expiration_modal = 'Multipliers Expiration Modal';
 
 jest.mock('Modules/Trading/Containers/radio-group-options-modal', () =>
     jest.fn(prop => (
@@ -34,24 +20,49 @@ jest.mock('Modules/Trading/Containers/radio-group-options-modal', () =>
         </div>
     ))
 );
+jest.mock('Modules/Trading/Containers/Multiplier/multiplier-amount-modal', () =>
+    jest.fn(({ is_open }) => (is_open ? multiplier_amount_modal : null))
+);
+jest.mock('Modules/Trading/Components/Form/TradeParams/Multiplier/expiration', () =>
+    jest.fn(() => multipliers_expiration)
+);
+jest.mock('Modules/Trading/Components/Form/TradeParams/Multiplier/expiration-modal', () =>
+    jest.fn(({ is_open }) => (is_open ? multipliers_expiration_modal : null))
+);
+jest.mock('Modules/Trading/Components/Form/TradeParams/Multiplier/info', () => jest.fn(() => multipliers_info));
 
 describe('AccumulatorOptionsWidget', () => {
-    const mockAccumulatorOptionsWidget = (mocked_store: TCoreStores) => {
+    let default_mocked_store: ReturnType<typeof mockStore>;
+
+    beforeEach(() => {
+        default_mocked_store = {
+            ...mockStore({}),
+            modules: {
+                trade: {
+                    growth_rate: 0.01,
+                    has_open_accu_contract: true,
+                    tick_size_barrier: 0,
+                },
+            },
+        };
+    });
+
+    const mockAccumulatorOptionsWidget = () => {
         return (
-            <TraderProviders store={mocked_store}>
+            <TraderProviders store={default_mocked_store}>
                 <AccumulatorOptionsWidget />
             </TraderProviders>
         );
     };
 
     it('should render component with extra tooltip', () => {
-        render(mockAccumulatorOptionsWidget(mockStore(default_mock_store_accumulators)));
+        render(mockAccumulatorOptionsWidget());
 
         expect(screen.getByText(/1%/i)).toBeInTheDocument();
         expect(screen.getByTestId(/dt_popover_wrapper/i)).toBeInTheDocument();
     });
     it('should render tooltip with text if user click on info icon, but should not open RadioGroupOptionsModal', () => {
-        render(mockAccumulatorOptionsWidget(mockStore(default_mock_store_accumulators)));
+        render(mockAccumulatorOptionsWidget());
 
         const info_icon = screen.getByTestId(/dt_popover_wrapper/i);
         userEvent.click(info_icon);
@@ -59,14 +70,9 @@ describe('AccumulatorOptionsWidget', () => {
         expect(screen.getByText(/Your stake will grow/i)).toBeInTheDocument();
         expect(screen.getByText(radio_group_options_modal)).toHaveAttribute('data-open', 'false');
     });
-    it('if Accum contract is not open, user is able to open RadioGroupOptionsModal', () => {
-        const new_mock_store = { ...default_mock_store_accumulators };
-        new_mock_store.modules.trade = {
-            growth_rate: 0.01,
-            has_open_accu_contract: false,
-            tick_size_barrier: 0,
-        };
-        render(mockAccumulatorOptionsWidget(mockStore(new_mock_store)));
+    it('if Accumulator contract is not open, user is able to open RadioGroupOptionsModal', () => {
+        default_mocked_store.modules.trade.has_open_accu_contract = false;
+        render(mockAccumulatorOptionsWidget());
 
         userEvent.click(screen.getByText('Open Modal'));
 
@@ -75,38 +81,112 @@ describe('AccumulatorOptionsWidget', () => {
 });
 
 describe('MultiplierOptionsWidget', () => {
-    const mockMultiplierOptionsWidget = (mocked_store: TCoreStores) => {
+    let default_mocked_store: ReturnType<typeof mockStore>;
+
+    beforeEach(() => {
+        default_mocked_store = {
+            ...mockStore({}),
+            modules: {
+                trade: {
+                    multiplier: 10,
+                    symbol: '1HZ150V',
+                },
+            },
+        };
+    });
+
+    const mockMultiplierOptionsWidget = () => {
         return (
-            <TraderProviders store={mocked_store}>
+            <TraderProviders store={default_mocked_store}>
                 <MultiplierOptionsWidget />
             </TraderProviders>
         );
     };
 
     it('should render component with multipliers value', () => {
-        render(mockMultiplierOptionsWidget(mockStore(default_mock_store_multipliers)));
+        render(mockMultiplierOptionsWidget());
 
         expect(screen.getByText(/x10/i)).toBeInTheDocument();
     });
     it('should not render new! label if chosen symbol is not synthetic or is equal to Vol 150 (1 sec) or 250 (1 sec)', () => {
-        render(mockMultiplierOptionsWidget(mockStore(default_mock_store_multipliers)));
+        render(mockMultiplierOptionsWidget());
 
         expect(screen.queryByText(new_label)).not.toBeInTheDocument();
     });
     it('should render new! label if chosen symbol is synthetic and is not equal to Vol 150 (1 sec) or 250 (1 sec)', () => {
-        const new_mock_store = { ...default_mock_store_multipliers };
-        new_mock_store.modules.trade.symbol = '1HZ100V';
-
-        render(mockMultiplierOptionsWidget(mockStore(new_mock_store)));
+        default_mocked_store.modules.trade.symbol = '1HZ100V';
+        render(mockMultiplierOptionsWidget());
 
         expect(screen.getByText(new_label)).toBeInTheDocument();
     });
     it('should open RadioGroupOptionsModal if user clicked on Multiplier mobile widget', () => {
-        render(mockMultiplierOptionsWidget(mockStore(default_mock_store_multipliers)));
+        render(mockMultiplierOptionsWidget());
 
         expect(screen.getByText(radio_group_options_modal)).toHaveAttribute('data-open', 'false');
         userEvent.click(screen.getByText(/x10/i));
 
         expect(screen.getByText(radio_group_options_modal)).toHaveAttribute('data-open', 'true');
+    });
+});
+
+describe('<MultiplierAmountWidget />', () => {
+    let default_mocked_store: ReturnType<typeof mockStore>;
+
+    beforeEach(() => {
+        default_mocked_store = {
+            ...mockStore({}),
+            modules: {
+                trade: {
+                    amount: 10,
+                    expiration: 1701215999,
+                    currency: 'USD',
+                    is_crypto_multiplier: false,
+                },
+            },
+        };
+    });
+
+    const mockMultiplierAmountWidget = () => {
+        return (
+            <TraderProviders store={default_mocked_store}>
+                <MultiplierAmountWidget />
+            </TraderProviders>
+        );
+    };
+
+    it('should render only amount of money and Multipliers Info if it is not crypro', () => {
+        render(mockMultiplierAmountWidget());
+
+        expect(screen.getByText(/10.00 USD/i)).toBeInTheDocument();
+        expect(screen.getByText(multipliers_info)).toBeInTheDocument();
+
+        expect(screen.queryByText(multipliers_expiration)).not.toBeInTheDocument();
+        expect(screen.queryByText(multiplier_amount_modal)).not.toBeInTheDocument();
+        expect(screen.queryByText(multipliers_expiration_modal)).not.toBeInTheDocument();
+    });
+    it('should render Multiplier Amount Modal if user clicked on amount button', () => {
+        render(mockMultiplierAmountWidget());
+
+        expect(screen.queryByText(multiplier_amount_modal)).not.toBeInTheDocument();
+        userEvent.click(screen.getByText(/10.00 USD/i));
+
+        expect(screen.getByText(multiplier_amount_modal)).toBeInTheDocument();
+    });
+    it('should render amount of money, Multipliers Info, Multipliers Expiration if it is crypro', () => {
+        default_mocked_store.modules.trade.is_crypto_multiplier = true;
+        render(mockMultiplierAmountWidget());
+
+        expect(screen.getByText(/10.00 USD/i)).toBeInTheDocument();
+        expect(screen.getByText(multipliers_info)).toBeInTheDocument();
+        expect(screen.getByText(multipliers_expiration)).toBeInTheDocument();
+    });
+    it('should render Multipliers Expiration Modal if it is crypro and user clicked on Expiration button', () => {
+        default_mocked_store.modules.trade.is_crypto_multiplier = true;
+        render(mockMultiplierAmountWidget());
+
+        expect(screen.queryByText(multipliers_expiration_modal)).not.toBeInTheDocument();
+        userEvent.click(screen.getByText('Expires on'));
+
+        expect(screen.getByText(multipliers_expiration_modal)).toBeInTheDocument();
     });
 });

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/expiration-modal.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/expiration-modal.tsx
@@ -23,7 +23,6 @@ const MultipliersExpirationModal = ({ is_open, toggleModal }: TMultipliersExpira
                     components={[<Expiration key={0} is_text_only text_size='xs' />]}
                 />
             </Text>
-
             <Modal.Footer has_separator>
                 <Button className='dc-btn__wide' large primary has_effect text={localize('OK')} onClick={toggleModal} />
             </Modal.Footer>

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/expiration-modal.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/expiration-modal.tsx
@@ -14,28 +14,18 @@ const MultipliersExpirationModal = ({ is_open, toggleModal }: TMultipliersExpira
         toggleModal={toggleModal}
         has_close_icon={false}
         should_header_stick_body={false}
-        height='auto'
-        width='calc(100vw - 3.2rem)'
         title={<Localize i18n_default_text='Expiration' />}
     >
         <Div100vhContainer className='mobile-widget-dialog__wrapper' max_autoheight_offset='48px'>
-            <div style={{ minHeight: '120px', padding: '1.6rem' }}>
-                <Text size='xs' color='general'>
-                    <Localize
-                        i18n_default_text='Your contract will be closed automatically at the next available asset price on <0></0>.'
-                        components={[<Expiration key={0} is_text_only text_size='xs' />]}
-                    />
-                </Text>
-            </div>
-            <Modal.Footer has_separator>
-                <Button
-                    style={{ width: '100%', height: '4rem' }}
-                    large
-                    primary
-                    has_effect
-                    text={localize('OK')}
-                    onClick={toggleModal}
+            <Text size='xs' color='general' as='div' className='dc-modal-body__expiration'>
+                <Localize
+                    i18n_default_text='Your contract will be closed automatically at the next available asset price on <0></0>.'
+                    components={[<Expiration key={0} is_text_only text_size='xs' />]}
                 />
+            </Text>
+
+            <Modal.Footer has_separator>
+                <Button className='dc-btn__wide' large primary has_effect text={localize('OK')} onClick={toggleModal} />
             </Modal.Footer>
         </Div100vhContainer>
     </Modal>

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/expiration-modal.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/expiration-modal.tsx
@@ -2,14 +2,13 @@ import React from 'react';
 import { Button, Div100vhContainer, Modal, Text } from '@deriv/components';
 import { localize, Localize } from '@deriv/translations';
 import Expiration from './expiration';
-import { observer } from '@deriv/stores';
 
 type TMultipliersExpirationModalProps = {
     is_open: boolean;
     toggleModal: () => void;
 };
 
-const MultipliersExpirationModal = observer(({ is_open, toggleModal }: TMultipliersExpirationModalProps) => (
+const MultipliersExpirationModal = ({ is_open, toggleModal }: TMultipliersExpirationModalProps) => (
     <Modal
         is_open={is_open}
         toggleModal={toggleModal}
@@ -40,6 +39,6 @@ const MultipliersExpirationModal = observer(({ is_open, toggleModal }: TMultipli
             </Modal.Footer>
         </Div100vhContainer>
     </Modal>
-));
+);
 
 export default MultipliersExpirationModal;

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/expiration.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/expiration.tsx
@@ -49,7 +49,7 @@ const Expiration = observer(({ is_text_only, text_size }: TExpirationProps) => {
                 ) : null
             }
         >
-            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', marginRight: '1.6rem' }}>
+            <div className='trade-container__fieldset-expiration'>
                 {expiration ? (
                     <Text size='xs' align='center'>
                         {date} at {timestamp}

--- a/packages/trader/src/sass/app/modules/trading.scss
+++ b/packages/trader/src/sass/app/modules/trading.scss
@@ -92,6 +92,12 @@
                 transform: translateX(5px);
             }
         }
+        &-expiration {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin-right: 1.6rem;
+        }
         &-wrapper {
             &--disabled {
                 .btn-purchase__box-shadow {


### PR DESCRIPTION
## Changes:

- Add unit tests and refactored old ones for mentioned above files
- Refactored _packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/expiration.tsx, packages/trader/src/Modules/Trading/Components/Form/TradeParams/Multiplier/expiration-modal.tsx_ . Moved inline-styles to css and removed unused `observer`.

### Screenshots:

<img width="1792" alt="Screenshot 2023-11-22 at 15 49 29" src="https://github.com/binary-com/deriv-app/assets/121025168/48122559-6e52-426c-af15-b0f134e22739">
