### PR TITLE
thisyahlen/TRAH-2303/chore: add breakpointprovider for device flags

### DIFF
--- a/packages/tradershub/src/App.tsx
+++ b/packages/tradershub/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 import { APIProvider } from '@deriv/api';
+import { BreakpointProvider } from '@deriv/quill-design';
 import AppContent from './AppContent';
 import { ModalProvider } from './components';
 import './index.scss';
@@ -7,6 +8,9 @@ import './index.scss';
 const App: FC = () => (
     <APIProvider standalone>
         <ModalProvider>
+            <BreakpointProvider>
+                <AppContent />
+            </BreakpointProvider>
             <AppContent />
         </ModalProvider>
     </APIProvider>


### PR DESCRIPTION
## Changes:

1. Add breakpointprovider to have access to isMobile, isDesktop and isTablet from @deriv/quill-design

