### PR TITLE
[wallets]Thisyahlen/wall 2794/icon platform not in order mt5 trade modal

### DIFF
--- a/packages/wallets/src/features/cfd/components/ModalTradeWrapper/ModalTradeWrapper.tsx
+++ b/packages/wallets/src/features/cfd/components/ModalTradeWrapper/ModalTradeWrapper.tsx
@@ -60,9 +60,10 @@ const ModalTradeWrapper: FC<PropsWithChildren<TModalTradeWrapper>> = ({ children
                         <div className='wallets-modal-trade-wrapper__footer-installations'>
                             <div className='wallets-modal-trade-wrapper__footer-installations-icons'>
                                 {appOrder.map(app => {
-                                    if (LinksMapper[platform][app as 'android' | 'huawei' | 'ios']) {
+                                    const AppsLinkMapper = LinksMapper[platform][app as 'android' | 'huawei' | 'ios'];
+                                    if (AppsLinkMapper) {
                                         const AppIcon = AppToIconMapper[app];
-                                        const appLink = LinksMapper[platform][app as 'android' | 'huawei' | 'ios'];
+                                        const appLink = AppsLinkMapper;
                                         return <AppIcon key={app} onClick={() => window.open(appLink)} />;
                                     }
                                     return null;

--- a/packages/wallets/src/features/cfd/components/ModalTradeWrapper/ModalTradeWrapper.tsx
+++ b/packages/wallets/src/features/cfd/components/ModalTradeWrapper/ModalTradeWrapper.tsx
@@ -46,6 +46,7 @@ type TModalTradeWrapper = {
 
 const ModalTradeWrapper: FC<PropsWithChildren<TModalTradeWrapper>> = ({ children, platform }) => {
     const { isDesktop } = useDevice();
+    const appOrder = ['ios', 'android', 'huawei'];
 
     return (
         <ModalStepWrapper
@@ -58,10 +59,13 @@ const ModalTradeWrapper: FC<PropsWithChildren<TModalTradeWrapper>> = ({ children
                         </WalletText>
                         <div className='wallets-modal-trade-wrapper__footer-installations'>
                             <div className='wallets-modal-trade-wrapper__footer-installations-icons'>
-                                {Object.keys(LinksMapper[platform]).map(app => {
-                                    const AppIcon = AppToIconMapper[app];
-                                    const appLink = LinksMapper[platform][app as 'android' | 'huawei' | 'ios'];
-                                    return <AppIcon key={app} onClick={() => window.open(appLink)} />;
+                                {appOrder.map(app => {
+                                    if (LinksMapper[platform][app as 'android' | 'huawei' | 'ios']) {
+                                        const AppIcon = AppToIconMapper[app];
+                                        const appLink = LinksMapper[platform][app as 'android' | 'huawei' | 'ios'];
+                                        return <AppIcon key={app} onClick={() => window.open(appLink)} />;
+                                    }
+                                    return null;
                                 })}
                             </div>
                             {isDesktop && (

--- a/packages/wallets/src/features/cfd/components/ModalTradeWrapper/ModalTradeWrapper.tsx
+++ b/packages/wallets/src/features/cfd/components/ModalTradeWrapper/ModalTradeWrapper.tsx
@@ -10,14 +10,13 @@ import { TPlatforms } from '../../../../types';
 import { PlatformDetails } from '../../constants';
 import './ModalTradeWrapper.scss';
 
-const LinksMapper: Record<
-    TPlatforms.All,
-    {
-        android: string;
-        huawei?: string;
-        ios: string;
-    }
-> = {
+type TAppLinks = {
+    android: string;
+    huawei?: string;
+    ios: string;
+};
+
+const LinksMapper: Record<TPlatforms.All, TAppLinks> = {
     ctrader: {
         android: 'https://play.google.com/store/apps/details?id=com.deriv.ct',
         ios: 'https://apps.apple.com/cy/app/ctrader/id767428811',
@@ -60,7 +59,7 @@ const ModalTradeWrapper: FC<PropsWithChildren<TModalTradeWrapper>> = ({ children
                         <div className='wallets-modal-trade-wrapper__footer-installations'>
                             <div className='wallets-modal-trade-wrapper__footer-installations-icons'>
                                 {appOrder.map(app => {
-                                    const AppsLinkMapper = LinksMapper[platform][app as 'android' | 'huawei' | 'ios'];
+                                    const AppsLinkMapper = LinksMapper[platform][app as keyof TAppLinks];
                                     if (AppsLinkMapper) {
                                         const AppIcon = AppToIconMapper[app];
                                         const appLink = AppsLinkMapper;


### PR DESCRIPTION
## Changes:
1. Fixed the order of the app icons in cfd trade modal

### Screenshots:

![2023-11-30_15-21](https://github.com/binary-com/deriv-app/assets/104053934/a28ddd70-1f3b-485b-8676-423c3371c7ef)

