### PR TITLE
[WALL] Rostislav / WALL-3069 / Use requests instead of subscriptions for exchange rates in transfer messages and transfer inputs

### DIFF
--- a/packages/api/src/hooks/index.ts
+++ b/packages/api/src/hooks/index.ts
@@ -36,6 +36,7 @@ export { default as useDxtradeServiceToken } from './useDxtradeServiceToken';
 export { default as useDynamicLeverage } from './useDynamicLeverage';
 export { default as useExchangeRate } from './useExchangeRate';
 export { default as useGetAccountStatus } from './useGetAccountStatus';
+export { default as useGetExchangeRate } from './useGetExchangeRate';
 export { default as useIdentityDocumentVerificationAdd } from './useIdentityDocumentVerificationAdd';
 export { default as useIsEuRegion } from './useIsEuRegion';
 export { default as useJurisdictionStatus } from './useJurisdictionStatus';

--- a/packages/api/src/hooks/useGetExchangeRate.ts
+++ b/packages/api/src/hooks/useGetExchangeRate.ts
@@ -1,0 +1,15 @@
+import useQuery from '../useQuery';
+
+type TProps = Required<Parameters<typeof useQuery<'exchange_rates'>>[1]>['payload'];
+
+const useGetExchangeRate = ({ base_currency, loginid, target_currency }: TProps) => {
+    const { data, ...rest } = useQuery('exchange_rates', { payload: { base_currency, loginid, target_currency } });
+
+    return {
+        /** The exchange rates response */
+        data: data?.exchange_rates,
+        ...rest,
+    };
+};
+
+export default useGetExchangeRate;

