### PR TITLE
[WALL] aum/WALL-3128/fix-light-mode-DF-iframe

### DIFF
--- a/packages/api/src/hooks/useCashierFiatAddress.ts
+++ b/packages/api/src/hooks/useCashierFiatAddress.ts
@@ -13,7 +13,7 @@ type TParams = Omit<
 /** A custom hook to get the deposit and withdrawal fiat address. */
 const useCashierFiatAddress = () => {
     const { data, mutate: _mutate, ...rest } = useMutation('cashier');
-    const iframe_url = typeof data?.cashier === 'string' ? data?.cashier : undefined;
+    const iframe_url = typeof data?.cashier === 'string' ? `${data?.cashier}&DarkMode=off` : undefined;
 
     const mutate = useCallback(
         (cashier: TCashierParam, payload?: TParams) =>


### PR DESCRIPTION
## Changes:

The iframe received Deposit-Fiat and Withdrawal-Fiat is in dark mode theme. As the theming is not yet done for the wallets project, we fix the iframe theme to light-mode.

### Screenshots:
<img width="1255" alt="Screenshot 2023-12-18 at 4 32 05 PM" src="https://github.com/binary-com/deriv-app/assets/125039206/087c0310-6951-4f27-9cb2-4baf82723d30">
<img width="1254" alt="Screenshot 2023-12-18 at 1 14 08 PM" src="https://github.com/binary-com/deriv-app/assets/125039206/f92a54e0-1088-4623-afc5-fa1f8429a868">
<img width="1723" alt="Screenshot 2023-12-18 at 1 14 21 PM" src="https://github.com/binary-com/deriv-app/assets/125039206/d75238cd-db5e-4e76-8493-c9d019ce2d51">

