### PR TITLE
[P2PS]-fix: advertiser badges not showing on initial load

### DIFF
--- a/packages/p2p/src/pages/advertiser-page/advertiser-page.jsx
+++ b/packages/p2p/src/pages/advertiser-page/advertiser-page.jsx
@@ -323,31 +323,29 @@ const AdvertiserPage = () => {
                             {!isEmptyObject(info) && (
                                 <div className='advertiser-page__rating'>
                                     <DesktopWrapper>
-                                        <React.Fragment>
-                                            <div className='advertiser-page__rating--row'>
-                                                <OnlineStatusIcon is_online={is_online} />
-                                                <OnlineStatusLabel
-                                                    is_online={is_online}
-                                                    last_online_time={last_online_time}
-                                                />
-                                            </div>
-                                            <div className='advertiser-page__rating--row'>
-                                                <Text
-                                                    className='advertiser-page__joined-since'
-                                                    color='less-prominent'
-                                                    size='xs'
-                                                >
-                                                    {joined_since ? (
-                                                        <Localize
-                                                            i18n_default_text='Joined {{days_since_joined}}d'
-                                                            values={{ days_since_joined: joined_since }}
-                                                        />
-                                                    ) : (
-                                                        <Localize i18n_default_text='Joined today' />
-                                                    )}
-                                                </Text>
-                                            </div>
-                                        </React.Fragment>
+                                        <div className='advertiser-page__rating--row'>
+                                            <OnlineStatusIcon is_online={is_online} />
+                                            <OnlineStatusLabel
+                                                is_online={is_online}
+                                                last_online_time={last_online_time}
+                                            />
+                                        </div>
+                                        <div className='advertiser-page__rating--row'>
+                                            <Text
+                                                className='advertiser-page__joined-since'
+                                                color='less-prominent'
+                                                size='xs'
+                                            >
+                                                {joined_since ? (
+                                                    <Localize
+                                                        i18n_default_text='Joined {{days_since_joined}}d'
+                                                        values={{ days_since_joined: joined_since }}
+                                                    />
+                                                ) : (
+                                                    <Localize i18n_default_text='Joined today' />
+                                                )}
+                                            </Text>
+                                        </div>
                                     </DesktopWrapper>
                                     {rating_average ? (
                                         <React.Fragment>

--- a/packages/p2p/src/pages/advertiser-page/advertiser-page.jsx
+++ b/packages/p2p/src/pages/advertiser-page/advertiser-page.jsx
@@ -5,7 +5,7 @@ import { useP2PAdvertiserAdverts } from 'Hooks';
 import { useHistory, useLocation } from 'react-router-dom';
 import { DesktopWrapper, Loading, MobileWrapper, Text } from '@deriv/components';
 import { useP2PAdvertInfo } from '@deriv/hooks';
-import { daysSince, isDesktop, isMobile, routes } from '@deriv/shared';
+import { daysSince, isDesktop, isEmptyObject, isMobile, routes } from '@deriv/shared';
 import { observer } from '@deriv/stores';
 
 import { Localize, localize } from 'Components/i18next';
@@ -170,6 +170,7 @@ const AdvertiserPage = () => {
             disposeCounterpartyAdvertiserIdReaction();
             advertiser_page_store.onUnmount();
             buy_sell_store.setShowAdvertiserPage(false);
+            advertiser_page_store.setCounterpartyAdvertiserInfo({});
         };
 
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -319,82 +320,84 @@ const AdvertiserPage = () => {
                                     </div>
                                 </div>
                             </MobileWrapper>
-                            <div className='advertiser-page__rating'>
-                                <DesktopWrapper>
-                                    <React.Fragment>
-                                        <div className='advertiser-page__rating--row'>
-                                            <OnlineStatusIcon is_online={is_online} />
-                                            <OnlineStatusLabel
-                                                is_online={is_online}
-                                                last_online_time={last_online_time}
-                                            />
-                                        </div>
-                                        <div className='advertiser-page__rating--row'>
-                                            <Text
-                                                className='advertiser-page__joined-since'
-                                                color='less-prominent'
-                                                size='xs'
-                                            >
-                                                {joined_since ? (
-                                                    <Localize
-                                                        i18n_default_text='Joined {{days_since_joined}}d'
-                                                        values={{ days_since_joined: joined_since }}
-                                                    />
-                                                ) : (
-                                                    <Localize i18n_default_text='Joined today' />
-                                                )}
-                                            </Text>
-                                        </div>
-                                    </React.Fragment>
-                                </DesktopWrapper>
-                                {rating_average ? (
-                                    <React.Fragment>
-                                        <div className='advertiser-page__rating--row'>
-                                            <Text color='prominent' size={isMobile() ? 'xxxs' : 'xs'}>
-                                                {rating_average_decimal}
-                                            </Text>
-                                            <StarRating
-                                                empty_star_className='advertiser-page__rating--star'
-                                                empty_star_icon='IcEmptyStar'
-                                                full_star_className='advertiser-page__rating--star'
-                                                full_star_icon='IcFullStar'
-                                                initial_value={rating_average_decimal}
-                                                is_readonly
-                                                number_of_stars={5}
-                                                should_allow_hover_effect={false}
-                                                star_size={isMobile() ? 17 : 20}
-                                            />
-                                            <div className='advertiser-page__rating--text'>
-                                                <Text color='less-prominent' size={isMobile() ? 'xxxs' : 'xs'}>
-                                                    {rating_count === 1 ? (
+                            {!isEmptyObject(info) && (
+                                <div className='advertiser-page__rating'>
+                                    <DesktopWrapper>
+                                        <React.Fragment>
+                                            <div className='advertiser-page__rating--row'>
+                                                <OnlineStatusIcon is_online={is_online} />
+                                                <OnlineStatusLabel
+                                                    is_online={is_online}
+                                                    last_online_time={last_online_time}
+                                                />
+                                            </div>
+                                            <div className='advertiser-page__rating--row'>
+                                                <Text
+                                                    className='advertiser-page__joined-since'
+                                                    color='less-prominent'
+                                                    size='xs'
+                                                >
+                                                    {joined_since ? (
                                                         <Localize
-                                                            i18n_default_text='({{number_of_ratings}} rating)'
-                                                            values={{ number_of_ratings: rating_count }}
+                                                            i18n_default_text='Joined {{days_since_joined}}d'
+                                                            values={{ days_since_joined: joined_since }}
                                                         />
                                                     ) : (
-                                                        <Localize
-                                                            i18n_default_text='({{number_of_ratings}} ratings)'
-                                                            values={{ number_of_ratings: rating_count }}
-                                                        />
+                                                        <Localize i18n_default_text='Joined today' />
                                                     )}
                                                 </Text>
                                             </div>
-                                        </div>
+                                        </React.Fragment>
+                                    </DesktopWrapper>
+                                    {rating_average ? (
+                                        <React.Fragment>
+                                            <div className='advertiser-page__rating--row'>
+                                                <Text color='prominent' size={isMobile() ? 'xxxs' : 'xs'}>
+                                                    {rating_average_decimal}
+                                                </Text>
+                                                <StarRating
+                                                    empty_star_className='advertiser-page__rating--star'
+                                                    empty_star_icon='IcEmptyStar'
+                                                    full_star_className='advertiser-page__rating--star'
+                                                    full_star_icon='IcFullStar'
+                                                    initial_value={rating_average_decimal}
+                                                    is_readonly
+                                                    number_of_stars={5}
+                                                    should_allow_hover_effect={false}
+                                                    star_size={isMobile() ? 17 : 20}
+                                                />
+                                                <div className='advertiser-page__rating--text'>
+                                                    <Text color='less-prominent' size={isMobile() ? 'xxxs' : 'xs'}>
+                                                        {rating_count === 1 ? (
+                                                            <Localize
+                                                                i18n_default_text='({{number_of_ratings}} rating)'
+                                                                values={{ number_of_ratings: rating_count }}
+                                                            />
+                                                        ) : (
+                                                            <Localize
+                                                                i18n_default_text='({{number_of_ratings}} ratings)'
+                                                                values={{ number_of_ratings: rating_count }}
+                                                            />
+                                                        )}
+                                                    </Text>
+                                                </div>
+                                            </div>
+                                            <div className='advertiser-page__rating--row'>
+                                                <RecommendedBy
+                                                    recommended_average={recommended_average}
+                                                    recommended_count={recommended_count}
+                                                />
+                                            </div>
+                                        </React.Fragment>
+                                    ) : (
                                         <div className='advertiser-page__rating--row'>
-                                            <RecommendedBy
-                                                recommended_average={recommended_average}
-                                                recommended_count={recommended_count}
-                                            />
+                                            <Text color='less-prominent' size={isMobile() ? 'xxxs' : 'xs'}>
+                                                <Localize i18n_default_text='Not rated yet' />
+                                            </Text>
                                         </div>
-                                    </React.Fragment>
-                                ) : (
-                                    <div className='advertiser-page__rating--row'>
-                                        <Text color='less-prominent' size={isMobile() ? 'xxxs' : 'xs'}>
-                                            <Localize i18n_default_text='Not rated yet' />
-                                        </Text>
-                                    </div>
-                                )}
-                            </div>
+                                    )}
+                                </div>
+                            )}
                             <div className='advertiser-page__row'>
                                 <TradeBadge
                                     is_poa_verified={!!full_verification}

--- a/packages/p2p/src/stores/advertiser-page-store.js
+++ b/packages/p2p/src/stores/advertiser-page-store.js
@@ -20,6 +20,7 @@ export default class AdvertiserPageStore extends BaseStore {
 
         makeObservable(this, {
             active_index: observable,
+            counterparty_advertiser_info: observable,
             counterparty_type: observable,
             api_error_message: observable,
             form_error_message: observable,


### PR DESCRIPTION
## Changes:

Currently in production, when a user visits client A, then goes back to buy sell page and then visits client B, we could see the details of client A in client B's page. This PR is to fix the issue. 

### Screenshots:

Please provide some screenshots of the change.
