### PR TITLE
[CRO] NikitK/CRO-357/Questionary adding by ab testing approach for new users right after email verification

### DIFF
--- a/packages/core/src/App/Containers/AccountSignupModal/account-signup-modal.jsx
+++ b/packages/core/src/App/Containers/AccountSignupModal/account-signup-modal.jsx
@@ -3,15 +3,16 @@ import { Form, Formik } from 'formik';
 import PropTypes from 'prop-types';
 
 import { Button, Checkbox, Dialog, Loading, Text } from '@deriv/components';
-import { getLocation, SessionStore } from '@deriv/shared';
-import { localize } from '@deriv/translations';
+import { getLocation, SessionStore, shuffleArray } from '@deriv/shared';
+import { getLanguage, localize } from '@deriv/translations';
+import { Analytics } from '@deriv/analytics';
 
 import { WS } from 'Services';
 import { connect } from 'Stores/connect';
-import { Analytics } from '@deriv/analytics';
 
 import CitizenshipForm from '../CitizenshipModal/set-citizenship-form.jsx';
 import PasswordSelectionModal from '../PasswordSelectionModal/password-selection-modal.jsx';
+import QuestionnaireModal from '../QuestionnaireModal';
 import ResidenceForm from '../SetResidenceModal/set-residence-form.jsx';
 
 import validateSignupFields from './validate-signup-fields.jsx';
