### PR TITLE
[COJ]likhith/[COJ-210]/fix: changed condition for POA trigger based on jurisdiction

### DIFF
--- a/packages/cfd/src/Containers/__tests__/cfd-financial-stp-real-account-signup.spec.js
+++ b/packages/cfd/src/Containers/__tests__/cfd-financial-stp-real-account-signup.spec.js
@@ -84,6 +84,15 @@ describe('<CFDFinancialStpRealAccountSignup />', () => {
         jest.clearAllMocks();
     });
 
+    const authenticated_with_idv = {
+        bvi: 1,
+        labuan: 1,
+        maltainvest: 0,
+        svg: 1,
+        vanuatu: 0,
+        virtual: 0,
+    };
+
     let mockRootStore = {
         notifications: {
             addNotificationByKey: jest.fn(),
@@ -125,6 +134,13 @@ describe('<CFDFinancialStpRealAccountSignup />', () => {
                 tax_identification_number: null,
                 tax_residence: null,
                 user_hash: '823341c18bfccb391b6bb5d77ab7e6a83991f82669c1ba4e5b01dbd2fd71c7fe',
+            },
+            account_status: {
+                authentication: {
+                    document: {
+                        authenticated_with_idv,
+                    },
+                },
             },
             authentication_status: {
                 document_status: 'none',
@@ -234,8 +250,26 @@ describe('<CFDFinancialStpRealAccountSignup />', () => {
     });
 
     it('should check for POA status when Jurisdiction is Labuan and resubmit status is set to true', () => {
+        const authenticated_with_idv = {
+            bvi: 1,
+            labuan: 0,
+            maltainvest: 0,
+            svg: 1,
+            vanuatu: 0,
+            virtual: 0,
+        };
         const new_mock_store = {
             ...mockRootStore,
+            client: {
+                ...mockRootStore.client,
+                account_status: {
+                    authentication: {
+                        document: {
+                            authenticated_with_idv,
+                        },
+                    },
+                },
+            },
             modules: {
                 ...mockRootStore.modules,
                 cfd: {

--- a/packages/cfd/src/Containers/cfd-financial-stp-real-account-signup.tsx
+++ b/packages/cfd/src/Containers/cfd-financial-stp-real-account-signup.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Div100vhContainer } from '@deriv/components';
-import { useIsAccountStatusPresent } from '@deriv/hooks';
-import { isDesktop, getAuthenticationStatusInfo } from '@deriv/shared';
+import { isDesktop, getAuthenticationStatusInfo, isPOARequiredForMT5 } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
 import type { TCoreStores } from '@deriv/stores/types';
 import CFDPOA from '../Components/cfd-poa';
@@ -87,8 +86,6 @@ const CFDFinancialStpRealAccountSignup = observer(({ onFinish }: TCFDFinancialSt
 
     const { need_poi_for_maltainvest, need_poi_for_bvi_labuan_vanuatu } = getAuthenticationStatusInfo(account_status);
 
-    const is_authenticated_with_idv_photoid = useIsAccountStatusPresent('authenticated_with_idv_photoid');
-
     const poi_config: TItemsState<typeof passthroughProps> = {
         body: CFDPOI,
         form_value: {
@@ -130,10 +127,7 @@ const CFDFinancialStpRealAccountSignup = observer(({ onFinish }: TCFDFinancialSt
     };
 
     const shouldShowPOA = () => {
-        if (JURISDICTION.LABUAN === jurisdiction_selected_shortcode && is_authenticated_with_idv_photoid) {
-            return true;
-        }
-        return !['pending', 'verified'].includes(authentication_status.document_status);
+        return isPOARequiredForMT5(account_status, jurisdiction_selected_shortcode);
     };
 
     const should_show_personal_details =
@@ -194,20 +188,13 @@ const CFDFinancialStpRealAccountSignup = observer(({ onFinish }: TCFDFinancialSt
 
     const form_value = getCurrent('form_value');
 
-    const passthrough: Partial<TCFDFinancialStpRealAccountSignupProps> & {
-        is_authenticated_with_idv_photoid?: boolean;
-    } = ((getCurrent('forwarded_props') || []) as TItemsState<typeof passthroughProps>['forwarded_props']).reduce(
-        (forwarded_prop, item) => {
-            return Object.assign(forwarded_prop, {
-                [item]: passthroughProps[item],
-            });
-        },
-        {}
-    );
-
-    if (shouldShowPOA()) {
-        passthrough.is_authenticated_with_idv_photoid = is_authenticated_with_idv_photoid;
-    }
+    const passthrough: Partial<TCFDFinancialStpRealAccountSignupProps> = (
+        (getCurrent('forwarded_props') || []) as TItemsState<typeof passthroughProps>['forwarded_props']
+    ).reduce((forwarded_prop, item) => {
+        return Object.assign(forwarded_prop, {
+            [item]: passthroughProps[item],
+        });
+    }, {});
 
     return (
         <Div100vhContainer

--- a/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal-content-wrapper.tsx
+++ b/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal-content-wrapper.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import React from 'react';
 import { Button, Modal } from '@deriv/components';
-import { getAuthenticationStatusInfo } from '@deriv/shared';
+import { getAuthenticationStatusInfo, isPOARequiredForMT5 } from '@deriv/shared';
 import { localize } from '@deriv/translations';
 import { TJurisdictionModalContentWrapperProps } from '../props.types';
 import JurisdictionModalContent from './jurisdiction-modal-content';
@@ -50,7 +50,6 @@ const JurisdictionModalContentWrapper = observer(({ openPasswordModal }: TJurisd
         poi_acknowledged_for_maltainvest,
         poa_acknowledged,
         need_poa_resubmission,
-        poa_resubmit_for_labuan,
     } = getAuthenticationStatusInfo(account_status);
 
     React.useEffect(() => {
@@ -146,6 +145,8 @@ const JurisdictionModalContentWrapper = observer(({ openPasswordModal }: TJurisd
             type: account_type.type,
         };
 
+        const is_poa_required_for_mt5 = isPOARequiredForMT5(account_status, jurisdiction_selected_shortcode);
+
         if (is_svg_selected) {
             openPasswordModal(type_of_account);
         } else if (is_vanuatu_selected) {
@@ -154,7 +155,8 @@ const JurisdictionModalContentWrapper = observer(({ openPasswordModal }: TJurisd
                 !poi_or_poa_not_submitted &&
                 !should_restrict_vanuatu_account_creation &&
                 poa_acknowledged &&
-                has_submitted_cfd_personal_details
+                has_submitted_cfd_personal_details &&
+                !is_poa_required_for_mt5
             ) {
                 openPasswordModal(type_of_account);
             } else {
@@ -166,7 +168,8 @@ const JurisdictionModalContentWrapper = observer(({ openPasswordModal }: TJurisd
                 !poi_or_poa_not_submitted &&
                 !should_restrict_bvi_account_creation &&
                 poa_acknowledged &&
-                has_submitted_cfd_personal_details
+                has_submitted_cfd_personal_details &&
+                !is_poa_required_for_mt5
             ) {
                 openPasswordModal(type_of_account);
             } else {
@@ -177,7 +180,7 @@ const JurisdictionModalContentWrapper = observer(({ openPasswordModal }: TJurisd
                 poi_acknowledged_for_bvi_labuan_vanuatu &&
                 poa_acknowledged &&
                 has_submitted_cfd_personal_details &&
-                !poa_resubmit_for_labuan
+                !is_poa_required_for_mt5
             ) {
                 openPasswordModal(type_of_account);
             } else {

--- a/packages/hooks/src/useIsAccountStatusPresent.ts
+++ b/packages/hooks/src/useIsAccountStatusPresent.ts
@@ -8,7 +8,6 @@ const AccountStatusList = [
     'allow_poa_resubmission',
     'allow_poi_resubmission',
     'authenticated',
-    'authenticated_with_idv_photoid',
     'cashier_locked',
     'crs_tin_information',
     'deposit_attempt',

--- a/packages/shared/src/utils/cfd/cfd.ts
+++ b/packages/shared/src/utils/cfd/cfd.ts
@@ -348,7 +348,6 @@ export const getAuthenticationStatusInfo = (account_status: GetAccountStatus): T
         manual: { status: manual_status } = {},
     } = services;
 
-    // const is_authenticated_with_idv_photoid = account_status?.status?.includes('authenticated_with_idv_photoid');
     const is_idv_revoked = account_status?.status?.includes('idv_revoked');
 
     const acknowledged_status: string[] = ['pending', 'verified'];

--- a/packages/shared/src/utils/cfd/cfd.ts
+++ b/packages/shared/src/utils/cfd/cfd.ts
@@ -332,7 +332,6 @@ type TAuthenticationStatusInfo = {
     poi_resubmit_for_maltainvest: boolean;
     poi_resubmit_for_bvi_labuan_vanuatu: boolean;
     poa_pending: boolean;
-    poa_resubmit_for_labuan: boolean;
     is_idv_revoked: boolean;
 };
 
@@ -349,7 +348,7 @@ export const getAuthenticationStatusInfo = (account_status: GetAccountStatus): T
         manual: { status: manual_status } = {},
     } = services;
 
-    const is_authenticated_with_idv_photoid = account_status?.status?.includes('authenticated_with_idv_photoid');
+    // const is_authenticated_with_idv_photoid = account_status?.status?.includes('authenticated_with_idv_photoid');
     const is_idv_revoked = account_status?.status?.includes('idv_revoked');
 
     const acknowledged_status: string[] = ['pending', 'verified'];
@@ -419,7 +418,6 @@ export const getAuthenticationStatusInfo = (account_status: GetAccountStatus): T
         !poi_verified_for_bvi_labuan_vanuatu;
 
     const poi_poa_verified_for_bvi_labuan_vanuatu: boolean = poi_verified_for_bvi_labuan_vanuatu && poa_verified;
-    const poa_resubmit_for_labuan = is_authenticated_with_idv_photoid;
 
     return {
         poa_status,
@@ -450,7 +448,6 @@ export const getAuthenticationStatusInfo = (account_status: GetAccountStatus): T
         poi_resubmit_for_maltainvest,
         poi_resubmit_for_bvi_labuan_vanuatu,
         poa_pending,
-        poa_resubmit_for_labuan,
         is_idv_revoked,
     };
 };
@@ -510,4 +507,10 @@ export const getMT5AccountTitle = ({ account_type, jurisdiction }: TGetMT5Accoun
     return `${getCFDPlatformNames(CFD_PLATFORMS.MT5)} ${getFormattedJurisdictionMarketTypes(
         account_type
     )} ${getFormattedJurisdictionCode(jurisdiction)}`;
+};
+
+export const isPOARequiredForMT5 = (account_status: GetAccountStatus, jurisdiction_shortcode: string) => {
+    const { authentication } = account_status;
+    // @ts-expect-error as the prop authenticated_with_idv is not yet present in GetAccountStatus
+    return !authentication?.document?.authenticated_with_idv[jurisdiction_shortcode];
 };


### PR DESCRIPTION
## Changes:

Changed the POA trigger condition used during MT5 account creation based on the below conditions
IDV verification status:

- IDV authenticated with POA scan - applicable for DBVI, DFX and DVL
- IDV authenticated with photo - applicable for DBVI
- IDV authenticated with address - applicable for DBVI
- IDV authenticated with photo + address - applicable for DBVI & DFX
