### PR TITLE
[WALL] Sergei / just suggestion / Add event listener for screen orientation for mobile devices

### DIFF
--- a/packages/wallets/src/AppContent.tsx
+++ b/packages/wallets/src/AppContent.tsx
@@ -25,6 +25,8 @@ const AppContent: React.FC = () => {
 
     useEffect(() => {
         defineViewportHeight();
+        screen.orientation.addEventListener('change', defineViewportHeight);
+        return () => screen.orientation.removeEventListener('change', defineViewportHeight);
     }, []);
 
     return (


### PR DESCRIPTION
## Changes:

Add `screen.orientation.addEventListener('change', defineViewportHeight);` for mobile devices to recalculate `vh` value

### Screenshots:

No screenshots, nothing changes
