### PR TITLE
[P2PS] Ameerul / P2PS-969 / Improve validation message for amount fields (FE)

### DIFF
--- a/packages/p2p/src/stores/my-ads-store.js
+++ b/packages/p2p/src/stores/my-ads-store.js
@@ -651,16 +651,16 @@ export default class MyAdsStore extends BaseStore {
 
         const getMaxTransactionLimitMessages = field_name => [
             localize('{{field_name}} is required', { field_name }),
-            localize('Enter a valid amount'),
-            localize('Enter a valid amount'),
+            localize('Only numbers are allowed.'),
+            localize('Only 2 decimals are allowed.'),
             localize('{{field_name}} should not exceed Amount', { field_name }),
             localize('{{field_name}} should not be below Min limit', { field_name }),
         ];
 
         const getMinTransactionLimitMessages = field_name => [
             localize('{{field_name}} is required', { field_name }),
-            localize('Enter a valid amount'),
-            localize('Enter a valid amount'),
+            localize('Only numbers are allowed.'),
+            localize('Only 2 decimals are allowed.'),
             localize('{{field_name}} should not exceed Amount', { field_name }),
             localize('{{field_name}} should not exceed Max limit', { field_name }),
         ];
@@ -788,16 +788,16 @@ export default class MyAdsStore extends BaseStore {
 
         const getMaxTransactionLimitMessages = field_name => [
             localize('{{field_name}} is required', { field_name }),
-            localize('Enter a valid amount'),
-            localize('Enter a valid amount'),
+            localize('Only numbers are allowed.'),
+            localize('Only 2 decimals are allowed.'),
             localize('{{field_name}} should not exceed Amount', { field_name }),
             localize('{{field_name}} should not be below Min limit', { field_name }),
         ];
 
         const getMinTransactionLimitMessages = field_name => [
             localize('{{field_name}} is required', { field_name }),
-            localize('Enter a valid amount'),
-            localize('Enter a valid amount'),
+            localize('Only numbers are allowed.'),
+            localize('Only 2 decimals are allowed.'),
             localize('{{field_name}} should not exceed Amount', { field_name }),
             localize('{{field_name}} should not exceed Max limit', { field_name }),
         ];

--- a/packages/p2p/src/stores/my-ads-store.js
+++ b/packages/p2p/src/stores/my-ads-store.js
@@ -652,7 +652,7 @@ export default class MyAdsStore extends BaseStore {
         const getMaxTransactionLimitMessages = field_name => [
             localize('{{field_name}} is required', { field_name }),
             localize('Only numbers are allowed.'),
-            localize('Only 2 decimals are allowed.'),
+            localize('Only up to 2 decimals are allowed.'),
             localize('{{field_name}} should not exceed Amount', { field_name }),
             localize('{{field_name}} should not be below Min limit', { field_name }),
         ];
@@ -660,7 +660,7 @@ export default class MyAdsStore extends BaseStore {
         const getMinTransactionLimitMessages = field_name => [
             localize('{{field_name}} is required', { field_name }),
             localize('Only numbers are allowed.'),
-            localize('Only 2 decimals are allowed.'),
+            localize('Only up to 2 decimals are allowed.'),
             localize('{{field_name}} should not exceed Amount', { field_name }),
             localize('{{field_name}} should not exceed Max limit', { field_name }),
         ];
@@ -789,7 +789,7 @@ export default class MyAdsStore extends BaseStore {
         const getMaxTransactionLimitMessages = field_name => [
             localize('{{field_name}} is required', { field_name }),
             localize('Only numbers are allowed.'),
-            localize('Only 2 decimals are allowed.'),
+            localize('Only up to 2 decimals are allowed.'),
             localize('{{field_name}} should not exceed Amount', { field_name }),
             localize('{{field_name}} should not be below Min limit', { field_name }),
         ];
@@ -797,7 +797,7 @@ export default class MyAdsStore extends BaseStore {
         const getMinTransactionLimitMessages = field_name => [
             localize('{{field_name}} is required', { field_name }),
             localize('Only numbers are allowed.'),
-            localize('Only 2 decimals are allowed.'),
+            localize('Only up to 2 decimals are allowed.'),
             localize('{{field_name}} should not exceed Amount', { field_name }),
             localize('{{field_name}} should not exceed Max limit', { field_name }),
         ];


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- Changed min and max validation messages to `Only up to 2 decimals are allowed.` if user enters more than 2 decimals and `Only numbers are allowed.` if the user enters non numbers. Previously the messages were only `Enter a valid amount.`

### Screenshots:

Please provide some screenshots of the change.
<img width="694" alt="Screenshot 2023-12-06 at 3 11 01 PM" src="https://github.com/binary-com/deriv-app/assets/103412909/ff4d71c1-867a-4d89-a5de-31f36ba3d8e1">
