### PR TITLE
[P2PS]-fix: issue where reason was not listed for fixed-to-float or viceversa

### DIFF
--- a/packages/p2p/src/pages/my-ads/my-ads-row-renderer.jsx
+++ b/packages/p2p/src/pages/my-ads/my-ads-row-renderer.jsx
@@ -100,6 +100,8 @@ const MyAdsRowRenderer = observer(({ row: advert }) => {
             updated_visibility_status = [...updated_visibility_status, 'advertiser_ads_paused'];
         if (!enable_action_point && updated_visibility_status.includes('advert_inactive'))
             updated_visibility_status = updated_visibility_status.filter(status => status !== 'advert_inactive');
+        if (enable_action_point && !updated_visibility_status.includes('advert_inactive'))
+            updated_visibility_status = [...updated_visibility_status, 'advert_inactive'];
         return updated_visibility_status;
     };
 


### PR DESCRIPTION
Currently when an ad is in floating rate, and in BO the rate is changed to fixed rate, or ad is in fixed and in BO the rate is changed to floating rate, the indication for the hidden ad will not be given. Its because the reason is determined based on the code obtained from the <visibility_status> field which appears only when the cron job is run. In production since the cron job is run only once in 24 hours, by any chance if the rate is changed and cron job is not run, the reason will not be visible. This PR fixes the issue by manually stating the reason until the value is received from BE.

### Screenshots:

Please provide some screenshots of the change.
