### PR TITLE
fix: to prevent add p2p-v2 route if it's already there

### DIFF
--- a/packages/cashier/src/containers/routes/binary-routes.tsx
+++ b/packages/cashier/src/containers/routes/binary-routes.tsx
@@ -23,7 +23,8 @@ const BinaryRoutes = (props: TBinaryRoutesProps) => {
     const { is_p2p_v2_enabled } = useFeatureFlags();
     const [routesConfig, setRoutesConfig] = React.useState(getRoutesConfig());
     useEffect(() => {
-        if (is_p2p_v2_enabled) {
+        const is_p2p_v2_added = routesConfig[0].routes?.some(route => route.path === routes.cashier_p2p_v2);
+        if (is_p2p_v2_enabled && !is_p2p_v2_added) {
             const routes_replicate = [...routesConfig];
             routes_replicate[0].routes?.push({
                 path: routes.cashier_p2p_v2,


### PR DESCRIPTION
## Changes:

This is to prevent adding redundant p2p-v2 entries in cashier sidebar.


### Screenshots:
<img width="369" alt="image" src="https://github.com/binary-com/deriv-app/assets/81898967/41443da2-0656-4c20-b18b-03e4acab9ad1">

