### PR TITLE
Bala/fix multipliers default selection

### DIFF
--- a/packages/trader/src/Modules/Trading/Containers/trade.jsx
+++ b/packages/trader/src/Modules/Trading/Containers/trade.jsx
@@ -44,11 +44,9 @@ const Trade = observer(() => {
         is_trade_enabled,
         is_turbos,
         is_vanilla,
-        onChange,
         onMount,
         onUnmount,
         prepareTradeStore,
-        setContractTypes,
         setIsDigitsWidgetActive,
         setMobileDigitView,
         should_show_active_symbols_loading,
@@ -107,18 +105,6 @@ const Trade = observer(() => {
         setTrySyntheticIndices(false);
         setTryOpenMarkets(false);
     }, [is_mobile, symbol, setDigits, setTrySyntheticIndices, is_synthetics_available]);
-
-    React.useEffect(() => {
-        const selectMultipliers = async () => {
-            await setContractTypes();
-
-            onChange({ target: { name: 'contract_type', value: 'multiplier' } });
-        };
-        if (!is_chart_loading && (is_synthetics_available || !is_market_closed)) {
-            selectMultipliers();
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [is_chart_loading]);
 
     const bottomWidgets = React.useCallback(({ digits: d, tick: t }) => {
         return <BottomWidgetsMobile digits={d} tick={t} setTick={setTick} setDigits={setDigits} />;


### PR DESCRIPTION
## Changes:

Trade section has multipliers selected by default. It should be rise/fall by default. A fix is added in this PR to remove code related to multipliers.


### Screenshots:

![image](https://github.com/binary-com/deriv-app/assets/56330681/41cc8eff-f6d4-44f9-ba9d-e64df3f80f7f)
