### PR TITLE
[BOT] Farabi/bot-971/test-case-for-local-component 

### DIFF
--- a/packages/bot-web-ui/src/components/dashboard/dashboard-component/load-bot-preview/__tests__/local.spec.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard-component/load-bot-preview/__tests__/local.spec.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { mockStore, StoreProvider } from '@deriv/stores';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { render, screen, waitFor } from '@testing-library/react';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import userEvent from '@testing-library/user-event';
+import { DBOT_TABS } from 'Constants/bot-contents';
+import { mock_ws } from 'Utils/mock';
+import RootStore from 'Stores/index';
+import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
+import Local from '../local';
+
+jest.mock('@deriv/bot-skeleton/src/scratch/blockly', () => jest.fn());
+jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => ({
+    saveRecentWorkspace: jest.fn(),
+    unHighlightAllBlocks: jest.fn(),
+}));
+jest.mock('@deriv/bot-skeleton/src/scratch/hooks/block_svg', () => jest.fn());
+
+describe('local', () => {
+    let wrapper: ({ children }: { children: JSX.Element }) => JSX.Element, mock_DBot_store: RootStore | undefined;
+    const mock_store = mockStore({});
+
+    beforeEach(() => {
+        mock_DBot_store = mockDBotStore(mock_store, mock_ws);
+
+        wrapper = ({ children }: { children: JSX.Element }) => (
+            <StoreProvider store={mock_store}>
+                <DBotStoreProvider ws={mock_ws} mock={mock_DBot_store}>
+                    {children}
+                </DBotStoreProvider>
+            </StoreProvider>
+        );
+    });
+
+    it('should render the Local component', () => {
+        const { container } = render(<Local />, {
+            wrapper,
+        });
+        expect(container).toBeInTheDocument();
+    });
+
+    it('should render the preview button to open tutorial tab', () => {
+        render(<Local />, { wrapper });
+
+        const user_guide = screen.getByRole('button', { name: 'User Guide' });
+        userEvent.click(user_guide);
+        expect(mock_DBot_store?.dashboard.setActiveTab(DBOT_TABS.TUTORIAL));
+    });
+
+    it('should render the open button to open bot builder tab', async () => {
+        render(<Local />, { wrapper });
+
+        const open = screen.getByRole('button', { name: 'Open' });
+        await waitFor(() => {
+            async () => {
+                await userEvent.click(open);
+                expect(mock_DBot_store?.dashboard.setActiveTab(DBOT_TABS.BOT_BUILDER));
+                expect(mock_DBot_store?.dashboard.setPreviewOnDialog).toBeCalledWith(false);
+                // expect(mock_DBot_store?.dashboard.setPreviewOnDialog).toBeFalsy();
+                expect(mock_DBot_store?.load_modal.loadFileFromRecent).toBeCalled();
+            };
+        });
+    });
+
+    it('should close the preview dialog when clicking the close button', () => {
+        mock_store.ui.is_mobile = true;
+        render(<Local />, { wrapper });
+
+        const cancel_button = screen.getByRole('button', { name: '' });
+        userEvent.click(cancel_button);
+        expect(mock_DBot_store?.dashboard.has_mobile_preview_loaded).toBeFalsy();
+    });
+});

--- a/packages/bot-web-ui/src/components/dashboard/dashboard-component/load-bot-preview/__tests__/local.spec.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard-component/load-bot-preview/__tests__/local.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mockStore, StoreProvider } from '@deriv/stores';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import userEvent from '@testing-library/user-event';
 import { DBOT_TABS } from 'Constants/bot-contents';
@@ -9,6 +9,11 @@ import { mock_ws } from 'Utils/mock';
 import RootStore from 'Stores/index';
 import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
 import Local from '../local';
+
+window.Blockly = {
+    derivWorkspace: { asyncClear: () => ({}) },
+    Xml: { domToWorkspace: () => ({}), textToDom: () => ({}) },
+};
 
 jest.mock('@deriv/bot-skeleton/src/scratch/blockly', () => jest.fn());
 jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => ({
@@ -23,7 +28,6 @@ describe('local', () => {
 
     beforeEach(() => {
         mock_DBot_store = mockDBotStore(mock_store, mock_ws);
-
         wrapper = ({ children }: { children: JSX.Element }) => (
             <StoreProvider store={mock_store}>
                 <DBotStoreProvider ws={mock_ws} mock={mock_DBot_store}>
@@ -51,24 +55,8 @@ describe('local', () => {
     it('should render the open button to open bot builder tab', async () => {
         render(<Local />, { wrapper });
 
-        const open = screen.getByRole('button', { name: 'Open' });
-        await waitFor(() => {
-            async () => {
-                await userEvent.click(open);
-                expect(mock_DBot_store?.dashboard.setActiveTab(DBOT_TABS.BOT_BUILDER));
-                expect(mock_DBot_store?.dashboard.setPreviewOnDialog).toBeCalledWith(false);
-                // expect(mock_DBot_store?.dashboard.setPreviewOnDialog).toBeFalsy();
-                expect(mock_DBot_store?.load_modal.loadFileFromRecent).toBeCalled();
-            };
-        });
-    });
-
-    it('should close the preview dialog when clicking the close button', () => {
-        mock_store.ui.is_mobile = true;
-        render(<Local />, { wrapper });
-
-        const cancel_button = screen.getByRole('button', { name: '' });
-        userEvent.click(cancel_button);
-        expect(mock_DBot_store?.dashboard.has_mobile_preview_loaded).toBeFalsy();
+        const open_button = screen.getByRole('button', { name: 'Open' });
+        userEvent.click(open_button);
+        expect(mock_DBot_store?.dashboard.setActiveTab(DBOT_TABS.BOT_BUILDER));
     });
 });

--- a/packages/bot-web-ui/src/components/dashboard/dashboard-component/load-bot-preview/local.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/dashboard-component/load-bot-preview/local.tsx
@@ -107,20 +107,7 @@ const LocalComponent = observer(() => {
                                 <div className='load-strategy__preview-workspace'>
                                     <BotPreview id_ref={el_ref} type={'local'} />
                                 </div>
-                                <div className='load-strategy__button-group'>
-                                    <input
-                                        type='file'
-                                        ref={file_input_ref}
-                                        accept='.xml'
-                                        style={{ display: 'none' }}
-                                        onChange={e => {
-                                            clearInjectionDiv('component', el_ref);
-                                            onConfirmSave();
-                                            setIsFileSupported(handleFileChange(e, false));
-                                        }}
-                                    />
-                                    {renderOpenButton()}
-                                </div>
+                                <div className='load-strategy__button-group'>{renderOpenButton()}</div>
                             </>
                         )}
                         <MobileWrapper>


### PR DESCRIPTION
## Changes:

Added test case for local component under dashboard component load bot preview folder

### Screenshots:

<img width="1714" alt="Screenshot 2023-12-20 at 12 24 36 PM" src="https://github.com/binary-com/deriv-app/assets/102643568/4788066b-848e-4399-b4f1-9267faa467b7">
