### PR TITLE
WALL-2763/fix: password meter to be full width

### DIFF
--- a/packages/wallets/src/components/Base/WalletPasswordField/WalletPasswordField.scss
+++ b/packages/wallets/src/components/Base/WalletPasswordField/WalletPasswordField.scss
@@ -28,7 +28,6 @@ $meter-widths: (
         position: absolute;
         top: 3.5rem;
         width: 100%;
-        max-width: 33.6rem;
         height: 0.4rem;
         transition: width 0.2s;
         background-color: map-get($meter-colors, initial);


### PR DESCRIPTION
## Changes:
1. Fixed an issue where password meter is not full width

### Screenshots:
![Screenshot 2023-11-27 at 9 28 40 AM](https://github.com/binary-com/deriv-app/assets/104053934/361893f1-ded2-4873-8d0f-1ec437107731)

