### PR TITLE
[P2PS] Ameerul /P2PS-1937 Remove the unused observables and functions in OrderStore

### DIFF
--- a/packages/p2p/src/components/order-details/order-details.jsx
+++ b/packages/p2p/src/components/order-details/order-details.jsx
@@ -91,7 +91,6 @@ const OrderDetails = observer(() => {
         const disposeListeners = sendbird_store.registerEventListeners();
         const disposeReactions = sendbird_store.registerMobXReactions();
 
-        order_store.getSettings();
         order_store.getWebsiteStatus();
         order_store.setRatingValue(0);
         order_store.setIsRecommended(undefined);

--- a/packages/p2p/src/stores/order-store.js
+++ b/packages/p2p/src/stores/order-store.js
@@ -25,7 +25,6 @@ export default class OrderStore {
             order_payment_method_details: observable,
             order_rerender_timeout: observable,
             rating_value: observable,
-            user_email_address: observable,
             verification_code: observable,
             verification_link_error_message: observable,
             should_navigate_to_buy_sell: observable,
@@ -35,7 +34,6 @@ export default class OrderStore {
             confirmOrderRequest: action.bound,
             confirmOrder: action.bound,
             getP2POrderList: action.bound,
-            getSettings: action.bound,
             getWebsiteStatus: action.bound,
             handleRating: action.bound,
             hideDetails: action.bound,
@@ -63,14 +61,12 @@ export default class OrderStore {
             setOrders: action.bound,
             setOrderRendererTimeout: action.bound,
             setQueryDetails: action.bound,
-            setData: action.bound,
             setOrderRating: action.bound,
             subscribeToCurrentOrder: action.bound,
             syncOrder: action.bound,
             unsubscribeFromCurrentOrder: action.bound,
             verifyEmailVerificationCode: action.bound,
             setRatingValue: action.bound,
-            setUserEmailAddress: action.bound,
             setVerificationCode: action.bound,
             setVerificationLinkErrorMessage: action.bound,
         });
@@ -103,7 +99,6 @@ export default class OrderStore {
     order_payment_method_details = null;
     order_rerender_timeout = null;
     rating_value = 0;
-    user_email_address = '';
     verification_code = '';
     verification_link_error_message = '';
 
@@ -208,14 +203,6 @@ export default class OrderStore {
                         this.setOrders(list);
                     }
                 }
-            }
-        });
-    }
-
-    getSettings() {
-        requestWS({ get_settings: 1 }).then(response => {
-            if (response && !response.error) {
-                this.setUserEmailAddress(response.get_settings.email);
             }
         });
     }
@@ -554,10 +541,6 @@ export default class OrderStore {
         this.should_navigate_to_buy_sell = should_navigate_to_buy_sell;
     }
 
-    setData(data) {
-        this.data = data;
-    }
-
     setErrorCode(error_code) {
         this.error_code = error_code;
     }
@@ -605,10 +588,6 @@ export default class OrderStore {
 
     setRatingValue(rating_value) {
         this.rating_value = rating_value;
-    }
-
-    setUserEmailAddress(user_email_address) {
-        this.user_email_address = user_email_address;
     }
 
     // This is only for the order confirmation request,


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- removed `data, setData, user_email_address, setUserEmailAddress, getSettings` from order store as they were unused.
- removed getSettings from order-details component as it only called `setUserEmailAddress` which was removed.

### Screenshots:

Please provide some screenshots of the change.

Did a quick sanity check on removing the `getSettings` function in order details: 


https://github.com/binary-com/deriv-app/assets/103412909/a109d6e0-afec-4513-a932-bc258d1f83a7


