### PR TITLE
[TRAH] shontzu/TRAH-2304/ButtonGroup-component-in-tradershub-package

### DIFF
--- a/packages/tradershub/src/components/Base/ButtonGroup/ButtonGroup.tsx
+++ b/packages/tradershub/src/components/Base/ButtonGroup/ButtonGroup.tsx
@@ -1,0 +1,24 @@
+import React, { FC, PropsWithChildren } from 'react';
+import classNames from 'classnames';
+
+type TButtonGroupProps = {
+    isFlex?: boolean;
+    isFullWidth?: boolean;
+    isVertical?: boolean;
+};
+
+const ButtonGroup: FC<PropsWithChildren<TButtonGroupProps>> = ({ children, isFlex, isFullWidth, isVertical }) => {
+    return (
+        <div
+            className={classNames('grid gap-3 grid-cols-[minmax(0,1fr)] grid-flow-col', {
+                'flex flex-col': isVertical,
+                'grid-cols-': isFlex,
+                'w-full': isFullWidth,
+            })}
+        >
+            {children}
+        </div>
+    );
+};
+
+export default ButtonGroup;

--- a/packages/tradershub/src/components/Base/ButtonGroup/ButtonGroup.tsx
+++ b/packages/tradershub/src/components/Base/ButtonGroup/ButtonGroup.tsx
@@ -1,24 +1,21 @@
 import React, { FC, PropsWithChildren } from 'react';
-import classNames from 'classnames';
+import { qtMerge } from '@deriv/quill-design';
 
-type TButtonGroupProps = {
-    isFlex?: boolean;
-    isFullWidth?: boolean;
-    isVertical?: boolean;
-};
+type TButtonGroupProps = { className?: string };
 
-const ButtonGroup: FC<PropsWithChildren<TButtonGroupProps>> = ({ children, isFlex, isFullWidth, isVertical }) => {
-    return (
-        <div
-            className={classNames('grid gap-3 grid-cols-[minmax(0,1fr)] grid-flow-col', {
-                'flex flex-col': isVertical,
-                'grid-cols-': isFlex,
-                'w-full': isFullWidth,
-            })}
-        >
-            {children}
-        </div>
-    );
-};
+/**
+ * `ButtonGroup` is a functional component that displays its children in a flex container.
+ * It uses the `qtMerge` function from `@deriv/quill-design` to combine predefined styles with any additional styles passed in through the `className` prop.
+ *
+ * @param {PropsWithChildren<TButtonGroupProps>} props - The properties that define the `ButtonGroup` component.
+ * @param {React.ReactNode} props.children - The child elements to be displayed within the `ButtonGroup`.
+ * @param {string} [props.className] - Additional CSS classes to apply to the `ButtonGroup`.
+ *
+ * @returns {React.ReactElement} A `div` element with the `ButtonGroup`'s children and the combined styles.
+ */
+
+const ButtonGroup: FC<PropsWithChildren<TButtonGroupProps>> = ({ children, className }) => (
+    <div className={qtMerge('flex flex-col align-center gap-400 lg:flex-row ', className)}> {children}</div>
+);
 
 export default ButtonGroup;

--- a/packages/tradershub/src/components/Base/ButtonGroup/index.ts
+++ b/packages/tradershub/src/components/Base/ButtonGroup/index.ts
@@ -1,0 +1,1 @@
+export { default as ButtonGroup } from './ButtonGroup';


### PR DESCRIPTION
## Changes:

- [CU](https://app.clickup.com/t/86bwu60ud)
- In order to move other dxtrade components from wallets to tradershub, some custom wallets components are missing and N/A in quill so we are adding it in the tradershub Base component directory

### Screenshots:

Please provide some screenshots of the change.
N/A
