### PR TITLE
[WALL] Aizad/WALL-3110/Compare Accounts Container Fix

### DIFF
--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/CompareAccountsScreen.scss
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/CompareAccountsScreen.scss
@@ -1,6 +1,6 @@
 .wallets-compare-accounts {
-    width: 100vw;
-    height: 100vh;
+    width: 100%;
+    height: 100%;
 
     @include mobile {
         margin: 0;
@@ -14,5 +14,10 @@
         display: flex;
         justify-content: center;
         padding: 2rem;
+
+        @include desktop {
+            margin: 0 auto;
+            max-width: 123.2rem;
+        }
     }
 }

--- a/packages/wallets/src/routes/CompareAccountsRoute/CompareAccountsRoute.scss
+++ b/packages/wallets/src/routes/CompareAccountsRoute/CompareAccountsRoute.scss
@@ -1,3 +1,6 @@
 .wallets-compare-accounts-route {
     background-color: #ffffff;
+    width: 100%;
+    height: 100vh;
+    overflow-x: hidden;
 }


### PR DESCRIPTION
## Changes:
- Added a `max-width` for the CompareAccounts container similar to production.

### Screenshots:
![image](https://github.com/binary-com/deriv-app/assets/103104395/23dea789-531f-4c52-9c16-ffa70c5b67f4)

