### PR TITLE
[WALL] Lubega /WALL-3053/ Chore: WalletTextField unit test

### DIFF
--- a/packages/wallets/src/components/Base/WalletTextField/WalletTextField.tsx
+++ b/packages/wallets/src/components/Base/WalletTextField/WalletTextField.tsx
@@ -49,10 +49,13 @@ const WalletTextField = forwardRef(
                     'wallets-textfield--disabled': disabled,
                     'wallets-textfield--error': isInvalid,
                 })}
+                data-testid='dt_wallets_textfield'
             >
-                <div className='wallets-textfield__box'>
+                <div className='wallets-textfield__box' data-testid='dt_wallets_textfield_box'>
                     {typeof renderLeftIcon === 'function' && (
-                        <div className='wallets-textfield__icon-left'>{renderLeftIcon()}</div>
+                        <div className='wallets-textfield__icon-left' data-testid='dt_wallets_textfield_icon_left'>
+                            {renderLeftIcon()}
+                        </div>
                     )}
                     <input
                         className='wallets-textfield__field'
@@ -71,7 +74,9 @@ const WalletTextField = forwardRef(
                         </label>
                     )}
                     {typeof renderRightIcon === 'function' && (
-                        <div className='wallets-textfield__icon-right'>{renderRightIcon()}</div>
+                        <div className='wallets-textfield__icon-right' data-testid='dt_wallets_textfield_icon_right'>
+                            {renderRightIcon()}
+                        </div>
                     )}
                 </div>
                 <div className='wallets-textfield__message-container'>
@@ -91,6 +96,7 @@ const WalletTextField = forwardRef(
                                     isError
                                     maxLength={maxLength}
                                     message={errorMessage as string}
+                                    messageVariant='error'
                                 />
                             )}
                         </>

--- a/packages/wallets/src/components/Base/WalletTextField/__tests__/HelperMessage.spec.tsx
+++ b/packages/wallets/src/components/Base/WalletTextField/__tests__/HelperMessage.spec.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import HelperMessage, { HelperMessageProps } from '../HelperMessage';
+
+describe('HelperMessage', () => {
+    const renderHelperMessage = (props: HelperMessageProps) => {
+        render(<HelperMessage {...props} />);
+    };
+
+    it('should render without errors and display message when provided', () => {
+        const message = 'This is a test message';
+        renderHelperMessage({ message });
+        expect(screen.getByText(message)).toBeInTheDocument();
+    });
+
+    it('should display error message when isError is true', () => {
+        const errorMessage = 'This is an error message';
+        renderHelperMessage({ isError: true, message: errorMessage });
+        expect(screen.getByText(errorMessage)).toBeInTheDocument();
+    });
+
+    it('should display character count when maxLength is provided', () => {
+        const maxLength = 10;
+        const inputValue = '1234567890';
+        renderHelperMessage({ inputValue, maxLength });
+        expect(screen.getByText(`${inputValue.length} / ${maxLength}`)).toBeInTheDocument();
+    });
+
+    it('should display 0 as character count when inputValue is not provided', () => {
+        const maxLength = 10;
+        renderHelperMessage({ maxLength });
+        expect(screen.getByText(`0 / ${maxLength}`)).toBeInTheDocument();
+    });
+});

