### PR TITLE
 [WALL] wojtek/WALL-3012/feat: dynamic load of zxcvbn library for password scoring

### DIFF
--- a/packages/wallets/src/components/Base/WalletPasswordField/WalletPasswordField.tsx
+++ b/packages/wallets/src/components/Base/WalletPasswordField/WalletPasswordField.tsx
@@ -1,17 +1,31 @@
 import React, { useCallback, useState } from 'react';
-import { passwordErrorMessage } from '../../../constants/password';
-import { Score, validatePassword, validPassword } from '../../../utils/password';
+import { Score, calculateScore, validPassword, isPasswordValid, passwordKeys } from '../../../utils/password';
 import { WalletTextField } from '../WalletTextField';
-import { WalletTextFieldProps } from '../WalletTextField/WalletTextField';
 import PasswordMeter from './PasswordMeter';
 import PasswordViewerIcon from './PasswordViewerIcon';
 import './WalletPasswordField.scss';
+import { passwordErrorMessage, passwordRegex, warningMessages } from '../../../constants/password';
+import { zxcvbn, zxcvbnOptions } from '@zxcvbn-ts/core';
+import { dictionary } from '@zxcvbn-ts/language-common';
+import { WalletPasswordFieldProps } from '../WalletPasswordFieldLazy/WalletPasswordFieldLazy';
 
