### PR TITLE
chore: add clickjacking preventation headers for cloudflare

### DIFF
--- a/packages/core/src/root_files/_headers
+++ b/packages/core/src/root_files/_headers
@@ -1,0 +1,4 @@
+/*
+  X-Frame-Options: sameorigin
+  Content-Security-Policy: frame-ancestors 'self';
+


### PR DESCRIPTION
This was taken from this PR:
https://github.com/binary-com/deriv-app/pull/11805/files#diff-50cb9f3ec9ba414669cac19486feb1dd8ede43c2d01a245dbce14a6f4d7e321a

I'm not convinced this will actually add the headers to cloudflare. So this PR will test to make sure it's there, and if it works, we can merge the other PR to remove the clickjacking js code snippet.