### PR TITLE
[WALL] [Fix] Aum/WALL-2778/fix-withdrawal-crypto-percentage-message

### DIFF
--- a/packages/wallets/src/features/cashier/modules/WithdrawalCrypto/components/WithdrawalCryptoForm/WithdrawalCryptoForm.tsx
+++ b/packages/wallets/src/features/cashier/modules/WithdrawalCrypto/components/WithdrawalCryptoForm/WithdrawalCryptoForm.tsx
@@ -120,7 +120,7 @@ const WithdrawalCryptoForm: React.FC<TWithdrawalCryptoFormProps> = ({
                             />
                             <WalletText color='less-prominent' size='xs'>
                                 {!Number.isNaN(parseFloat(values.cryptoAmount)) && activeWallet?.balance
-                                    ? Math.round(parseFloat(values.cryptoAmount) / activeWallet?.balance)
+                                    ? Math.round((parseFloat(values.cryptoAmount) * 100) / activeWallet?.balance)
                                     : '0'}
                                 % of available balance ({activeWallet?.display_balance})
                             </WalletText>


### PR DESCRIPTION
## Changes:

Found and fixed the issue with the percentage of the crypto withdrawal amount shown below the percentage selector. The calculated percentage was not multiplied by 100.
<img width="631" alt="Screenshot 2023-11-27 at 1 51 25 PM" src="https://github.com/binary-com/deriv-app/assets/125039206/6d00531d-2b13-4e8d-9a55-415cb3a3c846">
