### PR TITLE
[FEQ] chore: remove old github pages url handler

### DIFF
--- a/packages/core/src/index.html
+++ b/packages/core/src/index.html
@@ -113,30 +113,6 @@
         </script>
         <!-- End GTM Script -->
 
-        <!-- Start URL Handler -->
-        <script type="text/javascript">
-            (function (l) {
-                if (l.search) {
-                    var q = {};
-                    l.search
-                        .slice(1)
-                        .split('&')
-                        .forEach(function (v) {
-                            var a = v.split('=');
-                            q[a[0]] = a.slice(1).join('=').replace(/~and~/g, '&');
-                        });
-                    if (q.p !== undefined) {
-                        window.history.replaceState(
-                            null,
-                            null,
-                            l.pathname.slice(0, -1) + (q.p || '') + (q.q ? '?' + q.q : '') + l.hash
-                        );
-                    }
-                }
-            })(window.location);
-        </script>
-        <!-- End URL Handler -->
-
         <!--         TODO: Find alternative solution for Onfido dependency -->
         <script src="https://assets.onfido.com/web-sdk-releases/latest/onfido.min.js"></script>
         <link href="https://assets.onfido.com/web-sdk-releases/latest/style.css" rel="stylesheet" />


### PR DESCRIPTION
When we used GitHub pages, which doesn't/didn't fully support SPA's, we have to do some workarounds to handle the urls.

I think this was taken from:
https://gist.github.com/zHaytam/3a27cde534a25f0270fc7e1ed9bd375f

Anyway, now we use CloudFlare which supports always returning the index.html file with a 200 status, I don't believe this is needed anymore.