### PR TITLE
[wallets]thisyahlen/WALL-2919/chore: add unit test for CommonMistakesExamples

### DIFF
--- a/packages/wallets/src/features/accounts/screens/CommonMistakesExamples/__tests__/CommonMistakesExamples.spec.tsx
+++ b/packages/wallets/src/features/accounts/screens/CommonMistakesExamples/__tests__/CommonMistakesExamples.spec.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import CommonMistakesExamples from '../CommonMistakesExamples';
+
+jest.mock('../../../../../public/images/status-loss.svg', () => {
+    const MockStatusLoss = () => <img alt='StatusLoss' />;
+    MockStatusLoss.displayName = 'StatusLoss';
+    return MockStatusLoss;
+});
+
+describe('CommonMistakesExamples', () => {
+    it('renders the description and image', () => {
+        const mockDescription = 'Test description';
+        const mockImage = <img alt='mock' />;
+
+        render(<CommonMistakesExamples description={mockDescription} image={mockImage} />);
+
+        expect(screen.getByText(mockDescription)).toBeInTheDocument();
+        expect(screen.getByAltText('mock')).toBeInTheDocument();
+    });
+
+    it('renders the StatusLoss image', () => {
+        const mockDescription = 'Test description';
+        const mockImage = <img alt='mock' />;
+
+        render(<CommonMistakesExamples description={mockDescription} image={mockImage} />);
+
+        expect(screen.getByAltText('StatusLoss')).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Changes:
1. Add unit test for CommonMistakesExamples

### Screenshots:
![Screenshot 2023-12-08 at 12 10 32 PM](https://github.com/binary-com/deriv-app/assets/104053934/03efb85b-28b5-4cbd-a87b-9468661d1cce)

