### PR TITLE
[BOT]/Maryia/BOT-1141/fix: Reset the asset field to the previous value after an invalid search

### DIFF
--- a/packages/bot-web-ui/src/components/quick-strategy/selects/symbol.tsx
+++ b/packages/bot-web-ui/src/components/quick-strategy/selects/symbol.tsx
@@ -37,6 +37,7 @@ const SymbolSelect: React.FC = () => {
     const [active_symbols, setActiveSymbols] = React.useState([]);
     const [is_input_started, setIsInputStarted] = useState(false);
     const [input_value, setInputValue] = useState({ text: '', value: '' });
+    const [last_selected_symbol, setLastSelectedSymbol] = useState({ text: '', value: '' });
     const { setFieldValue, values } = useFormikContext<TFormData>();
 
     const sendAssetValueToRudderStack = (item: string) => {
@@ -105,6 +106,11 @@ const SymbolSelect: React.FC = () => {
             const selectedSymbol = symbols.find(symbol => symbol.value === values.symbol);
             if (selectedSymbol && selectedSymbol.text !== input_value.text) {
                 setInputValue({ text: selectedSymbol.text, value: selectedSymbol.value });
+                setLastSelectedSymbol({ text: selectedSymbol.text, value: selectedSymbol.value });
+                setIsInputStarted(false);
+            }
+            if (!selectedSymbol) {
+                setInputValue({ text: last_selected_symbol.text, value: last_selected_symbol.value });
                 setIsInputStarted(false);
             }
         }

--- a/packages/bot-web-ui/src/components/quick-strategy/selects/symbol.tsx
+++ b/packages/bot-web-ui/src/components/quick-strategy/selects/symbol.tsx
@@ -40,13 +40,14 @@ const SymbolSelect: React.FC = () => {
     const [last_selected_symbol, setLastSelectedSymbol] = useState({ text: '', value: '' });
     const { setFieldValue, values } = useFormikContext<TFormData>();
 
-    const sendAssetValueToRudderStack = (item: string) => {
-        Analytics.trackEvent('ce_bot_quick_strategy_form', {
-            action: 'choose_asset',
-            asset_type: item,
-            form_source: 'ce_bot_quick_strategy_form',
-        });
-    };
+    const symbols = useMemo(
+        () =>
+            active_symbols.map((symbol: TSymbol) => ({
+                component: <MarketOption key={symbol.text} symbol={symbol} />,
+                ...symbol,
+            })),
+        [active_symbols]
+    );
 
     useEffect(() => {
         const { active_symbols } = ApiHelpers.instance;
@@ -64,21 +65,20 @@ const SymbolSelect: React.FC = () => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    const symbols = useMemo(
-        () =>
-            active_symbols.map((symbol: TSymbol) => ({
-                component: <MarketOption key={symbol.text} symbol={symbol} />,
-                ...symbol,
-            })),
-        [active_symbols]
-    );
-
     useEffect(() => {
         const selected_symbol = symbols.find(symbol => symbol.value === values.symbol);
         if (selected_symbol) {
             setInputValue({ text: selected_symbol.text, value: selected_symbol.value });
         }
     }, [symbols, values.symbol, setInputValue]);
+
+    const sendAssetValueToRudderStack = (item: string) => {
+        Analytics.trackEvent('ce_bot_quick_strategy_form', {
+            action: 'choose_asset',
+            asset_type: item,
+            form_source: 'ce_bot_quick_strategy_form',
+        });
+    };
 
     const handleFocus = () => {
         if (is_desktop && !is_input_started) {


### PR DESCRIPTION
## Changes:

* fix: Reset the asset field to the previous value after an invalid search

When a user performs an invalid search on the Asset  field and moves away from the field without selecting anything, the previously saved value should be displayed.


https://github.com/binary-com/deriv-app/assets/103181650/6cec3228-587e-4311-9f53-444b47be4c68




