### PR TITLE
[WALL] [Fix] Rostislav / WALL-2689 / Demo transactions `reset_balance` workaround

### DIFF
--- a/packages/api/src/hooks/index.ts
+++ b/packages/api/src/hooks/index.ts
@@ -55,6 +55,7 @@ export { default as useTradingPlatformInvestorPasswordChange } from './useTradin
 export { default as useTradingPlatformInvestorPasswordReset } from './useTradingPlatformInvestorPasswordReset';
 export { default as useTradingPlatformPasswordChange } from './useTradingPlatformPasswordChange';
 export { default as useTransactions } from './useTransactions';
+export { default as useInfiniteTransactions } from './useInfiniteTransactions';
 export { default as useTransferBetweenAccounts } from './useTransferBetweenAccounts';
 export { default as useVerifyEmail } from './useVerifyEmail';
 export { default as useWalletAccountsList } from './useWalletAccountsList';

--- a/packages/api/src/hooks/useInfiniteTransactions.ts
+++ b/packages/api/src/hooks/useInfiniteTransactions.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
+import useInfiniteQuery from '../useInfiniteQuery';
 import { TSocketRequestPayload } from '../../types';
 import useAuthorize from './useAuthorize';
-import useQuery from '../useQuery';
 import useInvalidateQuery from '../useInvalidateQuery';
 import useActiveAccount from './useActiveAccount';
 import { displayMoney } from '../utils';
@@ -9,7 +9,7 @@ import { displayMoney } from '../utils';
 type TFilter = NonNullable<TSocketRequestPayload<'statement'>['payload']>['action_type'];
 
 /** A custom hook to get the summary of account transactions */
