### PR TITLE
[P2PS] Ameerul /P2PS-1969 Custom message for share my ad is not translated to other languages

### DIFF
--- a/packages/p2p/src/components/modal-manager/modals/share-my-ads-modal/share-my-ads-modal.tsx
+++ b/packages/p2p/src/components/modal-manager/modals/share-my-ads-modal/share-my-ads-modal.tsx
@@ -31,7 +31,7 @@ const ShareMyAdsModal = ({ advert }: TAdvert) => {
     const advert_url = `${websiteUrl()}cashier/p2p/advertiser?id=${advertiser_id}&advert_id=${id}`;
     const is_buy_ad = type === buy_sell.BUY;
     const custom_message = localize(
-        "Hi! I'd like to exchange {{first_currency}} for {{second_currency}} at {{rate_display}}{{rate_type}} on Deriv P2P.\n\nIf you're interested, check out my ad 👉\n\n{{- advert_url}}\n\nThanks!",
+        "Hi! I'd like to exchange {{first_currency}} for {{second_currency}} at {{rate_display}}{{rate_type}} on Deriv P2P.nnIf you're interested, check out my ad 👉nn{{- advert_url}}nnThanks!",
         {
             first_currency: is_buy_ad ? local_currency : account_currency,
             second_currency: is_buy_ad ? account_currency : local_currency,
@@ -40,6 +40,8 @@ const ShareMyAdsModal = ({ advert }: TAdvert) => {
             advert_url,
         }
     );
+
+    const formatted_message = custom_message.replace(/nn/g, '\n\n');
 
     const onCopy = (event: { stopPropagation: () => void }) => {
         copyToClipboard(advert_url);
@@ -65,7 +67,7 @@ const ShareMyAdsModal = ({ advert }: TAdvert) => {
 
     const handleShareLink = () => {
         navigator.share({
-            text: custom_message,
+            text: formatted_message,
         });
     };
 
@@ -127,7 +129,7 @@ const ShareMyAdsModal = ({ advert }: TAdvert) => {
                                 <Text weight='bold'>
                                     <Localize i18n_default_text='Share via' />
                                 </Text>
-                                <ShareMyAdsSocials advert_url={advert_url} custom_message={custom_message} />
+                                <ShareMyAdsSocials advert_url={advert_url} custom_message={formatted_message} />
                                 <MyProfileSeparatorContainer.Line
                                     className='share-my-ads-modal__line'
                                     is_invisible={false}


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- Because of how in `extract-translations.js` file it removes any escape characters from the strings turning the `\n` to `n`, decided to format the message to replace any instances of `nn` with `\n\n` to make sure the string is translated.
- The string in `share-my-ads-modal` file did not match with the one in messages.json since it still had `\n\n` so replaced with `nn`

### Screenshots:

Please provide some screenshots of the change.

https://github.com/binary-com/deriv-app/assets/103412909/3e8fb990-34be-4978-aa52-5be003d9af82

