### PR TITLE
[WEBREL] [CFDS] Hamza/WEBREL-1769/Content translation for "Verification explained" in the Jurisdiction selection table for CFDs

### DIFF
--- a/packages/cfd/src/Constants/jurisdiction-contents/jurisdiction-verification-contents.ts
+++ b/packages/cfd/src/Constants/jurisdiction-contents/jurisdiction-verification-contents.ts
@@ -12,7 +12,7 @@ export const jurisdictionVerificationContents = (): TJurisdictionVerificationCon
     required_verification_docs: {
         document_number: {
             icon: 'IcDocumentNumberVerification',
-            text: localize(`Document number (e.g. identity card, passport, driver's license)`),
+            text: localize("Document number (e.g. identity card, passport, driver's license)"),
         },
         selfie: {
             icon: 'IcSelfieVerification',
@@ -20,7 +20,7 @@ export const jurisdictionVerificationContents = (): TJurisdictionVerificationCon
         },
         identity_document: {
             icon: 'IcIdentityDocumentVerification',
-            text: localize(`A copy of your identity document (e.g. identity card, passport, driver's license)`),
+            text: localize("A copy of your identity document (e.g. identity card, passport, driver's license)"),
         },
         name_and_address: {
             icon: 'IcNameAndAddressVerification',

--- a/packages/cfd/src/Containers/jurisdiction-modal/__test__/jurisdiction-card-back.spec.tsx
+++ b/packages/cfd/src/Containers/jurisdiction-modal/__test__/jurisdiction-card-back.spec.tsx
@@ -35,7 +35,7 @@ describe('<JurisdictionCardBack />', () => {
         expect(screen.getByText('We need you to submit these in order to get this account:')).toBeInTheDocument();
         expect(screen.queryByText('A selfie of yourself.')).not.toBeInTheDocument();
         expect(
-            screen.queryByText(`Document number (e.g. identity card, passport, driver's license)`)
+            screen.queryByText("Document number (e.g. identity card, passport, driver's license)")
         ).not.toBeInTheDocument();
         expect(
             screen.queryByText(
@@ -43,7 +43,7 @@ describe('<JurisdictionCardBack />', () => {
             )
         ).not.toBeInTheDocument();
         expect(
-            screen.queryByText(`A copy of your identity document (e.g. identity card, passport, driver's license)`)
+            screen.queryByText("A copy of your identity document (e.g. identity card, passport, driver's license)")
         ).not.toBeInTheDocument();
         exampleVerificationMessage();
     });
@@ -53,11 +53,11 @@ describe('<JurisdictionCardBack />', () => {
         render(<JurisdictionCardBack {...mock_props} />);
         expect(screen.queryByText('A selfie of yourself.')).not.toBeInTheDocument();
         expect(
-            screen.queryByText(`A copy of your identity document (e.g. identity card, passport, driver's license)`)
+            screen.queryByText("A copy of your identity document (e.g. identity card, passport, driver's license)")
         ).not.toBeInTheDocument();
         expect(screen.getByText('We need you to submit these in order to get this account:')).toBeInTheDocument();
         expect(
-            screen.getByText(`Document number (e.g. identity card, passport, driver's license)`)
+            screen.getByText("Document number (e.g. identity card, passport, driver's license)")
         ).toBeInTheDocument();
         expect(
             screen.getByText(
@@ -73,7 +73,7 @@ describe('<JurisdictionCardBack />', () => {
         expect(screen.getByText('We need you to submit these in order to get this account:')).toBeInTheDocument();
         expect(screen.getByText('A selfie of yourself.')).toBeInTheDocument();
         expect(
-            screen.getByText(`A copy of your identity document (e.g. identity card, passport, driver's license)`)
+            screen.getByText("A copy of your identity document (e.g. identity card, passport, driver's license)")
         ).toBeInTheDocument();
         expect(
             screen.getByText(
@@ -82,7 +82,7 @@ describe('<JurisdictionCardBack />', () => {
         ).toBeInTheDocument();
         exampleVerificationMessage();
         expect(
-            screen.queryByText(`Document number (e.g. identity card, passport, driver's license)`)
+            screen.queryByText("Document number (e.g. identity card, passport, driver's license)")
         ).not.toBeInTheDocument();
     });
 


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.

Noticed that the sentence "A copy of your identity document (e.g. identity card, passport, driver's license)" is not translated according to the selected language.

### Screenshots:

Please provide some screenshots of the change.

![image](https://github.com/binary-com/deriv-app/assets/120543468/fe7c55bb-de1d-4a5e-bdc6-0c59617672ec)

