### PR TITLE
[WALL] [Fix] Rostislav / WALL-3134 & 3136 / Pending transactions UI issues

### DIFF
--- a/packages/api/src/hooks/useCryptoTransactions.ts
+++ b/packages/api/src/hooks/useCryptoTransactions.ts
@@ -156,7 +156,7 @@ const useCryptoTransactions = () => {
             /** Formatted transaction hash */
             formatted_transaction_hash: transaction.transaction_hash
                 ? getTruncatedString(transaction.transaction_hash, { type: 'middle' })
-                : 'NA',
+                : 'Pending',
             /** Formatted address hash */
             formatted_address_hash: transaction.address_hash
                 ? getTruncatedString(transaction.address_hash, { type: 'middle' })

--- a/packages/wallets/src/features/cashier/modules/Transactions/Transactions.scss
+++ b/packages/wallets/src/features/cashier/modules/Transactions/Transactions.scss
@@ -1,6 +1,7 @@
 .wallets-transactions {
     width: 100%;
     height: fit-content;
+    min-height: 100%;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/packages/wallets/src/features/cashier/modules/Transactions/Transactions.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/Transactions.tsx
@@ -87,7 +87,7 @@ const Transactions = () => {
             {isPendingActive && (
                 <TransactionsPending filter={filtersMapper.pending[filterValue] as TTransactionsPendingFilter} />
             )}
-            {wallet?.is_virtual && filterValue === 'deposit' ? (
+            {!isPendingActive && wallet?.is_virtual && filterValue === 'deposit' ? (
                 <TransactionsCompletedDemoResetBalance />
             ) : (
                 <TransactionsCompleted filter={filtersMapper.completed[filterValue] as TTransactionCompletedFilter} />

--- a/packages/wallets/src/features/cashier/modules/Transactions/Transactions.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/Transactions.tsx
@@ -87,11 +87,14 @@ const Transactions = () => {
             {isPendingActive && (
                 <TransactionsPending filter={filtersMapper.pending[filterValue] as TTransactionsPendingFilter} />
             )}
-            {!isPendingActive && wallet?.is_virtual && filterValue === 'deposit' ? (
-                <TransactionsCompletedDemoResetBalance />
-            ) : (
-                <TransactionsCompleted filter={filtersMapper.completed[filterValue] as TTransactionCompletedFilter} />
-            )}
+            {!isPendingActive &&
+                (wallet?.is_virtual && filterValue === 'deposit' ? (
+                    <TransactionsCompletedDemoResetBalance />
+                ) : (
+                    <TransactionsCompleted
+                        filter={filtersMapper.completed[filterValue] as TTransactionCompletedFilter}
+                    />
+                ))}
         </div>
     );
 };

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsPending/TransactionsPending.scss
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsPending/TransactionsPending.scss
@@ -2,6 +2,8 @@
     position: relative;
     width: 100%;
     max-width: 80rem;
+    display: flex;
+    flex-grow: 1;
 
     &__group-title {
         margin: 0 0 0.8rem 1.6rem;

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsPendingRow/TransactionsPendingRow.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsPendingRow/TransactionsPendingRow.tsx
@@ -118,9 +118,6 @@ const TransactionsCryptoRow: React.FC<TProps> = ({ transaction }) => {
                     className={{ 'wallets-transactions-pending-row__transaction-confirmations': !isMobile }}
                     name='Confirmations'
                     value={transaction.formatted_confirmations.toString()}
-                    valueTextProps={{
-                        align: isMobile ? 'start' : 'center',
-                    }}
                 />
                 {isMobile && (
                     <React.Fragment>


### PR DESCRIPTION
## Changes:

- [x] fix conditions for displaying completed and pending transactions
- [x] fix cropped tooltip for pending transactions
- [x] pending transactions transaction hash `NA` -> `Pending` if there's no hash received
- [x] "Confirmations" now aligned left as are all fields

### Screenshots:

<img width="1262" alt="Screenshot 2023-12-21 at 19 17 13" src="https://github.com/binary-com/deriv-app/assets/119863957/9b094a07-8ee0-43ca-83f0-93e19ae15e58">


