### PR TITLE
[wallets]thisyahlen/WALL-2640/fix: remove jurisdiction from real dxtrade success popup

### DIFF
--- a/packages/wallets/src/features/cfd/screens/CFDSuccess/CFDSuccess.tsx
+++ b/packages/wallets/src/features/cfd/screens/CFDSuccess/CFDSuccess.tsx
@@ -82,7 +82,8 @@ const CFDSuccess: React.FC<TSuccessProps> = ({
                             />
                             <div className='wallets-cfd-success__info'>
                                 <WalletText size='2xs'>
-                                    {platformTitlePrefix} {marketTypeTitle} {!isDemo && `(${landingCompanyName})`}
+                                    {platformTitlePrefix} {marketTypeTitle}{' '}
+                                    {!isDemo && !isAllDxtrade && `(${landingCompanyName})`}
                                 </WalletText>
                                 <WalletText color='primary' size='2xs'>
                                     {data?.currency} Wallet


### PR DESCRIPTION
## Changes:
1. Removed jurisdiction from dxtrade real success modal

### Screenshots:
![Screenshot 2023-11-30 at 5 21 19 PM](https://github.com/binary-com/deriv-app/assets/104053934/7e4373a8-45b1-4388-9cc7-557c4c8661e5)

