### PR TITLE
[CFDS] Hamza/PRODQA-928/[Trader's Hub] EU banner is missing for MF only account (#11781) 

### DIFF
--- a/packages/appstore/src/modules/traders-hub/__tests__/index.spec.tsx
+++ b/packages/appstore/src/modules/traders-hub/__tests__/index.spec.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { ContentFlag } from '@deriv/shared';
 import { StoreProvider, mockStore } from '@deriv/stores';
 import { render, screen } from '@testing-library/react';
 import { APIProvider } from '@deriv/api';
@@ -55,7 +54,7 @@ describe('TradersHub', () => {
     it('should display disclaimer if the user is from low risk eu country', () => {
         render_container({
             client: { is_logged_in: true },
-            traders_hub: { content_flag: ContentFlag.LOW_RISK_CR_EU },
+            traders_hub: { is_eu_user: true },
         });
         const disclaimer = screen.getByTestId('dt_traders_hub_disclaimer');
         expect(disclaimer).toBeInTheDocument();


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.

Fix the test cases failure due to changes of PRODQA-928

### Screenshots:

Please provide some screenshots of the change.

#### Before
<img width="1334" alt="image" src="https://github.com/binary-com/deriv-app/assets/120543468/e5285202-7385-45c1-be97-aab048ad07d8">

#### After

<img width="796" alt="image" src="https://github.com/binary-com/deriv-app/assets/120543468/6087f6bf-b5fb-4b0b-9cc3-e2707328968d">
