### PR TITLE
[COJ]/evgeniy/coj-423/fix handling unusual IDV errors

### DIFF
--- a/packages/shared/src/utils/helpers/format-response.ts
+++ b/packages/shared/src/utils/helpers/format-response.ts
@@ -93,7 +93,7 @@ export const formatIDVError = (errors: Array<TIDVErrorStatus>, status_code: stri
 
     const status: Array<TIDVErrorStatus> = [];
     errors.forEach(error => {
-        const error_key: TIDVErrorStatus = IDV_ERROR_STATUS[error].code;
+        const error_key: TIDVErrorStatus = IDV_ERROR_STATUS[error]?.code;
         if (error_key) {
             status.push(error_key);
         }


### PR DESCRIPTION
## Changes:

There are few IDV errors may come from IDV provider which are not handled on FE side.
The code should execute default 'failed' scenario.
Fixing here the error of reading the property on not exiting object.