### PR TITLE
[FEQ] Ameerul / FEQ-1004 / P2P Order Information Hook

### DIFF
--- a/packages/api/src/hooks/p2p/useAdvertList.ts
+++ b/packages/api/src/hooks/p2p/useAdvertList.ts
@@ -50,10 +50,9 @@ const useAdvertList = (
                 /** Indicates if the advertiser is currently online. */
                 is_online: Boolean(advert?.advertiser_details?.is_online),
                 /** Indicates that the advertiser was recommended in the most recent review by the current user. */
-                is_recommended:
-                    advert?.advertiser_details?.is_recommended === null
-                        ? null
-                        : Boolean(advert?.advertiser_details?.is_recommended),
+                is_recommended: Boolean(advert?.advertiser_details?.is_recommended),
+                /** Indicates that the advertiser has not been recommended yet. */
+                has_not_been_recommended: advert?.advertiser_details.is_recommended === null,
             },
         }));
     }, [flatten_data]);

--- a/packages/api/src/hooks/p2p/useAdvertList.ts
+++ b/packages/api/src/hooks/p2p/useAdvertList.ts
@@ -50,10 +50,11 @@ const useAdvertList = (
                 /** Indicates if the advertiser is currently online. */
                 is_online: Boolean(advert?.advertiser_details?.is_online),
                 /** Indicates that the advertiser was recommended in the most recent review by the current user. */
-                is_recommended: Boolean(advert?.advertiser_details?.is_recommended),
+                is_recommended:
+                    advert?.advertiser_details?.is_recommended === null
+                        ? null
+                        : Boolean(advert?.advertiser_details?.is_recommended),
             },
-            /** The advert creation time in epoch. */
-            created_time: advert?.created_time ? new Date(advert.created_time) : undefined,
         }));
     }, [flatten_data]);
 

--- a/packages/api/src/hooks/p2p/useOrderInfo.ts
+++ b/packages/api/src/hooks/p2p/useOrderInfo.ts
@@ -1,0 +1,69 @@
+import { useMemo } from 'react';
+import useQuery from '../../useQuery';
+import useAuthorize from '../useAuthorize';
+
+/** This custom hook that returns information about the given order ID */
+const useOrderInfo = (id: string) => {
+    const { isSuccess } = useAuthorize();
+    const { data, ...rest } = useQuery('p2p_order_info', { payload: { id }, options: { enabled: isSuccess } });
+
+    // modify the data to add additional information
+    const modified_data = useMemo(() => {
+        if (!data?.p2p_order_info) return undefined;
+
+        const {
+            advert_details,
+            advertiser_details,
+            client_details,
+            is_incoming,
+            is_reviewable,
+            is_seen,
+            review_details,
+            verification_pending,
+        } = data.p2p_order_info;
+
+        return {
+            ...data.p2p_order_info,
+            advert_details: {
+                ...advert_details,
+                /** Indicates if this is block trade advert or not. */
+                is_block_trade: Boolean(advert_details.block_trade),
+            },
+            advertiser_details: {
+                ...advertiser_details,
+                /** Indicates if the advertiser is currently online. */
+                is_online: Boolean(advertiser_details.is_online),
+                /** Indicates that the advertiser was recommended in the most recent review by the current user. */
+                is_recommended:
+                    advertiser_details.is_recommended === null ? null : Boolean(client_details.is_recommended),
+            },
+            client_details: {
+                ...client_details,
+                /** Indicates if the advertiser is currently online. */
+                is_online: Boolean(client_details.is_online),
+                /** Indicates that the client was recommended in the most recent review by the current user. */
+                is_recommended: client_details.is_recommended === null ? null : Boolean(client_details.is_recommended),
+            },
+            /** Indicates if the order is created for the advert of the client. */
+            is_incoming: Boolean(is_incoming),
+            /** Indicates if a review can be given. */
+            is_reviewable: Boolean(is_reviewable),
+            /** Indicates if the latest order changes have been seen by the current client. */
+            is_seen: Boolean(is_seen),
+            review_details: {
+                ...review_details,
+                /** Indicates if the advertiser is recommended or not. */
+                is_recommended: review_details?.recommended === null ? null : Boolean(review_details?.recommended),
+            },
+            /** Indicates that the seller in the process of confirming the order. */
+            verification_pending: Boolean(verification_pending),
+        };
+    }, [data?.p2p_order_info]);
+
+    return {
+        data: modified_data,
+        ...rest,
+    };
+};
+
+export default useOrderInfo;