--- a/packages/wallets/src/components/Base/WalletTextField/__tests__/WalletTextField.spec.tsx
+++ b/packages/wallets/src/components/Base/WalletTextField/__tests__/WalletTextField.spec.tsx
@@ -1,0 +1,111 @@
+import React, { createRef } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import HelperMessage from '../HelperMessage';
+import WalletTextField, { WalletTextFieldProps } from '../WalletTextField';
+
+jest.mock('../HelperMessage', () => jest.fn(() => null));
+
+describe('WalletTextField', () => {
+    const defaultProps: WalletTextFieldProps = {
+        defaultValue: '',
+        disabled: false,
+        isInvalid: false,
+        label: 'Test Label',
+        onChange: jest.fn(),
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    const getTextFieldEl = () => screen.getByTestId('dt_wallets_textfield');
+
+    it('should render the component with default props', () => {
+        render(<WalletTextField {...defaultProps} ref={createRef()} />);
+        expect(getTextFieldEl()).toHaveClass('wallets-textfield');
+        expect(getTextFieldEl()).not.toHaveClass('wallets-textfield--error');
+        expect(getTextFieldEl()).not.toHaveClass('wallets-textfield--disabled');
+    });
+
+    it('should handle change event correctly', () => {
+        render(<WalletTextField {...defaultProps} ref={createRef()} />);
+        const inputElement = screen.getByPlaceholderText('Test Label') as HTMLInputElement;
+
+        fireEvent.change(inputElement, { target: { value: 'new value' } });
+
+        expect(defaultProps.onChange).toHaveBeenCalledTimes(1);
+        expect(inputElement.value).toBe('new value');
+    });
+
+    it('should render disabled state correctly', () => {
+        render(<WalletTextField {...defaultProps} disabled ref={createRef()} />);
+        expect(getTextFieldEl()).toHaveClass('wallets-textfield--disabled', { exact: false });
+        expect(getTextFieldEl()).toHaveStyle('border: 1px solid var(--system-light-5-active-background, #eaeced)');
+    });
+
+    it('should render left and right icons correctly', () => {
+        render(
+            <WalletTextField
+                {...defaultProps}
+                ref={createRef()}
+                renderLeftIcon={() => <span>Left Icon</span>}
+                renderRightIcon={() => <span>Right Icon</span>}
+            />
+        );
+        expect(getTextFieldEl()).toHaveClass('wallets-textfield');
+        expect(screen.getByTestId('dt_wallets_textfield_icon_left')).toBeInTheDocument();
+        expect(screen.getByTestId('dt_wallets_textfield_icon_right')).toBeInTheDocument();
+    });
+
+    it('should render with a label correctly', () => {
+        render(<WalletTextField {...defaultProps} ref={createRef()} />);
+        expect(screen.getByLabelText('Test Label')).toBeInTheDocument();
+    });
+
+    it('should apply focus and validity styles to the textfield box', () => {
+        render(<WalletTextField {...defaultProps} ref={createRef()} />);
+        const textFieldBox = screen.getByTestId('dt_wallets_textfield_box');
+
+        fireEvent.focus(screen.getByLabelText('Test Label'));
+        expect(textFieldBox).toHaveStyle('border: 1px solid var(--brand-blue, #85acb0)');
+
+        fireEvent.blur(screen.getByLabelText('Test Label'));
+
+        fireEvent.change(screen.getByLabelText('Test Label'), { target: { value: 'test value' } });
+        expect(textFieldBox).toHaveStyle('border: 1px solid var(--brand-blue, #85acb0)');
+
+        fireEvent.change(screen.getByLabelText('Test Label'), { target: { value: 'invalid value' } });
+        expect(textFieldBox).toHaveStyle('border: 1px solid var(--status-light-danger, #ec3f3f)');
+    });
+
+    it('should render with a helper message correctly', () => {
+        render(<WalletTextField {...defaultProps} message='Helper message' ref={createRef()} showMessage />);
+
+        expect(HelperMessage).toHaveBeenCalled();
+        const helperMessageProps = (HelperMessage as jest.Mock).mock.calls[
+            (HelperMessage as jest.Mock).mock.calls.length - 1
+        ][0];
+
+        expect(helperMessageProps.inputValue).toBe('');
+        expect(helperMessageProps.isError).toBe(undefined);
+        expect(helperMessageProps.maxLength).toBe(undefined);
+        expect(helperMessageProps.message).toBe('Helper message');
+        expect(helperMessageProps.messageVariant).toBe('general');
+    });
+    it('should render with an error message correctly', () => {
+        render(<WalletTextField {...defaultProps} errorMessage='Invalid input' isInvalid ref={createRef()} />);
+        expect(getTextFieldEl()).toHaveClass('wallets-textfield--error', { exact: false });
+        expect(getTextFieldEl()).toHaveStyle('border: 1px solid var(--status-light-danger, #ec3f3f)');
+
+        expect(HelperMessage).toHaveBeenCalled();
+        const helperMessageProps = (HelperMessage as jest.Mock).mock.calls[
+            (HelperMessage as jest.Mock).mock.calls.length - 1
+        ][0];
+
+        expect(helperMessageProps.inputValue).toBe('');
+        expect(helperMessageProps.isError).toBe(true);
+        expect(helperMessageProps.maxLength).toBe(undefined);
+        expect(helperMessageProps.message).toBe('Invalid input');
+        expect(helperMessageProps.messageVariant).toBe('error');
+    });
+});

--- a/packages/wallets/src/components/Base/WalletTextField/__tests__/WalletTextField.spec.tsx
+++ b/packages/wallets/src/components/Base/WalletTextField/__tests__/WalletTextField.spec.tsx
@@ -7,7 +7,6 @@ jest.mock('../HelperMessage', () => jest.fn(() => null));
 
 describe('WalletTextField', () => {
     const defaultProps: WalletTextFieldProps = {
-        defaultValue: '',
         disabled: false,
         isInvalid: false,
         label: 'Test Label',
@@ -30,6 +29,7 @@ describe('WalletTextField', () => {
     it('should handle change event correctly', () => {
         render(<WalletTextField {...defaultProps} ref={createRef()} />);
         const inputElement = screen.getByPlaceholderText('Test Label') as HTMLInputElement;
+        expect(inputElement.value).toBe('');
 
         fireEvent.change(inputElement, { target: { value: 'new value' } });
 
@@ -40,7 +40,6 @@ describe('WalletTextField', () => {
     it('should render disabled state correctly', () => {
         render(<WalletTextField {...defaultProps} disabled ref={createRef()} />);
         expect(getTextFieldEl()).toHaveClass('wallets-textfield--disabled', { exact: false });
-        expect(getTextFieldEl()).toHaveStyle('border: 1px solid var(--system-light-5-active-background, #eaeced)');
     });
 
     it('should render left and right icons correctly', () => {
@@ -62,22 +61,6 @@ describe('WalletTextField', () => {
         expect(screen.getByLabelText('Test Label')).toBeInTheDocument();
     });
 
-    it('should apply focus and validity styles to the textfield box', () => {
-        render(<WalletTextField {...defaultProps} ref={createRef()} />);
-        const textFieldBox = screen.getByTestId('dt_wallets_textfield_box');
-
-        fireEvent.focus(screen.getByLabelText('Test Label'));
-        expect(textFieldBox).toHaveStyle('border: 1px solid var(--brand-blue, #85acb0)');
-
-        fireEvent.blur(screen.getByLabelText('Test Label'));
-
-        fireEvent.change(screen.getByLabelText('Test Label'), { target: { value: 'test value' } });
-        expect(textFieldBox).toHaveStyle('border: 1px solid var(--brand-blue, #85acb0)');
-
-        fireEvent.change(screen.getByLabelText('Test Label'), { target: { value: 'invalid value' } });
-        expect(textFieldBox).toHaveStyle('border: 1px solid var(--status-light-danger, #ec3f3f)');
-    });
-
     it('should render with a helper message correctly', () => {
         render(<WalletTextField {...defaultProps} message='Helper message' ref={createRef()} showMessage />);
 
@@ -92,10 +75,10 @@ describe('WalletTextField', () => {
         expect(helperMessageProps.message).toBe('Helper message');
         expect(helperMessageProps.messageVariant).toBe('general');
     });
+
     it('should render with an error message correctly', () => {
         render(<WalletTextField {...defaultProps} errorMessage='Invalid input' isInvalid ref={createRef()} />);
         expect(getTextFieldEl()).toHaveClass('wallets-textfield--error', { exact: false });
-        expect(getTextFieldEl()).toHaveStyle('border: 1px solid var(--status-light-danger, #ec3f3f)');
 
         expect(HelperMessage).toHaveBeenCalled();
         const helperMessageProps = (HelperMessage as jest.Mock).mock.calls[


### PR DESCRIPTION
## Changes:

- [x] Added unit test for WalletTextField and HelperMessage

### Screenshots:

<img width="1728" alt="image" src="https://github.com/binary-com/deriv-app/assets/142860499/aebf77a4-3737-4a37-ae18-4265ea598935">
