### PR TITLE
[P2PS] / Ameerul P2PS-2132 / Error message is not showing when enter invalid value for total amount, fixed rate, max, and min field

### DIFF
--- a/packages/p2p/src/pages/my-ads/create-ad-form.jsx
+++ b/packages/p2p/src/pages/my-ads/create-ad-form.jsx
@@ -139,12 +139,8 @@ const CreateAdForm = () => {
                 }}
                 onSubmit={my_ads_store.handleSubmit}
                 validate={my_ads_store.validateCreateAdForm}
-                initialErrors={{
-                    // Pass one error to ensure Post ad button is disabled initially.
-                    offer_amount: true,
-                }}
             >
-                {({ errors, handleChange, isSubmitting, isValid, setFieldValue, touched, values }) => {
+                {({ errors, handleChange, isSubmitting, isValid, setFieldTouched, setFieldValue, touched, values }) => {
                     const is_sell_advert = values.type === buy_sell.SELL;
 
                     const onChangeAdTypeHandler = user_input => {
@@ -222,6 +218,7 @@ const CreateAdForm = () => {
                                                                     {currency}
                                                                 </Text>
                                                             }
+                                                            onFocus={() => setFieldTouched('offer_amount', true)}
                                                             onChange={e => {
                                                                 my_ads_store.restrictLength(e, handleChange);
                                                             }}
@@ -244,7 +241,6 @@ const CreateAdForm = () => {
                                                                       )
                                                             }
                                                             is_relative_hint
-                                                            required
                                                         />
                                                     )}
                                                 </Field>
@@ -258,6 +254,7 @@ const CreateAdForm = () => {
                                                                 fiat_currency={currency}
                                                                 local_currency={local_currency}
                                                                 onChange={handleChange}
+                                                                onFocus={() => setFieldTouched('rate_type', true)}
                                                                 offset={{
                                                                     upper_limit: parseInt(
                                                                         floating_rate_store.float_rate_offset_limit
@@ -297,6 +294,7 @@ const CreateAdForm = () => {
                                                                 onChange={e => {
                                                                     my_ads_store.restrictLength(e, handleChange);
                                                                 }}
+                                                                onFocus={() => setFieldTouched('rate_type', true)}
                                                                 required
                                                             />
                                                         )
@@ -325,6 +323,7 @@ const CreateAdForm = () => {
                                                             onChange={e => {
                                                                 my_ads_store.restrictLength(e, handleChange);
                                                             }}
+                                                            onFocus={() => setFieldTouched('min_transaction', true)}
                                                             required
                                                         />
                                                     )}
@@ -350,6 +349,7 @@ const CreateAdForm = () => {
                                                             onChange={e => {
                                                                 my_ads_store.restrictLength(e, handleChange);
                                                             }}
+                                                            onFocus={() => setFieldTouched('max_transaction', true)}
                                                             required
                                                         />
                                                     )}
@@ -377,6 +377,7 @@ const CreateAdForm = () => {
                                                                 required
                                                                 has_character_counter
                                                                 max_characters={300}
+                                                                onFocus={() => setFieldTouched('contact_info', true)}
                                                             />
                                                         )}
                                                     </Field>
@@ -405,6 +406,9 @@ const CreateAdForm = () => {
                                                         }
                                                         has_character_counter
                                                         max_characters={300}
+                                                        onFocus={() =>
+                                                            setFieldTouched('default_advert_description', true)
+                                                        }
                                                         required
                                                     />
                                                 )}

--- a/packages/p2p/src/pages/my-ads/edit-ad-form.jsx
+++ b/packages/p2p/src/pages/my-ads/edit-ad-form.jsx
@@ -156,7 +156,7 @@ const EditAdForm = () => {
                 validate={my_ads_store.validateEditAdForm}
                 validateOnMount
             >
-                {({ dirty, errors, handleChange, isSubmitting, isValid, touched, values }) => {
+                {({ dirty, errors, handleChange, isSubmitting, isValid, setFieldTouched, touched, values }) => {
                     const is_sell_advert = values.type === buy_sell.SELL;
                     // Form should not be checked for value change when ad switch is triggered
                     const check_dirty =
@@ -201,6 +201,7 @@ const EditAdForm = () => {
                                                             onChange={e => {
                                                                 my_ads_store.restrictLength(e, handleChange);
                                                             }}
+                                                            onFocus={() => setFieldTouched('offer_amount', true)}
                                                             hint={
                                                                 // Using two "==" is intentional as we're checking for nullish
                                                                 // rather than falsy values.
@@ -242,6 +243,7 @@ const EditAdForm = () => {
                                                                         floating_rate_store.float_rate_offset_limit *
                                                                         -1,
                                                                 }}
+                                                                onFocus={() => setFieldTouched('rate_type', true)}
                                                                 required
                                                                 change_handler={e => {
                                                                     my_ads_store.restrictDecimalPlace(e, handleChange);
@@ -274,6 +276,7 @@ const EditAdForm = () => {
                                                                 onChange={e => {
                                                                     my_ads_store.restrictLength(e, handleChange);
                                                                 }}
+                                                                onFocus={() => setFieldTouched('rate_type', true)}
                                                                 required
                                                             />
                                                         )
@@ -302,6 +305,7 @@ const EditAdForm = () => {
                                                             onChange={e => {
                                                                 my_ads_store.restrictLength(e, handleChange);
                                                             }}
+                                                            onFocus={() => setFieldTouched('min_transaction', true)}
                                                             required
                                                         />
                                                     )}
@@ -327,6 +331,7 @@ const EditAdForm = () => {
                                                             onChange={e => {
                                                                 my_ads_store.restrictLength(e, handleChange);
                                                             }}
+                                                            onFocus={() => setFieldTouched('max_transaction', true)}
                                                             required
                                                         />
                                                     )}
@@ -352,6 +357,7 @@ const EditAdForm = () => {
                                                                 required
                                                                 has_character_counter
                                                                 max_characters={300}
+                                                                onFocus={() => setFieldTouched('contact_info', true)}
                                                             />
                                                         )}
                                                     </Field>
@@ -375,6 +381,7 @@ const EditAdForm = () => {
                                                         initial_character_count={description ? description.length : 0}
                                                         has_character_counter
                                                         max_characters={300}
+                                                        onFocus={() => setFieldTouched('description', true)}
                                                     />
                                                 )}
                                             </Field>

--- a/packages/p2p/src/stores/my-ads-store.js
+++ b/packages/p2p/src/stores/my-ads-store.js
@@ -704,12 +704,6 @@ export default class MyAdsStore extends BaseStore {
             }
         });
 
-        if (Object.values(errors).includes('Enter a valid amount')) {
-            Object.entries(errors).forEach(([key, value]) => {
-                errors[key] = value === 'Enter a valid amount' ? value : undefined;
-            });
-        }
-
         return errors;
     }
 
@@ -837,12 +831,6 @@ export default class MyAdsStore extends BaseStore {
                 }
             }
         });
-
-        if (Object.values(errors).includes('Enter a valid amount')) {
-            Object.entries(errors).forEach(([key, value]) => {
-                errors[key] = value === 'Enter a valid amount' ? value : undefined;
-            });
-        }
 
         return errors;
     }


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- Added `setFieldTouched` when user focuses on any of the input boxes because touched is only registered for onBlur event. Need to immediately set touched to true to get an immediate response.
- Removed if check if error object contains `Enter a valid amount.` string because it will override all the other errors if it exists in the object.

### Screenshots:

Please provide some screenshots of the change.
