### PR TITLE
WALL-2764/chore: fix swap free title in success modal

### DIFF
--- a/packages/wallets/src/features/cfd/screens/CFDSuccess/CFDSuccess.tsx
+++ b/packages/wallets/src/features/cfd/screens/CFDSuccess/CFDSuccess.tsx
@@ -36,13 +36,13 @@ const CFDSuccess: React.FC<TSuccessProps> = ({
     const isDemo = data?.is_virtual;
     const landingCompanyName = landingCompany.toUpperCase();
 
-    const isMarketTypeAll = marketType === 'all';
+    const isAllDxtrade = marketType === 'all' && platform === 'dxtrade';
 
     let marketTypeTitle = 'Deriv Apps';
 
     if (marketType && platform) {
         const isPlatformValid = Object.keys(PlatformDetails).includes(platform);
-        if (isMarketTypeAll && isPlatformValid) {
+        if (isAllDxtrade && isPlatformValid) {
             marketTypeTitle = PlatformDetails[platform].title;
         } else {
             marketTypeTitle = MarketTypeDetails[marketType].title;


### PR DESCRIPTION
## Changes:
1. Fixed the account title for swap free in success modal
### Screenshots:
Before: 
![2023-11-27_09-05](https://github.com/binary-com/deriv-app/assets/104053934/0f8e6315-7509-4125-ae4d-fd00859a3f6b)

After:
![Screenshot 2023-11-27 at 9 07 12 AM](https://github.com/binary-com/deriv-app/assets/104053934/b1bbf926-b2c9-4e6a-a0c6-ddeef0a6ac04)

