### PR TITLE
[DTRA] henry/webrel-54/fix: test coverage for portfolio component in the header

### DIFF
--- a/packages/trader/src/App/Containers/__tests__/populate-header.spec.tsx
+++ b/packages/trader/src/App/Containers/__tests__/populate-header.spec.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+import TraderProviders from '../../../trader-providers';
+import PopulateHeader from '../populate-header';
+import { mockStore } from '@deriv/stores';
+import { CONTRACT_TYPES } from '@deriv/shared';
+
+jest.mock('../../Components/Elements/TogglePositions/toggle-positions-mobile', () =>
+    jest.fn(() => <div>MockedTogglePositionsMobile</div>)
+);
+
+describe('<PopulateHeader />', () => {
+    let mock_store: ReturnType<typeof mockStore>;
+    beforeEach(() => {
+        mock_store = {
+            ...mockStore({
+                client: {
+                    currency: 'USD',
+                },
+                portfolio: {
+                    active_positions_count: 5,
+                    all_positions: [
+                        {
+                            contract_info: {
+                                underlying: 'test symbol',
+                                contract_type: CONTRACT_TYPES.ACCUMULATOR,
+                                entry_spot: 9454.1,
+                                contract_id: 1,
+                                shortcode: 'test',
+                                profit: 100,
+                            },
+                        },
+                        {
+                            contract_info: {
+                                underlying: 'test symbol',
+                                contract_type: CONTRACT_TYPES.ACCUMULATOR,
+                                entry_spot: 9467.78,
+                                contract_id: 2,
+                                shortcode: 'test',
+                                profit: 120,
+                            },
+                        },
+                    ],
+                    error: '',
+                    onClickSell: jest.fn(),
+                    onClickCancel: jest.fn(),
+                },
+            }),
+        };
+    });
+    const renderPopulateHeader = (mocked_store: ReturnType<typeof mockStore>) => {
+        return render(
+            <TraderProviders store={mocked_store}>
+                <PopulateHeader />
+            </TraderProviders>
+        );
+    };
+    it('Should render mocked toggle positions mobile', () => {
+        renderPopulateHeader(mock_store);
+        expect(screen.getByText('MockedTogglePositionsMobile')).toBeInTheDocument();
+    });
+});

--- a/packages/trader/src/App/Containers/__tests__/trade-header-extensions.spec.tsx
+++ b/packages/trader/src/App/Containers/__tests__/trade-header-extensions.spec.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
-import { screen, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import TraderProviders from '../../../trader-providers';
 import TradeHeaderExtensions from '../trade-header-extensions';
 import { mockStore } from '@deriv/stores';
-import { isMobile } from '@deriv/shared';
 
-jest.mock('../populate-header', () => jest.fn(() => <div>MockedPopulateHeader</div>));
 jest.mock('@deriv/shared', () => ({
     ...jest.requireActual('@deriv/shared'),
     WS: {

--- a/packages/trader/src/App/Containers/__tests__/trade-header-extensions.spec.tsx
+++ b/packages/trader/src/App/Containers/__tests__/trade-header-extensions.spec.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+import TraderProviders from '../../../trader-providers';
+import TradeHeaderExtensions from '../trade-header-extensions';
+import { mockStore } from '@deriv/stores';
+import { isMobile } from '@deriv/shared';
+
+jest.mock('../populate-header', () => jest.fn(() => <div>MockedPopulateHeader</div>));
+jest.mock('@deriv/shared', () => ({
+    ...jest.requireActual('@deriv/shared'),
+    WS: {
+        wait: jest.fn(() => Promise.resolve('authorized')),
+    },
+    isMobile: jest.fn(() => true),
+}));
+
+describe('<TradeHeaderExtensions />', () => {
+    let mock_store: ReturnType<typeof mockStore>;
+    beforeEach(() => {
+        mock_store = {
+            ...mockStore({
+                client: {
+                    is_logged_in: true,
+                    is_populating_account_list: false,
+                },
+                portfolio: {
+                    onMount: jest.fn(),
+                },
+                ui: {
+                    populateHeaderExtensions: jest.fn(item => item),
+                },
+                modules: {
+                    cashier: {
+                        general_store: {
+                            onMountCommon: jest.fn(),
+                            setAccountSwitchListener: jest.fn(),
+                        },
+                    },
+                },
+            }),
+        };
+    });
+    const renderTraderFooterExtensions = (mocked_store: ReturnType<typeof mockStore>) => {
+        return render(
+            <TraderProviders store={mocked_store}>
+                <TradeHeaderExtensions store={mocked_store} />
+            </TraderProviders>
+        );
+    };
+    it('populateHeaderExtensions should not be called with null if show_component is true', async () => {
+        renderTraderFooterExtensions(mock_store);
+        expect(mock_store.ui.populateHeaderExtensions).not.toHaveBeenCalledWith(null);
+    });
+    it('populateHeaderExtensions should be called with null if is_logged_in is false', async () => {
+        mock_store.client.is_logged_in = false;
+        renderTraderFooterExtensions(mock_store);
+        expect(mock_store.ui.populateHeaderExtensions).toHaveBeenCalledWith(null);
+    });
+});


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.

### Screenshots:
<img width="638" alt="Screenshot 2023-12-18 at 12 22 48 PM" src="https://github.com/binary-com/deriv-app/assets/118344354/5c13a69f-7f5d-490a-9a77-b1f2bef9d903">
<img width="636" alt="Screenshot 2023-12-19 at 2 49 09 PM" src="https://github.com/binary-com/deriv-app/assets/118344354/8aac2f62-49d9-4ae4-b261-1fb5688154b1">


Please provide some screenshots of the change.
