### PR TITLE
[BOT] shafin/BOT-771/chore add matches differs and over under with prediction block in quick strategy

### DIFF
--- a/packages/bot-skeleton/src/constants/config.js
+++ b/packages/bot-skeleton/src/constants/config.js
@@ -305,6 +305,8 @@ export const config = {
         DISABLED: {
             SYMBOLS: ['1HZ150V', '1HZ250V'],
             SUBMARKETS: ['crash_index', 'non_stable_coin', 'step_index'],
+            BARRIER_TRADE_TYPES: ['higherlower', 'touchnotouch', 'endsinout', 'staysinout', 'callputspread'],
+            PREDICTION_TRADE_TYPES: ['highlowticks'],
         },
         DEFAULT: {
             symbol: '1HZ100V',

--- a/packages/bot-skeleton/src/services/api/contracts-for.js
+++ b/packages/bot-skeleton/src/services/api/contracts-for.js
@@ -453,8 +453,8 @@ export default class ContractsFor {
 
         for (let j = 0; j < trade_types.length; j++) {
             const trade_type = trade_types[j];
-            const has_barrier = config.BARRIER_TRADE_TYPES.includes(trade_type.value);
-            const has_prediction = config.PREDICTION_TRADE_TYPES.includes(trade_type.value);
+            const has_barrier = config.QUICK_STRATEGY.DISABLED.BARRIER_TRADE_TYPES.includes(trade_type.value);
+            const has_prediction = config.QUICK_STRATEGY.DISABLED.PREDICTION_TRADE_TYPES.includes(trade_type.value);
 
             if (has_barrier || has_prediction) {
                 hidden_categories++;
@@ -467,8 +467,8 @@ export default class ContractsFor {
     getTradeTypeOptions = (trade_types, trade_type_category) => {
         const trade_type_options = [];
         trade_types.forEach(trade_type => {
-            const has_barrier = config.BARRIER_TRADE_TYPES.includes(trade_type.value);
-            const has_prediction = config.PREDICTION_TRADE_TYPES.includes(trade_type.value);
+            const has_barrier = config.QUICK_STRATEGY.DISABLED.BARRIER_TRADE_TYPES.includes(trade_type.value);
+            const has_prediction = config.QUICK_STRATEGY.DISABLED.PREDICTION_TRADE_TYPES.includes(trade_type.value);
             const is_muliplier = ['multiplier'].includes(trade_type.value);
 
             // TODO: Render extra inputs for barrier + prediction and multiplier types.

--- a/packages/bot-web-ui/src/components/quick-strategy/config.ts
+++ b/packages/bot-web-ui/src/components/quick-strategy/config.ts
@@ -1,6 +1,6 @@
 import { config as qs_config } from '@deriv/bot-skeleton';
 import { localize } from '@deriv/translations';
-import { MARTINGALE, D_ALEMBERT, OSCAR_GRIND } from './descriptions';
+import { D_ALEMBERT, MARTINGALE, OSCAR_GRIND } from './descriptions';
 import { TConfigItem, TStrategies, TValidationItem } from './types';
 
 export const FORM_TABS = [
@@ -148,6 +148,37 @@ const MAX_STAKE: TConfigItem = {
     attached: true,
 };
 
+const LABEL_LAST_DIGIT_PREDICTION: TConfigItem = {
+    type: 'label',
+    name: 'label_last_digit_prediction',
+    label: localize('Last Digit Prediction'),
+    description: localize('Your prediction of the last digit of the asset price.'),
+    should_have: [{ key: 'tradetype', value: '', multiple: ['matchesdiffers', 'overunder'] }],
+    hide_without_should_have: true,
+};
+
+const LAST_DIGIT_PREDICTION: TConfigItem = {
+    type: 'number',
+    name: 'last_digit_prediction',
+    validation: [
+        'number',
+        'required',
+        {
+            type: 'min',
+            value: 0,
+            getMessage: (min: string | number) =>
+                localize('The value must be equal or greater than {{ min }}', { min }),
+        },
+        {
+            type: 'max',
+            value: 9,
+            getMessage: (max: string | number) => localize('The value must be equal or less than {{ max }}', { max }),
+        },
+    ],
+    should_have: [{ key: 'tradetype', value: '', multiple: ['matchesdiffers', 'overunder'] }],
+    hide_without_should_have: true,
+};
+
 export const STRATEGIES: TStrategies = {
     MARTINGALE: {
         name: 'martingale_max-stake',
@@ -158,7 +189,18 @@ export const STRATEGIES: TStrategies = {
         long_description: MARTINGALE,
         fields: [
             [SYMBOL, TRADETYPE, CONTRACT_TYPE, LABEL_STAKE, STAKE, LABEL_DURATION, DURATION_TYPE, DURATION],
-            [LABEL_PROFIT, PROFIT, LABEL_LOSS, LOSS, LABEL_SIZE, SIZE, CHECKBOX_MAX_STAKE, MAX_STAKE],
+            [
+                LABEL_PROFIT,
+                PROFIT,
+                LABEL_LOSS,
+                LOSS,
+                LABEL_SIZE,
+                SIZE,
+                CHECKBOX_MAX_STAKE,
+                MAX_STAKE,
+                LABEL_LAST_DIGIT_PREDICTION,
+                LAST_DIGIT_PREDICTION,
+            ],
         ],
     },
     D_ALEMBERT: {
@@ -170,7 +212,18 @@ export const STRATEGIES: TStrategies = {
         long_description: D_ALEMBERT,
         fields: [
             [SYMBOL, TRADETYPE, CONTRACT_TYPE, LABEL_STAKE, STAKE, DURATION_TYPE, DURATION],
-            [LABEL_PROFIT, PROFIT, LABEL_LOSS, LOSS, LABEL_DALEMBERT_UNIT, UNIT, CHECKBOX_MAX_STAKE, MAX_STAKE],
+            [
+                LABEL_PROFIT,
+                PROFIT,
+                LABEL_LOSS,
+                LOSS,
+                LABEL_DALEMBERT_UNIT,
+                UNIT,
+                CHECKBOX_MAX_STAKE,
+                MAX_STAKE,
+                LABEL_LAST_DIGIT_PREDICTION,
+                LAST_DIGIT_PREDICTION,
+            ],
         ],
     },
     OSCARS_GRIND: {
@@ -182,7 +235,16 @@ export const STRATEGIES: TStrategies = {
         long_description: OSCAR_GRIND,
         fields: [
             [SYMBOL, TRADETYPE, CONTRACT_TYPE, LABEL_STAKE, STAKE, DURATION_TYPE, DURATION],
-            [LABEL_PROFIT, PROFIT, LABEL_LOSS, LOSS, CHECKBOX_MAX_STAKE, MAX_STAKE],
+            [
+                LABEL_PROFIT,
+                PROFIT,
+                LABEL_LOSS,
+                LOSS,
+                CHECKBOX_MAX_STAKE,
+                MAX_STAKE,
+                LABEL_LAST_DIGIT_PREDICTION,
+                LAST_DIGIT_PREDICTION,
+            ],
         ],
     },
     REVERSE_MARINGALE: {
@@ -193,7 +255,18 @@ export const STRATEGIES: TStrategies = {
         ),
         fields: [
             [SYMBOL, TRADETYPE, CONTRACT_TYPE, LABEL_STAKE, STAKE, LABEL_DURATION, DURATION_TYPE, DURATION],
-            [LABEL_PROFIT, PROFIT, LABEL_LOSS, LOSS, LABEL_SIZE, SIZE, CHECKBOX_MAX_STAKE, MAX_STAKE],
+            [
+                LABEL_PROFIT,
+                PROFIT,
+                LABEL_LOSS,
+                LOSS,
+                LABEL_SIZE,
+                SIZE,
+                CHECKBOX_MAX_STAKE,
+                MAX_STAKE,
+                LABEL_LAST_DIGIT_PREDICTION,
+                LAST_DIGIT_PREDICTION,
+            ],
         ],
     },
     REVERSE_D_ALEMBERT: {
@@ -204,7 +277,18 @@ export const STRATEGIES: TStrategies = {
         ),
         fields: [
             [SYMBOL, TRADETYPE, CONTRACT_TYPE, LABEL_STAKE, STAKE, LABEL_DURATION, DURATION_TYPE, DURATION],
-            [LABEL_PROFIT, PROFIT, LABEL_LOSS, LOSS, LABEL_DALEMBERT_UNIT, UNIT, CHECKBOX_MAX_STAKE, MAX_STAKE],
+            [
+                LABEL_PROFIT,
+                PROFIT,
+                LABEL_LOSS,
+                LOSS,
+                LABEL_DALEMBERT_UNIT,
+                UNIT,
+                CHECKBOX_MAX_STAKE,
+                MAX_STAKE,
+                LABEL_LAST_DIGIT_PREDICTION,
+                LAST_DIGIT_PREDICTION,
+            ],
         ],
     },
     '1_3_2_6': {
@@ -215,7 +299,7 @@ export const STRATEGIES: TStrategies = {
         ),
         fields: [
             [SYMBOL, TRADETYPE, CONTRACT_TYPE, LABEL_STAKE, STAKE, DURATION_TYPE, DURATION],
-            [LABEL_PROFIT, PROFIT, LABEL_LOSS, LOSS],
+            [LABEL_PROFIT, PROFIT, LABEL_LOSS, LOSS, LABEL_LAST_DIGIT_PREDICTION, LAST_DIGIT_PREDICTION],
         ],
     },
 };

--- a/packages/bot-web-ui/src/components/quick-strategy/form.tsx
+++ b/packages/bot-web-ui/src/components/quick-strategy/form.tsx
@@ -11,7 +11,7 @@ import QSInput from './inputs/qs-input';
 import QSCheckbox from './inputs/qs-checkbox';
 import QSInputLabel from './inputs/qs-input-label';
 import { STRATEGIES } from './config';
-import { TConfigItem, TFormData } from './types';
+import { TConfigItem, TFormData, TShouldHave } from './types';
 import { useFormikContext } from 'formik';
 
 const QuickStrategyForm = observer(() => {
@@ -42,6 +42,13 @@ const QuickStrategyForm = observer(() => {
         }
     };
 
+    const shouldEnable = (should_have: TShouldHave[]) =>
+        should_have.every(item => {
+            const item_value = values?.[item.key]?.toString();
+            if (item.multiple) return item.multiple.includes(item_value);
+            return values[item.key as keyof TFormData] === item.value;
+        });
+
     const renderForm = () => {
         return config.map((group, group_index) => {
             if (!group?.length) return null;
@@ -60,12 +67,10 @@ const QuickStrategyForm = observer(() => {
                             // Generic or common fields
                             case 'number': {
                                 if (!field.name) return null;
-                                const { should_have = [] } = field;
+                                const { should_have = [], hide_without_should_have = false } = field;
+                                const should_enable = shouldEnable(should_have);
                                 if (should_have?.length) {
-                                    const should_enable = should_have.every((item: TFormData) => {
-                                        return values[item.key as keyof TFormData] === item.value;
-                                    });
-                                    if (!should_enable && is_mobile) {
+                                    if (!should_enable && (is_mobile || hide_without_should_have)) {
                                         return null;
                                     }
                                     return (
@@ -81,11 +86,17 @@ const QuickStrategyForm = observer(() => {
                                 return <QSInput {...field} onChange={onChange} key={key} name={field.name as string} />;
                             }
 
-                            case 'label':
+                            case 'label': {
                                 if (!field.label) return null;
+                                const { should_have = [], hide_without_should_have = false } = field;
+                                const should_enable = shouldEnable(should_have);
+                                if (!should_enable && hide_without_should_have) {
+                                    return null;
+                                }
                                 return (
                                     <QSInputLabel key={key} label={field.label} description={field.description || ''} />
                                 );
+                            }
                             case 'checkbox':
                                 return (
                                     <QSCheckbox

--- a/packages/bot-web-ui/src/components/quick-strategy/quick-strategy.tsx
+++ b/packages/bot-web-ui/src/components/quick-strategy/quick-strategy.tsx
@@ -58,6 +58,7 @@ const FormikWrapper: React.FC<TFormikWrapper> = observer(({ children }) => {
         action: 'RUN',
         max_stake: 10,
         boolean_max_stake: false,
+        last_digit_prediction: '1',
     };
 
     React.useEffect(() => {
@@ -90,6 +91,8 @@ const FormikWrapper: React.FC<TFormikWrapper> = observer(({ children }) => {
                         }
                         const should_validate = field.should_have
                             ? field.should_have?.every(item => {
+                                  const item_value = formikData?.[item.key]?.toString();
+                                  if (item.multiple) return item.multiple.includes(item_value);
                                   return formikData?.[item.key] === item.value;
                               })
                             : true;

--- a/packages/bot-web-ui/src/components/quick-strategy/types.ts
+++ b/packages/bot-web-ui/src/components/quick-strategy/types.ts
@@ -21,7 +21,11 @@ export type TValidationItem =
           type: TValidationType;
           value: number | string;
       } & ValidationObject);
-
+export type TShouldHave = {
+    key: string;
+    value: string | number | boolean;
+    multiple?: string[];
+};
 export type TConfigItem = {
     type: string;
     name?: keyof TFormData;
@@ -32,10 +36,8 @@ export type TConfigItem = {
     attached?: boolean;
     hide?: string[];
     validation?: TValidationItem[];
-    should_have?: {
-        key: string;
-        value: string | number | boolean;
-    }[];
+    should_have?: TShouldHave[];
+    hide_without_should_have?: boolean;
 };
 
 export type TDescriptionItem = {


### PR DESCRIPTION
## Changes:

- This is a draft PR to test adding matches/differs and over/under in Quick Strategy with prediction block without changing 
anything on Bot Skeleton
- The idea here is to append the prediction block directly into the XML if last_digit_prediction is present in the form
- Also to show the matches/differs and over/under inside the QS we can handle it from the bot-skeleton config file without adding any new input type
- Finally to show/hide the input field from the config file should_have used along with hide_without_should_have introduced newly