### PR TITLE
[BOT] shafin/BOT-869/fix google drive showing connected even on abort action

### DIFF
--- a/packages/bot-web-ui/src/stores/google-drive-store.js
+++ b/packages/bot-web-ui/src/stores/google-drive-store.js
@@ -51,9 +51,11 @@ export default class GoogleDriveStore {
             client_id: this.client_id,
             scope: this.scope,
             callback: response => {
-                this.access_token = response.access_token;
-                this.updateSigninStatus(true);
-                localStorage.setItem('google_access_token', response.access_token);
+                if (response?.access_token && !response?.error) {
+                    this.access_token = response.access_token;
+                    this.updateSigninStatus(true);
+                    localStorage.setItem('google_access_token', response.access_token);
+                }
             },
         });
     };


### PR DESCRIPTION
## Changes:

- Added condition to check if the callback response has the access code and also it doesn't contain any error. Only then proceed to show the user as connected. 
