### PR TITLE
[CFDS] [Refactoring] Create an Atomic Button Component

### DIFF
--- a/packages/cfd/src/features/Components/button/__tests__/button.spec.tsx
+++ b/packages/cfd/src/features/Components/button/__tests__/button.spec.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Button from '../button';
+
+describe('<Button />', () => {
+    it('should renders Button with text', () => {
+        render(<Button>Click me</Button>);
+        expect(screen.getByText('Click me')).toBeInTheDocument();
+    });
+
+    it('should handle click events', () => {
+        const handleClick = jest.fn();
+        render(<Button onClick={handleClick}>Click me</Button>);
+        userEvent.click(screen.getByText('Click me'));
+        expect(handleClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('should displays loading state', () => {
+        render(<Button is_loading={true}>Click me</Button>);
+        expect(screen.getByText('Loading...')).toBeInTheDocument();
+    });
+
+    it('should disabled the Button when is_disabled is true', () => {
+        render(<Button is_disabled={true}>Click me</Button>);
+        const button = screen.getByRole('button', { name: /click me/i });
+        expect(button).toBeDisabled();
+    });
+
+    it('should renders ButtonGroup with children', () => {
+        render(
+            <Button.Group>
+                <Button>Button 1</Button>
+                <Button>Button 2</Button>
+            </Button.Group>
+        );
+        expect(screen.getByText('Button 1')).toBeInTheDocument();
+        expect(screen.getByText('Button 2')).toBeInTheDocument();
+    });
+});

--- a/packages/cfd/src/features/Components/button/button.scss
+++ b/packages/cfd/src/features/Components/button/button.scss
@@ -1,0 +1,178 @@
+.dc-btn {
+    vertical-align: middle;
+    align-items: center;
+    justify-content: center;
+    touch-action: manipulation;
+    cursor: pointer;
+    white-space: nowrap;
+    padding: 0 1.6rem;
+    display: inline-flex;
+    border: 0;
+    height: 3.2rem;
+    border-radius: 4px;
+    transition: all 0.2s cubic-bezier(0.65, 0.05, 0.36, 1);
+    outline: 0;
+    position: relative;
+    text-decoration: none;
+    user-select: none;
+    -webkit-touch-callout: none;
+    -webkit-tap-highlight-color: transparent;
+    /*
+     * Text will be transformed to sentence case in JS
+     * text-transform is declared in .dc-btn instead of .dc-btn__text
+     * to ensure consistency (even for children) as per styleguide
+     */
+    text-transform: none !important;
+
+    &__text {
+        display: flex;
+        pointer-events: none;
+    }
+    &--transparent {
+        background: transparent;
+    }
+    &__rounded {
+        border-radius: 24px;
+    }
+    &--primary {
+        background: var(--button-primary-default);
+        color: var(--text-colored-background);
+
+        &:hover:not([disabled]) {
+            background: var(--button-primary-hover);
+        }
+        &:active:not([disabled]) {
+            background: var(--button-primary-default);
+        }
+        &:disabled,
+        &[disabled] {
+            opacity: 0.32;
+            cursor: not-allowed !important;
+        }
+        .dc-btn__text,
+        .dc-btn__icon {
+            color: var(--text-colored-background);
+        }
+
+        &__light {
+            background: var(--button-primary-light-default);
+
+            &:hover:not([disabled]) {
+                background: var(--button-primary-light-hover);
+            }
+            &:active:not([disabled]) {
+                background: var(--button-primary-light-default);
+            }
+            &:disabled,
+            &[disabled] {
+                opacity: 0.32;
+                cursor: not-allowed !important;
+            }
+            .dc-btn__text,
+            .dc-btn__icon {
+                color: var(--brand-red-coral);
+            }
+        }
+    }
+    &--secondary {
+        background: transparent;
+        border: 1px solid var(--button-secondary-default);
+
+        &:hover:not([disabled]) {
+            background: var(--button-secondary-hover);
+        }
+        &:active:not([disabled]) {
+            border: 1px solid var(--button-secondary-default);
+        }
+        &:disabled,
+        &[disabled] {
+            opacity: 0.32;
+            cursor: not-allowed !important;
+        }
+        .dc-btn__text,
+        .dc-btn__icon {
+            color: var(--text-prominent);
+        }
+    }
+    &__small {
+        height: 2.4rem;
+        min-width: 4.8rem;
+        border-width: 1px;
+
+        .dc-btn__text {
+            font-size: 1.2rem;
+        }
+    }
+    &__medium {
+        height: 3.2rem;
+        min-width: 5.6rem;
+        border-width: 1px;
+
+        .dc-btn__text {
+            font-size: 1.4rem;
+        }
+    }
+    &__large {
+        height: 4rem;
+        min-width: 6.4rem;
+        border-width: 2px;
+
+        .dc-btn__text {
+            font-size: 1.4rem;
+        }
+    }
+    &__effect:focus:not(:active):after {
+        content: '';
+        position: absolute;
+        top: -0.1em;
+        left: -0.1em;
+        bottom: -0.1em;
+        right: -0.1em;
+        border-radius: inherit;
+        border: 0 solid var(--brand-secondary);
+        opacity: 0.4;
+        animation: buttonEffect 0.4s;
+        animation-fill-mode: forwards;
+        display: block;
+    }
+    &__group {
+        white-space: nowrap;
+
+        .dc-btn + .dc-btn {
+            margin-left: 8px;
+        }
+    }
+    &__button-group {
+        border-radius: 0 4px 4px 0;
+    }
+    /* TODO: confirm this button with designer are we still using this? */
+    /* postcss-bem-linter: ignore */
+    .initial-loader--btn {
+        background-color: unset;
+
+        /* postcss-bem-linter: ignore */
+        .initial-loader__barspinner--rect {
+            background-color: var(--text-colored-background);
+        }
+        /* postcss-bem-linter: ignore */
+        .barspinner {
+            margin: 0.6rem 4px 0 -4px;
+
+            /* postcss-bem-linter: ignore */
+            &__rect {
+                height: 35%;
+            }
+        }
+    }
+}
+
+@keyframes buttonEffect {
+    to {
+        opacity: 0;
+        top: -0.6em;
+        left: -0.6em;
+        bottom: -0.6em;
+        right: -0.6em;
+        border-width: 6px;
+    }
+}

--- a/packages/cfd/src/features/Components/button/button.scss
+++ b/packages/cfd/src/features/Components/button/button.scss
@@ -9,7 +9,7 @@
     display: inline-flex;
     border: 0;
     height: 3.2rem;
-    border-radius: 4px;
+    border-radius: 0.4rem;
     transition: all 0.2s cubic-bezier(0.65, 0.05, 0.36, 1);
     outline: 0;
     position: relative;
@@ -22,7 +22,7 @@
      * text-transform is declared in .dc-btn instead of .dc-btn__text
      * to ensure consistency (even for children) as per styleguide
      */
-    text-transform: none !important;
+    text-transform: none;
 
     &__text {
         display: flex;
@@ -32,7 +32,7 @@
         background: transparent;
     }
     &__rounded {
-        border-radius: 24px;
+        border-radius: 2.4rem;
     }
     &--primary {
         background: var(--button-primary-default);
@@ -47,7 +47,7 @@
         &:disabled,
         &[disabled] {
             opacity: 0.32;
-            cursor: not-allowed !important;
+            cursor: not-allowed;
         }
         .dc-btn__text,
         .dc-btn__icon {
@@ -66,7 +66,7 @@
             &:disabled,
             &[disabled] {
                 opacity: 0.32;
-                cursor: not-allowed !important;
+                cursor: not-allowed;
             }
             .dc-btn__text,
             .dc-btn__icon {
@@ -87,7 +87,7 @@
         &:disabled,
         &[disabled] {
             opacity: 0.32;
-            cursor: not-allowed !important;
+            cursor: not-allowed;
         }
         .dc-btn__text,
         .dc-btn__icon {
@@ -97,7 +97,7 @@
     &__small {
         height: 2.4rem;
         min-width: 4.8rem;
-        border-width: 1px;
+        border-width: 0.1rem;
 
         .dc-btn__text {
             font-size: 1.2rem;
@@ -106,7 +106,7 @@
     &__medium {
         height: 3.2rem;
         min-width: 5.6rem;
-        border-width: 1px;
+        border-width: 0.1rem;
 
         .dc-btn__text {
             font-size: 1.4rem;
@@ -139,11 +139,11 @@
         white-space: nowrap;
 
         .dc-btn + .dc-btn {
-            margin-left: 8px;
+            margin-left: 0.8rem;
         }
     }
     &__button-group {
-        border-radius: 0 4px 4px 0;
+        border-radius: 0 0.4rem 0.4rem 0;
     }
     /* TODO: confirm this button with designer are we still using this? */
     /* postcss-bem-linter: ignore */
@@ -156,7 +156,7 @@
         }
         /* postcss-bem-linter: ignore */
         .barspinner {
-            margin: 0.6rem 4px 0 -4px;
+            margin: 0.6rem 0.4rem 0 -0.4rem;
 
             /* postcss-bem-linter: ignore */
             &__rect {
@@ -173,6 +173,6 @@
         left: -0.6em;
         bottom: -0.6em;
         right: -0.6em;
-        border-width: 6px;
+        border-width: 0.6rem;
     }
 }

--- a/packages/cfd/src/features/Components/button/button.tsx
+++ b/packages/cfd/src/features/Components/button/button.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import classNames from 'classnames';
+import { TButtonProps, TButtonGroupProps } from './types';
+
+const ButtonGroup = ({ children, className }: TButtonGroupProps) => (
+    <div className={classNames('dc-btn__group', className)}>{children}</div>
+);
+const Button = ({
+    children,
+    className = '',
+    classNameSpan,
+    has_effect,
+    id,
+    is_disabled,
+    is_loading,
+    is_submit_success,
+    large,
+    medium,
+    onClick,
+    rounded,
+    tabIndex = 0,
+    wrapperClassName,
+    type,
+    primary,
+    primary_light,
+    secondary,
+    transparent,
+    small,
+    ...props
+}: Partial<TButtonProps>) => {
+    const classes = classNames(
+        'dc-btn',
+        {
+            'dc-btn__effect': has_effect,
+            'dc-btn--primary': primary,
+            'dc-btn--secondary': secondary,
+            'dc-btn--primary__light': primary_light,
+            'dc-btn__rounded': rounded,
+            'dc-btn__large': large,
+            'dc-btn__medium': medium,
+            'dc-btn__small': small,
+            'dc-btn--transparent': transparent,
+        },
+        className
+    );
+    const button = (
+        <button
+            id={id}
+            className={classes}
+            onClick={onClick}
+            disabled={is_disabled}
+            tabIndex={tabIndex}
+            type={is_submit_success ? 'button' : type || 'submit'}
+            {...props}
+        >
+            {is_loading && <p>Loading...</p>}
+            <p className={classNames('dc-btn__text', classNameSpan)}>{children}</p>
+        </button>
+    );
+    const wrapper = <div className={wrapperClassName}>{button}</div>;
+
+    return wrapperClassName ? wrapper : button;
+};
+
+Button.Group = ButtonGroup;
+
+export default Button;

--- a/packages/cfd/src/features/Components/button/index.ts
+++ b/packages/cfd/src/features/Components/button/index.ts
@@ -1,0 +1,4 @@
+import Button from './button';
+import './button.scss';
+
+export default Button;

--- a/packages/cfd/src/features/Components/button/types.ts
+++ b/packages/cfd/src/features/Components/button/types.ts
@@ -1,0 +1,25 @@
+export type TButtonCommonProps = {
+    has_effect: boolean;
+    is_disabled: boolean;
+    is_loading: boolean;
+    is_submit_success: boolean;
+    large: boolean;
+    medium: boolean;
+    primary: boolean;
+    primary_light: boolean;
+    rounded: boolean;
+    secondary: boolean;
+    small: boolean;
+    transparent: boolean;
+};
+export type TButtonProps = React.PropsWithChildren<React.ButtonHTMLAttributes<HTMLButtonElement>> &
+    TButtonCommonProps & {
+        classNameSpan: string;
+        type: 'button' | 'submit' | 'reset';
+        wrapperClassName: string;
+    };
+
+export type TButtonGroupProps = {
+    children: React.ReactNode | React.ReactNode[];
+    className?: string;
+};


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.

#### Description:
> This card serves the purpose of crafting an atomic Button Component tailored for the CFD package. Designed with precision, this component ensures seamless integration and optimal functionality withdifferent CFD environments. With a focus on modularity and efficiency, the atomic Button Component enhances the user experience, providing a robust and cohesive interface for CFD-related interactions.

#### Scope:

- [x] Add an Atomic Button Component in the features folder.

#### Expected Behaviour:

> An Atomic Button Component is added in the features/Components

- [x] - Having CTA as separate Components
- [x] - Have its own sass file
- [x] -  Include the unit tests
- [x] - Exported as default Button component.

### Screenshots:

Please provide some screenshots of the change.


#### After
<img width="328" alt="image" src="https://github.com/binary-com/deriv-app/assets/120543468/4972f354-46aa-41ee-be32-9c27faf98e1a">

