### PR TITLE
[P2PS] Ameerul /P2PS-1973 Newly created ads are being paused by default for first time ad creation.

### DIFF
--- a/packages/p2p/src/stores/general-store.js
+++ b/packages/p2p/src/stores/general-store.js
@@ -267,6 +267,7 @@ export default class GeneralStore extends BaseStore {
                 daily_sell_limit,
                 id,
                 is_approved,
+                is_listed,
                 name: advertiser_name,
             } = p2p_advertiser_create || {};
 
@@ -278,6 +279,7 @@ export default class GeneralStore extends BaseStore {
                 this.setAdvertiserBuyLimit(daily_buy_limit - daily_buy);
                 this.setAdvertiserSellLimit(daily_sell_limit - daily_sell);
                 this.setIsAdvertiser(!!is_approved);
+                this.setIsListed(!!is_listed);
                 this.setNickname(advertiser_name);
                 this.setNicknameError(undefined);
                 sendbird_store.handleP2pAdvertiserInfo(response);


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- Added `setIsListed` inside the `createAdvertiser` function to make sure the `Hide my ads` toggle is not toggled by default. 
- `setIsListed` is also called in `updateAdvertiserInfo` and even though it's a subscribable call, there will be no response after the advertiser has created their profile. Which is the original cause of the issue. 
- Thus need to keep both, one for after creating advertiser, and then in the `updateAdvertiserInfo` as this will always update the toggle, if it should be visible or not after creation of advertiser profile.

### Screenshots:

Please provide some screenshots of the change.

### Before:
https://github.com/binary-com/deriv-app/assets/103412909/3ce2852b-b1f4-40d4-8968-669113323b09

### After:
https://github.com/binary-com/deriv-app/assets/103412909/9ef2f975-bfb7-43fb-b27c-31ecb708b4ac