### PR TITLE
[WALL] Aizad/WALL-2784/ Minor fix on Investor Change Password Modal

### DIFF
--- a/packages/wallets/src/components/Base/WalletPasswordField/WalletPasswordField.tsx
+++ b/packages/wallets/src/components/Base/WalletPasswordField/WalletPasswordField.tsx
@@ -13,6 +13,7 @@ interface WalletPasswordFieldProps extends WalletTextFieldProps {
 
 const WalletPasswordField: React.FC<WalletPasswordFieldProps> = ({
     label,
+    name = 'wallet-passwordfield',
     onChange,
     password,
     shouldDisablePasswordMeter = false,
@@ -38,6 +39,7 @@ const WalletPasswordField: React.FC<WalletPasswordFieldProps> = ({
                 label={label}
                 message={isTouched ? errorMessage : ''}
                 messageVariant='warning'
+                name={name}
                 onChange={handleChange}
                 renderRightIcon={() => (
                     <PasswordViewerIcon setViewPassword={setIsPasswordVisible} viewPassword={isPasswordVisible} />

--- a/packages/wallets/src/components/Base/WalletPasswordField/WalletPasswordField.tsx
+++ b/packages/wallets/src/components/Base/WalletPasswordField/WalletPasswordField.tsx
@@ -13,7 +13,7 @@ interface WalletPasswordFieldProps extends WalletTextFieldProps {
 
 const WalletPasswordField: React.FC<WalletPasswordFieldProps> = ({
     label,
-    name = 'wallet-passwordfield',
+    name = 'walletPasswordField',
     onChange,
     password,
     shouldDisablePasswordMeter = false,

--- a/packages/wallets/src/components/Base/WalletTextField/WalletTextField.tsx
+++ b/packages/wallets/src/components/Base/WalletTextField/WalletTextField.tsx
@@ -26,7 +26,7 @@ const WalletTextField = forwardRef(
             maxLength,
             message,
             messageVariant = 'general',
-            name = 'wallet-textfield',
+            name = 'walletTextField',
             onChange,
             renderLeftIcon,
             renderRightIcon,

--- a/packages/wallets/src/features/cfd/screens/ChangePassword/ChangePassword.scss
+++ b/packages/wallets/src/features/cfd/screens/ChangePassword/ChangePassword.scss
@@ -61,7 +61,7 @@
             flex-direction: column;
             align-items: center;
             gap: 1.6rem;
-            min-width: 32.8rem;
+            width: 32.8rem;
         }
 
         &-buttons {

--- a/packages/wallets/src/features/cfd/screens/ChangePassword/MT5ChangeInvestorPasswordScreens.tsx
+++ b/packages/wallets/src/features/cfd/screens/ChangePassword/MT5ChangeInvestorPasswordScreens.tsx
@@ -41,13 +41,13 @@ const MT5ChangeInvestorPasswordScreens = () => {
                     <div className='wallets-change-password__investor-password-fields'>
                         <WalletPasswordField
                             label='Current investor password'
-                            name='current_password'
+                            name='currentPassword'
                             onChange={e => setCurrentInvestorPassword(e.target.value)}
                             password={currentInvestorPassword}
                         />
                         <WalletPasswordField
                             label='New investor password'
-                            name='new_password'
+                            name='newPassword'
                             onChange={e => setNewInvestorPassword(e.target.value)}
                             password={newInvestorPassword}
                         />

--- a/packages/wallets/src/features/cfd/screens/ChangePassword/MT5ChangeInvestorPasswordScreens.tsx
+++ b/packages/wallets/src/features/cfd/screens/ChangePassword/MT5ChangeInvestorPasswordScreens.tsx
@@ -40,14 +40,14 @@ const MT5ChangeInvestorPasswordScreens = () => {
                 <div className='wallets-change-password__investor-password'>
                     <div className='wallets-change-password__investor-password-fields'>
                         <WalletPasswordField
-                            key='current_password'
-                            label={`Current investor password`}
+                            label='Current investor password'
+                            name='current_password'
                             onChange={e => setCurrentInvestorPassword(e.target.value)}
                             password={currentInvestorPassword}
                         />
                         <WalletPasswordField
-                            key='new_password'
-                            label={`New investor password`}
+                            label='New investor password'
+                            name='new_password'
                             onChange={e => setNewInvestorPassword(e.target.value)}
                             password={newInvestorPassword}
                         />


### PR DESCRIPTION
Fixing minor issues on `<MT5InvestorChangePassword />` Modal

## Changes:
- added name prop inside of WalletPasswordField
- change stylings of password field so it resembles figma design
- minor code changes

### Screenshots:
**Before:**

https://github.com/binary-com/deriv-app/assets/103104395/e2a9274f-2043-4233-87b9-f21976dbc6ac


**After:**

https://github.com/binary-com/deriv-app/assets/103104395/405cebdd-7958-4ee3-9a35-b18fde1f1018