--- a/packages/api/src/hooks/p2p/useOrderInfo.ts
+++ b/packages/api/src/hooks/p2p/useOrderInfo.ts
@@ -34,15 +34,18 @@ const useOrderInfo = (id: string) => {
                 /** Indicates if the advertiser is currently online. */
                 is_online: Boolean(advertiser_details.is_online),
                 /** Indicates that the advertiser was recommended in the most recent review by the current user. */
-                is_recommended:
-                    advertiser_details.is_recommended === null ? null : Boolean(client_details.is_recommended),
+                is_recommended: Boolean(client_details.is_recommended),
+                /** Indicates that the advertiser has not been recommended yet. */
+                has_not_been_recommended: advertiser_details.is_recommended === null,
             },
             client_details: {
                 ...client_details,
                 /** Indicates if the advertiser is currently online. */
                 is_online: Boolean(client_details.is_online),
                 /** Indicates that the client was recommended in the most recent review by the current user. */
-                is_recommended: client_details.is_recommended === null ? null : Boolean(client_details.is_recommended),
+                is_recommended: Boolean(client_details.is_recommended),
+                /** Indicates that the client has not been recommended yet. */
+                has_not_been_recommended: client_details.is_recommended === null,
             },
             /** Indicates if the order is created for the advert of the client. */
             is_incoming: Boolean(is_incoming),
@@ -53,7 +56,9 @@ const useOrderInfo = (id: string) => {
             review_details: {
                 ...review_details,
                 /** Indicates if the advertiser is recommended or not. */
-                is_recommended: review_details?.recommended === null ? null : Boolean(review_details?.recommended),
+                is_recommended: Boolean(review_details?.recommended),
+                /** Indicates that the advertiser has not been recommended yet. */
+                has_not_been_recommended: review_details?.recommended === null,
             },
             /** Indicates that the seller in the process of confirming the order. */
             verification_pending: Boolean(verification_pending),

--- a/packages/api/src/hooks/p2p/useOrderInfo.ts
+++ b/packages/api/src/hooks/p2p/useOrderInfo.ts
@@ -61,6 +61,7 @@ const useOrderInfo = (id: string) => {
     }, [data?.p2p_order_info]);
 
     return {
+        /** The 'p2p_order_info' response. */
         data: modified_data,
         ...rest,
     };

--- a/packages/api/src/hooks/p2p/useOrderInfo.ts
+++ b/packages/api/src/hooks/p2p/useOrderInfo.ts
@@ -61,7 +61,7 @@ const useOrderInfo = (id: string) => {
                 has_not_been_recommended: review_details?.recommended === null,
             },
             /** Indicates that the seller in the process of confirming the order. */
-            verification_pending: Boolean(verification_pending),
+            is_verification_pending: Boolean(verification_pending),
         };
     }, [data?.p2p_order_info]);
 