-const useTransactions = () => {
+const useInfiniteTransactions = () => {
     const {
         data: { preferred_language },
         isFetching,
@@ -21,7 +21,7 @@ const useTransactions = () => {
     const fractional_digits = account?.currency_config?.fractional_digits || 2;
 
     const [filter, setFilter] = useState<TFilter>();
-    const { data, remove, ...rest } = useQuery('statement', {
+    const { data, fetchNextPage, remove, ...rest } = useInfiniteQuery('statement', {
         options: {
             enabled: !isFetching && isSuccess,
             getNextPageParam: (lastPage, pages) => {
@@ -46,11 +46,18 @@ const useTransactions = () => {
         return remove;
     }, [remove]);
 
+    // Flatten the data array.
+    const flatten_data = useMemo(() => {
+        if (!data?.pages?.length) return;
+
+        return data?.pages?.flatMap(page => page?.statement?.transactions);
+    }, [data?.pages]);
+
     // Modify the data.
     const modified_data = useMemo(() => {
-        if (!data?.statement?.transactions?.length) return;
+        if (!flatten_data?.length) return;
 
-        return data?.statement?.transactions?.map(transaction => ({
+        return flatten_data?.map(transaction => ({
             ...transaction,
             /** The transaction amount in currency format. */
             display_amount: displayMoney(transaction?.amount || 0, display_code, {
@@ -63,15 +70,17 @@ const useTransactions = () => {
                 preferred_language,
             }),
         }));
-    }, [data?.statement?.transactions, display_code, fractional_digits, preferred_language]);
+    }, [flatten_data, preferred_language, fractional_digits, display_code]);
 
     return {
         /** List of account transactions */
         data: modified_data,
+        /** Fetch the next page of transactions */
+        fetchNextPage,
         /** Filter the transactions by type */
         setFilter,
         ...rest,
     };
 };
 
-export default useTransactions;
+export default useInfiniteTransactions;

--- a/packages/wallets/src/features/cashier/modules/Transactions/Transactions.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/Transactions.tsx
@@ -4,7 +4,7 @@ import { useActiveWalletAccount } from '@deriv/api';
 import { ToggleSwitch, WalletDropdown, WalletText } from '../../../../components';
 import useDevice from '../../../../hooks/useDevice';
 import FilterIcon from '../../../../public/images/filter.svg';
-import { TransactionsCompleted, TransactionsPending } from './components';
+import { TransactionsCompleted, TransactionsCompletedDemoResetBalance, TransactionsPending } from './components';
 import './Transactions.scss';
 
 type TTransactionsPendingFilter = React.ComponentProps<typeof TransactionsPending>['filter'];
@@ -84,8 +84,11 @@ const Transactions = () => {
                     value={filterValue}
                 />
             </div>
-            {isPendingActive ? (
+            {isPendingActive && (
                 <TransactionsPending filter={filtersMapper.pending[filterValue] as TTransactionsPendingFilter} />
+            )}
+            {wallet?.is_virtual && filterValue === 'deposit' ? (
+                <TransactionsCompletedDemoResetBalance />
             ) : (
                 <TransactionsCompleted filter={filtersMapper.completed[filterValue] as TTransactionCompletedFilter} />
             )}

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompleted/TransactionsCompleted.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompleted/TransactionsCompleted.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
 import moment from 'moment';
-import { useActiveWalletAccount, useAllAccountsList, useTransactions } from '@deriv/api';
+import { useActiveWalletAccount, useAllAccountsList, useInfiniteTransactions } from '@deriv/api';
 import { TSocketRequestPayload } from '@deriv/api/types';
 import { Loader } from '../../../../../../components';
 import { WalletText } from '../../../../../../components/Base';
@@ -23,7 +23,7 @@ const TransactionsCompleted: React.FC<TProps> = ({ filter }) => {
         isFetching,
         isLoading: isTransactionListLoading,
         setFilter,
-    } = useTransactions();
+    } = useInfiniteTransactions();
     const { data: wallet, isLoading: isWalletLoading } = useActiveWalletAccount();
     const { data: accounts, isLoading: isAccountsListLoading } = useAllAccountsList();
 

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedDemoResetBalance/TransactionsCompletedDemoResetBalance.scss
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedDemoResetBalance/TransactionsCompletedDemoResetBalance.scss
@@ -1,0 +1,11 @@
+.wallets-transactions-completed-demo-reset-balance {
+    position: relative;
+
+    &__group-title {
+        margin: 0 0 0.8rem 1.6rem;
+
+        @include mobile {
+            margin-left: 0;
+        }
+    }
+}

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedDemoResetBalance/TransactionsCompletedDemoResetBalance.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedDemoResetBalance/TransactionsCompletedDemoResetBalance.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect } from 'react';
+import moment from 'moment';
+import { useActiveWalletAccount, useAllAccountsList, useTransactions } from '@deriv/api';
+import { Loader } from '../../../../../../components';
+import { WalletText } from '../../../../../../components/Base';
+import { TransactionsCompletedRow } from '../TransactionsCompletedRow';
+import { TransactionsNoDataState } from '../TransactionsNoDataState';
+import { TransactionsTable } from '../TransactionsTable';
+import './TransactionsCompletedDemoResetBalance.scss';
+
+const TransactionsCompletedDemoResetBalance: React.FC = () => {
+    const {
+        data: depositDemoTransactions,
+        isLoading: isDemoDepositsListLoading,
+        setFilter: setDepositFilter,
+    } = useTransactions();
+    const {
+        data: withdrawalDemoTransactions,
+        isLoading: isDemoWithdrawalsListLoading,
+        setFilter: setWithdrawalFilter,
+    } = useTransactions();
+    const { data: wallet, isLoading: isWalletLoading } = useActiveWalletAccount();
+    const { data: accounts, isLoading: isAccountsListLoading } = useAllAccountsList();
+
+    useEffect(() => {
+        setDepositFilter('deposit');
+        setWithdrawalFilter('withdrawal');
+    }, [setDepositFilter, setWithdrawalFilter]);
+
+    const isLoading =
+        isDemoDepositsListLoading || isDemoWithdrawalsListLoading || isWalletLoading || isAccountsListLoading;
+
+    const resetBalanceTransactions = [...(depositDemoTransactions ?? []), ...(withdrawalDemoTransactions ?? [])].sort(
+        (a, b) => (b.transaction_time ?? 0) - (a.transaction_time ?? 0)
+    );
+
+    if (!wallet || isLoading) return <Loader />;
+
+    if (!resetBalanceTransactions) return <TransactionsNoDataState />;
+
+    return (
+        <TransactionsTable
+            columns={[
+                {
+                    accessorFn: row => row.transaction_time && moment.unix(row.transaction_time).format('DD MMM YYYY'),
+                    accessorKey: 'date',
+                    header: 'Date',
+                },
+            ]}
+            data={resetBalanceTransactions}
+            groupBy={['date']}
+            rowGroupRender={transaction => (
+                <div className='wallets-transactions-completed-demo-reset-balance__group-title'>
+                    <WalletText color='primary' size='2xs'>
+                        {transaction.transaction_time &&
+                            moment.unix(transaction.transaction_time).format('DD MMM YYYY')}
+                    </WalletText>
+                </div>
+            )}
+            rowRender={transaction => (
+                <TransactionsCompletedRow accounts={accounts} transaction={transaction} wallet={wallet} />
+            )}
+        />
+    );
+};
+
+export default TransactionsCompletedDemoResetBalance;

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedDemoResetBalance/index.ts
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedDemoResetBalance/index.ts
@@ -1,0 +1,1 @@
+export { default as TransactionsCompletedDemoResetBalance } from './TransactionsCompletedDemoResetBalance';

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/TransactionsCompletedRow.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/TransactionsCompletedRow.tsx
@@ -7,7 +7,7 @@ import './TransactionsCompletedRow.scss';
 
 type TProps = {
     accounts: THooks.AllAccountsList;
-    transaction: THooks.Transactions;
+    transaction: THooks.InfiniteTransactions | THooks.Transactions;
     wallet: THooks.ActiveWalletAccount;
 };
 
@@ -34,6 +34,10 @@ const TransactionsCompletedRow: React.FC<TProps> = ({ accounts, transaction, wal
 
     const displayCurrency = wallet?.currency_config?.display_code || 'USD';
     const displayWalletName = `${displayCurrency} Wallet`;
+    const displayActionType =
+        wallet.is_virtual && ['deposit', 'withdrawal'].includes(transaction.action_type)
+            ? 'Reset balance'
+            : transaction.action_type.replace(/^\w/, c => c.toUpperCase());
 
     return (
         <div className='wallets-transactions-completed-row'>
@@ -43,7 +47,7 @@ const TransactionsCompletedRow: React.FC<TProps> = ({ accounts, transaction, wal
                     actionType={transaction.action_type}
                     currency={wallet?.currency ?? 'USD'}
                     displayAccountName={displayWalletName}
-                    displayActionType={transaction.action_type.replace(/^\w/, c => c.toUpperCase())}
+                    displayActionType={displayActionType}
                     isDemo={Boolean(wallet?.is_virtual)}
                 />
             ) : (

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/components/TransactionsCompletedRowAccountDetails/TransactionsCompletedRowAccountDetails.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/components/TransactionsCompletedRowAccountDetails/TransactionsCompletedRowAccountDetails.tsx
@@ -11,7 +11,7 @@ import './TransactionsCompletedRowAccountDetails.scss';
 
 type TProps = {
     accountType: string;
-    actionType: NonNullable<THooks.Transactions['action_type']>;
+    actionType: NonNullable<(THooks.InfiniteTransactions | THooks.Transactions)['action_type']>;
     currency: string;
     displayAccountName: string;
     displayActionType: string;

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/index.ts
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/index.ts
@@ -1,4 +1,5 @@
 export * from './TransactionsCompleted';
+export * from './TransactionsCompletedDemoResetBalance';
 export * from './TransactionsNoDataState';
 export * from './TransactionsPending';
 export * from './TransactionsPendingRow';

--- a/packages/wallets/src/types.ts
+++ b/packages/wallets/src/types.ts
@@ -16,6 +16,7 @@ import type {
     useDxtradeAccountsList,
     useDynamicLeverage,
     useExchangeRate,
+    useInfiniteTransactions,
     useMT5AccountsList,
     usePOA,
     usePOI,
@@ -50,6 +51,7 @@ export namespace THooks {
     export type CurrencyConfig = NonNullable<ReturnType<typeof useCurrencyConfig>['data']>[string];
     export type GetCurrencyConfig = NonNullable<ReturnType<typeof useCurrencyConfig>['getConfig']>;
     export type Transactions = NonNullable<ReturnType<typeof useTransactions>['data']>[number];
+    export type InfiniteTransactions = NonNullable<ReturnType<typeof useInfiniteTransactions>['data']>[number];
     export type TransferAccount = NonNullable<
         NonNullable<ReturnType<typeof useTransferBetweenAccounts>['data']>['accounts']
     >[number];


### PR DESCRIPTION
## Changes:

- [x] rename `useTransactions` to `useInfiniteTransactions`
- [x] add new hook `useTransactions` which is a `statement` call wrapper as well, but w/o pagination / lazy data loading, unlike `useInfiniteTransactions`
- [x] create new component for `reset_balance` transactions of demo wallets which only requests for `deposit` and `withdrawal` transactions, merges and sorts them by time, and renders

### Screenshots:

https://github.com/binary-com/deriv-app/assets/119863957/a325e9c5-41a0-4d98-b016-f9f1855e386f


