### PR TITLE
[WALL] [Fix] Rostislav / WALL-2731 / Temporary workaround for BE `statement` and `mt5_login_list` accounts `loginid` mimatch

### DIFF
--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/components/TransactionsCompletedRowTransferAccountDetails/TransactionsCompletedRowTransferAccountDetails.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/components/TransactionsCompletedRowTransferAccountDetails/TransactionsCompletedRowTransferAccountDetails.tsx
@@ -13,7 +13,10 @@ const TransactionsCompletedRowTransferAccountDetails: React.FC<TProps> = ({ acco
     const wallet = accounts.wallets?.find(account => account.loginid === loginid);
     const dtradeAccount = accounts.dtrade?.find(account => account.loginid === loginid);
     const dxtradeAccount = accounts.dxtrade?.find(account => account.login === loginid);
-    const mt5Account = accounts.mt5?.find(account => account.login === loginid);
+    // TODO: remove the `replace` calls once backend resolves `statement` and `mt5_login_list` accounts `loginid` inconsistency
+    const mt5Account = accounts.mt5?.find(
+        account => account.login?.replace(/^\D+/g, '') === loginid.replace(/^\D+/g, '')
+    );
     const ctraderAccount = accounts.ctrader?.find(account => account.login === loginid);
 
     const transferAccount = [wallet, dtradeAccount, dxtradeAccount, mt5Account, ctraderAccount].find(Boolean);


### PR DESCRIPTION
## Changes:

Transfer transaction lookup now has a temporary workaround for BE `statement` and `mt5_login_list` accounts `loginid` mismatch

### Screenshots:

<img width="1123" alt="Screenshot 2023-11-24 at 11 21 04" src="https://github.com/binary-com/deriv-app/assets/119863957/4ff0b5f1-844a-4619-ab14-ae6b0c11fea6">
