### PR TITLE
WALL-2762/fix: account name in enter password modal

### DIFF
--- a/packages/wallets/src/features/cfd/screens/EnterPassword/EnterPassword.tsx
+++ b/packages/wallets/src/features/cfd/screens/EnterPassword/EnterPassword.tsx
@@ -4,7 +4,7 @@ import { WalletButton, WalletPasswordField, WalletText } from '../../../../compo
 import useDevice from '../../../../hooks/useDevice';
 import { TMarketTypes, TPlatforms } from '../../../../types';
 import { validPassword } from '../../../../utils/passwordUtils';
-import { PlatformDetails } from '../../constants';
+import { MarketTypeDetails, PlatformDetails } from '../../constants';
 import './EnterPassword.scss';
 
 // TODO: Refactor the unnecessary props out once FlowProvider is integrated
@@ -31,7 +31,7 @@ const EnterPassword: React.FC<TProps> = ({
     const title = PlatformDetails[platform].title;
     const { data } = useActiveWalletAccount();
     const accountType = data?.is_virtual ? 'Demo' : 'Real';
-    const marketTypeTitle = platform === 'dxtrade' ? accountType : marketType;
+    const marketTypeTitle = platform === 'dxtrade' ? accountType : MarketTypeDetails[marketType].title;
 
     return (
         <div className='wallets-enter-password'>


### PR DESCRIPTION
## Changes:
1. Fixed to show the correct account name in enter password modal for MT5 

### Screenshots:
Before: 

https://github.com/binary-com/deriv-app/assets/104053934/4c250e31-8329-4578-93b6-5ce5e5eea6c7

After:


https://github.com/binary-com/deriv-app/assets/104053934/c45e056d-fd26-4ed8-9b83-c7f3a4286607

