### PR TITLE
[BOT] shafin/BOT-862/fix dont show warning pop-up when leaving bot if bot is not running

### DIFF
--- a/packages/bot-web-ui/src/stores/__tests__/route-prompt-store.spec.tsx
+++ b/packages/bot-web-ui/src/stores/__tests__/route-prompt-store.spec.tsx
@@ -9,8 +9,14 @@ const mockCommonStore = {
 };
 describe('RoutePromptDialogStore', () => {
     let route_store: RoutePromptDialogStore;
+    const root_store = {
+        run_panel: {
+            is_running: true,
+        },
+    };
+
     beforeEach(() => {
-        route_store = new RoutePromptDialogStore(null, mockCommonStore);
+        route_store = new RoutePromptDialogStore(root_store, mockCommonStore);
     });
 
     it('should set should_show to be false', () => {

--- a/packages/bot-web-ui/src/stores/route-prompt-dialog-store.js
+++ b/packages/bot-web-ui/src/stores/route-prompt-dialog-store.js
@@ -22,7 +22,7 @@ export default class RoutePromptDialogStore {
     last_location = null;
 
     shouldNavigateAfterPrompt(next_location) {
-        if (!this.is_confirmed) {
+        if (!this.is_confirmed && this?.root_store?.run_panel?.is_running) {
             this.last_location = next_location;
             if (next_location.pathname !== '/bot') this.should_show = true;
             return false;


### PR DESCRIPTION
## Changes:

- Added another check of `is_running` to the warning prompt showing logic