### PR TITLE
[Bot] fix: change tooltip position to top in QS modal for desktop view

### DIFF
--- a/packages/bot-web-ui/src/components/quick-strategy/inputs/qs-checkbox.tsx
+++ b/packages/bot-web-ui/src/components/quick-strategy/inputs/qs-checkbox.tsx
@@ -45,12 +45,7 @@ const QSCheckbox: React.FC<TQSCheckbox> = observer(
                                         data-testid='qs-checkbox'
                                     />
                                     <span>
-                                        <Popover
-                                            message={description}
-                                            zIndex='9999'
-                                            alignment={is_mobile ? 'top' : 'right'}
-                                            icon='info'
-                                        />
+                                        <Popover message={description} zIndex='9999' alignment='top' icon='info' />
                                     </span>
                                 </div>
                             </div>

--- a/packages/bot-web-ui/src/components/quick-strategy/inputs/qs-input-label.tsx
+++ b/packages/bot-web-ui/src/components/quick-strategy/inputs/qs-input-label.tsx
@@ -21,7 +21,7 @@ const QSInputLabel: React.FC<TQSInputLabel> = observer(({ label, description, fu
                     {label}
                 </Text>
                 <span>
-                    <Popover message={description} zIndex='9999' alignment={is_mobile ? 'top' : 'right'} icon='info' />
+                    <Popover message={description} zIndex='9999' alignment='top' icon='info' />
                 </span>
             </div>
         </div>


### PR DESCRIPTION
## Changes:

Made change in QS modal in bots , so that popover message appears at the top of lable.

### Screenshots:

<img width="739" alt="Screenshot 2023-11-22 at 5 00 14 PM" src="https://github.com/binary-com/deriv-app/assets/100689171/260ce18c-c9b4-4c96-b367-ffbfa1092489">

