### PR TITLE
[COJ] Evgeniy/COJ-1024/fix track.js error Object.hasOwn is not a function

### DIFF
--- a/packages/account/src/Components/forms/scroll-to-field-with-error.tsx
+++ b/packages/account/src/Components/forms/scroll-to-field-with-error.tsx
@@ -27,7 +27,7 @@ const ScrollToFieldWithError = ({
     }, [should_recollect_inputs_names]);
     React.useEffect(() => {
         const current_error_field_name =
-            all_page_inputs_names.find(input_name => Object.hasOwn(errors, input_name)) || '';
+            all_page_inputs_names.find(input_name => Object.prototype.hasOwnProperty.call(errors, input_name)) || '';
 
         if (fields_to_scroll_top?.includes(current_error_field_name)) {
             scrollToElement(current_error_field_name, 'start');


### PR DESCRIPTION

## Changes:

according to TrackJS log this error occurs in old browsers, because Object.hasOwn is not supported in old browsers.
so modifying it here to Object.prototype.hasOwnProperty.call() to apply the same functionality 

