### PR TITLE
[COJ]/likhith/KYC-1523/display appropriate POI screen for Highrisk user

### DIFF
--- a/packages/account/src/Sections/Verification/ProofOfIdentity/proof-of-identity-submission.jsx
+++ b/packages/account/src/Sections/Verification/ProofOfIdentity/proof-of-identity-submission.jsx
@@ -130,7 +130,6 @@ const POISubmission = observer(
                     IDV_ERROR_STATUS.DobMismatch.code,
                     IDV_ERROR_STATUS.NameMismatch.code,
                     IDV_ERROR_STATUS.NameDobMismatch.code,
-                    IDV_ERROR_STATUS.HighRisk.code,
                 ].includes(mismatch_status) &&
                 idv.submissions_left > 0
             ) {


### PR DESCRIPTION
## Changes:

Fixed the condition that was used to decide the screen to be displayed when a High risk user verified earlier by IDV opens POI screen