### PR TITLE
[WALL / WIP] Aizad/Adding Badge Components inside of Wallets

### DIFF
--- a/packages/wallets/src/components/Base/Badge/Badge.scss
+++ b/packages/wallets/src/components/Base/Badge/Badge.scss
@@ -1,0 +1,7 @@
+.wallets-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.8rem;
+    border-radius: 0.8rem;
+    background: var(--system-light-7-secondary-background, #f2f3f4);
+}

--- a/packages/wallets/src/components/Base/Badge/Badge.tsx
+++ b/packages/wallets/src/components/Base/Badge/Badge.tsx
@@ -1,5 +1,6 @@
-import React, { FC, cloneElement, ReactElement, PropsWithChildren, ReactNode } from 'react';
+import React, { Children, cloneElement, FC, ReactElement, ReactNode } from 'react';
 import classNames from 'classnames';
+import { TGenericSizes } from '../../../types';
 import { WalletText } from '../WalletText';
 import { WalletTextProps } from '../WalletText/WalletText';
 import './Badge.scss';
@@ -11,11 +12,14 @@ interface BadgeComponent extends FC<BadgeProps> {
 interface BadgeProps {
     children: ReactElement | ReactElement[];
     className?: string;
-    size: 'lg' | 'md' | 'sm' | 'xs'; // TODO: add css classes to handle the size of the badges and map it to the text sizes.
+    size: Extract<TGenericSizes, 'lg' | 'md' | 'sm' | 'xs'>; // TODO: add css classes to handle the size of the badges and map it to the text sizes.
 }
 
-interface BadgeTextProps extends WalletTextProps {
+interface BadgeTextProps {
+    children: WalletTextProps['children'];
+    color?: WalletTextProps['color'];
     isBold?: boolean;
+    size?: WalletTextProps['size'];
 }
 
 interface BadgeIconProps {
@@ -23,21 +27,19 @@ interface BadgeIconProps {
     className?: string;
 }
 
-const BadgeText: FC<BadgeTextProps> = ({ children, isBold = false, size = 'md', ...props }) => (
-    <WalletText size={size} weight={isBold ? 'bold' : 'initial'} {...props}>
+const BadgeText: FC<BadgeTextProps> = ({ children, color, isBold = false, size = 'md' }) => (
+    <WalletText color={color} size={size} weight={isBold ? 'bold' : 'initial'}>
         {children}
     </WalletText>
 );
 
 const BadgeIcon: FC<BadgeIconProps> = ({ children, className }) => <div className={className}>{children}</div>;
 
-const Badge: BadgeComponent = ({ children, className, size = 'md' }) => {
-    return (
-        <div className={classNames('wallets-badge', className)}>
-            {Children.map(children, child => cloneElement(child, { size }))}
-        </div>
-    );
-};
+const Badge: BadgeComponent = ({ children, className, size = 'md' }) => (
+    <div className={classNames('wallets-badge', className)}>
+        {Children.map(children, child => cloneElement(child, { size }))}
+    </div>
+);
 
 Badge.Text = BadgeText;
 Badge.Icon = BadgeIcon;

--- a/packages/wallets/src/components/Base/Badge/Badge.tsx
+++ b/packages/wallets/src/components/Base/Badge/Badge.tsx
@@ -1,0 +1,45 @@
+import React, { FC, cloneElement, ReactElement, PropsWithChildren, ReactNode } from 'react';
+import classNames from 'classnames';
+import { WalletText } from '../WalletText';
+import { WalletTextProps } from '../WalletText/WalletText';
+import './Badge.scss';
+
+interface BadgeComponent extends FC<BadgeProps> {
+    Icon: React.FC<BadgeIconProps>;
+    Text: React.FC<BadgeTextProps>;
+}
+interface BadgeProps {
+    children: ReactElement | ReactElement[];
+    className?: string;
+    size: 'lg' | 'md' | 'sm' | 'xs'; // TODO: add css classes to handle the size of the badges and map it to the text sizes.
+}
+
+interface BadgeTextProps extends WalletTextProps {
+    isBold?: boolean;
+}
+
+interface BadgeIconProps {
+    children: ReactNode;
+    className?: string;
+}
+
+const BadgeText: FC<BadgeTextProps> = ({ children, isBold = false, size = 'md', ...props }) => (
+    <WalletText size={size} weight={isBold ? 'bold' : 'initial'} {...props}>
+        {children}
+    </WalletText>
+);
+
+const BadgeIcon: FC<BadgeIconProps> = ({ children, className }) => <div className={className}>{children}</div>;
+
+const Badge: BadgeComponent = ({ children, className, size = 'md' }) => {
+    return (
+        <div className={classNames('wallets-badge', className)}>
+            {Children.map(children, child => cloneElement(child, { size }))}
+        </div>
+    );
+};
+
+Badge.Text = BadgeText;
+Badge.Icon = BadgeIcon;
+
+export default Badge;

--- a/packages/wallets/src/components/Base/Badge/index.ts
+++ b/packages/wallets/src/components/Base/Badge/index.ts
@@ -1,0 +1,1 @@
+export { default as Badge } from './Badge';

--- a/packages/wallets/src/components/Base/index.ts
+++ b/packages/wallets/src/components/Base/index.ts
@@ -1,5 +1,6 @@
 export * from '../WalletsPrimaryTabs';
 export * from './ATMAmountInput';
+export * from './Badge';
 export * from './Divider';
 export * from './IconButton';
 export * from './InlineMessage';


### PR DESCRIPTION
## 🚧  This is a R&D Card
The purpose of this PR is to show how we can benefit from using `Compound Components` for complex components.

## Changes:
- Adding Badge component within Base package
- Using Compound Components approach
- Supports both Icon and Text. 

Use Case:
`<Badge><Badge.Text>Badge</Badge.Text></Badge>`
`<Badge><Badge.Icon><IconChevronLeft /></Badge.Icon></Badge>`
```
<Badge>
    <Badge.Icon><IconChevronLeft /></Badge.Icon>
    <Badge.Text>Badge</Badge.Text>
</Badge>
```
```
<Badge>
   <Badge.Icon><IconChevronLeft /></Badge.Icon>
   <Badge.Text>Badge</Badge.Text>
   <Badge.Icon><IconChevronLeft /></Badge.Icon>
</Badge>
```
### Screenshots:
![image](https://github.com/binary-com/deriv-app/assets/103104395/ff316833-cbf4-46f1-9776-9bd44be0892e)
![image](https://github.com/binary-com/deriv-app/assets/103104395/1fbc7719-346d-452b-96bb-fbe75b33c8b0)
![image](https://github.com/binary-com/deriv-app/assets/103104395/7519b48b-94ba-48ac-a901-b62daf761398)
![image](https://github.com/binary-com/deriv-app/assets/103104395/7f259c66-f9ab-42a8-9dc2-90e4920d61d0)
![image](https://github.com/binary-com/deriv-app/assets/103104395/0fe5ac2b-3f7b-42c0-8576-ee82ae799e32)