### PR TITLE
[WALL] Sergei / wall - 2728 / CFDs and Options and multipliers text is displayed in blue color on iOS

### DIFF
--- a/packages/wallets/src/components/WalletsPrimaryTabs/WalletsPrimaryTabList.scss
+++ b/packages/wallets/src/components/WalletsPrimaryTabs/WalletsPrimaryTabList.scss
@@ -23,6 +23,7 @@
                 background-color: #ffffff;
                 margin: 0.6rem;
                 border-radius: 0.5rem;
+                color: var(--system-light-1-prominent-text, #333);
             }
 
             &--disabled {


### PR DESCRIPTION
## Changes:

- add color #333 for active tabs

## Card:

https://app.clickup.com/t/20696747/WALL-2728

### Screenshots:

![image](https://github.com/binary-com/deriv-app/assets/120570511/22ba7c80-c11d-4da5-99b8-02cc8fce17fc)
