### PR TITLE
[Fix] aum/WALL-2813/fix-crypto-withdrawal-message-overlap

### DIFF
--- a/packages/cashier/src/pages/withdrawal/withdrawal-crypto-form/withdrawal-crypto-form.scss
+++ b/packages/cashier/src/pages/withdrawal/withdrawal-crypto-form/withdrawal-crypto-form.scss
@@ -44,4 +44,8 @@
             }
         }
     }
+
+    & .withdraw__input {
+        margin-bottom: 3.2rem !important;
+    }
 }

--- a/packages/cashier/src/pages/withdrawal/withdrawal-crypto-form/withdrawal-crypto-form.scss
+++ b/packages/cashier/src/pages/withdrawal/withdrawal-crypto-form/withdrawal-crypto-form.scss
@@ -29,9 +29,6 @@
     &__percentage {
         &-container {
             margin-top: 2.4rem;
-            @include mobile {
-                margin-top: 0;
-            }
         }
         &-selector {
             margin-bottom: 1.6rem;
@@ -42,12 +39,6 @@
                 align-items: center;
                 width: 100%;
             }
-        }
-    }
-
-    & .withdraw__input {
-        @include mobile {
-            margin-bottom: 3.2rem !important;
         }
     }
 }

--- a/packages/cashier/src/pages/withdrawal/withdrawal-crypto-form/withdrawal-crypto-form.scss
+++ b/packages/cashier/src/pages/withdrawal/withdrawal-crypto-form/withdrawal-crypto-form.scss
@@ -46,6 +46,8 @@
     }
 
     & .withdraw__input {
-        margin-bottom: 3.2rem !important;
+        @include mobile {
+            margin-bottom: 3.2rem !important;
+        }
     }
 }


### PR DESCRIPTION
## Changes:

Fixed the spacing between the crypto-address-field and the percentage-selector in the crypto-withdrawal screen in cashier.

### Screenshots:

Broken:
<img height="450" src="https://github.com/binary-com/deriv-app/assets/125039206/6369dc76-b99a-4ca9-9e30-813065d29592" />
Fixed:
<img height="550" src="https://github.com/binary-com/deriv-app/assets/125039206/57217352-1890-4115-a071-0b7d3700c2f2">

