### PR TITLE
[TRAH] Aizad/TRAH-2305/Content Switcher

### DIFF
--- a/packages/tradershub/src/components/ContentSwitcher/ContentHeaderList.tsx
+++ b/packages/tradershub/src/components/ContentSwitcher/ContentHeaderList.tsx
@@ -1,6 +1,6 @@
-import React, { FC } from 'react';
+import React, { FC, memo } from 'react';
 import { Button, qtJoin, qtMerge } from '@deriv/quill-design';
-import { useTabsContext } from './ContentSwitcher';
+import { useContentSwitch } from './ContentSwitcher';
 
 type TContentHeaderList = {
     className?: string;
@@ -8,33 +8,33 @@ type TContentHeaderList = {
 };
 
 /**
- * List of of button headers for the content panels.
+ * List of button headers for the content panels.
  * @param {TContentHeaderList} props The props for the component.
  * @returns {JSX.Element} The rendered component.
  */
-
-const ContentHeaderList: FC<TContentHeaderList> = ({ className, list }) => {
-    const { activeTabIndex, setActiveTabIndex } = useTabsContext();
+const ContentHeaderList: FC<TContentHeaderList> = memo(({ className, list }) => {
+    const { activeTabIndex, setActiveTabIndex } = useContentSwitch();
 
     return (
         <div
             className={qtMerge('flex bg-system-light-secondary-background rounded-400 p-200 gap-200', className)}
             data-list-count={list.length}
         >
-            {list.map((tab, i) => (
+            {list.map((tabLabel, index) => (
                 <Button
-                    className={qtJoin('rounded-200', i !== activeTabIndex && 'bg-transparent font-regular')}
+                    className={qtJoin('rounded-200', index !== activeTabIndex && 'bg-transparent font-regular')}
                     colorStyle='white'
                     fullWidth
-                    key={i}
-                    onClick={() => setActiveTabIndex(i)}
+                    key={index}
+                    onClick={() => setActiveTabIndex(index)}
                     size='lg'
                 >
-                    {tab}
+                    {tabLabel}
                 </Button>
             ))}
         </div>
     );
-};
+});
 
+ContentHeaderList.displayName = 'ContentHeaderList';
 export default ContentHeaderList;

--- a/packages/tradershub/src/components/ContentSwitcher/ContentHeaderList.tsx
+++ b/packages/tradershub/src/components/ContentSwitcher/ContentHeaderList.tsx
@@ -25,7 +25,7 @@ const ContentHeaderList: FC<TContentHeaderList> = memo(({ className, list }) => 
                     className={qtJoin('rounded-200', index !== activeTabIndex && 'bg-transparent font-regular')}
                     colorStyle='white'
                     fullWidth
-                    key={index}
+                    key={`tradershub-tab-${tabLabel}`}
                     onClick={() => setActiveTabIndex(index)}
                     size='lg'
                 >

--- a/packages/tradershub/src/components/ContentSwitcher/ContentHeaderList.tsx
+++ b/packages/tradershub/src/components/ContentSwitcher/ContentHeaderList.tsx
@@ -1,0 +1,40 @@
+import React, { FC } from 'react';
+import { Button, qtJoin, qtMerge } from '@deriv/quill-design';
+import { useTabsContext } from './ContentSwitcher';
+
+type TContentHeaderList = {
+    className?: string;
+    list: string[];
+};
+
+/**
+ * List of of button headers for the content panels.
+ * @param {TContentHeaderList} props The props for the component.
+ * @returns {JSX.Element} The rendered component.
+ */
+
+const ContentHeaderList: FC<TContentHeaderList> = ({ className, list }) => {
+    const { activeTabIndex, setActiveTabIndex } = useTabsContext();
+
+    return (
+        <div
+            className={qtMerge('flex bg-system-light-secondary-background rounded-400 p-200 gap-200', className)}
+            data-list-count={list.length}
+        >
+            {list.map((tab, i) => (
+                <Button
+                    className={qtJoin('rounded-200', i !== activeTabIndex && 'bg-transparent font-regular')}
+                    colorStyle='white'
+                    fullWidth
+                    key={i}
+                    onClick={() => setActiveTabIndex(i)}
+                    size='lg'
+                >
+                    {tab}
+                </Button>
+            ))}
+        </div>
+    );
+};
+
+export default ContentHeaderList;

--- a/packages/tradershub/src/components/ContentSwitcher/ContentPanelContainer.tsx
+++ b/packages/tradershub/src/components/ContentSwitcher/ContentPanelContainer.tsx
@@ -1,5 +1,5 @@
 import React, { Children, PropsWithChildren } from 'react';
-import { useTabsContext } from './ContentSwitcher';
+import { useContentSwitch } from './ContentSwitcher';
 
 /**
  * Container for content panels.
@@ -8,7 +8,7 @@ import { useTabsContext } from './ContentSwitcher';
  * @returns {JSX.Element} The rendered component.
  */
 const ContentPanelContainer = ({ children }: PropsWithChildren) => {
-    const { activeTabIndex } = useTabsContext();
+    const { activeTabIndex } = useContentSwitch();
 
     return (
         <div>

--- a/packages/tradershub/src/components/ContentSwitcher/ContentPanelContainer.tsx
+++ b/packages/tradershub/src/components/ContentSwitcher/ContentPanelContainer.tsx
@@ -1,0 +1,24 @@
+import React, { Children, PropsWithChildren } from 'react';
+import { useTabsContext } from './ContentSwitcher';
+
+/**
+ * Container for content panels.
+ * Only the active panel's content will be rendered.
+ * @param {PropsWithChildren} props The props for the component.
+ * @returns {JSX.Element} The rendered component.
+ */
+const ContentPanelContainer = ({ children }: PropsWithChildren) => {
+    const { activeTabIndex } = useTabsContext();
+
+    return (
+        <div>
+            {Children.map(children, (child, index) => {
+                if (index !== activeTabIndex) return undefined;
+
+                return child;
+            })}
+        </div>
+    );
+};
+
+export default ContentPanelContainer;

--- a/packages/tradershub/src/components/ContentSwitcher/ContentSwitcher.tsx
+++ b/packages/tradershub/src/components/ContentSwitcher/ContentSwitcher.tsx
@@ -1,24 +1,11 @@
-import React, {
-    Children,
-    createContext,
-    Dispatch,
-    FC,
-    PropsWithChildren,
-    ReactNode,
-    SetStateAction,
-    useContext,
-    useState,
-} from 'react';
-import { Button, qtJoin, qtMerge } from '@deriv/quill-design';
+import React, { createContext, Dispatch, ReactNode, SetStateAction, useContext, useState } from 'react';
+import ContentHeaderList from './ContentHeaderList';
+import ContentPanelContainer from './ContentPanelContainer';
+import ContentTabPanel from './ContentTabPanel';
 
 type TTabContext = {
     activeTabIndex: number;
     setActiveTabIndex: Dispatch<SetStateAction<number>>;
-};
-
-type TContentHeaderList = {
-    className?: string;
-    list: string[];
 };
 
 type TContentSwitcher = {
@@ -76,63 +63,6 @@ const ContentSwitcher = ({ children, className }: TContentSwitcher) => {
         <TabsContext.Provider value={{ activeTabIndex, setActiveTabIndex }}>
             <div className={className}>{children}</div>
         </TabsContext.Provider>
-    );
-};
-
-/**
- * Container for content panels.
- * Only the active panel's content will be rendered.
- * @param {PropsWithChildren} props The props for the component.
- * @returns {JSX.Element} The rendered component.
- */
-const ContentPanelContainer = ({ children }: PropsWithChildren) => {
-    const { activeTabIndex } = useTabsContext();
-
-    return (
-        <div>
-            {Children.map(children, (child, index) => {
-                if (index !== activeTabIndex) return undefined;
-
-                return child;
-            })}
-        </div>
-    );
-};
-
-/**
- * Panel for displaying content.
- * @param {PropsWithChildren} props The props for the component.
- * @returns {JSX.Element} The rendered component.
- */
-const ContentTabPanel = ({ children }: PropsWithChildren) => <>{children}</>;
-
-/**
- * List of of button headers for the content panels.
- * @param {TContentHeaderList} props The props for the component.
- * @returns {JSX.Element} The rendered component.
- */
-
-const ContentHeaderList: FC<TContentHeaderList> = ({ className, list }) => {
-    const { activeTabIndex, setActiveTabIndex } = useTabsContext();
-
-    return (
-        <div
-            className={qtMerge('flex bg-system-light-secondary-background rounded-400 p-200', className)}
-            data-list-count={list.length}
-        >
-            {list.map((tab, i) => (
-                <Button
-                    className={qtJoin('rounded-200', i !== activeTabIndex && 'bg-transparent')}
-                    colorStyle='white'
-                    fullWidth
-                    key={i}
-                    onClick={() => setActiveTabIndex(i)}
-                    size='lg'
-                >
-                    {tab}
-                </Button>
-            ))}
-        </div>
     );
 };
 

--- a/packages/tradershub/src/components/ContentSwitcher/ContentSwitcher.tsx
+++ b/packages/tradershub/src/components/ContentSwitcher/ContentSwitcher.tsx
@@ -50,6 +50,24 @@ export const useTabsContext = () => {
  * Component for switching between different content panels.
  * @param {TContentSwitcher} props The props for the component.
  * @returns {JSX.Element} The rendered component.
+ *
+ * @example
+ * ```tsx
+ * <ContentSwitcher>
+ *     <ContentSwitcher.HeaderList list={['Tab 1', 'Tab 2', 'Tab 3']} />
+ *     <ContentSwitcher.PanelContainer>
+ *         <ContentSwitcher.Panel>
+ *          <Heading.H3>Tab 1</Heading.H3>
+ *         </ContentSwitcher.Panel>
+ *         <ContentSwitcher.Panel>
+ *          <Heading.H3>Tab 2</Heading.H3>
+ *         </ContentSwitcher.Panel>
+ *         <ContentSwitcher.Panel>
+ *          <Heading.H3>Tab 3</Heading.H3>
+ *         </ContentSwitcher.Panel>
+ *     </ContentSwitcher.PanelContainer>
+ * </ContentSwitcher>
+ * ```
  */
 const ContentSwitcher = ({ children, className }: TContentSwitcher) => {
     const [activeTabIndex, setActiveTabIndex] = useState(0);
@@ -104,11 +122,7 @@ const ContentHeaderList: FC<TContentHeaderList> = ({ className, list }) => {
         >
             {list.map((tab, i) => (
                 <Button
-                    className={qtJoin(
-                        'rounded-200',
-                        i !== activeTabIndex &&
-                            'bg-transparent hover:bg-transparent hover:bg-transparent enabled:bg-transparent'
-                    )}
+                    className={qtJoin('rounded-200', i !== activeTabIndex && 'bg-transparent')}
                     colorStyle='white'
                     fullWidth
                     key={i}

--- a/packages/tradershub/src/components/ContentSwitcher/ContentSwitcher.tsx
+++ b/packages/tradershub/src/components/ContentSwitcher/ContentSwitcher.tsx
@@ -1,0 +1,129 @@
+import React, {
+    Children,
+    createContext,
+    Dispatch,
+    FC,
+    PropsWithChildren,
+    ReactNode,
+    SetStateAction,
+    useContext,
+    useState,
+} from 'react';
+import { Button, qtJoin, qtMerge } from '@deriv/quill-design';
+
+type TTabContext = {
+    activeTabIndex: number;
+    setActiveTabIndex: Dispatch<SetStateAction<number>>;
+};
+
+type TContentHeaderList = {
+    className?: string;
+    list: string[];
+};
+
+type TContentSwitcher = {
+    children: ReactNode;
+    className?: string;
+};
+
+/**
+ * Context for managing tab state.
+ */
+const TabsContext = createContext<TTabContext | null>(null);
+
+/**
+ * Hook for accessing the tab context.
+ * @throws {Error} If the hook is used outside of a `<ContentSwitcher />`.
+ * @returns {TTabContext} The current tab context.
+ */
+export const useTabsContext = () => {
+    const context = useContext(TabsContext);
+
+    if (!context) {
+        throw new Error('Seems you forgot to wrap the components in "<ContentSwitcher />"');
+    }
+
+    return context;
+};
+
+/**
+ * Component for switching between different content panels.
+ * @param {TContentSwitcher} props The props for the component.
+ * @returns {JSX.Element} The rendered component.
+ */
+const ContentSwitcher = ({ children, className }: TContentSwitcher) => {
+    const [activeTabIndex, setActiveTabIndex] = useState(0);
+
+    return (
+        <TabsContext.Provider value={{ activeTabIndex, setActiveTabIndex }}>
+            <div className={className}>{children}</div>
+        </TabsContext.Provider>
+    );
+};
+
+/**
+ * Container for content panels.
+ * Only the active panel's content will be rendered.
+ * @param {PropsWithChildren} props The props for the component.
+ * @returns {JSX.Element} The rendered component.
+ */
+const ContentPanelContainer = ({ children }: PropsWithChildren) => {
+    const { activeTabIndex } = useTabsContext();
+
+    return (
+        <div>
+            {Children.map(children, (child, index) => {
+                if (index !== activeTabIndex) return undefined;
+
+                return child;
+            })}
+        </div>
+    );
+};
+
+/**
+ * Panel for displaying content.
+ * @param {PropsWithChildren} props The props for the component.
+ * @returns {JSX.Element} The rendered component.
+ */
+const ContentTabPanel = ({ children }: PropsWithChildren) => <>{children}</>;
+
+/**
+ * List of of button headers for the content panels.
+ * @param {TContentHeaderList} props The props for the component.
+ * @returns {JSX.Element} The rendered component.
+ */
+
+const ContentHeaderList: FC<TContentHeaderList> = ({ className, list }) => {
+    const { activeTabIndex, setActiveTabIndex } = useTabsContext();
+
+    return (
+        <div
+            className={qtMerge('flex bg-system-light-secondary-background rounded-400 p-200', className)}
+            data-list-count={list.length}
+        >
+            {list.map((tab, i) => (
+                <Button
+                    className={qtJoin(
+                        'rounded-200',
+                        i !== activeTabIndex &&
+                            'bg-transparent hover:bg-transparent hover:bg-transparent enabled:bg-transparent'
+                    )}
+                    colorStyle='white'
+                    fullWidth
+                    key={i}
+                    onClick={() => setActiveTabIndex(i)}
+                    size='lg'
+                >
+                    {tab}
+                </Button>
+            ))}
+        </div>
+    );
+};
+
+ContentSwitcher.HeaderList = ContentHeaderList;
+ContentSwitcher.PanelContainer = ContentPanelContainer;
+ContentSwitcher.Panel = ContentTabPanel;
+
+export default ContentSwitcher;

--- a/packages/tradershub/src/components/ContentSwitcher/ContentSwitcher.tsx
+++ b/packages/tradershub/src/components/ContentSwitcher/ContentSwitcher.tsx
@@ -1,9 +1,9 @@
-import React, { createContext, Dispatch, ReactNode, SetStateAction, useContext, useState } from 'react';
+import React, { createContext, Dispatch, ReactNode, SetStateAction, useContext, useMemo, useState } from 'react';
 import ContentHeaderList from './ContentHeaderList';
 import ContentPanelContainer from './ContentPanelContainer';
 import ContentTabPanel from './ContentTabPanel';
 
-type TTabContext = {
+type TContentContext = {
     activeTabIndex: number;
     setActiveTabIndex: Dispatch<SetStateAction<number>>;
 };
@@ -16,14 +16,14 @@ type TContentSwitcher = {
 /**
  * Context for managing tab state.
  */
-const TabsContext = createContext<TTabContext | null>(null);
+const TabsContext = createContext<TContentContext | null>(null);
 
 /**
  * Hook for accessing the tab context.
  * @throws {Error} If the hook is used outside of a `<ContentSwitcher />`.
- * @returns {TTabContext} The current tab context.
+ * @returns {TContentContext} The current tab context.
  */
-export const useTabsContext = () => {
+export const useContentSwitch = () => {
     const context = useContext(TabsContext);
 
     if (!context) {
@@ -58,9 +58,10 @@ export const useTabsContext = () => {
  */
 const ContentSwitcher = ({ children, className }: TContentSwitcher) => {
     const [activeTabIndex, setActiveTabIndex] = useState(0);
+    const value = useMemo(() => ({ activeTabIndex, setActiveTabIndex }), [activeTabIndex]);
 
     return (
-        <TabsContext.Provider value={{ activeTabIndex, setActiveTabIndex }}>
+        <TabsContext.Provider value={value}>
             <div className={className}>{children}</div>
         </TabsContext.Provider>
     );

--- a/packages/tradershub/src/components/ContentSwitcher/ContentTabPanel.tsx
+++ b/packages/tradershub/src/components/ContentSwitcher/ContentTabPanel.tsx
@@ -1,0 +1,10 @@
+import React, { PropsWithChildren } from 'react';
+
+/**
+ * Panel for displaying content.
+ * @param {PropsWithChildren} props The props for the component.
+ * @returns {JSX.Element} The rendered component.
+ */
+const ContentTabPanel = ({ children }: PropsWithChildren) => <>{children}</>;
+
+export default ContentTabPanel;

--- a/packages/tradershub/src/components/ContentSwitcher/index.ts
+++ b/packages/tradershub/src/components/ContentSwitcher/index.ts
@@ -1,3 +1,3 @@
-import ContentSwitcher, { useTabsContext } from './ContentSwitcher';
+import ContentSwitcher, { useContentSwitch } from './ContentSwitcher';
 
-export { ContentSwitcher, useTabsContext };
+export { ContentSwitcher, useContentSwitch };

--- a/packages/tradershub/src/components/ContentSwitcher/index.ts
+++ b/packages/tradershub/src/components/ContentSwitcher/index.ts
@@ -1,0 +1,3 @@
+import ContentSwitcher, { useTabsContext } from './ContentSwitcher';
+
+export { ContentSwitcher, useTabsContext };

--- a/packages/tradershub/src/components/index.ts
+++ b/packages/tradershub/src/components/index.ts
@@ -1,3 +1,4 @@
+export * from './ContentSwitcher';
 export * from './ModalProvider';
 export * from './ModalStepWrapper';
 export * from './ModalWrapper';


### PR DESCRIPTION
## Changes:
- Created Content Switcher component for `Non-EU & EU` and `Options & CFD`.
- Use `tailwindcss` and `@deriv/quill-design` for stylings.
- added TSDocs for component info.

### Screenshots:
Figma Design:
![image](https://github.com/binary-com/deriv-app/assets/103104395/a7fb7e5c-df4c-4a2c-ac22-cd33c03438be)

The component: 
<img width="1332" alt="image" src="https://github.com/binary-com/deriv-app/assets/103104395/e51dde1b-67ed-42be-89dd-175c1b751c79">

