### PR TITLE
Suisin/chore: update scss to not use max height for jurisdiction modal

### DIFF
--- a/packages/cfd/src/sass/cfd.scss
+++ b/packages/cfd/src/sass/cfd.scss
@@ -403,6 +403,7 @@
     .dc-modal-header {
         border-bottom: 2px solid var(--general-section-1);
     }
+    overflow-y: auto;
 }
 
 .poi-poa-submitted {

--- a/packages/components/src/components/modal/modal.scss
+++ b/packages/components/src/components/modal/modal.scss
@@ -86,10 +86,6 @@
         @include desktop {
             min-width: 440px !important;
             max-height: calc(100vh - #{$HEADER_HEIGHT} - #{$FOOTER_HEIGHT}) !important;
-
-            &_jurisdiction-modal {
-                max-height: none !important;
-            }
         }
         @include mobile {
             max-width: calc(100vw - 3.2rem) !important;

--- a/packages/components/src/components/modal/modal.scss
+++ b/packages/components/src/components/modal/modal.scss
@@ -86,6 +86,10 @@
         @include desktop {
             min-width: 440px !important;
             max-height: calc(100vh - #{$HEADER_HEIGHT} - #{$FOOTER_HEIGHT}) !important;
+
+            &_jurisdiction-modal {
+                max-height: none !important;
+            }
         }
         @include mobile {
             max-width: calc(100vw - 3.2rem) !important;


### PR DESCRIPTION
## Changes:

Fixed user have to scroll to see the next button issue for pop-up modal.

<img width="1237" alt="Screenshot 2023-12-13 at 12 03 56 PM" src="https://github.com/binary-com/deriv-app/assets/103026762/e0478688-5f54-4fb0-8e6c-9e164152d74e">

### Screenshots:
 Previous issue:

<img width="1227" alt="Screenshot 2023-12-13 at 12 04 28 PM" src="https://github.com/binary-com/deriv-app/assets/103026762/acd52e3f-3bdd-4fc8-9375-9bc9530fd052">