--- a/packages/api/src/hooks/p2p/useOrderList.ts
+++ b/packages/api/src/hooks/p2p/useOrderList.ts
@@ -81,6 +81,7 @@ const useOrderList = (
     return {
         /** The 'p2p_order_list' response. */
         data: modified_data,
+        /** Fetch the next page of orders. */
         loadMoreOrders: fetchNextPage,
         ...rest,
     };

--- a/packages/api/src/hooks/p2p/useOrderList.ts
+++ b/packages/api/src/hooks/p2p/useOrderList.ts
@@ -45,26 +45,33 @@ const useOrderList = (
                 /** Indicates if the advertiser is currently online. */
                 is_online: Boolean(advert?.advertiser_details?.is_online),
                 /** Indicates that the advertiser was recommended in the most recent review by the current user. */
-                is_recommended: Boolean(advert?.advertiser_details?.is_recommended),
+                is_recommended:
+                    advert?.advertiser_details?.is_recommended === null
+                        ? null
+                        : Boolean(advert?.advertiser_details?.is_recommended),
             },
             /** Details of the client who created the order. */
             client_details: {
                 ...advert?.client_details,
                 /** Indicates if the advertiser is currently online. */
-                is_online: Boolean(advert?.advertiser_details?.is_online),
+                is_online: Boolean(advert?.client_details?.is_online),
                 /** Indicates that the advertiser was recommended in the most recent review by the current user. */
-                is_recommended: Boolean(advert?.advertiser_details?.is_recommended),
+                is_recommended:
+                    advert?.client_details?.is_recommended === null
+                        ? null
+                        : Boolean(advert?.client_details?.is_recommended),
             },
             is_incoming: Boolean(advert?.is_incoming),
-            /** 1 if a review can be given, otherwise 0 */
+            /** Indicates if a review can be given. */
             is_reviewable: Boolean(advert?.is_reviewable),
-            /** 1 if the latest order changes have been seen by the current client, otherwise 0. */
+            /** Indicates if the latest order changes have been seen by the current client. */
             is_seen: Boolean(advert?.is_seen),
             /** Details of the review you gave for this order, if any. */
             review_details: {
                 ...advert?.review_details,
-                /** 1 if the advertiser is recommended, 0 if not recommended. */
-                is_recommended: Boolean(advert?.review_details?.recommended),
+                /** Indicates if the advertiser is recommended. */
+                is_recommended:
+                    advert?.review_details?.recommended === null ? null : Boolean(advert?.review_details?.recommended),
             },
             /** Indicates that the seller in the process of confirming the order. */
             is_verification_pending: Boolean(advert?.verification_pending),

--- a/packages/api/src/hooks/p2p/useOrderList.ts
+++ b/packages/api/src/hooks/p2p/useOrderList.ts
@@ -45,10 +45,9 @@ const useOrderList = (
                 /** Indicates if the advertiser is currently online. */
                 is_online: Boolean(advert?.advertiser_details?.is_online),
                 /** Indicates that the advertiser was recommended in the most recent review by the current user. */
-                is_recommended:
-                    advert?.advertiser_details?.is_recommended === null
-                        ? null
-                        : Boolean(advert?.advertiser_details?.is_recommended),
+                is_recommended: Boolean(advert?.advertiser_details?.is_recommended),
+                /** Indicates that the advertiser has not been recommended yet. */
+                has_not_been_recommended: advert?.advertiser_details?.is_recommended === null,
             },
             /** Details of the client who created the order. */
             client_details: {
@@ -56,10 +55,9 @@ const useOrderList = (
                 /** Indicates if the advertiser is currently online. */
                 is_online: Boolean(advert?.client_details?.is_online),
                 /** Indicates that the advertiser was recommended in the most recent review by the current user. */
-                is_recommended:
-                    advert?.client_details?.is_recommended === null
-                        ? null
-                        : Boolean(advert?.client_details?.is_recommended),
+                is_recommended: Boolean(advert?.client_details?.is_recommended),
+                /** Indicates that the advertiser has not been recommended yet. */
+                has_not_been_recommended: advert?.client_details?.is_recommended === null,
             },
             is_incoming: Boolean(advert?.is_incoming),
             /** Indicates if a review can be given. */
@@ -70,8 +68,9 @@ const useOrderList = (
             review_details: {
                 ...advert?.review_details,
                 /** Indicates if the advertiser is recommended. */
-                is_recommended:
-                    advert?.review_details?.recommended === null ? null : Boolean(advert?.review_details?.recommended),
+                is_recommended: Boolean(advert?.review_details?.recommended),
+                /** Indicates that the advertiser has not been recommended yet. */
+                has_not_been_recommended: advert?.review_details?.recommended === null,
             },
             /** Indicates that the seller in the process of confirming the order. */
             is_verification_pending: Boolean(advert?.verification_pending),


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- Created hook for p2p order information
- Changed return value for any instances of `is_recommended` as the null value represents the advertiser/client who have not been recommended yet.
- Changed tsdocs since the return value for some values are not 1 or 0 but boolean now. So removed any indication that it will return 1 or 0

### Screenshots:

Please provide some screenshots of the change.
