### PR TITLE
[Trader's Hub] EU banner is missing for MF only account

### DIFF
--- a/packages/appstore/src/modules/traders-hub/index.tsx
+++ b/packages/appstore/src/modules/traders-hub/index.tsx
@@ -38,11 +38,10 @@ const TradersHub = observer(() => {
                 setScrolled(true);
             }, 200);
         }, 100);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [is_tour_open]);
 
     const eu_title = content_flag === ContentFlag.EU_DEMO || content_flag === ContentFlag.EU_REAL || is_eu_user;
-
-    const is_eu_low_risk = content_flag === ContentFlag.LOW_RISK_CR_EU;
 
     const getPlatformToggleOptions = () => [
         { text: eu_title ? localize('Multipliers') : localize('Options & Multipliers'), value: 'options' },
@@ -111,7 +110,7 @@ const TradersHub = observer(() => {
                     {scrolled && <TourGuide />}
                 </div>
             </Div100vhContainer>
-            {is_eu_low_risk && (
+            {is_eu_user && (
                 <div data-testid='dt_traders_hub_disclaimer' className='disclaimer'>
                     <Text align='left' className='disclaimer-text' size={is_mobile ? 'xxxs' : 'xs'}>
                         <Localize

--- a/packages/stores/src/mockStore.ts
+++ b/packages/stores/src/mockStore.ts
@@ -495,6 +495,7 @@ const mock = (): TStores & { is_mock: boolean } => {
             setWalletModalActiveWalletID: jest.fn(),
             available_ctrader_accounts: [],
             toggleIsTourOpen: jest.fn(),
+            is_tour_open: false,
             is_demo_low_risk: false,
             is_mt5_notification_modal_visible: false,
             setMT5NotificationModal: jest.fn(),

--- a/packages/stores/types.ts
+++ b/packages/stores/types.ts
@@ -938,6 +938,7 @@ type TTradersHubStore = {
     available_dxtrade_accounts: TAvailableCFDAccounts[];
     available_ctrader_accounts: TAvailableCFDAccounts[];
     toggleIsTourOpen: (is_tour_open: boolean) => void;
+    is_tour_open: boolean;
     is_demo_low_risk: boolean;
     is_mt5_notification_modal_visible: boolean;
     setMT5NotificationModal: (value: boolean) => void;


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.

- Banner for EU account should visible on Trader's hub (Disclaimer banner as per screenshot below)
- Refer below screenshot for DIEL MF account:



CU Card:
[[Trader's Hub] EU banner is missing for MF only account](https://app.clickup.com/t/20696747/PRODQA-928)
### Screenshots:

Please provide some screenshots of the change.
![image](https://github.com/binary-com/deriv-app/assets/120543468/a68db6a7-2dde-4332-9694-7bc89d0f8e6b)
