### PR TITLE
[COJ]/likhith/fix: added null check to return default config for IDV countries

### DIFF
--- a/packages/account/src/Helpers/__tests__/utils.spec.tsx
+++ b/packages/account/src/Helpers/__tests__/utils.spec.tsx
@@ -134,6 +134,13 @@ describe('getDocumentData', () => {
             example_format: '081234567F53',
         });
     });
+
+    it('should return default document data for other countries', () => {
+        expect(getDocumentData('uy', 'national_id')).toEqual({
+            new_display_name: '',
+            example_format: '',
+        });
+    });
 });
 
 describe('getRegex', () => {

--- a/packages/account/src/Helpers/utils.tsx
+++ b/packages/account/src/Helpers/utils.tsx
@@ -77,7 +77,10 @@ export const getDocumentData = (country_code: string, document_type: string) => 
         example_format: '',
     };
     const IDV_DOCUMENT_DATA: any = getIDVDocuments(country_code);
-    return IDV_DOCUMENT_DATA[document_type] ?? DEFAULT_CONFIG;
+    if (IDV_DOCUMENT_DATA) {
+        return IDV_DOCUMENT_DATA[document_type] ?? DEFAULT_CONFIG;
+    }
+    return DEFAULT_CONFIG;
 };
 
 export const preventEmptyClipboardPaste = (e: React.ClipboardEvent<HTMLInputElement | HTMLTextAreaElement>) => {


### PR DESCRIPTION
## Changes:

Render default config structure for IDV supported countries that dosen't have custom config on FE side. 
These countries will use data from API and render the IDV supported documents and the validation for the IDV document number
