### PR TITLE
[CFDS] Hamza/CFDS-2816/Submit your POI and POA modal is showing incorrect modal

### DIFF
--- a/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts-button.tsx
+++ b/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts-button.tsx
@@ -50,10 +50,10 @@ const CFDCompareAccountsButton = observer(({ trading_platforms, is_demo }: TComp
 
     const {
         poi_or_poa_not_submitted,
-        poi_acknowledged_for_vanuatu_maltainvest,
-        poi_acknowledged_for_bvi_labuan,
+        poi_acknowledged_for_maltainvest,
+        poi_acknowledged_for_bvi_labuan_vanuatu,
+        poa_resubmit_for_labuan,
         poa_acknowledged,
-        poa_pending,
     } = getAuthenticationStatusInfo(account_status);
 
     const type_of_account = {
@@ -104,13 +104,13 @@ const CFDCompareAccountsButton = observer(({ trading_platforms, is_demo }: TComp
     const is_account_status_verified = getAccountVerficationStatus(
         market_type_shortcode,
         poi_or_poa_not_submitted,
-        poi_acknowledged_for_vanuatu_maltainvest,
-        poi_acknowledged_for_bvi_labuan,
+        poi_acknowledged_for_maltainvest,
+        poi_acknowledged_for_bvi_labuan_vanuatu,
         poa_acknowledged,
-        poa_pending,
+        poa_resubmit_for_labuan,
+        has_submitted_personal_details,
         should_restrict_bvi_account_creation,
         should_restrict_vanuatu_account_creation,
-        has_submitted_personal_details,
         is_demo
     );
 

--- a/packages/cfd/src/Helpers/compare-accounts-config.ts
+++ b/packages/cfd/src/Helpers/compare-accounts-config.ts
@@ -339,13 +339,13 @@ const ctrader_data: TModifiedTradingPlatformAvailableAccount = {
 const getAccountVerficationStatus = (
     market_type_shortcode: string,
     poi_or_poa_not_submitted: boolean,
-    poi_acknowledged_for_vanuatu_maltainvest: boolean,
-    poi_acknowledged_for_bvi_labuan: boolean,
+    poi_acknowledged_for_maltainvest: boolean,
+    poi_acknowledged_for_bvi_labuan_vanuatu: boolean,
     poa_acknowledged: boolean,
-    poa_pending: boolean,
+    poa_resubmit_for_labuan: boolean,
+    has_submitted_personal_details: boolean,
     should_restrict_bvi_account_creation: boolean,
     should_restrict_vanuatu_account_creation: boolean,
-    has_submitted_personal_details: boolean,
     is_demo?: boolean
 ) => {
     switch (market_type_shortcode) {
@@ -356,7 +356,7 @@ const getAccountVerficationStatus = (
         case MARKET_TYPE_SHORTCODE.SYNTHETIC_BVI:
         case MARKET_TYPE_SHORTCODE.FINANCIAL_BVI:
             if (
-                poi_acknowledged_for_bvi_labuan &&
+                poi_acknowledged_for_bvi_labuan_vanuatu &&
                 !poi_or_poa_not_submitted &&
                 !should_restrict_bvi_account_creation &&
                 has_submitted_personal_details &&
@@ -368,7 +368,7 @@ const getAccountVerficationStatus = (
         case MARKET_TYPE_SHORTCODE.SYNTHETIC_VANUATU:
         case MARKET_TYPE_SHORTCODE.FINANCIAL_VANUATU:
             if (
-                poi_acknowledged_for_vanuatu_maltainvest &&
+                poi_acknowledged_for_bvi_labuan_vanuatu &&
                 !poi_or_poa_not_submitted &&
                 !should_restrict_vanuatu_account_creation &&
                 has_submitted_personal_details &&
@@ -379,13 +379,18 @@ const getAccountVerficationStatus = (
             return false;
 
         case MARKET_TYPE_SHORTCODE.FINANCIAL_LABUAN:
-            if (poi_acknowledged_for_bvi_labuan && poa_acknowledged && has_submitted_personal_details) {
+            if (
+                poi_acknowledged_for_bvi_labuan_vanuatu &&
+                poa_acknowledged &&
+                has_submitted_personal_details &&
+                !poa_resubmit_for_labuan
+            ) {
                 return true;
             }
             return false;
 
         case MARKET_TYPE_SHORTCODE.FINANCIAL_MALTA_INVEST:
-            if ((poi_acknowledged_for_vanuatu_maltainvest && poa_acknowledged) || is_demo) {
+            if ((poi_acknowledged_for_maltainvest && poa_acknowledged) || is_demo) {
                 return true;
             }
             return false;


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.

#### Steps to Reproduce:

1. Create Deriv account
2. Make POI and POA verified
3. Try to create MT5 BVI/DVL/Vanuatu from compare account table


#### Issue:
Submit your proof of identity and address modal with the message "Your documents were submitted successfully" is shown before password prompt.

#### Expected Behaviour:
There shouldn't be any message shown when the account is already POI and POA verified. It should only show password prompt.

### Screenshots:

Please provide some screenshots of the change.

#### Before

![image](https://github.com/binary-com/deriv-app/assets/120543468/d2424ecf-33a9-4b8e-b84a-e9964720aaf1)


#### After

![image](https://github.com/binary-com/deriv-app/assets/120543468/e1b8d281-3f20-45bf-b61d-8a9e3ca8cd25)
