### PR TITLE
[wallets]thisyahlen/WALL-2821/fix: remove border and adjust padding in add more wallets section to match design

### DIFF
--- a/packages/wallets/src/components/WalletsAddMoreCarousel/WalletsAddMoreCarousel.scss
+++ b/packages/wallets/src/components/WalletsAddMoreCarousel/WalletsAddMoreCarousel.scss
@@ -21,10 +21,9 @@
     &__carousel {
         overflow: hidden;
         background-color: #fff;
-        padding: 3.2rem 1.6rem;
+        padding: 3.2rem 2.4rem;
         border-radius: 0.8rem;
         position: relative;
-        border: 0.1rem solid #d6dadb;
         height: 100%;
 
         @include mobile {


### PR DESCRIPTION
## Changes:
1. Remove border and adjust padding in add more wallets section to match design

### Screenshots:

![Screenshot 2023-12-01 at 10 06 43 AM](https://github.com/binary-com/deriv-app/assets/104053934/f8545f2b-1889-48bc-ac35-95d86da4f6b4)