--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferForm/TransferForm.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferForm/TransferForm.tsx
@@ -63,13 +63,11 @@ const TransferForm = () => {
                                     mobileAccountsListRef={mobileAccountsListRef}
                                 />
                             </div>
-                            {exchangeRatesUSD && exchangeRatesWalletCurrency && (
-                                <TransferMessages
-                                    exchangeRatesUSD={exchangeRatesUSD}
-                                    exchangeRatesWalletCurrency={exchangeRatesWalletCurrency}
-                                    key={values.fromAmount.toString() + values.toAmount.toString()}
-                                />
-                            )}
+                            <TransferMessages
+                                exchangeRatesUSD={exchangeRatesUSD}
+                                exchangeRatesWalletCurrency={exchangeRatesWalletCurrency}
+                                key={values.fromAmount.toString() + values.toAmount.toString()}
+                            />
                             <div className='wallets-transfer__fields-section'>
                                 <TransferFormAmountInput
                                     exchangeRatesWalletCurrency={exchangeRatesWalletCurrency}

--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferMessages/TransferMessages.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferMessages/TransferMessages.tsx
@@ -7,8 +7,8 @@ import { TInitialTransferFormValues } from '../../types';
 import './TransferMessages.scss';
 
 type TProps = {
-    exchangeRatesUSD: THooks.ExchangeRate;
-    exchangeRatesWalletCurrency: THooks.ExchangeRate;
+    exchangeRatesUSD?: THooks.ExchangeRate;
+    exchangeRatesWalletCurrency?: THooks.ExchangeRate;
 };
 
 const TransferMessages: React.FC<TProps> = ({ exchangeRatesUSD, exchangeRatesWalletCurrency }) => {

--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferMessages/TransferMessages.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferMessages/TransferMessages.tsx
@@ -1,14 +1,26 @@
 import React from 'react';
 import { useFormikContext } from 'formik';
 import { FadedAnimatedList, WalletAlertMessage } from '../../../../../../components';
+import { THooks } from '../../../../../../types';
 import { useTransferMessages } from '../../hooks';
 import { TInitialTransferFormValues } from '../../types';
 import './TransferMessages.scss';
 
-const TransferMessages = () => {
+type TProps = {
+    exchangeRatesUSD: THooks.ExchangeRate;
+    exchangeRatesWalletCurrency: THooks.ExchangeRate;
+};
+
+const TransferMessages: React.FC<TProps> = ({ exchangeRatesUSD, exchangeRatesWalletCurrency }) => {
     const { values } = useFormikContext<TInitialTransferFormValues>();
 
-    const messages = useTransferMessages(values.fromAccount, values.toAccount, values);
+    const messages = useTransferMessages(
+        values.fromAccount,
+        values.toAccount,
+        values,
+        exchangeRatesUSD,
+        exchangeRatesWalletCurrency
+    );
 
     return (
         <FadedAnimatedList className='wallets-transfer-messages'>

--- a/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/types/types.ts
+++ b/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/types/types.ts
@@ -9,7 +9,8 @@ export type TMessage = {
 export type TMessageFnProps = {
     activeWallet: THooks.ActiveWalletAccount;
     displayMoney?: (amount: number, currency: string, fractionalDigits: number) => string;
-    exchangeRates?: THooks.ExchangeRate;
+    exchangeRatesUSD?: THooks.ExchangeRate;
+    exchangeRatesWalletCurrency?: THooks.ExchangeRate;
     limits?: THooks.AccountLimits;
     sourceAccount: NonNullable<TAccount>;
     sourceAmount: number;

--- a/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/useTransferMessages.ts
+++ b/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/useTransferMessages.ts
@@ -13,8 +13,8 @@ const useTransferMessages = (
     fromAccount: NonNullable<TAccount> | undefined,
     toAccount: NonNullable<TAccount> | undefined,
     formData: TInitialTransferFormValues,
-    exchangeRatesUSD: THooks.ExchangeRate,
-    exchangeRatesWalletCurrency: THooks.ExchangeRate
+    exchangeRatesUSD?: THooks.ExchangeRate,
+    exchangeRatesWalletCurrency?: THooks.ExchangeRate
 ) => {
     const { data: authorizeData } = useAuthorize();
     const { data: activeWallet } = useActiveWalletAccount();

--- a/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/useTransferMessages.ts
+++ b/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/useTransferMessages.ts
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
-import { useAccountLimits, useActiveWalletAccount, useAuthorize, useExchangeRate, usePOI } from '@deriv/api';
+import { useCallback } from 'react';
+import { useAccountLimits, useActiveWalletAccount, useAuthorize, usePOI } from '@deriv/api';
 import { displayMoney as displayMoney_ } from '@deriv/api/src/utils';
 import { THooks } from '../../../../../../types';
 import { TAccount, TInitialTransferFormValues } from '../../types';
@@ -12,61 +12,19 @@ import { TMessage, TMessageFnProps } from './types';
 const useTransferMessages = (
     fromAccount: NonNullable<TAccount> | undefined,
     toAccount: NonNullable<TAccount> | undefined,
-    formData: TInitialTransferFormValues
+    formData: TInitialTransferFormValues,
+    exchangeRatesUSD: THooks.ExchangeRate,
+    exchangeRatesWalletCurrency: THooks.ExchangeRate
 ) => {
     const { data: authorizeData } = useAuthorize();
     const { data: activeWallet } = useActiveWalletAccount();
     const { preferred_language: preferredLanguage } = authorizeData;
     const { data: poi } = usePOI();
     const { data: accountLimits } = useAccountLimits();
-    const { data: exchangeRatesRaw, subscribe, unsubscribe } = useExchangeRate();
-
-    const [exchangeRates, setExchangeRates] = useState<THooks.ExchangeRate>();
 
     const isTransferBetweenWallets =
         fromAccount?.account_category === 'wallet' && toAccount?.account_category === 'wallet';
     const isAccountVerified = poi?.is_verified;
-
-    useEffect(
-        () => setExchangeRates(prev => ({ ...prev, rates: { ...prev?.rates, ...exchangeRatesRaw?.rates } })),
-        [exchangeRatesRaw?.rates]
-    );
-
-    useEffect(() => {
-        if (!fromAccount?.currency || !toAccount?.currency || !activeWallet?.currency || !activeWallet?.loginid) return;
-        unsubscribe();
-        if (!isAccountVerified && isTransferBetweenWallets) {
-            subscribe({
-                base_currency: activeWallet.currency,
-                loginid: activeWallet.loginid,
-                target_currency:
-                    activeWallet.loginid === fromAccount.loginid ? toAccount.currency : fromAccount.currency,
-            });
-        } else {
-            subscribe({
-                base_currency: 'USD',
-                loginid: activeWallet.loginid,
-                target_currency: toAccount.currency,
-            });
-            if (fromAccount.currency !== toAccount.currency)
-                subscribe({
-                    base_currency: 'USD',
-                    loginid: activeWallet.loginid,
-                    target_currency: fromAccount.currency,
-                });
-            return unsubscribe;
-        }
-    }, [
-        activeWallet?.currency,
-        activeWallet?.loginid,
-        fromAccount?.currency,
-        fromAccount?.loginid,
-        isAccountVerified,
-        isTransferBetweenWallets,
-        subscribe,
-        toAccount?.currency,
-        unsubscribe,
-    ]);
 
     const displayMoney = useCallback(
         (amount: number, currency: string, fractionalDigits: number) =>
@@ -95,7 +53,8 @@ const useTransferMessages = (
         const message = messageFn({
             activeWallet,
             displayMoney,
-            exchangeRates,
+            exchangeRatesUSD,
+            exchangeRatesWalletCurrency,
             limits: accountLimits,
             sourceAccount: fromAccount,
             sourceAmount,

--- a/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/utils/messageFunctions.ts
+++ b/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/utils/messageFunctions.ts
@@ -4,7 +4,7 @@ import { TMessageFnProps } from '../types';
 const lifetimeAccountLimitsBetweenWalletsMessageFn = ({
     activeWallet,
     displayMoney,
-    exchangeRates,
+    exchangeRatesWalletCurrency,
     limits,
     sourceAccount,
     sourceAmount,
@@ -23,9 +23,11 @@ const lifetimeAccountLimitsBetweenWalletsMessageFn = ({
 
     if (
         !sourceAccount.currency ||
-        !exchangeRates?.rates?.[sourceAccount.currency] ||
+        (sourceAccount.currency !== activeWallet.currency &&
+            !exchangeRatesWalletCurrency?.rates?.[sourceAccount.currency]) ||
         !targetAccount.currency ||
-        !exchangeRates?.rates?.[targetAccount.currency] ||
+        (targetAccount.currency !== activeWallet.currency &&
+            !exchangeRatesWalletCurrency?.rates?.[targetAccount.currency]) ||
         !sourceAccount.currencyConfig ||
         !targetAccount.currencyConfig
     )
@@ -35,10 +37,14 @@ const lifetimeAccountLimitsBetweenWalletsMessageFn = ({
 
     const allowedSumConverted =
         allowedSumActiveWalletCurrency *
-        (exchangeRates?.rates[transferDirection === 'from' ? targetAccount.currency : sourceAccount.currency] ?? 1);
+        (exchangeRatesWalletCurrency?.rates?.[
+            transferDirection === 'from' ? targetAccount.currency : sourceAccount.currency
+        ] ?? 1);
     const availableSumConverted =
         availableSumActiveWalletCurrency *
-        (exchangeRates?.rates[transferDirection === 'from' ? targetAccount.currency : sourceAccount.currency] ?? 1);
+        (exchangeRatesWalletCurrency?.rates?.[
+            transferDirection === 'from' ? targetAccount.currency : sourceAccount.currency
+        ] ?? 1);
 
     const sourceCurrencyLimit = transferDirection === 'from' ? allowedSumActiveWalletCurrency : allowedSumConverted;
     const targetCurrencyLimit = transferDirection === 'from' ? allowedSumConverted : allowedSumActiveWalletCurrency;
@@ -90,7 +96,7 @@ const lifetimeAccountLimitsBetweenWalletsMessageFn = ({
 
 const cumulativeAccountLimitsMessageFn = ({
     displayMoney,
-    exchangeRates,
+    exchangeRatesUSD,
     limits,
     sourceAccount,
     sourceAmount,
@@ -112,19 +118,19 @@ const cumulativeAccountLimitsMessageFn = ({
 
     if (
         !sourceAccount.currency ||
-        !exchangeRates?.rates?.[sourceAccount.currency] ||
+        (sourceAccount.currency !== 'USD' && !exchangeRatesUSD?.rates?.[sourceAccount.currency]) ||
         !targetAccount.currency ||
-        !exchangeRates?.rates?.[targetAccount.currency] ||
+        (targetAccount.currency !== 'USD' && !exchangeRatesUSD?.rates?.[targetAccount.currency]) ||
         !sourceAccount.currencyConfig ||
         !targetAccount.currencyConfig
     )
         return null;
 
-    const sourceCurrencyLimit = allowedSumUSD * (exchangeRates.rates[sourceAccount.currency] ?? 1);
-    const targetCurrencyLimit = allowedSumUSD * (exchangeRates.rates[targetAccount.currency] ?? 1);
+    const sourceCurrencyLimit = allowedSumUSD * (exchangeRatesUSD?.rates?.[sourceAccount.currency] ?? 1);
+    const targetCurrencyLimit = allowedSumUSD * (exchangeRatesUSD?.rates?.[targetAccount.currency] ?? 1);
 
-    const sourceCurrencyRemainder = availableSumUSD * (exchangeRates.rates[sourceAccount.currency] ?? 1);
-    const targetCurrencyRemainder = availableSumUSD * (exchangeRates.rates[targetAccount.currency] ?? 1);
+    const sourceCurrencyRemainder = availableSumUSD * (exchangeRatesUSD?.rates?.[sourceAccount.currency] ?? 1);
+    const targetCurrencyRemainder = availableSumUSD * (exchangeRatesUSD?.rates?.[targetAccount.currency] ?? 1);
 
     const formattedSourceCurrencyLimit = displayMoney?.(
         sourceCurrencyLimit,


### PR DESCRIPTION
## Changes:

- [x] add `useGetExchangeRate`
- [x] switch to using timer-initiated exchange rates requests instead of subscriptions in transfer

### Screenshots:

https://github.com/binary-com/deriv-app/assets/119863957/11b54aae-7873-4515-9523-728372d9db0e


