### PR TITLE
[wallets]thisyahlen/wall-3006/chore: add unit test for usedevice hook

### DIFF
--- a/packages/wallets/src/hooks/__tests__/useDevice.spec.ts
+++ b/packages/wallets/src/hooks/__tests__/useDevice.spec.ts
@@ -1,0 +1,33 @@
+import { renderHook } from '@testing-library/react-hooks';
+import useDevice from '../useDevice';
+
+const mockWindowSize = jest.fn();
+jest.mock('usehooks-ts', () => ({
+    useWindowSize: () => mockWindowSize(),
+}));
+
+describe('useDevice', () => {
+    it('should correctly identify a desktop device', () => {
+        mockWindowSize.mockReturnValue({ width: 1024 });
+        const { result } = renderHook(() => useDevice());
+        expect(result.current.isDesktop).toBe(true);
+        expect(result.current.isMobile).toBe(false);
+        expect(result.current.isTablet).toBe(false);
+    });
+
+    it('should correctly identify a mobile device', () => {
+        mockWindowSize.mockReturnValue({ width: 767 });
+        const { result } = renderHook(() => useDevice());
+        expect(result.current.isMobile).toBe(true);
+        expect(result.current.isDesktop).toBe(false);
+        expect(result.current.isTablet).toBe(false);
+    });
+
+    it('should correctly identify a tablet device', () => {
+        mockWindowSize.mockReturnValue({ width: 768 });
+        const { result } = renderHook(() => useDevice());
+        expect(result.current.isTablet).toBe(true);
+        expect(result.current.isDesktop).toBe(false);
+        expect(result.current.isMobile).toBe(false);
+    });
+});


### PR DESCRIPTION
## Changes:
1. Add unit test to useDevice hook in wallets package

### Screenshots:
![Screenshot 2023-12-07 at 3 37 39 PM](https://github.com/binary-com/deriv-app/assets/104053934/b641b1d3-3dd5-448b-b7f7-0876ca7f29c0)
