### PR TITLE
fix: leaving already pop up not shown at all issue

### DIFF
--- a/packages/bot-web-ui/src/stores/route-prompt-dialog-store.js
+++ b/packages/bot-web-ui/src/stores/route-prompt-dialog-store.js
@@ -22,7 +22,7 @@ export default class RoutePromptDialogStore {
     last_location = null;
 
     shouldNavigateAfterPrompt(next_location) {
-        if (!this.is_confirmed && this?.root_store?.run_panel?.is_running) {
+        if (!this.is_confirmed) {
             this.last_location = next_location;
             if (next_location.pathname !== '/bot') this.should_show = true;
             return false;

--- a/packages/bot-web-ui/src/stores/run-panel-store.js
+++ b/packages/bot-web-ui/src/stores/run-panel-store.js
@@ -654,11 +654,12 @@ export default class RunPanelStore {
 
     showErrorMessage(data) {
         const { journal } = this.root_store;
-        const { notifications } = this.core;
+        const { notifications, ui } = this.core;
         journal.onError(data);
         if (journal.journal_filters.some(filter => filter === message_types.ERROR)) {
             this.toggleDrawer(true);
             this.setActiveTabIndex(run_panel.JOURNAL);
+            ui.setPromptHandler(false);
         } else {
             notifications.addNotificationMessage(journalError(this.switchToJournal));
             notifications.removeNotificationMessage({ key: 'bot_error' });


### PR DESCRIPTION
## Changes:

- Unregister the `setPromptHandler` if the bot is stopped due to an error
- Change back the `shouldNavigateAfterPrompt` method to the previous implementation