### PR TITLE
[BOT]Maryia/BOT-1012/Adapt to changes made in SmartCharts to show chart while building bot on desktop

### DIFF
--- a/packages/bot-web-ui/src/components/chart/chart.scss
+++ b/packages/bot-web-ui/src/components/chart/chart.scss
@@ -2,12 +2,14 @@
     &__chart-container {
         position: relative;
         top: 0;
+
         &-wrapper {
             position: absolute;
             top: 0;
             width: 100vw;
             background-color: var(--general-main-1);
         }
+
         .cq-context {
             div.ciq-chart {
                 div.stx_jump_today.home > svg {
@@ -18,10 +20,12 @@
                 }
             }
         }
+
         .injectionDiv {
             // Hide scratch workspace when switch to chart
             display: none;
         }
+
         .cq-dialog-portal {
             position: absolute;
         }
@@ -38,6 +42,7 @@
                 &.ciq-disabled {
                     display: none;
                 }
+
                 @include mobile {
                     min-width: 17rem;
                     max-width: 26rem;
@@ -46,6 +51,7 @@
                     .cq-menu-btn {
                         padding: 0.2rem;
                     }
+
                     .cq-symbol-select-btn {
                         margin: 0.2rem;
 
@@ -53,9 +59,11 @@
                             transform: scale(1);
                             margin-left: auto;
                         }
+
                         .cq-symbol {
                             font-size: 1.2rem;
                         }
+
                         .cq-chart-price {
                             display: none;
                         }
@@ -99,12 +107,14 @@
                             top: 0.8rem;
                             left: 0.8rem;
                         }
+
                         & > .ic-icon {
                             top: 0.6rem;
                         }
                     }
                 }
             }
+
             .app-contents .ciq-menu {
                 margin: 0;
             }
