### PR TITLE
[dtra]/Ahmad/showing digits on the Matchers/Differs contract type on mobile screen

### DIFF
--- a/packages/trader/src/Modules/Trading/Containers/trade.jsx
+++ b/packages/trader/src/Modules/Trading/Containers/trade.jsx
@@ -201,7 +201,7 @@ const Trade = observer(() => {
                                     is_disabled={
                                         !show_digits_stats ||
                                         !is_trade_enabled ||
-                                        form_components.length ||
+                                        form_components.length === 0 ||
                                         is_chart_loading ||
                                         should_show_active_symbols_loading
                                     }


### PR DESCRIPTION
## Changes:

It was a bug where the digits were not visible on the mobile screen for the matchers/differs contract type.


### Screenshots:

