### PR TITLE
[WALL] Rostislav / WALL-2296 / Correct `TransactionStatus` positioning in crypto deposit & withdrawal

### DIFF
--- a/packages/wallets/src/features/cashier/modules/DepositCrypto/DepositCrypto.scss
+++ b/packages/wallets/src/features/cashier/modules/DepositCrypto/DepositCrypto.scss
@@ -3,6 +3,7 @@
     width: 100%;
     display: flex;
     justify-content: center;
+    gap: 2.4rem;
 
     @include mobile {
         height: fit-content;
@@ -19,6 +20,18 @@
         @include mobile {
             padding: 0;
             gap: 1.6rem;
+        }
+    }
+
+    &__side-pane {
+        height: fit-content;
+        display: flex;
+        flex: 1 1 0;
+        justify-content: flex-end;
+
+        .wallets-transaction-status {
+            margin-top: -2.4rem;
+            margin-right: 2.4rem;
         }
     }
 }

--- a/packages/wallets/src/features/cashier/modules/DepositCrypto/DepositCrypto.tsx
+++ b/packages/wallets/src/features/cashier/modules/DepositCrypto/DepositCrypto.tsx
@@ -10,6 +10,7 @@ import './DepositCrypto.scss';
 const DepositCrypto = () => {
     return (
         <div className='wallets-deposit-crypto'>
+            <div className='wallets-deposit-crypto__side-pane' />
             <div className='wallets-deposit-crypto__main-content'>
                 <DepositCryptoCurrencyDetails />
                 <DepositCryptoAddress />
@@ -17,7 +18,9 @@ const DepositCrypto = () => {
                 <Divider />
                 <DepositCryptoTryFiatOnRamp />
             </div>
-            <TransactionStatus transactionType='deposit' />
+            <div className='wallets-deposit-crypto__side-pane'>
+                <TransactionStatus transactionType='deposit' />
+            </div>
         </div>
     );
 };

--- a/packages/wallets/src/features/cashier/modules/TransactionStatus/TransactionStatus.scss
+++ b/packages/wallets/src/features/cashier/modules/TransactionStatus/TransactionStatus.scss
@@ -1,12 +1,8 @@
 .wallets-transaction-status {
     width: 100%;
 
-    /* This positioning is temporary, ideally it should be determined by the parent component whenever we use `TransactionStatus` */
     @include desktop {
-        position: absolute;
-        top: -2.4rem;
-        right: 2.4rem;
-        max-width: 28.2rem;
+        width: 28.2rem;
     }
 
     display: flex;

--- a/packages/wallets/src/features/cashier/modules/WithdrawalCrypto/WithdrawalCrypto.scss
+++ b/packages/wallets/src/features/cashier/modules/WithdrawalCrypto/WithdrawalCrypto.scss
@@ -1,8 +1,9 @@
 .wallets-withdrawal-crypto {
     position: relative;
+    width: 100%;
     display: flex;
     justify-content: center;
-    width: 100%;
+    gap: 2.4rem;
 
     @include mobile {
         flex-direction: column;
@@ -25,6 +26,18 @@
         & .wallets-textfield {
             width: 100%;
             max-width: none;
+        }
+    }
+
+    &__side-pane {
+        height: fit-content;
+        display: flex;
+        flex: 1 1 0;
+        justify-content: flex-end;
+
+        .wallets-transaction-status {
+            margin-top: -2.4rem;
+            margin-right: 2.4rem;
         }
     }
 }

--- a/packages/wallets/src/features/cashier/modules/WithdrawalCrypto/WithdrawalCrypto.tsx
+++ b/packages/wallets/src/features/cashier/modules/WithdrawalCrypto/WithdrawalCrypto.tsx
@@ -37,6 +37,7 @@ const WithdrawalCrypto: React.FC<TWithdrawalCryptoProps> = ({ onClose, verificat
 
     return (
         <div className='wallets-withdrawal-crypto'>
+            <div className='wallets-withdrawal-crypto__side-pane' />
             <div className='wallets-withdrawal-crypto__content'>
                 <WalletText weight='bold'>
                     Withdraw {activeWallet?.currency ? getConfig(activeWallet?.currency)?.name : ''} (
@@ -50,7 +51,9 @@ const WithdrawalCrypto: React.FC<TWithdrawalCryptoProps> = ({ onClose, verificat
                     verificationCode={verificationCode}
                 />
             </div>
-            <TransactionStatus transactionType='withdrawal' />
+            <div className='wallets-withdrawal-crypto__side-pane'>
+                <TransactionStatus transactionType='withdrawal' />
+            </div>
         </div>
     );
 };


### PR DESCRIPTION
## Changes:

Position `TransactionStatus` in crypto deposit & withdrawal in a way that avoids overlapping on smaller desktop screens.

### Screenshots:

https://github.com/binary-com/deriv-app/assets/119863957/f6add4c7-ef46-44d6-aa5c-e805828ae0cb

