### PR TITLE
[WALL] [Fix] Rostislav / WALL-3092 / Fix transfer ATM fields position on mobile

### DIFF
--- a/packages/wallets/src/components/Base/ATMAmountInput/ATMAmountInput.scss
+++ b/packages/wallets/src/components/Base/ATMAmountInput/ATMAmountInput.scss
@@ -10,6 +10,10 @@
         inset: 0;
         color: var(--system-light-2-general-text, #333);
 
+        @include mobile {
+            inset: auto 0 0;
+        }
+
         &:disabled {
             color: var(--system-light-4-disabled-text, #d6d6d6);
         }


### PR DESCRIPTION
## Changes:

- [x] make the ATM inputs stick to the bottom on mobile
