### PR TITLE
[P2PS] Ameerul / P2PS-1327 / Show "Cashier maintenance" in P2P when Cashier is down due to maintenance

### DIFF
--- a/packages/p2p/src/components/app-content.jsx
+++ b/packages/p2p/src/components/app-content.jsx
@@ -4,7 +4,7 @@ import { isAction, reaction } from 'mobx';
 import { observer } from 'mobx-react-lite';
 
 import { Loading, Tabs } from '@deriv/components';
-import { useP2PNotificationCount } from '@deriv/hooks';
+import { useIsSystemMaintenance, useP2PNotificationCount } from '@deriv/hooks';
 import { isMobile } from '@deriv/shared';
 import { useStore } from '@deriv/stores';
 
@@ -26,6 +26,7 @@ const AppContent = ({ order_id }) => {
         client: { loginid },
     } = useStore();
     const notification_count = useP2PNotificationCount();
+    const is_system_maintenance = useIsSystemMaintenance();
     const history = useHistory();
 
     const handleDisclaimerTimeout = time_lapsed => {
@@ -36,7 +37,7 @@ const AppContent = ({ order_id }) => {
     };
 
     React.useEffect(() => {
-        if (!general_store.should_show_dp2p_blocked) {
+        if (!general_store.should_show_dp2p_blocked && !is_system_maintenance) {
             const time_lapsed = getHoursDifference(localStorage.getItem(`p2p_${loginid}_disclaimer_shown`));
             if (time_lapsed === undefined || time_lapsed > INTERVAL_DURATION) {
                 showModal({ key: 'DisclaimerModal', props: { handleDisclaimerTimeout } });
@@ -77,10 +78,12 @@ const AppContent = ({ order_id }) => {
         return <Loading is_fullscreen={false} />;
     }
 
-    // return empty or else the tabs will be shown above when displaying the advertiser page
+    // return empty or else the tabs will be shown above when displaying the advertiser page or when system maintenance is on
+    // or when the user is blocked from using DP2P
     if (
         (buy_sell_store?.show_advertiser_page && !buy_sell_store.should_show_verification) ||
-        general_store.should_show_dp2p_blocked
+        general_store.should_show_dp2p_blocked ||
+        is_system_maintenance
     ) {
         return <></>;
     }

--- a/packages/p2p/src/components/cashier-under-maintenance/__tests__/cashier-under-maintentance.spec.tsx
+++ b/packages/p2p/src/components/cashier-under-maintenance/__tests__/cashier-under-maintentance.spec.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import CashierUnderMaintenance from '../cashier-under-maintenance';
+import { render, screen } from '@testing-library/react';
+
+describe('<CashierUnderMaintenance />', () => {
+    it('should render the CashierUnderMaintenance', () => {
+        render(<CashierUnderMaintenance />);
+
+        expect(screen.getByText('Cashier is currently down for maintenance')).toBeInTheDocument();
+        expect(screen.getByText(/Please check back in a few minutes\./s)).toBeInTheDocument();
+    });
+});

--- a/packages/p2p/src/components/cashier-under-maintenance/cashier-under-maintenance.scss
+++ b/packages/p2p/src/components/cashier-under-maintenance/cashier-under-maintenance.scss
@@ -1,0 +1,18 @@
+.cashier-under-maintenance {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    max-width: 65rem;
+
+    @include mobile {
+        padding: 1.6rem;
+    }
+
+    &__icon {
+        margin-bottom: 2.4rem;
+    }
+
+    &__title {
+        margin-bottom: 0.8rem;
+    }
+}

--- a/packages/p2p/src/components/cashier-under-maintenance/cashier-under-maintenance.tsx
+++ b/packages/p2p/src/components/cashier-under-maintenance/cashier-under-maintenance.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Icon, Text } from '@deriv/components';
+import { Localize } from 'Components/i18next';
+
+const CashierUnderMaintenance = () => {
+    return (
+        <div className='cashier-under-maintenance'>
+            <Icon className='cashier-under-maintenance__icon' icon='IcCashierUnderMaintenance' size={128} />
+            <Text className='cashier-under-maintenance__title' weight='bold'>
+                <Localize i18n_default_text='Cashier is currently down for maintenance' />
+            </Text>
+            <Text align='center'>
+                <Localize
+                    i18n_default_text='Please check back in a few minutes.<0></0>Thank you for your patience.'
+                    components={[<br key={0} />]}
+                />
+            </Text>
+        </div>
+    );
+};
+
+export default CashierUnderMaintenance;

--- a/packages/p2p/src/components/cashier-under-maintenance/cashier-under-maintenance.tsx
+++ b/packages/p2p/src/components/cashier-under-maintenance/cashier-under-maintenance.tsx
@@ -2,21 +2,19 @@ import React from 'react';
 import { Icon, Text } from '@deriv/components';
 import { Localize } from 'Components/i18next';
 
-const CashierUnderMaintenance = () => {
-    return (
-        <div className='cashier-under-maintenance'>
-            <Icon className='cashier-under-maintenance__icon' icon='IcCashierUnderMaintenance' size={128} />
-            <Text className='cashier-under-maintenance__title' weight='bold'>
-                <Localize i18n_default_text='Cashier is currently down for maintenance' />
-            </Text>
-            <Text align='center'>
-                <Localize
-                    i18n_default_text='Please check back in a few minutes.<0></0>Thank you for your patience.'
-                    components={[<br key={0} />]}
-                />
-            </Text>
-        </div>
-    );
-};
+const CashierUnderMaintenance = () => (
+    <div className='cashier-under-maintenance'>
+        <Icon className='cashier-under-maintenance__icon' icon='IcCashierUnderMaintenance' size={128} />
+        <Text className='cashier-under-maintenance__title' weight='bold'>
+            <Localize i18n_default_text='Cashier is currently down for maintenance' />
+        </Text>
+        <Text align='center'>
+            <Localize
+                i18n_default_text='Please check back in a few minutes.<0></0>Thank you for your patience.'
+                components={[<br key={0} />]}
+            />
+        </Text>
+    </div>
+);
 
 export default CashierUnderMaintenance;

--- a/packages/p2p/src/components/cashier-under-maintenance/index.ts
+++ b/packages/p2p/src/components/cashier-under-maintenance/index.ts
@@ -1,0 +1,4 @@
+import CashierUnderMaintenance from './cashier-under-maintenance';
+import './cashier-under-maintenance.scss';
+
+export default CashierUnderMaintenance;

--- a/packages/p2p/src/components/routes/routes.jsx
+++ b/packages/p2p/src/components/routes/routes.jsx
@@ -1,22 +1,25 @@
 import React from 'react';
 import { withRouter } from 'react-router';
 import { observer, useStore } from '@deriv/stores';
+import { useIsSystemMaintenance } from '@deriv/hooks';
 import { useStores } from 'Stores';
+import Dp2pBlocked from 'Components/dp2p-blocked';
+import CashierUnderMaintenance from 'Components/cashier-under-maintenance';
 import BinaryRoutes from './binary-routes';
 import ErrorComponent from './error-component';
-import Dp2pBlocked from 'Components/dp2p-blocked';
 
 const Routes = observer(() => {
     const { general_store } = useStores();
     const { client, common } = useStore();
     const { is_logged_in, is_logging_in } = client;
     const { error, has_error } = common;
+    const is_system_maintenance = useIsSystemMaintenance();
 
     if (has_error) return <ErrorComponent {...error} />;
 
-    if (general_store.should_show_dp2p_blocked) {
-        return <Dp2pBlocked />;
-    }
+    if (is_system_maintenance) return <CashierUnderMaintenance />;
+
+    if (general_store.should_show_dp2p_blocked) return <Dp2pBlocked />;
 
     return <BinaryRoutes is_logged_in={is_logged_in} is_logging_in={is_logging_in} />;
 });


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- Instead of using the `CashierLocked` component inside cashier package, opted to create our own since we don't need the extra checks for p2p.
- Added new component `CashierUnderMaintenance` which will be shown if cashier is under maintenance by checking the `useIsSystemMaintenance` hook. 
- Placed it above if the user is blocked as this takes higher precedence
- Added the hook in app-content in p2p to make sure the tabs and disclaimer modal dont show as it shows the cashier maintenance message
- Added test cases

### Screenshots:

Please provide some screenshots of the change.
<img width="1713" alt="Screenshot 2023-12-06 at 4 27 57 PM" src="https://github.com/binary-com/deriv-app/assets/103412909/467806ab-ddfd-4c5b-8da1-1c05f75b8c5c">

https://github.com/binary-com/deriv-app/assets/103412909/601f0ecd-db06-4b91-8000-9d57e5f1205f