### PR TITLE
WALL-2749/feat: add error modal to cfd

### DIFF
--- a/packages/wallets/src/features/cashier/modules/WithdrawalCrypto/components/WithdrawalCryptoForm/components/WithdrawalCryptoAmountConverter/WithdrawalCryptoAmountConverter.tsx
+++ b/packages/wallets/src/features/cashier/modules/WithdrawalCrypto/components/WithdrawalCryptoForm/components/WithdrawalCryptoAmountConverter/WithdrawalCryptoAmountConverter.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import classNames from 'classnames';
 import { Field, FieldProps, useFormikContext } from 'formik';
-import ArrowBold from '../../../../../../../../public/images/ic-back-arrow.svg';
 import { WalletTextField } from '../../../../../../../../components';
+import ArrowBold from '../../../../../../../../public/images/ic-back-arrow.svg';
 import type { THooks } from '../../../../../../../../types';
 import type { TForm } from '../../WithdrawalCryptoForm';
 import './WithdrawalCryptoAmountConverter.scss';
@@ -46,7 +46,15 @@ const WithdrawalCryptoAmountConverter = ({ activeWallet, exchangeRate, getCurren
                     ),
                 });
         }
-    }, [activeWallet?.currency, exchangeRate?.rates]);
+    }, [
+        FRACTIONAL_DIGITS_CRYPTO,
+        FRACTIONAL_DIGITS_FIAT,
+        activeWallet?.currency,
+        exchangeRate?.rates,
+        isCryptoInputActive,
+        setValues,
+        values,
+    ]);
 
     const validateCryptoInput = (value: string) => {
         if (!value.length) return;

--- a/packages/wallets/src/features/cfd/modals/DxtradeEnterPasswordModal/DxtradeEnterPasswordModal.tsx
+++ b/packages/wallets/src/features/cfd/modals/DxtradeEnterPasswordModal/DxtradeEnterPasswordModal.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useAccountStatus, useActiveWalletAccount, useCreateOtherCFDAccount, useDxtradeAccountsList } from '@deriv/api';
-import { SentEmailContent } from '../../../../components';
+import { SentEmailContent, WalletError } from '../../../../components';
 import { ModalStepWrapper, ModalWrapper, WalletButton, WalletButtonGroup } from '../../../../components/Base';
 import { useModal } from '../../../../components/ModalProvider';
 import useDevice from '../../../../hooks/useDevice';
@@ -14,7 +14,7 @@ const DxtradeEnterPasswordModal = () => {
     const { isMobile } = useDevice();
     const [password, setPassword] = useState('');
     const { data: getAccountStatus, isSuccess: accountStatusSuccess } = useAccountStatus();
-    const { isLoading, isSuccess, mutate } = useCreateOtherCFDAccount();
+    const { error, isLoading, isSuccess, mutate, status } = useCreateOtherCFDAccount();
     const { data: dxtradeAccount, isSuccess: dxtradeAccountListSuccess } = useDxtradeAccountsList();
     const { data: activeWallet } = useActiveWalletAccount();
     const { hide, show } = useModal();
@@ -117,6 +117,10 @@ const DxtradeEnterPasswordModal = () => {
             );
         }
     }, [isSuccess, accountStatusSuccess, show, isDxtradePasswordNotSet, isLoading, onSubmit, password]);
+
+    if (status === 'error') {
+        return <WalletError errorMessage={error?.error.message} onClick={() => hide()} title={error?.error?.code} />;
+    }
 
     if (isMobile) {
         return (

--- a/packages/wallets/src/features/cfd/modals/JurisdictionModal/JurisdictionModal.tsx
+++ b/packages/wallets/src/features/cfd/modals/JurisdictionModal/JurisdictionModal.tsx
@@ -52,7 +52,7 @@ const JurisdictionModal = () => {
 
     useEffect(() => {
         setModalState('selectedJurisdiction', selectedJurisdiction);
-    }, [selectedJurisdiction]);
+    }, [selectedJurisdiction, setModalState]);
 
     if (isLoading) return <h1>Loading...</h1>;
 

--- a/packages/wallets/src/features/cfd/modals/MT5PasswordModal/MT5PasswordModal.tsx
+++ b/packages/wallets/src/features/cfd/modals/MT5PasswordModal/MT5PasswordModal.tsx
@@ -7,7 +7,7 @@ import {
     useSettings,
     useTradingPlatformPasswordChange,
 } from '@deriv/api';
-import { SentEmailContent } from '../../../../components';
+import { SentEmailContent, WalletError } from '../../../../components';
 import { ModalStepWrapper, ModalWrapper, WalletButton, WalletButtonGroup } from '../../../../components/Base';
 import { useModal } from '../../../../components/ModalProvider';
 import useDevice from '../../../../hooks/useDevice';
@@ -23,7 +23,7 @@ type TProps = {
 
 const MT5PasswordModal: React.FC<TProps> = ({ marketType, platform }) => {
     const [password, setPassword] = useState('');
-    const { isLoading: createMT5AccountLoading, isSuccess, mutate } = useCreateMT5Account();
+    const { error, isLoading: createMT5AccountLoading, isSuccess, mutate, status } = useCreateMT5Account();
     const { isLoading: tradingPlatformPasswordChangeLoading, mutate: tradingPasswordChange } =
         useTradingPlatformPasswordChange();
     const { data: activeWallet } = useActiveWalletAccount();
@@ -176,6 +176,10 @@ const MT5PasswordModal: React.FC<TProps> = ({ marketType, platform }) => {
                     ))}
             </ModalStepWrapper>
         );
+    }
+
+    if (status === 'error') {
+        return <WalletError errorMessage={error?.error.message} onClick={() => hide()} title={error?.error?.code} />;
     }
 
     return (

--- a/packages/wallets/src/features/cfd/screens/EnterPassword/EnterPassword.tsx
+++ b/packages/wallets/src/features/cfd/screens/EnterPassword/EnterPassword.tsx
@@ -3,6 +3,7 @@ import { useActiveWalletAccount } from '@deriv/api';
 import { WalletButton, WalletPasswordField, WalletText } from '../../../../components/Base';
 import useDevice from '../../../../hooks/useDevice';
 import { TMarketTypes, TPlatforms } from '../../../../types';
+import { validPassword } from '../../../../utils/passwordUtils';
 import { PlatformDetails } from '../../constants';
 import './EnterPassword.scss';
 
@@ -47,7 +48,7 @@ const EnterPassword: React.FC<TProps> = ({
                 <div className='wallets-enter-password__buttons'>
                     <WalletButton onClick={onSecondaryClick} size='lg' text='Forgot password?' variant='outlined' />
                     <WalletButton
-                        disabled={!password || isLoading}
+                        disabled={!password || isLoading || !validPassword(password)}
                         isLoading={isLoading}
                         onClick={onPrimaryClick}
                         size='lg'


### PR DESCRIPTION
## Changes:
1. Add error modal to show if there is any error when creating cfd account from BE

### Screenshots:

https://github.com/binary-com/deriv-app/assets/104053934/69c1576f-19c6-4a27-85d5-df35a4db2af7


