### PR TITLE
[WALL] Aizad/WALL-3117/ Fix spacing issue inside Compare Accounts Modal for demo

### DIFF
--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/CompareAccountsCard.tsx
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/CompareAccountsCard.tsx
@@ -52,6 +52,7 @@ const CompareAccountsCard = ({
                     shortCode={shortCode}
                 />
                 <InstrumentsLabelHighlighted
+                    isDemo={isDemo}
                     isEuRegion={isEuRegion}
                     marketType={marketType}
                     platform={platform}

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/InstrumentsLabelHighlighted.scss
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/InstrumentsLabelHighlighted.scss
@@ -8,8 +8,6 @@
     }
 
     &--demo {
-        @include desktop {
-            padding-top: 1.6rem;
-        }
+        padding-top: 1.6rem;
     }
 }

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/InstrumentsLabelHighlighted.scss
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/InstrumentsLabelHighlighted.scss
@@ -1,9 +1,15 @@
 .wallets-compare-accounts-outline {
     display: flex;
     flex-direction: column;
-    padding: 4rem 2.4rem 0;
+    padding: 4rem 1.8rem 0rem;
     border-radius: 2.4rem;
     @include mobile {
         padding: 7rem 1.5rem 0;
+    }
+
+    &--demo {
+        @include desktop {
+            padding-top: 1.6rem;
+        }
     }
 }

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/InstrumentsLabelHighlighted.tsx
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/InstrumentsLabelHighlighted.tsx
@@ -1,21 +1,34 @@
 import React from 'react';
+import classNames from 'classnames';
 import { THooks, TPlatforms } from '../../../../types';
 import { getHighlightedIconLabel } from './compareAccountsConfig';
 import InstrumentsIconWithLabel from './InstrumentsIconWithLabel';
 import './InstrumentsLabelHighlighted.scss';
 
 type TInstrumentsLabelHighlighted = {
+    isDemo: boolean;
     isEuRegion: boolean;
     marketType: THooks.AvailableMT5Accounts['market_type'];
     platform: TPlatforms.All;
     shortCode: THooks.AvailableMT5Accounts['shortcode'];
 };
 
-const InstrumentsLabelHighlighted = ({ isEuRegion, marketType, platform, shortCode }: TInstrumentsLabelHighlighted) => {
+const InstrumentsLabelHighlighted = ({
+    isDemo,
+    isEuRegion,
+    marketType,
+    platform,
+    shortCode,
+}: TInstrumentsLabelHighlighted) => {
     const iconData = [...getHighlightedIconLabel(platform, isEuRegion, marketType, shortCode)];
 
     return (
-        <div className={'wallets-compare-accounts-outline'} data-testid='dt_compare_cfd_account_outline__container'>
+        <div
+            className={classNames('wallets-compare-accounts-outline', {
+                'wallets-compare-accounts-outline--demo': isDemo,
+            })}
+            data-testid='dt_compare_cfd_account_outline__container'
+        >
             {iconData.map(item => (
                 <InstrumentsIconWithLabel key={item.text} {...item} />
             ))}


### PR DESCRIPTION
## Changes:
- added alternative classname for demo to fix spacing between Icon List and text description within `InstrumentsLabelHighlighted`

### Screenshots:
Before:
![image](https://github.com/binary-com/deriv-app/assets/103104395/c31160fa-ea18-464e-9b61-92de2c8e1212)
After:
![image](https://github.com/binary-com/deriv-app/assets/103104395/0ceb4710-d8e4-46e3-b871-95aa3ab81546)

