### PR TITLE
[FEQ] chore: abstract mock oauth url logic[

### DIFF
--- a/packages/integration/src/exampleMock.ts
+++ b/packages/integration/src/exampleMock.ts
@@ -11,12 +11,13 @@ async function main() {
         accounts: DEFAULT_ACCOUNTS,
     };
 
-    const url = generateOauthLoginFromAccounts('https://localhost:8443', state.accounts);
+    const oauthLoginUrl = generateOauthLoginFromAccounts('https://localhost:8443', state.accounts);
+    const query = Object.fromEntries(oauthLoginUrl.searchParams);
 
     // eslint-disable-next-line no-console
-    console.log(`You can login at:\n${url}`);
+    console.log(`You can login at:\n${oauthLoginUrl}`);
 
-    await createMockServer(state, {}, [general, auth, residentsList, statesList], { port: 10443 });
+    await createMockServer(state, query, [general, auth, residentsList, statesList], { port: 10443 });
     process.stdout.write('Listening on localhost:10443');
 }
 

--- a/packages/integration/src/exampleMock.ts
+++ b/packages/integration/src/exampleMock.ts
@@ -3,9 +3,20 @@ import general from './mocks/general';
 import auth from './mocks/auth';
 import residentsList from './mocks/general/residentsList';
 import statesList from './mocks/general/statesList';
+import { DEFAULT_ACCOUNTS } from './mocks/auth/authorize';
+import generateOauthLoginFromAccounts from './utils/mocks/generateOauthLoginFromAccounts';
 
 async function main() {
-    await createMockServer({}, {}, [general, auth, residentsList, statesList], { port: 10443 });
+    const state = {
+        accounts: DEFAULT_ACCOUNTS,
+    };
+
+    const url = generateOauthLoginFromAccounts('https://localhost:8443', state.accounts);
+
+    // eslint-disable-next-line no-console
+    console.log(`You can login at:\n${url}`);
+
+    await createMockServer(state, {}, [general, auth, residentsList, statesList], { port: 10443 });
     process.stdout.write('Listening on localhost:10443');
 }
 

--- a/packages/integration/src/utils/mocks/generateOauthLoginFromAccounts.ts
+++ b/packages/integration/src/utils/mocks/generateOauthLoginFromAccounts.ts
@@ -1,0 +1,21 @@
+export default function generateOauthLoginFromAccounts(baseURL, accounts) {
+    const url = new URL('/', baseURL);
+    const params = new URLSearchParams();
+
+    const query = accounts?.reduce((query, account, index) => {
+        return {
+            ...query,
+            [`acct${index + 1}`]: account.id,
+            [`token${index + 1}`]: account.token,
+            [`cur${index + 1}`]: account.currency,
+        };
+    }, {});
+
+    Object.entries(query || {}).forEach(([key, value]) => {
+        params.append(key, String(value));
+    });
+
+    url.search = params.toString();
+
+    return url;
+}

--- a/packages/integration/src/utils/mocks/mocks.ts
+++ b/packages/integration/src/utils/mocks/mocks.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'events';
 import { Server as WsServer } from 'ws';
 import { generate } from 'selfsigned';
 import { Page, expect } from '@playwright/test';
+import generateOauthLoginFromAccounts from './generateOauthLoginFromAccounts';
 
 import type {
     APITokenRequest,
@@ -555,15 +556,8 @@ async function setupMocks({ baseURL, page, state, mocks }: SetupMocksOptions) {
         throw new Error('baseURL is required');
     }
 
-    const query = state?.accounts?.reduce((query, account, index) => {
-        return {
-            ...query,
-            [`acct${index + 1}`]: account.id,
-            [`token${index + 1}`]: account.token,
-            [`cur${index + 1}`]: account.currency,
-        };
-    }, {});
-
+    const oauthLoginUrl = generateOauthLoginFromAccounts(baseURL, state?.accounts);
+    const query = Object.fromEntries(oauthLoginUrl.searchParams);
     const mockServer = await createMockServer(state || {}, query, mocks);
 
     page.addListener('close', () => {
@@ -579,16 +573,7 @@ async function setupMocks({ baseURL, page, state, mocks }: SetupMocksOptions) {
         );
     }, mockServer.url);
 
-    const url = new URL('/', baseURL);
-    const params = new URLSearchParams();
-
-    Object.entries(query || {}).forEach(([key, value]) => {
-        params.append(key, String(value));
-    });
-
-    url.search = params.toString();
-
-    await page.goto(url.href);
+    await page.goto(oauthLoginUrl.href);
 
     await expect
         .poll(


### PR DESCRIPTION
This abstracts the oauth url generation, and allows us to print the url when creating a standalone mock server.

<img width="1667" alt="Screenshot 2023-11-29 at 17 12 33" src="https://github.com/binary-com/deriv-app/assets/129744061/16febf3a-28ef-472c-8ca9-ecc4730686a0">