@@ -114,6 +124,7 @@
     .smartcharts-mobile {
         .cq-context {
             z-index: 99;
+
             .sc-mcd__category:last-child {
                 margin-bottom: 3rem !important;
             }
@@ -122,10 +133,13 @@
         & .cq-chart-title .cq-menu-dropdown {
             position: fixed;
             height: 100% !important;
+
             .sc-dialog {
                 height: 100% !important;
+
                 &__body {
                     height: inherit !important;
+
                     .sc-mcd {
                         height: inherit !important;
                         min-width: auto !important;

--- a/packages/bot-web-ui/src/components/chart/chart.scss
+++ b/packages/bot-web-ui/src/components/chart/chart.scss
@@ -2,14 +2,12 @@
     &__chart-container {
         position: relative;
         top: 0;
-
         &-wrapper {
             position: absolute;
             top: 0;
             width: 100vw;
             background-color: var(--general-main-1);
         }
-
         .cq-context {
             div.ciq-chart {
                 div.stx_jump_today.home > svg {
@@ -20,12 +18,10 @@
                 }
             }
         }
-
         .injectionDiv {
             // Hide scratch workspace when switch to chart
             display: none;
         }
-
         .cq-dialog-portal {
             position: absolute;
         }
@@ -42,7 +38,6 @@
                 &.ciq-disabled {
                     display: none;
                 }
-
                 @include mobile {
                     min-width: 17rem;
                     max-width: 26rem;
@@ -51,7 +46,6 @@
                     .cq-menu-btn {
                         padding: 0.2rem;
                     }
-
                     .cq-symbol-select-btn {
                         margin: 0.2rem;
 
@@ -59,11 +53,9 @@
                             transform: scale(1);
                             margin-left: auto;
                         }
-
                         .cq-symbol {
                             font-size: 1.2rem;
                         }
-
                         .cq-chart-price {
                             display: none;
                         }
@@ -107,14 +99,12 @@
                             top: 0.8rem;
                             left: 0.8rem;
                         }
-
                         & > .ic-icon {
                             top: 0.6rem;
                         }
                     }
                 }
             }
-
             .app-contents .ciq-menu {
                 margin: 0;
             }
@@ -124,7 +114,6 @@
     .smartcharts-mobile {
         .cq-context {
             z-index: 99;
-
             .sc-mcd__category:last-child {
                 margin-bottom: 3rem !important;
             }
@@ -133,13 +122,10 @@
         & .cq-chart-title .cq-menu-dropdown {
             position: fixed;
             height: 100% !important;
-
             .sc-dialog {
                 height: 100% !important;
-
                 &__body {
                     height: inherit !important;
-
                     .sc-mcd {
                         height: inherit !important;
                         min-width: auto !important;

--- a/packages/bot-web-ui/src/components/chart/chart.tsx
+++ b/packages/bot-web-ui/src/components/chart/chart.tsx
@@ -26,7 +26,7 @@ const Chart = observer(({ show_digits_stats }: { show_digits_stats: boolean }) =
         wsSubscribe,
     } = chart_store;
     const { is_drawer_open } = run_panel;
-    const { is_enabled_modal_chart } = dashboard;
+    const { is_chart_modal_visible } = dashboard;
     const is_socket_opened = common.is_socket_opened;
     const settings = {
         assetInformation: false, // ui.is_chart_asset_info_visible,
@@ -41,7 +41,7 @@ const Chart = observer(({ show_digits_stats }: { show_digits_stats: boolean }) =
         <div
             className={classNames('dashboard__chart-wrapper', {
                 'dashboard__chart-wrapper--expanded': is_drawer_open && !isMobile(),
-                'dashboard__chart-wrapper--modal': is_enabled_modal_chart && !isMobile(),
+                'dashboard__chart-wrapper--modal': is_chart_modal_visible && !isMobile(),
             })}
         >
             <SmartChart

--- a/packages/bot-web-ui/src/components/chart/chart.tsx
+++ b/packages/bot-web-ui/src/components/chart/chart.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import classNames from 'classnames';
-import { isDesktop, isMobile } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
 import { useDBotStore } from 'Stores/useDBotStore';
 import ToolbarWidgets from './toolbar-widgets';
@@ -25,6 +24,9 @@ const Chart = observer(({ show_digits_stats }: { show_digits_stats: boolean }) =
         wsSendRequest,
         wsSubscribe,
     } = chart_store;
+    const {
+        ui: { is_mobile, is_desktop },
+    } = useStore();
     const { is_drawer_open } = run_panel;
     const { is_chart_modal_visible } = dashboard;
     const is_socket_opened = common.is_socket_opened;
@@ -40,8 +42,8 @@ const Chart = observer(({ show_digits_stats }: { show_digits_stats: boolean }) =
     return (
         <div
             className={classNames('dashboard__chart-wrapper', {
-                'dashboard__chart-wrapper--expanded': is_drawer_open && !isMobile(),
-                'dashboard__chart-wrapper--modal': is_chart_modal_visible && !isMobile(),
+                'dashboard__chart-wrapper--expanded': is_drawer_open && !is_mobile,
+                'dashboard__chart-wrapper--modal': is_chart_modal_visible && !is_mobile,
             })}
         >
             <SmartChart
@@ -55,8 +57,8 @@ const Chart = observer(({ show_digits_stats }: { show_digits_stats: boolean }) =
                     <ToolbarWidgets updateChartType={updateChartType} updateGranularity={updateGranularity} />
                 )}
                 chartType={chart_type}
-                isMobile={isMobile()}
-                enabledNavigationWidget={isDesktop()}
+                isMobile={is_mobile}
+                enabledNavigationWidget={is_desktop}
                 granularity={granularity}
                 requestAPI={wsSendRequest}
                 requestForget={wsForget}

--- a/packages/bot-web-ui/src/components/chart/chart.tsx
+++ b/packages/bot-web-ui/src/components/chart/chart.tsx
@@ -9,7 +9,7 @@ import { ChartTitle, SmartChart } from './v1';
 const Chart = observer(({ show_digits_stats }: { show_digits_stats: boolean }) => {
     const barriers: [] = [];
     const { common, ui } = useStore();
-    const { chart_store, run_panel } = useDBotStore();
+    const { chart_store, run_panel, dashboard } = useDBotStore();
 
     const {
         chart_type,
@@ -26,6 +26,7 @@ const Chart = observer(({ show_digits_stats }: { show_digits_stats: boolean }) =
         wsSubscribe,
     } = chart_store;
     const { is_drawer_open } = run_panel;
+    const { is_enabled_modal_chart } = dashboard;
     const is_socket_opened = common.is_socket_opened;
     const settings = {
         assetInformation: false, // ui.is_chart_asset_info_visible,
@@ -40,6 +41,7 @@ const Chart = observer(({ show_digits_stats }: { show_digits_stats: boolean }) =
         <div
             className={classNames('dashboard__chart-wrapper', {
                 'dashboard__chart-wrapper--expanded': is_drawer_open && !isMobile(),
+                'dashboard__chart-wrapper--modal': is_enabled_modal_chart && !isMobile(),
             })}
         >
             <SmartChart

--- a/packages/bot-web-ui/src/components/dashboard/bot-builder/toolbar/workspace-group.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/bot-builder/toolbar/workspace-group.tsx
@@ -28,7 +28,7 @@ const WorkspaceGroup = observer(
         toggleSaveModal,
     }: TWorkspaceGroup) => {
         const { dashboard } = useDBotStore();
-        const { setPreviewOnPopup, setEnabledModalChart } = dashboard;
+        const { setPreviewOnPopup, setChartModalVisibility } = dashboard;
 
         return (
             <div className='toolbar__group toolbar__group-btn' data-testid='dt_toolbar_group_btn'>
@@ -68,7 +68,7 @@ const WorkspaceGroup = observer(
                         popover_message={localize('Charts')}
                         icon='IcChartsTabDbot'
                         icon_id='db-toolbar__charts-button'
-                        action={() => setEnabledModalChart()}
+                        action={() => setChartModalVisibility()}
                     />
                 )}
                 <div className='vertical-divider' />

--- a/packages/bot-web-ui/src/components/dashboard/bot-builder/toolbar/workspace-group.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/bot-builder/toolbar/workspace-group.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { observer, useStore } from '@deriv/stores';
 import { localize } from '@deriv/translations';
+import { DesktopWrapper } from '@deriv/components';
 import { useDBotStore } from 'Stores/useDBotStore';
 import ToolbarIcon from './toolbar-icon';
 
@@ -26,9 +27,6 @@ const WorkspaceGroup = observer(
         toggleLoadModal,
         toggleSaveModal,
     }: TWorkspaceGroup) => {
-        const {
-            ui: { is_desktop },
-        } = useStore();
         const { dashboard } = useDBotStore();
         const { setPreviewOnPopup, setChartModalVisibility } = dashboard;
 
@@ -65,14 +63,14 @@ const WorkspaceGroup = observer(
                     data_testid='dt_toolbar_sort_button'
                     action={onSortClick}
                 />
-                {is_desktop && (
+                <DesktopWrapper>
                     <ToolbarIcon
                         popover_message={localize('Charts')}
                         icon='IcChartsTabDbot'
                         icon_id='db-toolbar__charts-button'
                         action={() => setChartModalVisibility()}
                     />
-                )}
+                </DesktopWrapper>
                 <div className='vertical-divider' />
                 <ToolbarIcon
                     popover_message={localize('Undo')}

--- a/packages/bot-web-ui/src/components/dashboard/bot-builder/toolbar/workspace-group.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/bot-builder/toolbar/workspace-group.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { isMobile } from '@deriv/shared';
-import { observer } from '@deriv/stores';
+import { observer, useStore } from '@deriv/stores';
 import { localize } from '@deriv/translations';
 import { useDBotStore } from 'Stores/useDBotStore';
 import ToolbarIcon from './toolbar-icon';
@@ -27,6 +26,9 @@ const WorkspaceGroup = observer(
         toggleLoadModal,
         toggleSaveModal,
     }: TWorkspaceGroup) => {
+        const {
+            ui: { is_desktop },
+        } = useStore();
         const { dashboard } = useDBotStore();
         const { setPreviewOnPopup, setChartModalVisibility } = dashboard;
 
@@ -63,7 +65,7 @@ const WorkspaceGroup = observer(
                     data_testid='dt_toolbar_sort_button'
                     action={onSortClick}
                 />
-                {!isMobile() && (
+                {is_desktop && (
                     <ToolbarIcon
                         popover_message={localize('Charts')}
                         icon='IcChartsTabDbot'

--- a/packages/bot-web-ui/src/components/dashboard/bot-builder/toolbar/workspace-group.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/bot-builder/toolbar/workspace-group.tsx
@@ -67,7 +67,7 @@ const WorkspaceGroup = observer(
                     <ToolbarIcon
                         popover_message={localize('Charts')}
                         icon='IcChartsTabDbot'
-                        icon_id='db-toolbar__sort-button'
+                        icon_id='db-toolbar__charts-button'
                         action={() => setEnabledModalChart()}
                     />
                 )}

--- a/packages/bot-web-ui/src/components/dashboard/bot-builder/toolbar/workspace-group.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/bot-builder/toolbar/workspace-group.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { isMobile } from '@deriv/shared';
 import { observer } from '@deriv/stores';
 import { localize } from '@deriv/translations';
 import { useDBotStore } from 'Stores/useDBotStore';
@@ -27,7 +28,7 @@ const WorkspaceGroup = observer(
         toggleSaveModal,
     }: TWorkspaceGroup) => {
         const { dashboard } = useDBotStore();
-        const { setPreviewOnPopup } = dashboard;
+        const { setPreviewOnPopup, setEnabledModalChart } = dashboard;
 
         return (
             <div className='toolbar__group toolbar__group-btn' data-testid='dt_toolbar_group_btn'>
@@ -62,6 +63,14 @@ const WorkspaceGroup = observer(
                     data_testid='dt_toolbar_sort_button'
                     action={onSortClick}
                 />
+                {!isMobile() && (
+                    <ToolbarIcon
+                        popover_message={localize('Charts')}
+                        icon='IcChartsTabDbot'
+                        icon_id='db-toolbar__sort-button'
+                        action={() => setEnabledModalChart()}
+                    />
+                )}
                 <div className='vertical-divider' />
                 <ToolbarIcon
                     popover_message={localize('Undo')}

--- a/packages/bot-web-ui/src/components/dashboard/bot-builder/toolbar/workspace-group.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/bot-builder/toolbar/workspace-group.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { observer, useStore } from '@deriv/stores';
+import { observer } from '@deriv/stores';
 import { localize } from '@deriv/translations';
 import { DesktopWrapper } from '@deriv/components';
 import { useDBotStore } from 'Stores/useDBotStore';

--- a/packages/bot-web-ui/src/components/dashboard/dashboard-component/__tests__/chart-modal-desktop.spec.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard-component/__tests__/chart-modal-desktop.spec.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { mockStore, StoreProvider } from '@deriv/stores';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { act, render, screen } from '@testing-library/react';
+import RootStore from 'Stores/index';
+import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
+import ChartModalDesktop from '../chart-modal/chart-modal-desktop';
+import { mock_ws } from 'Utils/mock';
+
+jest.mock('@deriv/shared', () => ({
+    ...jest.requireActual('@deriv/shared'),
+    isMobile: jest.fn(() => false),
+}));
+
+jest.mock('@deriv/bot-skeleton/src/scratch/blockly', () => jest.fn());
+jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => ({
+    saveRecentWorkspace: jest.fn(),
+    unHighlightAllBlocks: jest.fn(),
+}));
+
+jest.mock('@deriv/bot-skeleton/src/scratch/hooks/block_svg', () => jest.fn());
+jest.mock('@deriv/deriv-charts', () => ({
+    setSmartChartsPublicPath: jest.fn(),
+}));
+
+jest.mock('../../../chart', () => ({
+    __esModule: true,
+    default: () => <div>Mocked Chart component</div>,
+}));
+
+describe('ChartModalDesktop', () => {
+    beforeEach(() => {
+        jest.resetModules();
+    });
+
+    let wrapper: ({ children }: { children: JSX.Element }) => JSX.Element, mock_DBot_store: RootStore | undefined;
+
+    beforeAll(() => {
+        const mock_store = mockStore({});
+        mock_DBot_store = mockDBotStore(mock_store, mock_ws);
+
+        mock_DBot_store?.dashboard?.setChartModalVisibility();
+
+        wrapper = ({ children }: { children: JSX.Element }) => (
+            <StoreProvider store={mock_store}>
+                <DBotStoreProvider ws={mock_ws} mock={mock_DBot_store}>
+                    {children}
+                </DBotStoreProvider>
+            </StoreProvider>
+        );
+    });
+
+    it('should render ChartModalDesktop', () => {
+        render(<ChartModalDesktop />, {
+            wrapper,
+        });
+
+        const chart_modal_dialog = screen.queryByText('Mocked Chart component');
+
+        expect(chart_modal_dialog).toBeInTheDocument();
+    });
+
+    it('should show ChartModalDesktop modal after resizing screen', async () => {
+        const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+
+        render(<ChartModalDesktop />, {
+            wrapper,
+        });
+
+        const resizeEvent = new Event('resize');
+        Object.defineProperty(window, 'innerWidth', { value: 80000 });
+        Object.defineProperty(window, 'innerHeight', { value: 6000 });
+
+        act(() => {
+            window.dispatchEvent(resizeEvent);
+        });
+
+        const draggable_element = await screen.findByTestId('react-rnd-wrapper');
+        const computedStyle = window.getComputedStyle(draggable_element);
+        const transformValue = computedStyle.getPropertyValue('transform');
+
+        expect(addEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function));
+        expect(transformValue).toBe('translate(0px,0px)');
+
+        addEventListenerSpy.mockRestore();
+
+        const chart_modal_dialog = screen.queryByTestId('chart-modal-dialog');
+        expect(chart_modal_dialog).toBeInTheDocument();
+    });
+});

--- a/packages/bot-web-ui/src/components/dashboard/dashboard-component/__tests__/chart-modal.spec.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard-component/__tests__/chart-modal.spec.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ChartModal from '../chart-modal';
+
+jest.mock('../../../chart/chart.tsx', () => jest.fn(() => <div>SmartChart chart</div>));
+
+describe('ChartModal', () => {
+    const mockSetEnabledModalChart = jest.fn();
+
+    it('Should render the ChartModal component', () => {
+        render(<ChartModal setEnabledModalChart={mockSetEnabledModalChart} />);
+
+        expect(screen.getByText('SmartChart chart')).toBeInTheDocument();
+    });
+
+    it('should call setEnabledModalChart when close button is clicked', () => {
+        const { container } = render(<ChartModal setEnabledModalChart={mockSetEnabledModalChart} />);
+
+        // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+        const button = container.querySelector('#db-toolbar__close-button');
+
+        if (button) {
+            userEvent.click(button);
+            expect(mockSetEnabledModalChart).toHaveBeenCalledTimes(1);
+        } else {
+            throw new Error('Button <ToolbarIcon> with id "db-toolbar__close-button" -  not found');
+        }
+    });
+});

--- a/packages/bot-web-ui/src/components/dashboard/dashboard-component/__tests__/chart-modal.spec.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard-component/__tests__/chart-modal.spec.tsx
@@ -17,6 +17,7 @@ describe('ChartModal', () => {
     it('should call setEnabledModalChart when close button is clicked', () => {
         const { container } = render(<ChartModal setEnabledModalChart={mockSetEnabledModalChart} />);
 
+        //<ToolbarIcon> is a wrapper around other components and the data-testid is not passed to the final DOM element
         // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
         const button = container.querySelector('#db-toolbar__close-button');
 

--- a/packages/bot-web-ui/src/components/dashboard/dashboard-component/__tests__/chart-modal.spec.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard-component/__tests__/chart-modal.spec.tsx
@@ -6,16 +6,16 @@ import ChartModal from '../chart-modal';
 jest.mock('../../../chart/chart.tsx', () => jest.fn(() => <div>SmartChart chart</div>));
 
 describe('ChartModal', () => {
-    const mockSetEnabledModalChart = jest.fn();
+    const mockSetChartModalVisibility = jest.fn();
 
     it('Should render the ChartModal component', () => {
-        render(<ChartModal setEnabledModalChart={mockSetEnabledModalChart} />);
+        render(<ChartModal setChartModalVisibility={mockSetChartModalVisibility} />);
 
         expect(screen.getByText('SmartChart chart')).toBeInTheDocument();
     });
 
-    it('should call setEnabledModalChart when close button is clicked', () => {
-        const { container } = render(<ChartModal setEnabledModalChart={mockSetEnabledModalChart} />);
+    it('should call setChartModalVisibility when close button is clicked', () => {
+        const { container } = render(<ChartModal setChartModalVisibility={mockSetChartModalVisibility} />);
 
         //<ToolbarIcon> is a wrapper around other components and the data-testid is not passed to the final DOM element
         // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
@@ -23,7 +23,7 @@ describe('ChartModal', () => {
 
         if (button) {
             userEvent.click(button);
-            expect(mockSetEnabledModalChart).toHaveBeenCalledTimes(1);
+            expect(mockSetChartModalVisibility).toHaveBeenCalledTimes(1);
         } else {
             throw new Error('Button <ToolbarIcon> with id "db-toolbar__close-button" -  not found');
         }

--- a/packages/bot-web-ui/src/components/dashboard/dashboard-component/chart-modal/chart-modal-desktop.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard-component/chart-modal/chart-modal-desktop.tsx
@@ -28,8 +28,8 @@ const ChartModalDesktop = observer(() => {
     const modalWidth = 426;
     const modalHeight = 481;
 
-    const xAxisValue = (screenDimensions.width - modalWidth) / 4;
-    const yAxisValue = (screenDimensions.height - modalHeight) / 6;
+    const xAxisValue = (screenDimensions.width - modalWidth) / 2;
+    const yAxisValue = (screenDimensions.height - modalHeight) / 2;
 
     const yaxis = yAxisValue >= 0 ? yAxisValue : 0;
     const xaxis = xAxisValue >= 0 ? xAxisValue : 0;

--- a/packages/bot-web-ui/src/components/dashboard/dashboard-component/chart-modal/chart-modal-desktop.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard-component/chart-modal/chart-modal-desktop.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect } from 'react';
+import { localize } from '@deriv/translations';
+import { useDBotStore } from 'Stores/useDBotStore';
+import Chart from 'Components/chart';
+import Draggable from '../../../draggable';
+import { observer } from '@deriv/stores';
+
+const ChartModalDesktop = observer(() => {
+    const { dashboard } = useDBotStore();
+    const { is_chart_modal_visible, setChartModalVisibility } = dashboard;
+
+    const [screenDimensions, setScreenDimensions] = React.useState({ width: 0, height: 0 });
+
+    const handleResize = () => {
+        setScreenDimensions({ width: window.innerWidth, height: window.innerHeight });
+    };
+
+    useEffect(() => {
+        window.addEventListener('resize', handleResize);
+
+        setScreenDimensions({ width: window.innerWidth, height: window.innerHeight });
+
+        return () => {
+            window.removeEventListener('resize', handleResize);
+        };
+    }, []);
+
+    const modalWidth = 426;
+    const modalHeight = 481;
+
+    const xAxisValue = (screenDimensions.width - modalWidth) / 4;
+    const yAxisValue = (screenDimensions.height - modalHeight) / 6;
+
+    const yaxis = yAxisValue >= 0 ? yAxisValue : 0;
+    const xaxis = xAxisValue >= 0 ? xAxisValue : 0;
+
+    return (
+        <Draggable
+            bounds='.dashboard__main'
+            xaxis={xaxis}
+            yaxis={yaxis}
+            is_visible={is_chart_modal_visible}
+            header_title={localize('Chart')}
+            onCloseDraggable={setChartModalVisibility}
+            minWidth={modalWidth}
+            width={modalWidth}
+            dragHandleClassName='react-rnd-wrapper-header'
+        >
+            <div className='chart-modal-dialog' data-testid='chart-modal-dialog'>
+                <Chart show_digits_stats={false} />
+            </div>
+        </Draggable>
+    );
+});
+
+export default ChartModalDesktop;

--- a/packages/bot-web-ui/src/components/dashboard/dashboard-component/chart-modal/chart-modal.scss
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard-component/chart-modal/chart-modal.scss
@@ -1,12 +1,12 @@
-$value-cubic-bezier: cubic-bezier(0.25, 0.1, 0.1, 0.25);
-$modal-height: 48.1vh;
-
-@mixin align-items-center {
-    display: flex;
-    align-items: center;
-}
-
 .bot-dashboard:has(.chart-modal-dialog) {
+    --value-cubic-bezier: cubic-bezier(0.25, 0.1, 0.1, 0.25);
+    --modal-height: 48.1vh;
+
+    @mixin align-items-center {
+        display: flex;
+        align-items: center;
+    }
+
     #id-charts {
         color: var(--fill-normal-1);
         stroke-opacity: 30%;
@@ -14,16 +14,15 @@ $modal-height: 48.1vh;
     }
 
     .chart-modal-dialog {
-        height: $modal-height;
-        max-height: $modal-height;
-
+        height: var(--modal-height);
+        max-height: var(--modal-height);
         @include align-items-center;
         justify-content: center;
         z-index: 999;
-        transition: opacity 0.25s $value-cubic-bezier;
+        transition: opacity 0.25s var(--value-cubic-bezier);
 
         .dashboard__chart-wrapper--modal {
-            height: $modal-height;
+            height: var(--modal-height);
         }
 
         .sc-navigation-widget {

--- a/packages/bot-web-ui/src/components/dashboard/dashboard-component/chart-modal/chart-modal.scss
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard-component/chart-modal/chart-modal.scss
@@ -1,0 +1,137 @@
+$value-cubic-bezier: cubic-bezier(0.25, 0.1, 0.1, 0.25);
+
+@mixin align-items-center {
+    display: flex;
+    align-items: center;
+}
+
+.bot-dashboard:has(.chart-modal-dialog) {
+    #id-charts {
+        color: var(--fill-normal-1);
+        stroke-opacity: 30%;
+        pointer-events: none;
+    }
+
+    .chart-modal-dialog {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 100%;
+        height: 100%;
+
+        @include align-items-center;
+        justify-content: center;
+        z-index: 999;
+        transition: opacity 0.25s $value-cubic-bezier;
+
+        .sc-navigation-widget {
+            display: none;
+        }
+
+        .cq-symbols-display {
+            .cq-menu-btn {
+                padding: 0.2rem;
+            }
+
+            .cq-symbol-select-btn {
+                margin: 0.2rem;
+
+                .cq-symbol-dropdown {
+                    transform: scale(1);
+                    margin-left: auto;
+                }
+
+                .cq-symbol {
+                    font-size: 1.4rem;
+                }
+
+                .cq-chart-price {
+                    display: none;
+                }
+
+                .cq-symbol-info {
+                    min-height: unset;
+                }
+            }
+        }
+
+        .sc-toolbar-widget {
+            bottom: 4vh;
+            top: unset;
+            border-width: 0;
+            border-radius: 2rem;
+            cursor: pointer;
+            background: var(--general-section-1);
+
+            .sc-tooltip:not(:first-child) {
+                display: none;
+            }
+
+            .cq-menu-btn {
+                .sc-chart-mode__menu__timeperiod {
+                    top: 0.6rem;
+                    left: 1rem;
+                }
+            }
+
+            .cq-menu-btn:hover {
+                background: none;
+            }
+        }
+
+        &__dialog {
+            max-width: 56rem;
+            max-height: 48.1rem;
+            min-width: 42.6rem;
+            min-height: 17.6rem;
+
+            margin-top: -4.8rem;
+            padding: 0 0.45rem;
+            border-radius: 0.8rem;
+            box-sizing: border-box;
+
+            @include align-items-center;
+            justify-content: space-around;
+            flex-direction: column;
+            box-shadow: 0 2px 8px 0 var(--shadow-menu);
+            background-color: var(--general-main-2);
+            transition: transform 0.25s $value-cubic-bezier, opacity 0.25s $value-cubic-bezier;
+        }
+
+        &__header-wrapper {
+            width: 100%;
+            @include align-items-center;
+            justify-content: space-between;
+
+            margin-top: 1.4rem;
+            margin-bottom: 1rem;
+            padding-left: 2.4rem;
+            padding-right: 2.4rem;
+
+            .chart-modal-dialog__header--close {
+                cursor: pointer;
+            }
+        }
+
+        .cq-chart-title {
+            .cq-menu-dropdown {
+                position: fixed;
+                height: 46rem;
+                left: unset;
+
+                .sc-dialog {
+                    height: 100% !important;
+
+                    &__body {
+                        height: inherit !important;
+
+                        .sc-mcd {
+                            height: inherit !important;
+                            min-width: auto !important;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/bot-web-ui/src/components/dashboard/dashboard-component/chart-modal/chart-modal.scss
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard-component/chart-modal/chart-modal.scss
@@ -45,10 +45,6 @@ $value-cubic-bezier: cubic-bezier(0.25, 0.1, 0.1, 0.25);
                     font-size: 1.4rem;
                 }
 
-                .cq-chart-price {
-                    display: none;
-                }
-
                 .cq-symbol-info {
                     min-height: unset;
                 }

--- a/packages/bot-web-ui/src/components/dashboard/dashboard-component/chart-modal/chart-modal.scss
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard-component/chart-modal/chart-modal.scss
@@ -1,4 +1,5 @@
 $value-cubic-bezier: cubic-bezier(0.25, 0.1, 0.1, 0.25);
+$modal-height: 48.1vh;
 
 @mixin align-items-center {
     display: flex;
@@ -13,16 +14,17 @@ $value-cubic-bezier: cubic-bezier(0.25, 0.1, 0.1, 0.25);
     }
 
     .chart-modal-dialog {
-        position: absolute;
-        left: 0;
-        top: 0;
-        width: 100%;
-        height: 100%;
+        height: $modal-height;
+        max-height: $modal-height;
 
         @include align-items-center;
         justify-content: center;
         z-index: 999;
         transition: opacity 0.25s $value-cubic-bezier;
+
+        .dashboard__chart-wrapper--modal {
+            height: $modal-height;
+        }
 
         .sc-navigation-widget {
             display: none;
@@ -72,40 +74,6 @@ $value-cubic-bezier: cubic-bezier(0.25, 0.1, 0.1, 0.25);
 
             .cq-menu-btn:hover {
                 background: none;
-            }
-        }
-
-        &__dialog {
-            max-width: 56rem;
-            max-height: 48.1rem;
-            min-width: 42.6rem;
-            min-height: 17.6rem;
-
-            margin-top: -4.8rem;
-            padding: 0 0.45rem;
-            border-radius: 0.8rem;
-            box-sizing: border-box;
-
-            @include align-items-center;
-            justify-content: space-around;
-            flex-direction: column;
-            box-shadow: 0 2px 8px 0 var(--shadow-menu);
-            background-color: var(--general-main-2);
-            transition: transform 0.25s $value-cubic-bezier, opacity 0.25s $value-cubic-bezier;
-        }
-
-        &__header-wrapper {
-            width: 100%;
-            @include align-items-center;
-            justify-content: space-between;
-
-            margin-top: 1.4rem;
-            margin-bottom: 1rem;
-            padding-left: 2.4rem;
-            padding-right: 2.4rem;
-
-            .chart-modal-dialog__header--close {
-                cursor: pointer;
             }
         }
 

--- a/packages/bot-web-ui/src/components/dashboard/dashboard-component/chart-modal/chart-modal.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard-component/chart-modal/chart-modal.tsx
@@ -4,7 +4,7 @@ import { Localize, localize } from '@deriv/translations';
 import Chart from 'Components/chart';
 import ToolbarIcon from '../../bot-builder/toolbar/toolbar-icon';
 
-const ChartModal = ({ setEnabledModalChart }: { setEnabledModalChart: () => void }) => (
+const ChartModal = ({ setChartModalVisibility }: { setChartModalVisibility: () => void }) => (
     <div className='chart-modal-dialog'>
         <div className='chart-modal-dialog__dialog'>
             <div className='chart-modal-dialog__header-wrapper'>
@@ -16,7 +16,7 @@ const ChartModal = ({ setEnabledModalChart }: { setEnabledModalChart: () => void
                         popover_message={localize('Close')}
                         icon='IcCross'
                         icon_id='db-toolbar__close-button'
-                        action={() => setEnabledModalChart()}
+                        action={() => setChartModalVisibility()}
                     />
                 </div>
             </div>

--- a/packages/bot-web-ui/src/components/dashboard/dashboard-component/chart-modal/chart-modal.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard-component/chart-modal/chart-modal.tsx
@@ -1,28 +1,13 @@
-import React from 'react';
-import { Text } from '@deriv/components';
-import { Localize, localize } from '@deriv/translations';
-import Chart from 'Components/chart';
-import ToolbarIcon from '../../bot-builder/toolbar/toolbar-icon';
+import React, { Suspense } from 'react';
+import { Loading } from '@deriv/components';
+import { observer, useStore } from '@deriv/stores';
+import ChartModalDesktop from './chart-modal-desktop';
 
-const ChartModal = ({ setChartModalVisibility }: { setChartModalVisibility: () => void }) => (
-    <div className='chart-modal-dialog'>
-        <div className='chart-modal-dialog__dialog'>
-            <div className='chart-modal-dialog__header-wrapper'>
-                <Text weight='bold' line_height='xxl'>
-                    <Localize i18n_default_text='Chart' />
-                </Text>
-                <div className='dc-dialog__header--close'>
-                    <ToolbarIcon
-                        popover_message={localize('Close')}
-                        icon='IcCross'
-                        icon_id='db-toolbar__close-button'
-                        action={() => setChartModalVisibility()}
-                    />
-                </div>
-            </div>
-            <Chart show_digits_stats={false} />
-        </div>
-    </div>
-);
+export const ChartModal = observer(() => {
+    const {
+        ui: { is_desktop },
+    } = useStore();
+    return <Suspense fallback={<Loading />}>{is_desktop && <ChartModalDesktop />}</Suspense>;
+});
 
 export default ChartModal;

--- a/packages/bot-web-ui/src/components/dashboard/dashboard-component/chart-modal/chart-modal.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard-component/chart-modal/chart-modal.tsx
@@ -15,7 +15,7 @@ const ChartModal = ({ setEnabledModalChart }: { setEnabledModalChart: () => void
                     <ToolbarIcon
                         popover_message={localize('Close')}
                         icon='IcCross'
-                        icon_id='db-toolbar__sort-button'
+                        icon_id='db-toolbar__close-button'
                         action={() => setEnabledModalChart()}
                     />
                 </div>

--- a/packages/bot-web-ui/src/components/dashboard/dashboard-component/chart-modal/chart-modal.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard-component/chart-modal/chart-modal.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Text } from '@deriv/components';
+import { Localize, localize } from '@deriv/translations';
+import Chart from 'Components/chart';
+import ToolbarIcon from '../../bot-builder/toolbar/toolbar-icon';
+
+const ChartModal = ({ setEnabledModalChart }: { setEnabledModalChart: () => void }) => (
+    <div className='chart-modal-dialog'>
+        <div className='chart-modal-dialog__dialog'>
+            <div className='chart-modal-dialog__header-wrapper'>
+                <Text weight='bold' line_height='xxl'>
+                    <Localize i18n_default_text='Chart' />
+                </Text>
+                <div className='dc-dialog__header--close'>
+                    <ToolbarIcon
+                        popover_message={localize('Close')}
+                        icon='IcCross'
+                        icon_id='db-toolbar__sort-button'
+                        action={() => setEnabledModalChart()}
+                    />
+                </div>
+            </div>
+            <Chart show_digits_stats={false} />
+        </div>
+    </div>
+);
+
+export default ChartModal;

--- a/packages/bot-web-ui/src/components/dashboard/dashboard-component/chart-modal/index.ts
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard-component/chart-modal/index.ts
@@ -1,0 +1,4 @@
+import ChartModal from './chart-modal';
+import './chart-modal.scss';
+
+export default ChartModal;

--- a/packages/bot-web-ui/src/components/dashboard/dashboard-component/index.ts
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard-component/index.ts
@@ -1,3 +1,2 @@
-import DashboardComponent from './dashboard-component';
-
-export default DashboardComponent;
+export { default as ChartModal } from './chart-modal';
+export { default as DashboardComponent } from './dashboard-component';

--- a/packages/bot-web-ui/src/components/dashboard/dashboard.scss
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard.scss
@@ -207,6 +207,17 @@
         &--expanded {
             width: calc(100vw - 39.8rem);
         }
+
+        &--modal {
+            // position: fixed !important;
+            z-index: 99999999 !important;
+            width: 400px !important;
+            height: 500px !important;
+            // top: 0;
+            // left: calc(100% - 80rem);
+            // position: absolute;
+            // dashboard_chart-wrapper
+        }
     }
 
     &__toolbox {

--- a/packages/bot-web-ui/src/components/dashboard/dashboard.scss
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard.scss
@@ -209,14 +209,7 @@
         }
 
         &--modal {
-            // position: fixed !important;
-            z-index: 99999999 !important;
-            width: 400px !important;
-            height: 500px !important;
-            // top: 0;
-            // left: calc(100% - 80rem);
-            // position: absolute;
-            // dashboard_chart-wrapper
+            width: 40rem;
         }
     }
 

--- a/packages/bot-web-ui/src/components/dashboard/dashboard.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard.tsx
@@ -19,19 +19,12 @@ import Tutorial from './tutorial-tab';
 
 const Dashboard = observer(() => {
     const { dashboard, load_modal, run_panel, quick_strategy, summary_card } = useDBotStore();
-    const {
-        active_tab,
-        active_tour,
-        is_chart_modal_visible,
-        setActiveTab,
-        setWebSocketState,
-        setActiveTour,
-        setTourDialogVisibility,
-    } = dashboard;
+    const { active_tab, active_tour, setActiveTab, setWebSocketState, setActiveTour, setTourDialogVisibility } =
+        dashboard;
     const { onEntered, dashboard_strategies } = load_modal;
     const { is_dialog_open, is_drawer_open, dialog_options, onCancelButtonClick, onCloseDialog, onOkButtonClick } =
         run_panel;
-    const { is_open, is_strategy_modal_open } = quick_strategy;
+    const { is_open } = quick_strategy;
     const { cancel_button_text, ok_button_text, title, message } = dialog_options as { [key: string]: string };
     const { clear } = summary_card;
     const { DASHBOARD, BOT_BUILDER } = DBOT_TABS;

--- a/packages/bot-web-ui/src/components/dashboard/dashboard.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard.tsx
@@ -5,13 +5,11 @@ import dbot from '@deriv/bot-skeleton/src/scratch/dbot';
 import { initTrashCan } from '@deriv/bot-skeleton/src/scratch/hooks/trashcan';
 import { api_base } from '@deriv/bot-skeleton/src/services/api/api-base';
 import { DesktopWrapper, Dialog, MobileWrapper, Tabs } from '@deriv/components';
-import { isMobile } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
 import { Localize } from '@deriv/translations';
 import Chart from 'Components/chart';
 import { DBOT_TABS, TAB_IDS } from 'Constants/bot-contents';
 import { useDBotStore } from 'Stores/useDBotStore';
-import Draggable from '../draggable';
 import RunPanel from '../run-panel';
 import RunStrategy from './dashboard-component/run-strategy';
 import { tour_list } from './dbot-tours/utils';
@@ -25,7 +23,6 @@ const Dashboard = observer(() => {
         active_tab,
         active_tour,
         is_chart_modal_visible,
-        setChartModalVisibility,
         setActiveTab,
         setWebSocketState,
         setActiveTour,
@@ -38,10 +35,9 @@ const Dashboard = observer(() => {
     const { cancel_button_text, ok_button_text, title, message } = dialog_options as { [key: string]: string };
     const { clear } = summary_card;
     const { DASHBOARD, BOT_BUILDER } = DBOT_TABS;
-    const is_mobile = isMobile();
     const init_render = React.useRef(true);
     const { ui } = useStore();
-    const { url_hashed_values } = ui;
+    const { url_hashed_values, is_mobile } = ui;
     const hash = ['dashboard', 'bot_builder', 'chart', 'tutorial'];
 
     let tab_value: number | string = active_tab;
@@ -191,16 +187,7 @@ const Dashboard = observer(() => {
             >
                 {message}
             </Dialog>
-            <Draggable
-                xaxis={window.innerWidth / 2}
-                yaxis={window.innerHeight / 2}
-                is_visible={is_chart_modal_visible}
-                header_title=''
-                onCloseDraggable={setChartModalVisibility}
-                dragHandleClassName={'chart-modal-dialog__header-wrapper'}
-            >
-                <ChartModal setChartModalVisibility={setChartModalVisibility} />
-            </Draggable>
+            <ChartModal />
             <StrategyNotification />
         </React.Fragment>
     );

--- a/packages/bot-web-ui/src/components/dashboard/dashboard.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard.tsx
@@ -170,6 +170,7 @@ const Dashboard = observer(() => {
                     <RunStrategy />
                     <RunPanel />
                 </div>
+                <ChartModal />
             </DesktopWrapper>
             <MobileWrapper>{!is_open && <RunPanel />}</MobileWrapper>
             <Dialog
@@ -187,7 +188,6 @@ const Dashboard = observer(() => {
             >
                 {message}
             </Dialog>
-            <ChartModal />
             <StrategyNotification />
         </React.Fragment>
     );

--- a/packages/bot-web-ui/src/components/dashboard/dashboard.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard.tsx
@@ -197,6 +197,7 @@ const Dashboard = observer(() => {
                 is_visible={is_chart_modal_visible}
                 header_title=''
                 onCloseDraggable={setChartModalVisibility}
+                dragHandleClassName={'chart-modal-dialog__header-wrapper'}
             >
                 <ChartModal setChartModalVisibility={setChartModalVisibility} />
             </Draggable>

--- a/packages/bot-web-ui/src/components/dashboard/dashboard.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard.tsx
@@ -24,8 +24,8 @@ const Dashboard = observer(() => {
     const {
         active_tab,
         active_tour,
-        is_enabled_modal_chart,
-        setEnabledModalChart,
+        is_chart_modal_visible,
+        setChartModalVisibility,
         setActiveTab,
         setWebSocketState,
         setActiveTour,
@@ -194,11 +194,11 @@ const Dashboard = observer(() => {
             <Draggable
                 xaxis={window.innerWidth / 2}
                 yaxis={window.innerHeight / 2}
-                is_visible={is_enabled_modal_chart}
+                is_visible={is_chart_modal_visible}
                 header_title=''
-                onCloseDraggable={setEnabledModalChart}
+                onCloseDraggable={setChartModalVisibility}
             >
-                <ChartModal setEnabledModalChart={setEnabledModalChart} />
+                <ChartModal setChartModalVisibility={setChartModalVisibility} />
             </Draggable>
             <StrategyNotification />
         </React.Fragment>

--- a/packages/bot-web-ui/src/components/dashboard/dashboard.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard.tsx
@@ -7,25 +7,35 @@ import { api_base } from '@deriv/bot-skeleton/src/services/api/api-base';
 import { DesktopWrapper, Dialog, MobileWrapper, Tabs } from '@deriv/components';
 import { isMobile } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
-import { localize } from '@deriv/translations';
+import { Localize } from '@deriv/translations';
 import Chart from 'Components/chart';
 import { DBOT_TABS, TAB_IDS } from 'Constants/bot-contents';
 import { useDBotStore } from 'Stores/useDBotStore';
+import Draggable from '../draggable';
 import RunPanel from '../run-panel';
 import RunStrategy from './dashboard-component/run-strategy';
 import { tour_list } from './dbot-tours/utils';
-import DashboardComponent from './dashboard-component';
+import { ChartModal, DashboardComponent } from './dashboard-component';
 import StrategyNotification from './strategy-notification';
 import Tutorial from './tutorial-tab';
 
 const Dashboard = observer(() => {
     const { dashboard, load_modal, run_panel, quick_strategy, summary_card } = useDBotStore();
-    const { active_tab, active_tour, setActiveTab, setWebSocketState, setActiveTour, setTourDialogVisibility } =
-        dashboard;
+    const {
+        active_tab,
+        active_tour,
+        is_enabled_modal_chart,
+        setEnabledModalChart,
+        setActiveTab,
+        setWebSocketState,
+        setActiveTour,
+        setTourDialogVisibility,
+    } = dashboard;
     const { onEntered, dashboard_strategies } = load_modal;
     const { is_dialog_open, is_drawer_open, dialog_options, onCancelButtonClick, onCloseDialog, onOkButtonClick } =
         run_panel;
-    const { is_open } = quick_strategy;
+    const { is_open, is_strategy_modal_open } = quick_strategy;
+    const { cancel_button_text, ok_button_text, title, message } = dialog_options as { [key: string]: string };
     const { clear } = summary_card;
     const { DASHBOARD, BOT_BUILDER } = DBOT_TABS;
     const is_mobile = isMobile();
@@ -132,14 +142,26 @@ const Dashboard = observer(() => {
                         onTabItemClick={handleTabChange}
                         top
                     >
-                        <div icon='IcDashboardComponentTab' label={localize('Dashboard')} id='id-dbot-dashboard'>
+                        <div
+                            icon='IcDashboardComponentTab'
+                            label={<Localize i18n_default_text='Dashboard' />}
+                            id='id-dbot-dashboard'
+                        >
                             <DashboardComponent handleTabChange={handleTabChange} />
                         </div>
-                        <div icon='IcBotBuilderTabIcon' label={localize('Bot Builder')} id='id-bot-builder' />
-                        <div icon='IcChartsTabDbot' label={localize('Charts')} id='id-charts'>
+                        <div
+                            icon='IcBotBuilderTabIcon'
+                            label={<Localize i18n_default_text='Bot Builder' />}
+                            id='id-bot-builder'
+                        />
+                        <div icon='IcChartsTabDbot' label={<Localize i18n_default_text='Charts' />} id='id-charts'>
                             <Chart />
                         </div>
-                        <div icon='IcTutorialsTabs' label={localize('Tutorials')} id='id-tutorials'>
+                        <div
+                            icon='IcTutorialsTabs'
+                            label={<Localize i18n_default_text='Tutorials' />}
+                            id='id-tutorials'
+                        >
                             <div className='tutorials-wrapper'>
                                 <Tutorial />
                             </div>
@@ -155,9 +177,9 @@ const Dashboard = observer(() => {
             </DesktopWrapper>
             <MobileWrapper>{!is_open && <RunPanel />}</MobileWrapper>
             <Dialog
-                cancel_button_text={dialog_options.cancel_button_text || localize('Cancel')}
+                cancel_button_text={cancel_button_text || <Localize i18n_default_text='Cancel' />}
                 className={'dc-dialog__wrapper--fixed'}
-                confirm_button_text={dialog_options.ok_button_text || localize('OK')}
+                confirm_button_text={ok_button_text || <Localize i18n_default_text='OK' />}
                 has_close_icon
                 is_mobile_full_width={false}
                 is_visible={is_dialog_open}
@@ -165,10 +187,19 @@ const Dashboard = observer(() => {
                 onClose={onCloseDialog}
                 onConfirm={onOkButtonClick || onCloseDialog}
                 portal_element_id='modal_root'
-                title={dialog_options.title}
+                title={title}
             >
-                {dialog_options.message}
+                {message}
             </Dialog>
+            <Draggable
+                xaxis={window.innerWidth / 2}
+                yaxis={window.innerHeight / 2}
+                is_visible={is_enabled_modal_chart}
+                header_title=''
+                onCloseDraggable={setEnabledModalChart}
+            >
+                <ChartModal setEnabledModalChart={setEnabledModalChart} />
+            </Draggable>
             <StrategyNotification />
         </React.Fragment>
     );

--- a/packages/bot-web-ui/src/components/draggable/draggable.scss
+++ b/packages/bot-web-ui/src/components/draggable/draggable.scss
@@ -1,4 +1,5 @@
 .react-rnd-wrapper {
+    transform: none !important;
     z-index: var(--zindex-draggable-modal);
     transition: opacity 0.25s cubic-bezier(0.25, 0.1, 0.1, 0.25);
     cursor: default !important;

--- a/packages/bot-web-ui/src/components/draggable/draggable.tsx
+++ b/packages/bot-web-ui/src/components/draggable/draggable.tsx
@@ -33,6 +33,8 @@ export default function Draggable({
     xaxis = 0,
     yaxis = 0,
 }: PropsWithChildren<DraggableProps>) {
+    const element_bounds = document.querySelector(bounds as string)?.getBoundingClientRect();
+
     return is_visible ? (
         <Rnd
             bounds={bounds}
@@ -44,10 +46,18 @@ export default function Draggable({
                 width,
                 height,
             }}
+            style={{
+                left: xaxis,
+                top: yaxis,
+            }}
             dragHandleClassName={dragHandleClassName}
             enableResizing={enableResizing}
             minHeight={height}
             minWidth={minWidth}
+            onDrag={(e, data) => {
+                data.node.style.left = `${data.lastX + data.deltaX}px`;
+                data.node.style.top = `${data.lastY + data.deltaY}px`;
+            }}
             onDragStart={e => {
                 // on responsive devices touch event is not triggering the close button action
                 // need to handle it manually

--- a/packages/bot-web-ui/src/components/draggable/draggable.tsx
+++ b/packages/bot-web-ui/src/components/draggable/draggable.tsx
@@ -58,6 +58,8 @@ export default function Draggable({
             minHeight={height}
             minWidth={minWidth}
             onDrag={(e, data) => {
+                //we need these calculations since we no longer use the 'transform: translate(x, y)' property
+                //as it causes unexpected behaviour of Beta Chart styles & helps avoid bounce bug upon the first drag
                 data.node.style.left = `${data.lastX - first_drag_x + first_left + data.deltaX}px`;
                 data.node.style.top = `${data.lastY - first_drag_y + first_top + data.deltaY}px`;
             }}

--- a/packages/bot-web-ui/src/components/draggable/draggable.tsx
+++ b/packages/bot-web-ui/src/components/draggable/draggable.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, useState } from 'react';
 import { Rnd } from 'react-rnd';
 import { CSSTransition } from 'react-transition-group';
 import { Icon } from '@deriv/components';
@@ -33,7 +33,10 @@ export default function Draggable({
     xaxis = 0,
     yaxis = 0,
 }: PropsWithChildren<DraggableProps>) {
-    const element_bounds = document.querySelector(bounds as string)?.getBoundingClientRect();
+    const [first_drag_x, setFirstDragX] = useState(xaxis);
+    const [first_drag_y, setFirstDragY] = useState(yaxis);
+    const [first_left, setFirstLeft] = useState(0);
+    const [first_top, setFirstTop] = useState(0);
 
     return is_visible ? (
         <Rnd
@@ -55,10 +58,14 @@ export default function Draggable({
             minHeight={height}
             minWidth={minWidth}
             onDrag={(e, data) => {
-                data.node.style.left = `${data.lastX + data.deltaX}px`;
-                data.node.style.top = `${data.lastY + data.deltaY}px`;
+                data.node.style.left = `${data.lastX - first_drag_x + first_left + data.deltaX}px`;
+                data.node.style.top = `${data.lastY - first_drag_y + first_top + data.deltaY}px`;
             }}
-            onDragStart={e => {
+            onDragStart={(e, data) => {
+                setFirstDragX(data.x);
+                setFirstDragY(data.y);
+                setFirstLeft(parseInt(data.node.style.left));
+                setFirstTop(parseInt(data.node.style.top));
                 // on responsive devices touch event is not triggering the close button action
                 // need to handle it manually
                 const parentElement = (e?.target as HTMLDivElement)?.parentElement;

--- a/packages/bot-web-ui/src/stores/dashboard-store.ts
+++ b/packages/bot-web-ui/src/stores/dashboard-store.ts
@@ -43,6 +43,7 @@ export interface IDashboardStore {
     showVideoDialog: (param: { [key: string]: string }) => void;
     strategy_save_type: string;
     toast_message: string;
+    is_enabled_modal_chart: boolean;
 }
 
 export default class DashboardStore implements IDashboardStore {
@@ -90,6 +91,7 @@ export default class DashboardStore implements IDashboardStore {
             toast_message: observable,
             setStrategySaveType: action.bound,
             setShowMobileTourDialog: action.bound,
+            is_enabled_modal_chart: observable,
         });
         this.root_store = root_store;
         this.tutorials_combined_content = [...user_guide_content, ...guide_content, ...faq_content];
@@ -155,6 +157,7 @@ export default class DashboardStore implements IDashboardStore {
     strategy_save_type = 'unsaved';
     toast_message = '';
     is_web_socket_intialised = true;
+    is_enabled_modal_chart = false;
 
     get is_dark_mode() {
         const {
@@ -178,6 +181,10 @@ export default class DashboardStore implements IDashboardStore {
     setOpenSettings = (toast_message: string, show_toast = true) => {
         this.toast_message = toast_message;
         this.show_toast = show_toast;
+    };
+
+    setEnabledModalChart = () => {
+        this.is_enabled_modal_chart = !this.is_enabled_modal_chart;
     };
 
     setIsFileSupported = (is_file_supported: boolean) => {

--- a/packages/bot-web-ui/src/stores/dashboard-store.ts
+++ b/packages/bot-web-ui/src/stores/dashboard-store.ts
@@ -1,10 +1,7 @@
 import { action, computed, makeObservable, observable, reaction } from 'mobx';
-
 import { setColors } from '@deriv/bot-skeleton';
 import { isMobile } from '@deriv/shared';
-
 import { clearInjectionDiv } from 'Constants/load-modal';
-
 import { setTourSettings, tour_type, TTourType } from '../components/dashboard/dbot-tours/utils';
 import {
     faq_content,
@@ -14,6 +11,7 @@ import {
     TGuideContent,
     TUserGuideContent,
 } from 'Components/dashboard/tutorial-tab/config';
+import RootStore from './root-store';
 
 export interface IDashboardStore {
     active_tab: number;
@@ -43,14 +41,14 @@ export interface IDashboardStore {
     showVideoDialog: (param: { [key: string]: string }) => void;
     strategy_save_type: string;
     toast_message: string;
-    is_enabled_modal_chart: boolean;
+    is_chart_modal_visible: boolean;
 }
 
 export default class DashboardStore implements IDashboardStore {
-    root_store: any;
+    root_store: RootStore;
     tutorials_combined_content: (TFaqContent | TGuideContent | TUserGuideContent)[] = [];
 
-    constructor(root_store: any) {
+    constructor(root_store: RootStore) {
         makeObservable(this, {
             active_tab_tutorials: observable,
             active_tab: observable,
@@ -91,7 +89,7 @@ export default class DashboardStore implements IDashboardStore {
             toast_message: observable,
             setStrategySaveType: action.bound,
             setShowMobileTourDialog: action.bound,
-            is_enabled_modal_chart: observable,
+            is_chart_modal_visible: observable,
         });
         this.root_store = root_store;
         this.tutorials_combined_content = [...user_guide_content, ...guide_content, ...faq_content];
@@ -157,7 +155,7 @@ export default class DashboardStore implements IDashboardStore {
     strategy_save_type = 'unsaved';
     toast_message = '';
     is_web_socket_intialised = true;
-    is_enabled_modal_chart = false;
+    is_chart_modal_visible = false;
 
     get is_dark_mode() {
         const {
@@ -183,8 +181,8 @@ export default class DashboardStore implements IDashboardStore {
         this.show_toast = show_toast;
     };
 
-    setEnabledModalChart = () => {
-        this.is_enabled_modal_chart = !this.is_enabled_modal_chart;
+    setChartModalVisibility = () => {
+        this.is_chart_modal_visible = !this.is_chart_modal_visible;
     };
 
     setIsFileSupported = (is_file_supported: boolean) => {


### PR DESCRIPTION
## Changes:

Being able to see the charts while building a bot:
1.1 The chart view should be displayed as a pop-up window with an **active background** 
1.2 The chart pop-up window should be **movable around the screen**. The user should not be allowed to resize the screen. 
1.3 Tab(text and icon) should be **disabled** when modal window with charts are active 
1.4 To be handled only **for desktop**
1.5 Make as per design, available buttons for the desktop version on the modal window should be different depending on the full window on the tab charts 
1.6 Adjust the market dropdown list in the chart modal window
1.7 The modal window should not extend beyond the **screen boundaries**, the user should have the ability to drag the window always
1.8 Fixed signature label Beta chart
1.9  Fix bounce bug upon loading chart modal, center it
1.10 Test cases provided

<img width="1712" alt="Screenshot 2023-10-05 at 13 39 43" src="https://github.com/binary-com/deriv-app/assets/103181650/69d97b34-797e-489c-a888-cd3083526792"> 
<img width="1712" alt="Screenshot 2023-10-05 at 13 39 48" src="https://github.com/binary-com/deriv-app/assets/103181650/e3b9e6e3-87aa-4cc2-a8f1-441565bc2545">
<img width="1712" alt="Screenshot 2023-10-05 at 13 41 31" src="https://github.com/binary-com/deriv-app/assets/103181650/ce89244b-9d25-433c-978f-9b78a175bb1c">
<img width="1724" alt="Screenshot 2023-11-10 at 16 11 45" src="https://github.com/binary-com/deriv-app/assets/103181650/250a85bc-f903-4f52-9b95-28e8a98ca9ba">

Beta Chart:


https://github.com/binary-com/deriv-app/assets/103181650/666a0118-2667-48a6-9cb2-0a01d862a961
