### PR TITLE
[WALL] Aizad/WALL-3121/Deriv cTrader heading inside of Compare Accounts Modal

### DIFF
--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/CompareAccountsTitleIcon.tsx
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/CompareAccountsTitleIcon.tsx
@@ -48,7 +48,7 @@ const getAccountCardTitle = (shortCode: TMarketWithShortCode | TPlatforms.OtherA
         case CFD_PLATFORMS.DXTRADE:
             return isDemo ? 'Deriv X Demo' : 'Deriv X';
         case CFD_PLATFORMS.CTRADER:
-            return isDemo ? 'cTrader Demo' : 'cTrader';
+            return isDemo ? 'Deriv cTrader Demo' : 'Deriv cTrader';
         default:
             return isDemo ? 'CFDs Demo' : 'CFDs';
     }


### PR DESCRIPTION
## Changes:
- Change cTrader title from `cTrader` & `cTrader Demo` to `Deriv cTrader` && `Deriv cTrader Demo`

### Screenshots:

![image](https://github.com/binary-com/deriv-app/assets/103104395/b2bf0376-678b-4182-8a3d-4cac2b2c8ffb)
![image](https://github.com/binary-com/deriv-app/assets/103104395/3dd7a9b4-366b-4259-bf45-af95e623d2aa)
