### PR TITLE
[WALL] Aizad/WALL-2828/Fix issues related to Password Meter component and Enter Password Modal in Deriv X

### DIFF
--- a/packages/wallets/src/components/Base/WalletPasswordField/WalletPasswordField.scss
+++ b/packages/wallets/src/components/Base/WalletPasswordField/WalletPasswordField.scss
@@ -39,7 +39,7 @@ $meter-widths: (
                 background-color: $color;
                 width: map-get($meter-widths, $key);
                 height: 0.4rem;
-                border-radius: 0 0 1.6rem 1.6rem;
+                border-radius: 1.6rem;
                 transition: width 0.3s;
                 z-index: 2;
             }

--- a/packages/wallets/src/components/Base/WalletPasswordField/WalletPasswordField.tsx
+++ b/packages/wallets/src/components/Base/WalletPasswordField/WalletPasswordField.tsx
@@ -18,6 +18,7 @@ const WalletPasswordField: React.FC<WalletPasswordFieldProps> = ({
     onChange,
     password,
     shouldDisablePasswordMeter = false,
+    showMessage,
 }) => {
     const [isPasswordVisible, setIsPasswordVisible] = useState(false);
     const [isTouched, setIsTouched] = useState(false);
@@ -46,7 +47,7 @@ const WalletPasswordField: React.FC<WalletPasswordFieldProps> = ({
                 renderRightIcon={() => (
                     <PasswordViewerIcon setViewPassword={setIsPasswordVisible} viewPassword={isPasswordVisible} />
                 )}
-                showMessage
+                showMessage={showMessage}
                 type={isPasswordVisible ? 'text' : 'password'}
                 value={password}
             />

--- a/packages/wallets/src/constants/passwordConstants.ts
+++ b/packages/wallets/src/constants/passwordConstants.ts
@@ -21,7 +21,7 @@ export const passwordErrorMessage = {
 };
 
 export const warningMessages: Record<passwordKeys, string> = {
-    common: 'This is a commonly used password.',
+    common: 'This is a very common password.',
     commonNames: 'Common names and surnames are easy to guess.',
     dates: 'Dates are easy to guess.',
     extendedRepeat: 'Repeated character patterns like "abcabcabc" are easy to guess.',

--- a/packages/wallets/src/features/cfd/screens/EnterPassword/EnterPassword.tsx
+++ b/packages/wallets/src/features/cfd/screens/EnterPassword/EnterPassword.tsx
@@ -42,7 +42,13 @@ const EnterPassword: React.FC<TProps> = ({
                 <WalletText size='sm'>
                     Enter your {title} password to add a {title} {marketTypeTitle} account.
                 </WalletText>
-                <WalletPasswordField label={`${title} password`} onChange={onPasswordChange} password={password} />
+                <WalletPasswordField
+                    label={`${title} password`}
+                    onChange={onPasswordChange}
+                    password={password}
+                    shouldDisablePasswordMeter
+                    showMessage={false}
+                />
             </div>
             {isDesktop && (
                 <div className='wallets-enter-password__buttons'>


### PR DESCRIPTION
## Changes:
- Change border radius for password meter
- Change warning message to resemble the one in production
- Remove password meter and warning messages inside of Enter Password modal

### Screenshots:
1. Password meter width is not aligned properly

![Screenshot 2023-12-01 at 1 59 57 PM](https://github.com/binary-com/deriv-app/assets/103104395/1aa7cd5a-0772-41e1-974d-457344bf0a2c)

3. Change warning message from **" This is a very commonly password"** to be **"This is a very common password"**
![Screenshot 2023-12-01 at 2 00 47 PM](https://github.com/binary-com/deriv-app/assets/103104395/2e6d6d5c-40e9-4f13-9ada-ad2fe9094e1c)

4. Remove password meter and warning messages inside of `EnterPassword` Modal 

https://github.com/binary-com/deriv-app/assets/103104395/342b827c-2889-4a7c-a01f-91602192bcb5



