### PR TITLE
Suisin/chore: remove back-side-content from svg bvi migration

### DIFF
--- a/packages/cfd/src/Containers/mt5-migration-modal/__test__/mt5-migration-front-side-content.spec.tsx
+++ b/packages/cfd/src/Containers/mt5-migration-modal/__test__/mt5-migration-front-side-content.spec.tsx
@@ -3,6 +3,7 @@ import MT5MigrationFrontSideContent from '../mt5-migration-front-side-content';
 import { render, screen } from '@testing-library/react';
 import { StoreProvider, mockStore } from '@deriv/stores';
 import { useMT5SVGEligibleToMigrate } from '@deriv/hooks';
+import { CFDStoreProvider } from 'Stores/Modules/CFD/Helpers/useCfdStores';
 
 jest.mock('@deriv/hooks', () => ({
     ...jest.requireActual('@deriv/hooks'),
@@ -24,7 +25,9 @@ describe('MT5MigrationFrontSideContent', () => {
 
     const renderComponent = () => {
         const wrapper = ({ children }: { children: JSX.Element }) => (
-            <StoreProvider store={mock_store}>{children}</StoreProvider>
+            <StoreProvider store={mock_store}>
+                <CFDStoreProvider>{children}</CFDStoreProvider>
+            </StoreProvider>
         );
         mockUseMT5SVGEligibleToMigrate.mockReturnValue(response);
         render(<MT5MigrationFrontSideContent />, { wrapper });
@@ -37,7 +40,7 @@ describe('MT5MigrationFrontSideContent', () => {
             eligible_svg_to_bvi_financial_accounts: false,
             eligible_svg_to_vanuatu_derived_accounts: false,
             eligible_svg_to_vanuatu_financial_accounts: false,
-            getEligibleAccountToMigrate: jest.fn(),
+            getEligibleAccountToMigrate: jest.fn(() => 'bvi'),
             has_derived_and_financial_mt5: false,
             has_derived_mt5_to_migrate: false,
             has_svg_accounts_to_migrate: false,
@@ -53,12 +56,14 @@ describe('MT5MigrationFrontSideContent', () => {
         expect(
             getByTextCaseInsensitive('We’re upgrading your SVG account(s) by moving them to the bvi jurisdiction.')
         ).toBeInTheDocument();
-        expect(screen.getByText(/Click/)).toBeInTheDocument();
+        expect(screen.getByText(/By clicking on/)).toBeInTheDocument();
         const elements = screen.getAllByText(/Next/);
         elements.forEach(element => {
             expect(element).toBeInTheDocument();
         });
-        expect(screen.getByText(/to start your transition./)).toBeInTheDocument();
+        expect(
+            screen.getByText(/you agree to move your SVG MT5 account\(s\) under Deriv \(V\) Ltd/)
+        ).toBeInTheDocument();
     });
 
     it('should render svg to bvi derived Icons', () => {

--- a/packages/cfd/src/Containers/mt5-migration-modal/__test__/mt5-migration-front-side-content.spec.tsx
+++ b/packages/cfd/src/Containers/mt5-migration-modal/__test__/mt5-migration-front-side-content.spec.tsx
@@ -61,9 +61,7 @@ describe('MT5MigrationFrontSideContent', () => {
         elements.forEach(element => {
             expect(element).toBeInTheDocument();
         });
-        expect(
-            screen.getByText(/you agree to move your SVG MT5 account\(s\) under Deriv \(V\) Ltd/)
-        ).toBeInTheDocument();
+        expect(screen.getByText(/you agree to move your SVG MT5 account\(s\) under Deriv bvi Ltd/)).toBeInTheDocument();
     });
 
     it('should render svg to bvi derived Icons', () => {

--- a/packages/cfd/src/Containers/mt5-migration-modal/__test__/mt5-migration-modal-content.spec.tsx
+++ b/packages/cfd/src/Containers/mt5-migration-modal/__test__/mt5-migration-modal-content.spec.tsx
@@ -15,11 +15,6 @@ jest.mock('../mt5-migration-front-side-content', () => {
     return MockMT5FrontsideContent;
 });
 
-jest.mock('../mt5-migration-back-side-content', () => {
-    const MockMT5BacksideContent = () => <div>MT5BacksideContent</div>;
-    return MockMT5BacksideContent;
-});
-
 const mockUseMT5MigrationModalContext = useMT5MigrationModalContext as jest.MockedFunction<
     typeof useMT5MigrationModalContext
 >;
@@ -47,11 +42,5 @@ describe('MT5MigrationModalContent', () => {
     it('should render MT5MigrationModalContent by showing frontside of the modal', () => {
         renderComponent();
         expect(screen.getByText('MT5FrontsideContent')).toBeInTheDocument();
-    });
-
-    it('should render backside of the modal', () => {
-        response.show_modal_front_side = false;
-        renderComponent();
-        expect(screen.getByText('MT5BacksideContent')).toBeInTheDocument();
     });
 });

--- a/packages/cfd/src/Containers/mt5-migration-modal/mt5-migration-front-side-content.tsx
+++ b/packages/cfd/src/Containers/mt5-migration-modal/mt5-migration-front-side-content.tsx
@@ -1,27 +1,54 @@
 import React from 'react';
-import { Button, Modal, Text } from '@deriv/components';
+import { Button, Modal, Text, StaticUrl } from '@deriv/components';
 import { useMT5SVGEligibleToMigrate } from '@deriv/hooks';
-import { getFormattedJurisdictionCode, Jurisdiction, JURISDICTION_MARKET_TYPES } from '@deriv/shared';
+import {
+    getFormattedJurisdictionCode,
+    Jurisdiction,
+    JURISDICTION_MARKET_TYPES,
+    DBVI_COMPANY_NAMES,
+    CFD_PLATFORMS,
+} from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
 import { Localize } from '@deriv/translations';
 import MT5MigrationAccountIcons from './mt5-migration-account-icons';
-import { useMT5MigrationModalContext } from './mt5-migration-modal-context';
+import { useCfdStore } from '../../Stores/Modules/CFD/Helpers/useCfdStores';
+import Icon from '@deriv/components/src/components/icon/icon';
 
 const MT5MigrationFrontSideContent = observer(() => {
-    const { ui } = useStore();
-    const { is_mobile } = ui;
-    const content_size = is_mobile ? 'xs' : 's';
+    const { ui, common } = useStore();
+    const { is_mobile, setMT5MigrationModalEnabled, toggleMT5MigrationModal } = ui;
+    const { setAppstorePlatform } = common;
+    const { enableCFDPasswordModal, mt5_migration_error, setJurisdictionSelectedShortcode } = useCfdStore();
+    const content_size = is_mobile ? 'xxs' : 'xs';
     const {
         eligible_account_to_migrate_label,
         eligible_svg_to_bvi_derived_accounts,
         eligible_svg_to_bvi_financial_accounts,
         eligible_svg_to_vanuatu_derived_accounts,
         eligible_svg_to_vanuatu_financial_accounts,
+        getEligibleAccountToMigrate,
     } = useMT5SVGEligibleToMigrate();
-    const { setShowModalFrontSide } = useMT5MigrationModalContext();
+
+    const onConfirmMigration = () => {
+        setAppstorePlatform(CFD_PLATFORMS.MT5);
+        setJurisdictionSelectedShortcode(getEligibleAccountToMigrate());
+        setMT5MigrationModalEnabled(true);
+        toggleMT5MigrationModal();
+        enableCFDPasswordModal();
+    };
 
     return (
         <React.Fragment>
+            {!!mt5_migration_error && (
+                <div className='mt5-migration-modal__error'>
+                    <div className='mt5-migration-modal__error-header'>
+                        <Icon icon='IcAlertDanger' />
+                        <Text align='center' size='xs'>
+                            <Localize i18n_default_text={mt5_migration_error} value={{ mt5_migration_error }} />
+                        </Text>
+                    </div>
+                </div>
+            )}
             <div className='mt5-migration-modal__description'>
                 <Text as='p' size={content_size} align='center'>
                     <Localize
@@ -54,16 +81,23 @@ const MT5MigrationFrontSideContent = observer(() => {
                     )}
                 </div>
             </div>
-            <div>
+            <div className='mt5-migration-modal__message'>
                 <Text as='p' size={content_size} align='center'>
                     <Localize
-                        i18n_default_text='Click <0>Next</0> to start your transition.'
-                        components={[<strong key={0} />]}
+                        i18n_default_text='By clicking on "<0>Next</0>" you agree to move your SVG MT5 account(s) under Deriv (V) Ltd’s <1>terms and conditions</1>.'
+                        components={[
+                            <strong key={0} />,
+                            <StaticUrl
+                                key={0}
+                                className='link'
+                                href={DBVI_COMPANY_NAMES[getEligibleAccountToMigrate()].tnc_url}
+                            />,
+                        ]}
                     />
                 </Text>
             </div>
             <Modal.Footer has_separator>
-                <Button type='button' has_effect large primary onClick={() => setShowModalFrontSide(false)}>
+                <Button type='button' has_effect large primary onClick={onConfirmMigration}>
                     <Localize i18n_default_text='Next' />
                 </Button>
             </Modal.Footer>

--- a/packages/cfd/src/Containers/mt5-migration-modal/mt5-migration-front-side-content.tsx
+++ b/packages/cfd/src/Containers/mt5-migration-modal/mt5-migration-front-side-content.tsx
@@ -95,7 +95,7 @@ const MT5MigrationFrontSideContent = observer(() => {
                             />,
                         ]}
                         values={{
-                            account: Jurisdiction.SVG,
+                            account: Jurisdiction.SVG.toUpperCase(),
                             platform: getCFDPlatformNames(CFD_PLATFORMS.MT5),
                             account_to_migrate: eligible_account_to_migrate_label,
                         }}

--- a/packages/cfd/src/Containers/mt5-migration-modal/mt5-migration-front-side-content.tsx
+++ b/packages/cfd/src/Containers/mt5-migration-modal/mt5-migration-front-side-content.tsx
@@ -84,7 +84,7 @@ const MT5MigrationFrontSideContent = observer(() => {
             <div className='mt5-migration-modal__message'>
                 <Text as='p' size={content_size} align='center'>
                     <Localize
-                        i18n_default_text='By clicking on "<0>Next</0>" you agree to move your SVG MT5 account(s) under Deriv (V) Ltd’s <1>terms and conditions</1>.'
+                        i18n_default_text='By clicking on <0>"Next"</0> you agree to move your SVG {{platform}} account(s) under Deriv {{account_to_migrate}} Ltd’s <1>terms and conditions</1>.'
                         components={[
                             <strong key={0} />,
                             <StaticUrl
@@ -93,6 +93,10 @@ const MT5MigrationFrontSideContent = observer(() => {
                                 href={DBVI_COMPANY_NAMES[getEligibleAccountToMigrate()].tnc_url}
                             />,
                         ]}
+                        values={{
+                            platform: CFD_PLATFORMS.MT5.toUpperCase(),
+                            account_to_migrate: eligible_account_to_migrate_label,
+                        }}
                     />
                 </Text>
             </div>

--- a/packages/cfd/src/Containers/mt5-migration-modal/mt5-migration-front-side-content.tsx
+++ b/packages/cfd/src/Containers/mt5-migration-modal/mt5-migration-front-side-content.tsx
@@ -7,6 +7,7 @@ import {
     JURISDICTION_MARKET_TYPES,
     DBVI_COMPANY_NAMES,
     CFD_PLATFORMS,
+    getCFDPlatformNames,
 } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
 import { Localize } from '@deriv/translations';
@@ -84,7 +85,7 @@ const MT5MigrationFrontSideContent = observer(() => {
             <div className='mt5-migration-modal__message'>
                 <Text as='p' size={content_size} align='center'>
                     <Localize
-                        i18n_default_text='By clicking on <0>"Next"</0> you agree to move your SVG {{platform}} account(s) under Deriv {{account_to_migrate}} Ltd’s <1>terms and conditions</1>.'
+                        i18n_default_text='By clicking on <0>"Next"</0> you agree to move your {{account}} {{platform}} account(s) under Deriv {{account_to_migrate}} Ltd’s <1>terms and conditions</1>.'
                         components={[
                             <strong key={0} />,
                             <StaticUrl
@@ -94,7 +95,8 @@ const MT5MigrationFrontSideContent = observer(() => {
                             />,
                         ]}
                         values={{
-                            platform: CFD_PLATFORMS.MT5.toUpperCase(),
+                            account: Jurisdiction.SVG,
+                            platform: getCFDPlatformNames(CFD_PLATFORMS.MT5),
                             account_to_migrate: eligible_account_to_migrate_label,
                         }}
                     />

--- a/packages/cfd/src/Containers/mt5-migration-modal/mt5-migration-modal-content.tsx
+++ b/packages/cfd/src/Containers/mt5-migration-modal/mt5-migration-modal-content.tsx
@@ -2,20 +2,22 @@ import React from 'react';
 import { Div100vhContainer } from '@deriv/components';
 import { observer, useStore } from '@deriv/stores';
 import MT5MigrationFrontSideContent from './mt5-migration-front-side-content';
-import MT5MigrationBackSideContent from './mt5-migration-back-side-content';
-import { useMT5MigrationModalContext } from './mt5-migration-modal-context';
+/* Temperory commented out these components because the new design is not ready yet */
+// import MT5MigrationBackSideContent from './mt5-migration-back-side-content';
+// import { useMT5MigrationModalContext } from './mt5-migration-modal-context';
 
 const MT5MigrationModalContent = observer(() => {
     const { ui } = useStore();
     const { is_mobile } = ui;
-    const { show_modal_front_side } = useMT5MigrationModalContext();
+    // const { show_modal_front_side } = useMT5MigrationModalContext();
     return (
         <Div100vhContainer
             className='mt5-migration-modal__mobile-container'
             height_offset='150px'
             is_bypassed={!is_mobile}
         >
-            {show_modal_front_side ? <MT5MigrationFrontSideContent /> : <MT5MigrationBackSideContent />}
+            <MT5MigrationFrontSideContent />
+            {/* {show_modal_front_side ? <MT5MigrationFrontSideContent /> : <MT5MigrationBackSideContent />} */}
         </Div100vhContainer>
     );
 });

--- a/packages/cfd/src/Containers/mt5-migration-modal/mt5-migration-modal-content.tsx
+++ b/packages/cfd/src/Containers/mt5-migration-modal/mt5-migration-modal-content.tsx
@@ -2,14 +2,10 @@ import React from 'react';
 import { Div100vhContainer } from '@deriv/components';
 import { observer, useStore } from '@deriv/stores';
 import MT5MigrationFrontSideContent from './mt5-migration-front-side-content';
-/* Temperory commented out these components because the new design is not ready yet */
-// import MT5MigrationBackSideContent from './mt5-migration-back-side-content';
-// import { useMT5MigrationModalContext } from './mt5-migration-modal-context';
 
 const MT5MigrationModalContent = observer(() => {
     const { ui } = useStore();
     const { is_mobile } = ui;
-    // const { show_modal_front_side } = useMT5MigrationModalContext();
     return (
         <Div100vhContainer
             className='mt5-migration-modal__mobile-container'
@@ -17,7 +13,6 @@ const MT5MigrationModalContent = observer(() => {
             is_bypassed={!is_mobile}
         >
             <MT5MigrationFrontSideContent />
-            {/* {show_modal_front_side ? <MT5MigrationFrontSideContent /> : <MT5MigrationBackSideContent />} */}
         </Div100vhContainer>
     );
 });

--- a/packages/cfd/src/Containers/mt5-migration-modal/mt5-migration-modal.scss
+++ b/packages/cfd/src/Containers/mt5-migration-modal/mt5-migration-modal.scss
@@ -16,6 +16,9 @@
         margin: 1.6rem;
         text-align: unset;
     }
+    &__message {
+        padding: 0 3.2rem 3.2rem;
+    }
     &__description {
         margin: 3.2rem 2.4rem 0;
         @include mobile {

--- a/packages/cfd/src/Containers/mt5-migration-modal/mt5-migration-modal.tsx
+++ b/packages/cfd/src/Containers/mt5-migration-modal/mt5-migration-modal.tsx
@@ -28,13 +28,6 @@ const MT5MigrationModal = observer(() => {
         </Text>
     );
 
-    React.useEffect(() => {
-        if (is_mt5_migration_modal_open) {
-            const has_mt5_migration_error = !!mt5_migration_error;
-            setShowModalFrontSide(has_mt5_migration_error);
-        }
-    }, [mt5_migration_error, setShowModalFrontSide, is_mt5_migration_modal_open]);
-
     const closeModal = () => {
         setShowModalFrontSide(true);
         setMT5MigrationModalEnabled(false);
@@ -45,11 +38,7 @@ const MT5MigrationModal = observer(() => {
         if (mt5_migration_error) {
             return 'auto';
         }
-        /* Temperory commented out these components because the new design is not ready yet */
-        // else if (show_modal_front_side) {
         return no_of_svg_accounts_to_migrate > 1 ? '54.2rem' : '44rem';
-        // }
-        // return '61.6rem';
     };
 
     return (

--- a/packages/cfd/src/Containers/mt5-migration-modal/mt5-migration-modal.tsx
+++ b/packages/cfd/src/Containers/mt5-migration-modal/mt5-migration-modal.tsx
@@ -31,7 +31,7 @@ const MT5MigrationModal = observer(() => {
     React.useEffect(() => {
         if (is_mt5_migration_modal_open) {
             const has_mt5_migration_error = !!mt5_migration_error;
-            setShowModalFrontSide(!has_mt5_migration_error);
+            setShowModalFrontSide(has_mt5_migration_error);
         }
     }, [mt5_migration_error, setShowModalFrontSide, is_mt5_migration_modal_open]);
 
@@ -42,12 +42,14 @@ const MT5MigrationModal = observer(() => {
     };
 
     const getModalHeight = () => {
-        if (show_modal_front_side) {
-            return no_of_svg_accounts_to_migrate > 1 ? '54.2rem' : '44rem';
-        } else if (mt5_migration_error) {
+        if (mt5_migration_error) {
             return 'auto';
         }
-        return '61.6rem';
+        /* Temperory commented out these components because the new design is not ready yet */
+        // else if (show_modal_front_side) {
+        return no_of_svg_accounts_to_migrate > 1 ? '54.2rem' : '44rem';
+        // }
+        // return '61.6rem';
     };
 
     return (


### PR DESCRIPTION
## Changes:

Remove mt5-migration-back-side-content from mt5 migration pop up modal and update content in mt5-migration-front-side-content.

Figma design is as below:
https://www.figma.com/file/p3d3hK27vuQtA4BDhTjjpp/branch/rfB1heNl8v1aT5bwi0fGtM/Release-(Rebuild)---Low-risk-ROW-Trader%E2%80%99s-hub?type=design&node-id=502-240141&mode=design&t=XOZBkabLclXWAbxq-0

### Screenshots:


