### PR TITLE
[BOT] chore: add QS loss threshold warning message for users

### DIFF
--- a/packages/bot-web-ui/src/components/quick-strategy/form-wrappers/desktop-form-wrapper.tsx
+++ b/packages/bot-web-ui/src/components/quick-strategy/form-wrappers/desktop-form-wrapper.tsx
@@ -7,6 +7,7 @@ import { observer } from '@deriv/stores';
 import { localize } from '@deriv/translations';
 import { useDBotStore } from 'Stores/useDBotStore';
 import { STRATEGIES } from '../config';
+import useQsSubmitHandler from './useQsSubmitHandler';
 import '../quick-strategy.scss';
 
 type TDesktopFormWrapper = {
@@ -16,9 +17,10 @@ type TDesktopFormWrapper = {
 const FormWrapper: React.FC<TDesktopFormWrapper> = observer(({ children }) => {
     // const [active_tab, setActiveTab] = React.useState('TRADE_PARAMETERS');
     const { submitForm, isValid, setFieldValue, validateForm } = useFormikContext();
-    const { quick_strategy, run_panel } = useDBotStore();
-    const { selected_strategy, setSelectedStrategy, setFormVisibility, toggleStopBotDialog } = quick_strategy;
+    const { quick_strategy } = useDBotStore();
+    const { selected_strategy, setSelectedStrategy, setFormVisibility } = quick_strategy;
     const strategy = STRATEGIES[selected_strategy as keyof typeof STRATEGIES];
+    const { handleSubmit } = useQsSubmitHandler();
     const handleClose = () => {
         setFormVisibility(false);
     };
@@ -34,17 +36,6 @@ const FormWrapper: React.FC<TDesktopFormWrapper> = observer(({ children }) => {
     const onEdit = async () => {
         await setFieldValue('action', 'EDIT');
         submitForm();
-    };
-
-    const handleSubmit = async () => {
-        if (run_panel.is_running) {
-            await setFieldValue('action', 'EDIT');
-            submitForm();
-            toggleStopBotDialog();
-        } else {
-            await setFieldValue('action', 'RUN');
-            submitForm();
-        }
     };
 
     return (

--- a/packages/bot-web-ui/src/components/quick-strategy/form-wrappers/mobile-form-wrapper.tsx
+++ b/packages/bot-web-ui/src/components/quick-strategy/form-wrappers/mobile-form-wrapper.tsx
@@ -5,6 +5,7 @@ import { observer } from '@deriv/stores';
 import { localize } from '@deriv/translations';
 import { useDBotStore } from 'Stores/useDBotStore';
 import { STRATEGIES } from '../config';
+import useQsSubmitHandler from './useQsSubmitHandler';
 import '../quick-strategy.scss';
 
 type TMobileFormWrapper = {
@@ -13,9 +14,11 @@ type TMobileFormWrapper = {
 
 const MobileFormWrapper: React.FC<TMobileFormWrapper> = observer(({ children }) => {
     // const [active_tab, setActiveTab] = React.useState('TRADE_PARAMETERS');
-    const { submitForm, isValid, setFieldValue, validateForm } = useFormikContext();
-    const { quick_strategy, run_panel } = useDBotStore();
-    const { selected_strategy, setSelectedStrategy, toggleStopBotDialog } = quick_strategy;
+    const { isValid, validateForm } = useFormikContext();
+    const { quick_strategy } = useDBotStore();
+    const { selected_strategy, setSelectedStrategy } = quick_strategy;
+    const { handleSubmit } = useQsSubmitHandler();
+
     const strategy = STRATEGIES[selected_strategy as keyof typeof STRATEGIES];
 
     React.useEffect(() => {
@@ -31,17 +34,6 @@ const MobileFormWrapper: React.FC<TMobileFormWrapper> = observer(({ children }) 
         text: STRATEGIES[key as keyof typeof STRATEGIES].label,
         description: STRATEGIES[key as keyof typeof STRATEGIES].description,
     }));
-
-    const handleSubmit = async () => {
-        if (run_panel.is_running) {
-            await setFieldValue('action', 'EDIT');
-            submitForm();
-            toggleStopBotDialog();
-        } else {
-            await setFieldValue('action', 'RUN');
-            submitForm();
-        }
-    };
 
     return (
         <div className='qs'>
@@ -96,7 +88,7 @@ const MobileFormWrapper: React.FC<TMobileFormWrapper> = observer(({ children }) 
                         <Button
                             primary
                             data-testid='qs-run-button'
-                            type='submit'
+                            type='button'
                             onClick={handleSubmit}
                             disabled={!isValid}
                         >

--- a/packages/bot-web-ui/src/components/quick-strategy/form-wrappers/useQsSubmitHandler.tsx
+++ b/packages/bot-web-ui/src/components/quick-strategy/form-wrappers/useQsSubmitHandler.tsx
@@ -1,0 +1,49 @@
+import { useFormikContext } from 'formik';
+import { useStore } from '@deriv/stores';
+import { useDBotStore } from 'Stores/useDBotStore';
+import { TFormData } from '../types';
+
+const useQsSubmitHandler = () => {
+    const { client } = useStore();
+    const { currency, balance, is_logged_in } = client;
+    const { submitForm, setFieldValue, values } = useFormikContext<TFormData>();
+    const { quick_strategy, run_panel } = useDBotStore();
+    const { toggleStopBotDialog, setLossThresholdWarningData, loss_threshold_warning_data } = quick_strategy;
+
+    const handleSubmit = async () => {
+        const loss_amount = Number(values?.loss ?? 0);
+        const profit_threshold = Number(values?.profit ?? 0);
+        const stored_dont_show_warning_value = localStorage?.getItem('qs-dont-show-loss-threshold-warning');
+        const dont_show_warning = JSON.parse(stored_dont_show_warning_value ?? 'false');
+        if (
+            !loss_threshold_warning_data.already_shown &&
+            (loss_amount > 0.5 * Number(balance ?? 0) || loss_amount > 2 * profit_threshold) &&
+            is_logged_in &&
+            !dont_show_warning
+        ) {
+            setLossThresholdWarningData({
+                show: true,
+                loss_amount,
+                currency,
+                already_shown: true,
+            });
+        } else {
+            proceedFormSubmission();
+        }
+    };
+
+    const proceedFormSubmission = async () => {
+        if (run_panel.is_running) {
+            await setFieldValue('action', 'EDIT');
+            submitForm();
+            toggleStopBotDialog();
+        } else {
+            await setFieldValue('action', 'RUN');
+            submitForm();
+        }
+    };
+
+    return { handleSubmit, proceedFormSubmission };
+};
+
+export default useQsSubmitHandler;

--- a/packages/bot-web-ui/src/components/quick-strategy/inputs/qs-input.tsx
+++ b/packages/bot-web-ui/src/components/quick-strategy/inputs/qs-input.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import { Field, FieldProps, useFormikContext } from 'formik';
 import { Input, Popover } from '@deriv/components';
 import { observer, useStore } from '@deriv/stores';
+import { useDBotStore } from 'Stores/useDBotStore';
 
 type TQSInput = {
     name: string;
@@ -19,6 +20,9 @@ const QSInput: React.FC<TQSInput> = observer(
         const {
             ui: { is_mobile },
         } = useStore();
+        const { quick_strategy } = useDBotStore();
+        const { loss_threshold_warning_data } = quick_strategy;
+
         const [has_focus, setFocus] = React.useState(false);
         const { setFieldValue, setFieldTouched } = useFormikContext();
         const is_number = type === 'number';
@@ -59,7 +63,11 @@ const QSInput: React.FC<TQSInput> = observer(
                                 >
                                     <Input
                                         data_testId='qs-input'
-                                        className={classNames('qs__input', { error: has_error })}
+                                        className={classNames(
+                                            'qs__input',
+                                            { error: has_error },
+                                            { highlight: loss_threshold_warning_data?.highlight_field?.includes(name) }
+                                        )}
                                         type={type}
                                         leading_icon={
                                             is_number ? (

--- a/packages/bot-web-ui/src/components/quick-strategy/parts/__tests__/loss-threshold-warning.spec.tsx
+++ b/packages/bot-web-ui/src/components/quick-strategy/parts/__tests__/loss-threshold-warning.spec.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { Formik } from 'formik';
+import { mockStore, StoreProvider } from '@deriv/stores';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { render, screen, waitFor } from '@testing-library/react';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import userEvent from '@testing-library/user-event';
+import { mock_ws } from 'Utils/mock';
+import RootStore from 'Stores/root-store';
+import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
+import LossThresholdWarningDialog from '../loss-threshold-warning-dialog';
+
+jest.mock('@deriv/bot-skeleton/src/scratch/blockly', () => jest.fn());
+jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => jest.fn());
+jest.mock('@deriv/bot-skeleton/src/scratch/hooks/block_svg', () => jest.fn());
+
+window.Blockly = {
+    Xml: {
+        textToDom: jest.fn(),
+        domToText: jest.fn(),
+    },
+};
+
+describe('LossThresholdWarningDialog', () => {
+    let wrapper: ({ children }: { children: JSX.Element }) => JSX.Element, mock_DBot_store: RootStore | undefined;
+
+    beforeEach(() => {
+        const mock_store = mockStore({
+            ui: {
+                is_mobile: true,
+            },
+        });
+        mock_DBot_store = mockDBotStore(mock_store, mock_ws);
+        const mock_onSubmit = jest.fn();
+        const initial_value = {
+            durationtype: 1,
+            symbol: 'R_100',
+            tradetype: 'callput',
+        };
+
+        wrapper = ({ children }: { children: JSX.Element }) => (
+            <StoreProvider store={mock_store}>
+                <DBotStoreProvider ws={mock_ws} mock={mock_DBot_store}>
+                    <Formik initialValues={initial_value} onSubmit={mock_onSubmit}>
+                        {children}
+                    </Formik>
+                </DBotStoreProvider>
+            </StoreProvider>
+        );
+    });
+    it('should render LossThresholdWarningDialog', () => {
+        const { container } = render(<LossThresholdWarningDialog />, {
+            wrapper,
+        });
+        expect(container).toBeInTheDocument();
+    });
+
+    it('should handle edit the amount button click', () => {
+        mock_DBot_store?.quick_strategy.setLossThresholdWarningData({
+            show: true,
+        });
+        render(<LossThresholdWarningDialog />, {
+            wrapper,
+        });
+        const edit_amount_btn = screen.getByRole('button', { name: /Edit the amount/i });
+        userEvent.click(edit_amount_btn);
+        expect(mock_DBot_store?.quick_strategy.loss_threshold_warning_data.show).toBeFalsy();
+    });
+
+    it('should handle continue button click', async () => {
+        mock_DBot_store?.quick_strategy.setLossThresholdWarningData({
+            show: true,
+        });
+        render(<LossThresholdWarningDialog />, {
+            wrapper,
+        });
+        const continue_btn = screen.getByRole('button', { name: /Yes, continue/i });
+        userEvent.click(continue_btn);
+        await waitFor(() => {
+            expect(mock_DBot_store?.quick_strategy.loss_threshold_warning_data.show).toBeFalsy();
+        });
+    });
+
+    it('should handle dont show again checkbox click', () => {
+        mock_DBot_store?.quick_strategy.setLossThresholdWarningData({
+            show: true,
+        });
+        render(<LossThresholdWarningDialog />, {
+            wrapper,
+        });
+        const checkbox = screen.getByRole('checkbox', { name: /Do not show this message again./i });
+        userEvent.click(checkbox);
+        expect(localStorage.getItem('qs-dont-show-loss-threshold-warning')).toEqual('true');
+    });
+});

--- a/packages/bot-web-ui/src/components/quick-strategy/parts/loss-threshold-warning-dialog.scss
+++ b/packages/bot-web-ui/src/components/quick-strategy/parts/loss-threshold-warning-dialog.scss
@@ -1,0 +1,34 @@
+.loss-threshold-warning-dialog {
+    &__body-text {
+        font-size: 1.5rem;
+        line-height: 18px;
+        margin: 12px 0px;
+        margin-bottom: 22px;
+        color: var(--text-general);
+    }
+
+    .dc-dialog {
+        &__header {
+            &--title {
+                max-width: 90%;
+            }
+        }
+        &__footer {
+            @include mobile {
+                display: flex;
+                width: 100%;
+                flex-wrap: unset;
+            }
+        }
+        &__button:not(:last-child) {
+            @include mobile {
+                margin-right: 6px;
+            }
+        }
+        &__button {
+            @include mobile {
+                margin-left: 6px;
+            }
+        }
+    }
+}

--- a/packages/bot-web-ui/src/components/quick-strategy/parts/loss-threshold-warning-dialog.tsx
+++ b/packages/bot-web-ui/src/components/quick-strategy/parts/loss-threshold-warning-dialog.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { Checkbox, Dialog } from '@deriv/components';
+import { observer } from '@deriv/stores';
+import { Localize, localize } from '@deriv/translations';
+import { useDBotStore } from 'Stores/useDBotStore';
+import useQsSubmitHandler from '../form-wrappers/useQsSubmitHandler';
+import './loss-threshold-warning-dialog.scss';
+
+const base_classname = 'loss-threshold-warning-dialog';
+
+const LossThresholdWarningDialog = observer(() => {
+    const { quick_strategy } = useDBotStore();
+    const { loss_threshold_warning_data, setLossThresholdWarningData, initializeLossThresholdWarningData } =
+        quick_strategy;
+    const { proceedFormSubmission } = useQsSubmitHandler();
+
+    const handleAmountEdit = () => {
+        setLossThresholdWarningData({
+            show: false,
+            highlight_field: ['loss'],
+        });
+    };
+
+    const handleContinueBot = () => {
+        initializeLossThresholdWarningData();
+        proceedFormSubmission();
+    };
+
+    const handleDontShowAgain = () => {
+        const stored_dont_show_warning_value = localStorage?.getItem('qs-dont-show-loss-threshold-warning');
+        const dont_show_warning = JSON.parse(stored_dont_show_warning_value ?? 'false');
+        localStorage?.setItem('qs-dont-show-loss-threshold-warning', `${!dont_show_warning}`);
+    };
+
+    return (
+        <Dialog
+            portal_element_id='modal_root_absolute'
+            title={localize('Are you sure you want to continue?')}
+            is_visible={loss_threshold_warning_data.show}
+            confirm_button_text={localize('Yes, continue')}
+            onConfirm={handleContinueBot}
+            cancel_button_text={localize('Edit the amount')}
+            onCancel={handleAmountEdit}
+            is_mobile_full_width={false}
+            has_close_icon={false}
+            className={base_classname}
+        >
+            <div className={`${base_classname}__body-text`}>
+                <Localize
+                    i18n_default_text={`Please confirm that your loss threshold amount is ${loss_threshold_warning_data.loss_amount} ${loss_threshold_warning_data.currency}.`}
+                />
+            </div>
+            <Checkbox
+                defaultChecked={false}
+                label={localize('Do not show this message again.')}
+                onChange={handleDontShowAgain}
+            />
+        </Dialog>
+    );
+});
+
+export default LossThresholdWarningDialog;

--- a/packages/bot-web-ui/src/components/quick-strategy/quick-strategy.scss
+++ b/packages/bot-web-ui/src/components/quick-strategy/quick-strategy.scss
@@ -437,7 +437,9 @@
 
     &__input {
         margin: 0;
-
+        &.highlight {
+            border: 1px solid var(--status-warning);
+        }
         .dc-input {
             &__container {
                 height: var(--input-height);

--- a/packages/bot-web-ui/src/components/quick-strategy/quick-strategy.tsx
+++ b/packages/bot-web-ui/src/components/quick-strategy/quick-strategy.tsx
@@ -8,6 +8,7 @@ import { localize } from '@deriv/translations';
 import { useDBotStore } from 'Stores/useDBotStore';
 import DesktopFormWrapper from './form-wrappers/desktop-form-wrapper';
 import MobileFormWrapper from './form-wrappers/mobile-form-wrapper';
+import LossThresholdWarningDialog from './parts/loss-threshold-warning-dialog';
 import { STRATEGIES } from './config';
 import Form from './form';
 import { TConfigItem, TFormData } from './types';
@@ -33,7 +34,14 @@ const getErrorMessage = (dir: 'MIN' | 'MAX', value: number, type = 'DEFAULT') =>
 
 const FormikWrapper: React.FC<TFormikWrapper> = observer(({ children }) => {
     const { quick_strategy } = useDBotStore();
-    const { selected_strategy, form_data, onSubmit, setValue, current_duration_min_max } = quick_strategy;
+    const {
+        selected_strategy,
+        form_data,
+        onSubmit,
+        setValue,
+        current_duration_min_max,
+        initializeLossThresholdWarningData,
+    } = quick_strategy;
     const config: TConfigItem[][] = STRATEGIES[selected_strategy]?.fields;
     const [dynamic_schema, setDynamicSchema] = useState(Yup.object().shape({}));
 
@@ -58,6 +66,7 @@ const FormikWrapper: React.FC<TFormikWrapper> = observer(({ children }) => {
             initial_value[key as keyof TFormData] = data[key];
             setValue(key, data[key]);
         });
+        initializeLossThresholdWarningData();
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
@@ -164,6 +173,7 @@ const QuickStrategy = observer(() => {
     return (
         <FormikWrapper>
             <FormikForm>
+                <LossThresholdWarningDialog />
                 {is_mobile ? (
                     <MobileFullPageModal
                         is_modal_open={is_open}

--- a/packages/bot-web-ui/src/stores/quick-strategy-store.ts
+++ b/packages/bot-web-ui/src/stores/quick-strategy-store.ts
@@ -11,6 +11,14 @@ export type TActiveSymbol = {
     value: string;
 };
 
+export type TLossThresholdWarningData = {
+    show: boolean;
+    loss_amount?: string | number;
+    currency?: string;
+    highlight_field?: Array<string>;
+    already_shown?: boolean;
+};
+
 interface IQuickStrategyStore {
     current_duration_min_max: {
         min: number;
@@ -20,8 +28,12 @@ interface IQuickStrategyStore {
     is_open: boolean;
     selected_strategy: string;
     form_data: TFormData;
+    loss_threshold_warning_data: {
+        show: boolean;
+    };
     is_contract_dialog_open: boolean;
     is_stop_bot_dialog_open: boolean;
+    setLossThresholdWarningData: (data: TLossThresholdWarningData) => void;
     setFormVisibility: (is_open: boolean) => void;
     setSelectedStrategy: (strategy: string) => void;
     setValue: (name: string, value: string) => void;
@@ -46,6 +58,9 @@ export default class QuickStrategyStore implements IQuickStrategyStore {
         min: 0,
         max: 10,
     };
+    loss_threshold_warning_data: TLossThresholdWarningData = {
+        show: false,
+    };
 
     constructor(root_store: RootStore) {
         makeObservable(this, {
@@ -54,11 +69,14 @@ export default class QuickStrategyStore implements IQuickStrategyStore {
             is_contract_dialog_open: observable,
             is_open: observable,
             is_stop_bot_dialog_open: observable,
+            initializeLossThresholdWarningData: action,
             selected_strategy: observable,
+            loss_threshold_warning_data: observable,
             onSubmit: action,
             setCurrentDurationMinMax: action,
             setFormVisibility: action,
             setSelectedStrategy: action,
+            setLossThresholdWarningData: action,
             setValue: action,
             toggleStopBotDialog: action,
         });
@@ -72,6 +90,21 @@ export default class QuickStrategyStore implements IQuickStrategyStore {
             }
         );
     }
+
+    setLossThresholdWarningData = (data: TLossThresholdWarningData) => {
+        this.loss_threshold_warning_data = {
+            ...this.loss_threshold_warning_data,
+            ...data,
+        };
+    };
+
+    initializeLossThresholdWarningData = () => {
+        this.loss_threshold_warning_data = {
+            show: false,
+            highlight_field: [],
+            already_shown: false,
+        };
+    };
 
     setFormVisibility = (is_open: boolean) => {
         this.is_open = is_open;


### PR DESCRIPTION
## Changes:

- Added useQsSubmitHandler as middleware between form submission and loss threshold validation. It could be used for other validation in the future as well.
- Added loss threshold warning dialog to show the message
- Added field highlight style
- Added test cases

<img width="1119" alt="Screenshot 2023-11-27 at 12 14 02 PM" src="https://github.com/binary-com/deriv-app/assets/129021108/2508f62f-e00c-4d1e-bde0-5105e7b7130e">