@@ -35,6 +36,10 @@ const AccountSignup = ({
     const [pw_input, setPWInput] = React.useState('');
     const [is_password_modal, setIsPasswordModal] = React.useState(false);
     const [is_disclaimer_accepted, setIsDisclaimerAccepted] = React.useState(false);
+    const [is_questionnaire, setIsQuestionnaire] = React.useState(false);
+    const [ab_questionnaire, setABQuestionnaire] = React.useState();
+    const [modded_state, setModdedState] = React.useState({});
+    const language = getLanguage();
 
     const checkResidenceIsBrazil = selected_country =>
         selected_country && residence_list[indexOfSelection(selected_country)]?.value?.toLowerCase() === 'br';
@@ -58,6 +63,23 @@ const AccountSignup = ({
             }
             setIsLoading(false);
         });
+        // need to modify data from ab testing platform to reach translation and tracking needs
+        const fetchQuestionnarieData = () => {
+            let ab_value = Analytics.getFeatureValue('questionnaire-config', 'inactive');
+            const default_ab_value = ab_value;
+            ab_value = ab_value?.[language] ?? ab_value?.EN ?? ab_value;
+            if (ab_value?.show_answers_in_random_order) {
+                ab_value = [
+                    { ...default_ab_value.default },
+                    {
+                        ...ab_value,
+                        answers: shuffleArray(ab_value.answers),
+                    },
+                ];
+            } else if (ab_value !== 'inactive') ab_value = [{ ...default_ab_value.default }, { ...ab_value }];
+            return ab_value;
+        };
+        setABQuestionnaire(fetchQuestionnarieData());
 
         Analytics.trackEvent('ce_virtual_signup_form', {
             action: 'signup_confirmed',
@@ -75,6 +97,8 @@ const AccountSignup = ({
     const indexOfSelection = selected_country =>
         residence_list.findIndex(item => item.text.toLowerCase() === selected_country?.toLowerCase());
 
+    const handleSignup = () => onSignup(modded_state, onSignupComplete);
+
     const onSignupPassthrough = values => {
         const index_of_selected_residence = indexOfSelection(values.residence);
         const index_of_selected_citizenship = indexOfSelection(values.citizenship);
@@ -84,8 +108,12 @@ const AccountSignup = ({
             residence: residence_list[index_of_selected_residence].value,
             citizenship: residence_list[index_of_selected_citizenship].value,
         };
+        setModdedState(modded_values);
 
-        onSignup(modded_values, onSignupComplete);
+        // a/b test
+        ab_questionnaire === 'inactive'
+            ? onSignup(modded_values, onSignupComplete)
+            : setIsQuestionnaire(!!ab_questionnaire);
     };
 
     const onSignupComplete = error => {
@@ -188,19 +216,28 @@ const AccountSignup = ({
                                     </div>
                                 </div>
                             ) : (
-                                <PasswordSelectionModal
-                                    api_error={api_error}
-                                    errors={errors}
-                                    handleBlur={handleBlur}
-                                    handleChange={handleChange}
-                                    isModalVisible={isModalVisible}
-                                    isSubmitting={isSubmitting}
-                                    touched={touched}
-                                    pw_input={pw_input}
-                                    setFieldTouched={setFieldTouched}
-                                    updatePassword={updatePassword}
-                                    values={values}
-                                />
+                                <React.Fragment>
+                                    {is_questionnaire ? (
+                                        <QuestionnaireModal
+                                            ab_questionnaire={ab_questionnaire}
+                                            handleSignup={handleSignup}
+                                        />
+                                    ) : (
+                                        <PasswordSelectionModal
+                                            api_error={api_error}
+                                            errors={errors}
+                                            handleBlur={handleBlur}
+                                            handleChange={handleChange}
+                                            isModalVisible={isModalVisible}
+                                            isSubmitting={isSubmitting}
+                                            touched={touched}
+                                            pw_input={pw_input}
+                                            setFieldTouched={setFieldTouched}
+                                            updatePassword={updatePassword}
+                                            values={values}
+                                        />
+                                    )}
+                                </React.Fragment>
                             )}
                         </Form>
                     )}

--- a/packages/core/src/App/Containers/QuestionnaireModal/__tests__/questionnaire-modal.spec.tsx
+++ b/packages/core/src/App/Containers/QuestionnaireModal/__tests__/questionnaire-modal.spec.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Formik } from 'formik';
+import { render, screen } from '@testing-library/react';
+import QuestionnaireModal from '../questionnaire-modal';
+import userEvent from '@testing-library/user-event';
+import crypto from 'crypto';
+
+describe('QuestionnaireModal', () => {
+    const mock_props = {
+        ab_questionnaire: [
+            {
+                id: '1',
+                question: 'Default question',
+                show_answers_in_random_order: true,
+                answers: [
+                    { code: 'a', text: 'Default A' },
+                    { code: 'b', text: 'Default B', header: 'Default Header B' },
+                ],
+            },
+            {
+                id: '1',
+                question: 'Sample question',
+                show_answers_in_random_order: false,
+                answers: [
+                    { code: 'a', text: 'Option A' },
+                    { code: 'b', text: 'Option B', header: 'Header B' },
+                ],
+            },
+        ],
+        handleSignup: jest.fn(),
+    };
+
+    let modal_root_el: HTMLDivElement;
+
+    beforeAll(() => {
+        modal_root_el = document.createElement('div');
+        modal_root_el.setAttribute('id', 'modal_root');
+        document.body.appendChild(modal_root_el);
+
+        Object.defineProperty(global, 'crypto', {
+            value: {
+                getRandomValues: (arr: Uint32Array) => crypto.randomBytes(arr.length),
+            },
+        });
+    });
+
+    afterAll(() => {
+        document.body.removeChild(modal_root_el);
+    });
+
+    it('renders QuestionnaireModal component correctly', () => {
+        render(
+            <Formik initialValues={{}} onSubmit={jest.fn()}>
+                <QuestionnaireModal {...mock_props} />
+            </Formik>
+        );
+        expect(screen.getByText('Sample question')).toBeInTheDocument();
+    });
+
+    it('calls handleSignup when an answer is clicked', () => {
+        render(
+            <Formik initialValues={{}} onSubmit={jest.fn()}>
+                <QuestionnaireModal {...mock_props} />
+            </Formik>
+        );
+        const option_a = screen.getByTestId('a_questionnaire');
+        userEvent.click(option_a);
+        expect(mock_props.handleSignup).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/core/src/App/Containers/QuestionnaireModal/index.ts
+++ b/packages/core/src/App/Containers/QuestionnaireModal/index.ts
@@ -1,0 +1,3 @@
+import QuestionnaireModal from './questionnaire-modal';
+
+export default QuestionnaireModal;

--- a/packages/core/src/App/Containers/QuestionnaireModal/questionnaire-modal.scss
+++ b/packages/core/src/App/Containers/QuestionnaireModal/questionnaire-modal.scss
@@ -1,0 +1,66 @@
+.questionnaire-modal {
+    border-radius: 1.6rem;
+
+    @include mobile {
+        border-radius: 1.6rem;
+        padding-inline: 0;
+    }
+    .dc-btn {
+        height: unset;
+        padding: unset;
+    }
+    .dc-modal__container_questionnaire-modal {
+        padding-block: 3.8rem;
+    }
+    &__answers {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        gap: 1.6rem;
+        padding-block-start: 3.2rem;
+
+        &_content {
+            display: flex;
+            justify-content: space-between;
+            inline-size: 32.8rem;
+            padding-block: 2rem;
+            padding-inline: 1.6rem;
+            box-shadow: 0 0.4rem 0.6rem -0.2rem rgba(14, 14, 14, 0.03), 0 1.2rem 1.6rem -0.4rem rgba(14, 14, 14, 0.08);
+            border-radius: $BORDER-RADIUS * 4;
+            border: 0.1rem solid var(--general-active);
+            @include mobile {
+                inline-size: 28rem;
+            }
+            &:hover {
+                box-shadow: 0 0.2rem 0.8rem 0 var(--shadow-menu);
+            }
+        }
+    }
+    &__options {
+        display: flex;
+        flex-direction: row;
+        justify-content: center;
+        flex-wrap: wrap;
+        gap: 1.6rem;
+        padding-block-start: 3.2rem;
+
+        &_card {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-inline-size: 15rem;
+            min-block-size: 13.8rem;
+            box-shadow: 0 0.4rem 0.6rem -0.2rem rgba(14, 14, 14, 0.03), 0 1.2rem 1.6rem -0.4rem rgba(14, 14, 14, 0.08);
+            border-radius: $BORDER-RADIUS * 4;
+            border: 0.1rem solid var(--general-active);
+            &:hover {
+                box-shadow: 0 0.2rem 0.8rem 0 var(--shadow-menu);
+            }
+            @include mobile {
+                min-inline-size: 13.2rem;
+                min-block-size: 13.8rem;
+            }
+        }
+    }
+}

--- a/packages/core/src/App/Containers/QuestionnaireModal/questionnaire-modal.tsx
+++ b/packages/core/src/App/Containers/QuestionnaireModal/questionnaire-modal.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import classNames from 'classnames';
+import { Analytics } from '@deriv/analytics';
+import { Button, Text } from '@deriv/components';
+import './questionnaire-modal.scss';
+
+type TAnswers = {
+    code: string;
+    text: string;
+    header?: string;
+};
+type TABQuestionnaire = {
+    id: string;
+    question: string;
+    show_answers_in_random_order: boolean;
+    answers: TAnswers[];
+};
+export type TQuestionnaireModal = {
+    ab_questionnaire: TABQuestionnaire[];
+    handleSignup: (...args: any) => void;
+};
+
+const QuestionnaireModal = ({ ab_questionnaire, handleSignup }: TQuestionnaireModal) => {
+    const a_variant = !!ab_questionnaire[1].answers?.[0]?.header;
+    React.useEffect(() => {
+        Analytics.trackEvent('ce_questionnaire_form', {
+            action: 'open',
+        });
+    }, [ab_questionnaire]);
+
+    const onClickAnswer = (answer_code: string, answer_index: number) => {
+        Analytics.trackEvent('ce_questionnaire_form', {
+            action: 'choose_answer',
+            question: ab_questionnaire[0].question,
+            answer_content: ab_questionnaire[0].answers.filter(({ code }) => code === answer_code)[0].text,
+            answer_code,
+            answer_index,
+        });
+        handleSignup();
+    };
+
+    return (
+        <div className='questionnaire-modal'>
+            <Text as='h2' size='xs' weight='bold' align='center'>
+                {ab_questionnaire[1].question}
+            </Text>
+            <ul
+                data-testid='questionnaire-modal-variant'
+                className={classNames({
+                    'questionnaire-modal__answers': a_variant,
+                    'questionnaire-modal__options': !a_variant,
+                })}
+            >
+                {ab_questionnaire[1]?.answers.map(({ code, text, header }, index) => {
+                    return (
+                        <Button
+                            key={`${code}_questionnaire`}
+                            data-testid={`${code}_questionnaire`}
+                            onClick={() => onClickAnswer(code, index + 1)}
+                            transparent
+                        >
+                            <li
+                                className={classNames({
+                                    'questionnaire-modal__answers_content': a_variant,
+                                    'questionnaire-modal__options_card': !a_variant,
+                                })}
+                            >
+                                {header && (
+                                    <Text as='p' size='xs' weight='bold'>
+                                        {header}
+                                    </Text>
+                                )}
+                                <Text as='p' size='xs'>
+                                    {text}
+                                </Text>
+                            </li>
+                        </Button>
+                    );
+                })}
+            </ul>
+        </div>
+    );
+};
+
+export default QuestionnaireModal;


### PR DESCRIPTION
## Changes:
Adding a user experience survey immediately after setting a password. 
`onSignupComplete` fn moved from creating password to choose an answer in new modal form about trader's experience. 
The questionnaire has 2 options taken from the Growthbook platform:
A: {
  "question": "Which type of trading are you interested in?",
  "id": 1,
  "answers": [
    {"code": "1_1", "text": "Not sure"},
    {"code": "1_2", "text": "CFDs"},
    {"code": "1_3", "text": "Options"},
    {"code": "1_4", "text": "both"}
  ]
}
B: {
  "question": "How would you rate your trading experience?",
  "id": 1,
  "answers": [
    {"code": "1_1", "header": "Beginner:", "text": "I have no experience"},
    {"code": "1_2", "header": "Intermediate:", "text": "I have basic skills"},
    {"code": "1_3", "header": "Experienced:", "text": "I have advanced skills"},
    {"code": "1_4", "header": "Master:", "text": "I’m a professional"}
  ]
}
C: `inactive` to disable previous 2 variants. i.e. nothing changes for user
When the experiment is done/disabled, the `inactive` fallback string can be used to disable A/B testing in the application and the current flow will be the same as in the current production.

For testing purpose, It's always A option
You can go through onboarding where modal exist by https://deriv-app-git-fork-nikitk-deriv-cro-357-onboarding-quiestionary.binary.sx/redirect?action=signup&code=KKzqrt18&date_first_contact=2023-10-24&signup_device=desktop

### Screenshots:
Test coverage:
![Screenshot 2023-12-19 at 10 59 22](https://github.com/binary-com/deriv-app/assets/103182473/ed27268a-c144-4fa4-bd91-823c90c44e40)
A Desktop:
<img width="800" alt="Screenshot 2023-12-24 at 2 02 34 AM" src="https://github.com/binary-com/deriv-app/assets/103177211/465df6f7-ff3f-4c6b-9e81-d30c7f81fef1">
A Mobile:
<img width="350" alt="Screenshot 2023-12-24 at 2 04 15 AM" src="https://github.com/binary-com/deriv-app/assets/103177211/c28c51b4-73bb-4ad8-aa62-1eab1cc3d9da">
B Desktop:
<img width="800" alt="Screenshot 2023-12-24 at 2 05 31 AM" src="https://github.com/binary-com/deriv-app/assets/103177211/6beb9e06-2b94-4c9c-99ff-733e7b624033">
B Mobile:
<img width="350" alt="Screenshot 2023-12-24 at 2 06 17 AM" src="https://github.com/binary-com/deriv-app/assets/103177211/f5ae66c1-132f-428b-b740-0d24a4a05aca">


