### PR TITLE
chore: reroute dtrade to own path

### DIFF
--- a/packages/core/src/App/Constants/routes-config.js
+++ b/packages/core/src/App/Constants/routes-config.js
@@ -361,7 +361,7 @@ const getModules = () => {
             ],
         },
         {
-            path: routes.root,
+            path: routes.trade,
             component: Trader,
             getTitle: () => localize('Trader'),
             routes: [
@@ -373,6 +373,14 @@ const getModules = () => {
                 },
                 { path: routes.error404, component: Trader, getTitle: () => localize('Error 404') },
             ],
+        },
+        {
+            path: routes.root,
+            component: ({ history }) => {
+                history.push('/dtrader');
+                return null;
+            },
+            getTitle: () => localize('Deriv'),
         },
     ];
 

--- a/packages/shared/src/utils/routes/routes.ts
+++ b/packages/shared/src/utils/routes/routes.ts
@@ -41,7 +41,7 @@ export const routes = {
     settings: '/settings',
     statement: '/reports/statement',
     token: '/settings/token',
-    trade: '/',
+    trade: '/dtrader',
     bot: '/bot',
     cashier: '/cashier',
     cashier_deposit: '/cashier/deposit',


### PR DESCRIPTION
- Put the DTrader app in it's own path at `/dtrader`
- Change the root `/`, which currently renders the DTrader app, to redirect to `/dtrader`