-interface WalletPasswordFieldProps extends WalletTextFieldProps {
-    password: string;
-    passwordError?: boolean;
-    shouldDisablePasswordMeter?: boolean;
-}
+export const validatePassword = (password: string) => {
+    const score = calculateScore(password);
+    let errorMessage = '';
+
+    const options = { dictionary: { ...dictionary } };
+    zxcvbnOptions.setOptions(options);
+
+    const { feedback } = zxcvbn(password);
+    if (!passwordRegex.isLengthValid.test(password)) {
+        errorMessage = passwordErrorMessage.invalidLength;
+    } else if (!isPasswordValid(password)) {
+        errorMessage = passwordErrorMessage.missingCharacter;
+    } else {
+        errorMessage = warningMessages[feedback.warning as passwordKeys] ?? '';
+    }
+    return { errorMessage, score };
+};
 
 const WalletPasswordField: React.FC<WalletPasswordFieldProps> = ({
     autoComplete,

--- a/packages/wallets/src/components/Base/WalletPasswordField/index.ts
+++ b/packages/wallets/src/components/Base/WalletPasswordField/index.ts
@@ -1,1 +1,0 @@
-export { default as WalletPasswordField } from './WalletPasswordField';

--- a/packages/wallets/src/components/Base/WalletPasswordFieldLazy/WalletPasswordFieldLazy.tsx
+++ b/packages/wallets/src/components/Base/WalletPasswordFieldLazy/WalletPasswordFieldLazy.tsx
@@ -1,0 +1,21 @@
+import React, { lazy, Suspense } from 'react';
+import { WalletTextFieldProps } from '../WalletTextField/WalletTextField';
+import Loader from '../../Loader/Loader';
+
+export interface WalletPasswordFieldProps extends WalletTextFieldProps {
+    password: string;
+    passwordError?: boolean;
+    shouldDisablePasswordMeter?: boolean;
+}
+
+const WalletPasswordFieldLazyContainer = lazy(
+    () => import('../WalletPasswordField/WalletPasswordField')
+) as React.FC<WalletPasswordFieldProps>;
+
+const WalletPasswordFieldLazy: React.FC<WalletPasswordFieldProps> = props => (
+    <Suspense fallback={<Loader isFullScreen={false} />}>
+        <WalletPasswordFieldLazyContainer {...props} />
+    </Suspense>
+);
+
+export default WalletPasswordFieldLazy;

--- a/packages/wallets/src/components/Base/WalletPasswordFieldLazy/index.ts
+++ b/packages/wallets/src/components/Base/WalletPasswordFieldLazy/index.ts
@@ -1,0 +1,1 @@
+export { default as WalletPasswordFieldLazy } from './WalletPasswordFieldLazy';

--- a/packages/wallets/src/components/Base/index.ts
+++ b/packages/wallets/src/components/Base/index.ts
@@ -13,6 +13,6 @@ export * from './WalletButton';
 export * from './WalletButtonGroup';
 export * from './WalletClipboard';
 export * from './WalletDropdown';
-export * from './WalletPasswordField';
+export * from './WalletPasswordFieldLazy';
 export * from './WalletText';
 export * from './WalletTextField';

--- a/packages/wallets/src/features/cfd/screens/ChangePassword/InvestorPassword/MT5ChangeInvestorPasswordInputsScreen.tsx
+++ b/packages/wallets/src/features/cfd/screens/ChangePassword/InvestorPassword/MT5ChangeInvestorPasswordInputsScreen.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { Formik } from 'formik';
 import { useTradingPlatformInvestorPasswordChange } from '@deriv/api';
-import { WalletButton, WalletPasswordField, WalletsActionScreen, WalletText } from '../../../../../components';
+import { WalletButton, WalletsActionScreen, WalletText } from '../../../../../components';
 import { useModal } from '../../../../../components/ModalProvider';
 import useDevice from '../../../../../hooks/useDevice';
 import { validPassword } from '../../../../../utils/password';
 import { PlatformDetails } from '../../../constants';
+import { WalletPasswordFieldLazy } from '../../../../../components/Base';
 
 type TFormInitialValues = {
     currentPassword: string;
@@ -65,14 +66,14 @@ const MT5ChangeInvestorPasswordInputsScreen: React.FC<TProps> = ({ sendEmail, se
                     {({ handleChange, handleSubmit, values }) => (
                         <form className='wallets-change-investor-password-screens__form' onSubmit={handleSubmit}>
                             <div className='wallets-change-investor-password-screens__form-fields'>
-                                <WalletPasswordField
+                                <WalletPasswordFieldLazy
                                     autoComplete='current-password'
                                     label='Current investor password'
                                     name='currentPassword'
                                     onChange={handleChange}
                                     password={values.currentPassword}
                                 />
-                                <WalletPasswordField
+                                <WalletPasswordFieldLazy
                                     autoComplete='new-password'
                                     label='New investor password'
                                     name='newPassword'

--- a/packages/wallets/src/features/cfd/screens/CreatePassword/CreatePassword.tsx
+++ b/packages/wallets/src/features/cfd/screens/CreatePassword/CreatePassword.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { WalletButton, WalletPasswordField, WalletText } from '../../../../components/Base';
+import { WalletButton, WalletText, WalletPasswordFieldLazy } from '../../../../components/Base';
 import useDevice from '../../../../hooks/useDevice';
 import { TPlatforms } from '../../../../types';
 import { validPassword } from '../../../../utils/password';
@@ -38,7 +38,7 @@ const CreatePassword: React.FC<TProps> = ({
                 </WalletText>
             </div>
 
-            <WalletPasswordField label={`${title} password`} onChange={onPasswordChange} password={password} />
+            <WalletPasswordFieldLazy label={`${title} password`} onChange={onPasswordChange} password={password} />
             {!isMobile && (
                 <WalletButton
                     disabled={!password || isLoading || !validPassword(password)}

--- a/packages/wallets/src/features/cfd/screens/EnterPassword/EnterPassword.tsx
+++ b/packages/wallets/src/features/cfd/screens/EnterPassword/EnterPassword.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useActiveWalletAccount } from '@deriv/api';
-import { WalletButton, WalletPasswordField, WalletText } from '../../../../components/Base';
+import { WalletButton, WalletText, WalletPasswordFieldLazy } from '../../../../components/Base';
 import useDevice from '../../../../hooks/useDevice';
 import { TMarketTypes, TPlatforms } from '../../../../types';
 import { validPassword } from '../../../../utils/password';
@@ -45,7 +45,7 @@ const EnterPassword: React.FC<TProps> = ({
                     <WalletText size='sm'>
                         Enter your {title} password to add a {title} {marketTypeTitle} account.
                     </WalletText>
-                    <WalletPasswordField
+                    <WalletPasswordFieldLazy
                         label={`${title} password`}
                         onChange={onPasswordChange}
                         password={password}

--- a/packages/wallets/src/utils/password.ts
+++ b/packages/wallets/src/utils/password.ts
@@ -1,6 +1,4 @@
-import { zxcvbn, zxcvbnOptions } from '@zxcvbn-ts/core';
-import { dictionary } from '@zxcvbn-ts/language-common';
-import { passwordErrorMessage, passwordRegex, passwordValues, warningMessages } from '../constants/password';
+import { passwordRegex, passwordValues } from '../constants/password';
 
 export type Score = 0 | 1 | 2 | 3 | 4;
 export type passwordKeys =
@@ -54,22 +52,4 @@ export const calculateScore = (password: string) => {
     if (!isPasswordStrong(password) && isPasswordValid(password) && !isPasswordModerate(password)) return 2;
     if (!isPasswordStrong(password) && isPasswordValid(password) && isPasswordModerate(password)) return 3;
     if (isPasswordStrong(password)) return 4;
-};
-
-export const validatePassword = (password: string) => {
-    const score = calculateScore(password);
-    let errorMessage = '';
-
-    const options = { dictionary: { ...dictionary } };
-    zxcvbnOptions.setOptions(options);
-
-    const { feedback } = zxcvbn(password);
-    if (!passwordRegex.isLengthValid.test(password)) {
-        errorMessage = passwordErrorMessage.invalidLength;
-    } else if (!isPasswordValid(password)) {
-        errorMessage = passwordErrorMessage.missingCharacter;
-    } else {
-        errorMessage = warningMessages[feedback.warning as passwordKeys] || '';
-    }
-    return { errorMessage, score };
 };


### PR DESCRIPTION
## Changes:

Dynamic loading of zxcvbn library due to its size. Using react lazy.
Zxcvbn library is now loaded on demand, only when you actually display component with password field.
Looks like its pretty easy and re-usable pattern for anything, including onfido, gives loader for free and pretty much all the hassle/boilerplate of loading is abstracted away from developer.

As per discussions - ideally we should consider removing this library entirely.

### Screenshots:

No change - password field works as previously.
