### PR TITLE
[CFDs][Refactoring] Hirad/CFDs-2960/Removal of ui states from the CFD package

### DIFF
--- a/packages/appstore/src/components/modals/modal-manager.tsx
+++ b/packages/appstore/src/components/modals/modal-manager.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { observer } from 'mobx-react-lite';
 import { ResetTradingPasswordModal } from '@deriv/account';
-import { useFeatureFlags } from '@deriv/hooks';
+import { useFeatureFlags, useCurrentList } from '@deriv/hooks';
 import { TTradingPlatformAvailableAccount } from './account-type-modal/types';
 import MT5AccountTypeModal from './account-type-modal';
 import RegulatorsCompareModal from './regulators-compare-modal';
@@ -30,11 +30,11 @@ type TCurrentList = DetailsOfEachMT5Loginid & {
 const ModalManager = () => {
     const store = useStores();
     const { is_wallet_enabled } = useFeatureFlags();
+    const { current_list } = useCurrentList();
     const { common, client, modules, traders_hub, ui } = store;
     const { is_logged_in, is_eu, is_eu_country, is_populating_mt5_account_list, verification_code } = client;
     const { platform } = common;
     const {
-        current_list,
         enableCFDPasswordModal,
         is_mt5_trade_modal_visible,
         setAccountType,
@@ -90,14 +90,15 @@ const ModalManager = () => {
         const should_be_enabled = (list_item: TCurrentList) =>
             platform === 'dxtrade' ? list_item.enabled === 1 : true;
         const acc = current_list_keys.some(
-            key => key.startsWith(`${platform}.real.${acc_type}`) && should_be_enabled(current_list[key])
+            key =>
+                key.startsWith(`${platform}.real.${acc_type}`) && should_be_enabled(current_list[key] as TCurrentList)
         )
             ? Object.keys(current_list)
                   .filter(key => key.startsWith(`${platform}.real.${acc_type}`))
                   .reduce((_acc, cur) => {
                       _acc.push(current_list[cur]);
                       return _acc;
-                  }, [] as DetailsOfEachMT5Loginid[])
+                  }, [] as Omit<DetailsOfEachMT5Loginid[], 'balance'> & { balance?: number | null }[])
             : undefined;
         return acc;
     };

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -14,6 +14,7 @@ export { default as useCryptoTransactions } from './useCryptoTransactions';
 export { default as useCurrencyConfig } from './useCurrencyConfig';
 export { default as useCurrentAccountDetails } from './useCurrentAccountDetails';
 export { default as useCurrentCurrencyConfig } from './useCurrentCurrencyConfig';
+export { default as useCurrentList } from './useCurrentList';
 export { default as useDepositCryptoAddress } from './useDepositCryptoAddress';
 export { default as useDepositFiatAddress } from './useDepositFiatAddress';
 export { default as useDepositLocked } from './useDepositLocked';

--- a/packages/hooks/src/useCurrentList.ts
+++ b/packages/hooks/src/useCurrentList.ts
@@ -1,0 +1,51 @@
+import { useStore } from '@deriv/stores';
+import { useMT5AccountsList, useDxtradeAccountsList, useCtraderAccountsList } from '@deriv/api';
+import { getAccountListKey, CFD_PLATFORMS, Jurisdiction } from '@deriv/shared';
+
+type MT5AccountsList = NonNullable<ReturnType<typeof useMT5AccountsList>['data']>[number];
+type DxtradeAccountsList = NonNullable<ReturnType<typeof useDxtradeAccountsList>['data']>[number];
+type CtraderAccountsList = NonNullable<ReturnType<typeof useCtraderAccountsList>['data']>[number];
+
+type TCurrentList = {
+    [key: string]: MT5AccountsList | DxtradeAccountsList | CtraderAccountsList;
+};
+
+/* 
+    This hook is used to get the cfd existing_accounts_data
+*/
+const useCurrentList = () => {
+    const current_list: TCurrentList = {};
+    const { traders_hub } = useStore();
+    const { data: mt5_accounts } = useMT5AccountsList();
+    const { data: dxtrade_accounts } = useDxtradeAccountsList();
+    const { data: ctrader_accounts } = useCtraderAccountsList();
+    const show_eu_related_content = traders_hub.show_eu_related_content;
+
+    mt5_accounts
+        ?.filter(acc =>
+            show_eu_related_content
+                ? acc.landing_company_short === Jurisdiction.MALTA_INVEST
+                : acc.landing_company_short !== Jurisdiction.MALTA_INVEST
+        )
+        .forEach(account => {
+            current_list[getAccountListKey(account, CFD_PLATFORMS.MT5, account.landing_company_short)] = {
+                ...account,
+            };
+        });
+
+    dxtrade_accounts?.forEach(account => {
+        current_list[getAccountListKey(account, CFD_PLATFORMS.DXTRADE, account.landing_company_short)] = {
+            ...account,
+        };
+    });
+
+    ctrader_accounts?.forEach(account => {
+        current_list[getAccountListKey(account, CFD_PLATFORMS.CTRADER, account.landing_company_short)] = {
+            ...account,
+        };
+    });
+
+    return { current_list };
+};
+
+export default useCurrentList;

--- a/packages/shared/src/utils/cfd/cfd.ts
+++ b/packages/shared/src/utils/cfd/cfd.ts
@@ -40,7 +40,7 @@ export const getMT5Title = (account_type: string) => {
 
 type TPlatform = 'dxtrade' | 'mt5' | 'ctrader';
 type TMarketType = 'financial' | 'synthetic' | 'gaming' | 'all' | undefined;
-type TShortcode = 'svg' | 'bvi' | 'labuan' | 'vanuatu' | 'maltainvest';
+type TShortcode = DetailsOfEachMT5Loginid['landing_company_short'];
 type TGetAccount = {
     market_type: TMarketType;
     sub_account_type?: TAccount['sub_account_type'];
@@ -245,7 +245,11 @@ export const setSharedCFDText = (all_shared_CFD_text: { [key: string]: () => voi
     CFD_text_translated = all_shared_CFD_text;
 };
 
-type TAccount = DetailsOfEachMT5Loginid & { platform: string };
+type TAccount = Omit<DetailsOfEachMT5Loginid, 'balance' | 'display_balance'> & {
+    platform: string;
+    balance?: number | null;
+    display_balance?: string | null;
+};
 export const getAccountListKey = (account: TAccount, platform: TPlatform, shortcode?: TShortcode) => {
     return `${account.platform || platform}.${account.account_type}.${getCFDAccountKey({
         market_type: account.market_type,


### PR DESCRIPTION
## Changes:

To enable the provision of UI states set in the trader's hub, it is necessary to integrate a CFD Provider into the CFD package.

### Screenshots:

Please provide some screenshots of the change.

<img width="919" alt="image" src="https://github.com/binary-com/deriv-app/assets/91878582/189858c6-3356-4fef-a297-3339a89f1f40">

