### PR TITLE
[WALL] Aizad/WALL-2727/Adding Logic inside of MT5ChangePassword

### DIFF
--- a/packages/wallets/src/components/SentEmailContent/SentEmailContent.tsx
+++ b/packages/wallets/src/components/SentEmailContent/SentEmailContent.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useCountdown } from 'usehooks-ts';
-import { useSettings, useVerifyEmail } from '@deriv/api';
+import { useActiveWalletAccount, useSettings, useVerifyEmail } from '@deriv/api';
 import { PlatformDetails } from '../../features/cfd/constants';
 import useDevice from '../../hooks/useDevice';
 import ChangePassword from '../../public/images/change-password-email.svg';
@@ -56,6 +56,16 @@ const SentEmailContent: React.FC<TProps> = ({ description, platform }) => {
         if (count === 0) setHasCountdownStarted(false);
     }, [count]);
 
+    const { data: activeWallet } = useActiveWalletAccount();
+
+    let redirectTo = platform === 'mt5' ? 1 : 2;
+
+    if (!activeWallet?.is_virtual) {
+        redirectTo = Number(`${redirectTo}0`);
+    } else if (activeWallet?.is_virtual) {
+        redirectTo = Number(`${redirectTo}1`);
+    }
+
     return (
         <div className='wallets-sent-email-content'>
             <WalletsActionScreen
@@ -92,6 +102,9 @@ const SentEmailContent: React.FC<TProps> = ({ description, platform }) => {
                                         platform === 'mt5'
                                             ? 'trading_platform_mt5_password_reset'
                                             : 'trading_platform_dxtrade_password_reset',
+                                    url_parameters: {
+                                        redirect_to: redirectTo,
+                                    },
                                     verify_email: data?.email,
                                 });
                                 resetCountdown();

--- a/packages/wallets/src/components/SentEmailContent/SentEmailContent.tsx
+++ b/packages/wallets/src/components/SentEmailContent/SentEmailContent.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { platformPasswordResetRedirectLink } from 'src/utils/cfdUtils';
 import { useCountdown } from 'usehooks-ts';
 import { useActiveWalletAccount, useSettings, useVerifyEmail } from '@deriv/api';
 import { PlatformDetails } from '../../features/cfd/constants';
