### PR TITLE
[WALL] george / WALL-2781 / improve account selection logic in transfer section

### DIFF
--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormAmountInput/TransferFormAmountInput.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormAmountInput/TransferFormAmountInput.tsx
@@ -29,6 +29,7 @@ const TransferFormAmountInput: React.FC<TProps> = ({ fieldName }) => {
         ? fromAccount?.currencyConfig?.fractional_digits
         : toAccount?.currencyConfig?.fractional_digits;
     const isAmountInputDisabled = fieldName === 'toAmount' && !toAccount;
+    const isAmountFieldActive = fieldName === values.activeAmountFieldName;
 
     useEffect(() => {
         if (!fromAccount?.currency || !toAccount?.currency || !activeWallet?.loginid) return;
@@ -49,7 +50,7 @@ const TransferFormAmountInput: React.FC<TProps> = ({ fieldName }) => {
 
     const amountConverterHandler = useCallback(
         (value: number) => {
-            if (!toAccount?.currency || !exchangeRate?.rates) return;
+            if (!toAccount?.currency || !exchangeRate?.rates || !isAmountFieldActive) return;
 
             const toRate = exchangeRate.rates[toAccount.currency];
 
@@ -68,6 +69,7 @@ const TransferFormAmountInput: React.FC<TProps> = ({ fieldName }) => {
         [
             exchangeRate?.rates,
             fromAccount?.currencyConfig?.fractional_digits,
+            isAmountFieldActive,
             isFromAmountFieldName,
             setFieldValue,
             toAccount?.currency,
@@ -83,7 +85,8 @@ const TransferFormAmountInput: React.FC<TProps> = ({ fieldName }) => {
 
     const onChangeHandler = useCallback(
         (value: number) => {
-            if (fieldName !== values.activeAmountFieldName) return;
+            if (!isAmountFieldActive) return;
+
             if (isSameCurrency) {
                 setValues(prev => ({ ...prev, fromAmount: value, toAmount: value }));
             } else {
@@ -94,7 +97,7 @@ const TransferFormAmountInput: React.FC<TProps> = ({ fieldName }) => {
                 setFieldValue(fieldName, value);
             }
         },
-        [fieldName, isSameCurrency, setFieldValue, setValues, values.activeAmountFieldName]
+        [fieldName, isAmountFieldActive, isSameCurrency, setFieldValue, setValues]
     );
 
     const onFocusHandler = useCallback(() => {

--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormDropdown/TransferFormDropdown.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormDropdown/TransferFormDropdown.tsx
@@ -21,6 +21,7 @@ const TransferFormDropdown: React.FC<TProps> = ({ fieldName, mobileAccountsListR
     const { fromAccount, toAccount } = values;
     const { isMobile } = useDevice();
     const modal = useModal();
+    const isFromAccountDropdown = fieldName === 'fromAccount';
 
     const toAccountList = useMemo(() => {
         if (!activeWallet) return { tradingAccounts: [], walletAccounts: [] };
@@ -33,30 +34,57 @@ const TransferFormDropdown: React.FC<TProps> = ({ fieldName, mobileAccountsListR
         return { tradingAccounts: [], walletAccounts: [activeWallet] };
     }, [accounts?.tradingAccounts, accounts?.walletAccounts, activeWallet, fromAccount?.loginid]);
 
-    const selectedAccount = fieldName === 'fromAccount' ? fromAccount : toAccount;
-    const accountsList = fieldName === 'fromAccount' ? accounts : toAccountList;
-    const label = fieldName === 'fromAccount' ? 'Transfer from' : 'Transfer to';
+    const selectedAccount = isFromAccountDropdown ? fromAccount : toAccount;
+    const accountsList = isFromAccountDropdown ? accounts : toAccountList;
+    const label = isFromAccountDropdown ? 'Transfer from' : 'Transfer to';
     const badgeLabel = selectedAccount?.demo_account ? 'virtual' : selectedAccount?.landingCompanyName;
 
     const handleSelect = useCallback(
         (account: TInitialTransferFormValues['fromAccount']) => {
             if (account?.loginid === selectedAccount?.loginid) return;
 
-            setValues(prev => {
-                const fromAccount = fieldName === 'fromAccount' ? account : prev.fromAccount;
-                const computedToAccount = account?.loginid !== activeWallet?.loginid ? activeWallet : undefined;
-                const toAccount = fieldName === 'toAccount' ? account : computedToAccount;
-                return {
+            const swapAccounts = () => {
+                setValues(prev => {
+                    return {
+                        ...prev,
+                        activeAmountFieldName: undefined,
+                        fromAccount: isFromAccountDropdown ? account : prev.toAccount,
+                        fromAmount: prev.toAmount,
+                        toAccount: isFromAccountDropdown ? prev.fromAccount : account,
+                        toAmount: prev.fromAmount,
+                    };
+                });
+            };
+
+            if (isFromAccountDropdown) {
+                if (account?.loginid === values.toAccount?.loginid) {
+                    swapAccounts();
+                } else {
+                    setValues(prev => {
+                        const toAccount = account?.loginid !== activeWallet?.loginid ? activeWallet : undefined;
+
+                        return {
+                            ...prev,
+                            activeAmountFieldName: undefined,
+                            fromAccount: account,
+                            fromAmount: 0,
+                            toAccount,
+                            toAmount: 0,
+                        };
+                    });
+                }
+            } else if (account?.loginid === values.fromAccount?.loginid) {
+                swapAccounts();
+            } else {
+                setValues(prev => ({
                     ...prev,
-                    activeAmountFieldName: undefined,
-                    fromAccount,
-                    fromAmount: 0,
-                    toAccount,
+                    activeAmountFieldName: 'fromAmount',
+                    toAccount: account,
                     toAmount: 0,
-                };
-            });
+                }));
+            }
         },
-        [activeWallet, fieldName, selectedAccount?.loginid, setValues]
+        [activeWallet, isFromAccountDropdown, selectedAccount?.loginid, setValues, values.fromAccount, values.toAccount]
     );
 
     return (


### PR DESCRIPTION
## Changes:

Implement next rules for account selection in transfer section:

1. We reset the amount inputs **_only if transfer from_account is changed_**.
2. If selected **to_account** equals current **from_account** and vice versa, we swap/interchange accounts and amounts.
3. If the user selected **to_account**, **from_amount** will stay the same and **to_amount** will be recalculated accordingly depending on **to_account_currency**.
4. If the user selects the same account, no changes are made to the existing accounts and amounts.
