### PR TITLE
[CFDS] [Refactoring] Add the is_mt5_allowed in the useAccessiblePlatforms

### DIFF
--- a/packages/api/src/hooks/useAccesiblePlatforms.ts
+++ b/packages/api/src/hooks/useAccesiblePlatforms.ts
@@ -14,12 +14,19 @@ const useAccesiblePlatforms = () => {
         const is_ctrader_available = landing_company?.ctrader?.all?.standard === 'svg';
         /** check if dxtrade is in the landing_company response */
         const is_dxtrade_available = landing_company?.dxtrade_all_company;
+        /** check if MT5 is in the landing_company response */
+        const is_mt5_available =
+            landing_company?.mt_financial_company ||
+            landing_company?.mt_gaming_company ||
+            landing_company?.mt_all_company;
 
         return {
             /** is ctrader accessible for this country of residence */
             is_ctrader_available: !!is_ctrader_available,
             /** is dxtrade accessible for this country of residence */
             is_dxtrade_available: !!is_dxtrade_available,
+            /** is mt5 accessible for this country of residence */
+            is_mt5_available: !!is_mt5_available,
         };
     }, [landing_company]);
 


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
#### Clickup Card:
[[Refactoring] Add the is_mt5_allowed in the useAccessiblePlatforms](https://app.clickup.com/t/20696747/CFDS-1505)

#### Description:
- Update the useAccessiblePlatforms  to contains the check for MT5 Platform.
For now we have checks only for Ctrader and Deriv X accounts.

#### Scope:

- We need to add the check for MT5 Accounts so we can use this in Traders Hub to show only Accessible Platforms in that particular client's residence country.

#### Acceptance Criteria:
- Only accessible platforms should be shown to client based on client's residence country.


### Screenshots:
- Landing Company Response in case of MT5 Accessible by client country of residence

![image](https://github.com/binary-com/deriv-app/assets/120543468/6ba0f9a9-f373-47da-ab2a-85c1233875ad)



- Landing Company Response in case of MT5 not accessible by client country of residence

![image](https://github.com/binary-com/deriv-app/assets/120543468/fab57d3d-a8c6-4505-9451-5cb97e0f6434)


Please provide some screenshots of the change.