@@ -58,18 +59,6 @@ const SentEmailContent: React.FC<TProps> = ({ description, platform }) => {
 
     const { data: activeWallet } = useActiveWalletAccount();
 
-    let redirectTo: number;
-
-    switch (platform) {
-        case 'mt5':
-            redirectTo = activeWallet?.is_virtual ? 11 : 10;
-            break;
-        case 'dxtrade':
-        default:
-            redirectTo = activeWallet?.is_virtual ? 21 : 20;
-            break;
-    }
-
     return (
         <div className='wallets-sent-email-content'>
             <WalletsActionScreen
@@ -107,7 +96,10 @@ const SentEmailContent: React.FC<TProps> = ({ description, platform }) => {
                                             ? 'trading_platform_mt5_password_reset'
                                             : 'trading_platform_dxtrade_password_reset',
                                     url_parameters: {
-                                        redirect_to: redirectTo,
+                                        redirect_to: platformPasswordResetRedirectLink(
+                                            platform || 'mt5',
+                                            activeWallet?.is_virtual
+                                        ),
                                     },
                                     verify_email: data?.email,
                                 });

--- a/packages/wallets/src/components/SentEmailContent/SentEmailContent.tsx
+++ b/packages/wallets/src/components/SentEmailContent/SentEmailContent.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { platformPasswordResetRedirectLink } from 'src/utils/cfdUtils';
 import { useCountdown } from 'usehooks-ts';
 import { useActiveWalletAccount, useSettings, useVerifyEmail } from '@deriv/api';
 import { PlatformDetails } from '../../features/cfd/constants';
@@ -10,6 +9,7 @@ import EmailFirewallIcon from '../../public/images/ic-email-firewall.svg';
 import EmailSpamIcon from '../../public/images/ic-email-spam.svg';
 import EmailTypoIcon from '../../public/images/ic-email-typo.svg';
 import { TPlatforms } from '../../types';
+import { platformPasswordResetRedirectLink } from '../../utils/cfdUtils';
 import { WalletButton, WalletText } from '../Base';
 import { WalletsActionScreen } from '../WalletsActionScreen';
 import './SentEmailContent.scss';

--- a/packages/wallets/src/components/SentEmailContent/SentEmailContent.tsx
+++ b/packages/wallets/src/components/SentEmailContent/SentEmailContent.tsx
@@ -58,12 +58,16 @@ const SentEmailContent: React.FC<TProps> = ({ description, platform }) => {
 
     const { data: activeWallet } = useActiveWalletAccount();
 
-    let redirectTo = platform === 'mt5' ? 1 : 2;
+    let redirectTo: number;
 
-    if (activeWallet?.is_virtual) {
-        redirectTo = Number(`${redirectTo}1`);
-    } else {
-        redirectTo = Number(`${redirectTo}0`);
+    switch (platform) {
+        case 'mt5':
+            redirectTo = activeWallet?.is_virtual ? 11 : 10;
+            break;
+        case 'dxtrade':
+        default:
+            redirectTo = activeWallet?.is_virtual ? 21 : 20;
+            break;
     }
 
     return (

--- a/packages/wallets/src/components/SentEmailContent/SentEmailContent.tsx
+++ b/packages/wallets/src/components/SentEmailContent/SentEmailContent.tsx
@@ -60,10 +60,10 @@ const SentEmailContent: React.FC<TProps> = ({ description, platform }) => {
 
     let redirectTo = platform === 'mt5' ? 1 : 2;
 
-    if (!activeWallet?.is_virtual) {
-        redirectTo = Number(`${redirectTo}0`);
-    } else if (activeWallet?.is_virtual) {
+    if (activeWallet?.is_virtual) {
         redirectTo = Number(`${redirectTo}1`);
+    } else {
+        redirectTo = Number(`${redirectTo}0`);
     }
 
     return (

--- a/packages/wallets/src/features/cfd/screens/ChangePassword/MT5ChangePasswordScreens.tsx
+++ b/packages/wallets/src/features/cfd/screens/ChangePassword/MT5ChangePasswordScreens.tsx
@@ -20,12 +20,16 @@ const MT5ChangePasswordScreens: React.FC<MT5ChangePasswordScreensProps> = ({ pla
     const { mutate } = useVerifyEmail();
     const { data: activeWallet } = useActiveWalletAccount();
 
-    let redirectTo = platform === 'mt5' ? 1 : 2;
+    let redirectTo: number;
 
-    if (activeWallet?.is_virtual) {
-        redirectTo = Number(`${redirectTo}1`);
-    } else {
-        redirectTo = Number(`${redirectTo}0`);
+    switch (platform) {
+        case 'mt5':
+            redirectTo = activeWallet?.is_virtual ? 11 : 10;
+            break;
+        case 'dxtrade':
+        default:
+            redirectTo = activeWallet?.is_virtual ? 21 : 20;
+            break;
     }
 
     const handleSendEmail = async () => {

--- a/packages/wallets/src/features/cfd/screens/ChangePassword/MT5ChangePasswordScreens.tsx
+++ b/packages/wallets/src/features/cfd/screens/ChangePassword/MT5ChangePasswordScreens.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useActiveWalletAccount, useSettings, useVerifyEmail } from '@deriv/api';
 import { SentEmailContent, WalletButton, WalletsActionScreen, WalletText } from '../../../../components';
 import { useModal } from '../../../../components/ModalProvider';
 import MT5PasswordIcon from '../../../../public/images/ic-mt5-password.svg';
@@ -15,6 +16,32 @@ const MT5ChangePasswordScreens: React.FC<MT5ChangePasswordScreensProps> = ({ pla
     const handleClick = (nextScreen: TChangePasswordScreenIndex) => setActiveScreen(nextScreen);
 
     const { hide } = useModal();
+    const { data } = useSettings();
+    const { mutate } = useVerifyEmail();
+    const { data: activeWallet } = useActiveWalletAccount();
+
+    let redirectTo = platform === 'mt5' ? 1 : 2;
+
+    if (activeWallet?.is_virtual) {
+        redirectTo = Number(`${redirectTo}1`);
+    } else {
+        redirectTo = Number(`${redirectTo}0`);
+    }
+
+    const handleSendEmail = async () => {
+        if (data.email) {
+            await mutate({
+                type:
+                    platform === 'mt5'
+                        ? 'trading_platform_mt5_password_reset'
+                        : 'trading_platform_dxtrade_password_reset',
+                url_parameters: {
+                    redirect_to: redirectTo,
+                },
+                verify_email: data.email,
+            });
+        }
+    };
 
     const ChangePasswordScreens = {
         confirmationScreen: {
@@ -26,7 +53,14 @@ const MT5ChangePasswordScreens: React.FC<MT5ChangePasswordScreensProps> = ({ pla
             button: (
                 <div className='wallets-change-password__btn'>
                     <WalletButton onClick={() => hide()} size='lg' text='Cancel' variant='outlined' />
-                    <WalletButton onClick={() => handleClick('emailVerification')} size='lg' text='Confirm' />
+                    <WalletButton
+                        onClick={() => {
+                            handleSendEmail();
+                            handleClick('emailVerification');
+                        }}
+                        size='lg'
+                        text='Confirm'
+                    />
                 </div>
             ),
             headingText: `Confirm to change your ${platformTitle} password`,

--- a/packages/wallets/src/features/cfd/screens/ChangePassword/MT5ChangePasswordScreens.tsx
+++ b/packages/wallets/src/features/cfd/screens/ChangePassword/MT5ChangePasswordScreens.tsx
@@ -4,8 +4,10 @@ import { SentEmailContent, WalletButton, WalletsActionScreen, WalletText } from 
 import { useModal } from '../../../../components/ModalProvider';
 import MT5PasswordIcon from '../../../../public/images/ic-mt5-password.svg';
 import { TPlatforms } from '../../../../types';
+import { platformPasswordResetRedirectLink } from '../../../../utils/cfdUtils';
 
 type MT5ChangePasswordScreensProps = {
+    isVirtual?: boolean;
     platform: TPlatforms.All;
     platformTitle: string;
 };
@@ -20,18 +22,6 @@ const MT5ChangePasswordScreens: React.FC<MT5ChangePasswordScreensProps> = ({ pla
     const { mutate } = useVerifyEmail();
     const { data: activeWallet } = useActiveWalletAccount();
 
-    let redirectTo: number;
-
-    switch (platform) {
-        case 'mt5':
-            redirectTo = activeWallet?.is_virtual ? 11 : 10;
-            break;
-        case 'dxtrade':
-        default:
-            redirectTo = activeWallet?.is_virtual ? 21 : 20;
-            break;
-    }
-
     const handleSendEmail = async () => {
         if (data.email) {
             await mutate({
@@ -40,7 +30,7 @@ const MT5ChangePasswordScreens: React.FC<MT5ChangePasswordScreensProps> = ({ pla
                         ? 'trading_platform_mt5_password_reset'
                         : 'trading_platform_dxtrade_password_reset',
                 url_parameters: {
-                    redirect_to: redirectTo,
+                    redirect_to: platformPasswordResetRedirectLink(platform, activeWallet?.is_virtual),
                 },
                 verify_email: data.email,
             });

--- a/packages/wallets/src/utils/cfdUtils.ts
+++ b/packages/wallets/src/utils/cfdUtils.ts
@@ -1,0 +1,11 @@
+import { TPlatforms } from '../types';
+
+export const platformPasswordResetRedirectLink = (platform: TPlatforms.All, isVirtual?: boolean) => {
+    switch (platform) {
+        case 'mt5':
+            return isVirtual ? 11 : 10;
+        case 'dxtrade':
+        default:
+            return isVirtual ? 21 : 20;
+    }
+};


### PR DESCRIPTION
## Changes:
- added `useVerifyEmail` hook inside of `<ChangeMT5Passwords />` to send password reset link via email.
- updated  `useVerifyEmail` hook inside of `<SentEmailContent />` by adding `url_parameter` inside.

### Screenshots:
![Screenshot 2023-11-29 at 11 08 26 AM](https://github.com/binary-com/deriv-app/assets/103104395/83b500aa-bac9-45b4-9601-49959cdc857d)
![Screenshot 2023-11-29 at 11 08 00 AM](https://github.com/binary-com/deriv-app/assets/103104395/3ff75b8a-0f24-4386-bc5a-7f02324262e4)
![Screenshot 2023-11-29 at 11 12 23 AM](https://github.com/binary-com/deriv-app/assets/103104395/a0827ec2-a8cc-4811-b1b4-08d123f9f7bd)

