### PR TITLE
[TRAH] Aizad/FEQ-1352/Refactoring Modal Step Wrapper

### DIFF
--- a/packages/tradershub/src/components/Modal/Modal.classnames.ts
+++ b/packages/tradershub/src/components/Modal/Modal.classnames.ts
@@ -1,0 +1,17 @@
+import { cva, VariantProps } from 'class-variance-authority';
+import { ExcludeAllNull } from '@deriv/quill-design';
+
+export const ModalFooterClass = cva(
+    'grid grid-cols-2 gap-400 p-800 border border-solid border-t-100 border-system-light-secondary-background bottom-0 lg:flex lg:items-center lg:px-1200 lg:py-800',
+    {
+        variants: {
+            align: {
+                center: 'lg:justify-center',
+                left: 'lg:justify-start',
+                right: 'lg:justify-end',
+            },
+        },
+    }
+);
+
+export type TModalFooterClass = ExcludeAllNull<VariantProps<typeof ModalFooterClass>>;

--- a/packages/tradershub/src/components/Modal/Modal.tsx
+++ b/packages/tradershub/src/components/Modal/Modal.tsx
@@ -1,0 +1,29 @@
+import React, { ReactNode } from 'react';
+import { qtMerge } from '@deriv/quill-design';
+import ModalContent from './ModalContent';
+import ModalFooter from './ModalFooter';
+import ModalHeader from './ModalHeader';
+
+type TModal = {
+    children: ReactNode;
+    className?: string;
+};
+
+const Modal = ({ children, className }: TModal) => {
+    return (
+        <div
+            className={qtMerge(
+                'flex flex-col h-screen w-screen bg-background-primary-base lg:mx-auto lg:h-full lg:w-full lg:rounded-400',
+                className
+            )}
+        >
+            {children}
+        </div>
+    );
+};
+
+Modal.Header = ModalHeader;
+Modal.Content = ModalContent;
+Modal.Footer = ModalFooter;
+
+export default Modal;

--- a/packages/tradershub/src/components/Modal/Modal.tsx
+++ b/packages/tradershub/src/components/Modal/Modal.tsx
@@ -1,14 +1,58 @@
-import React, { ReactNode } from 'react';
+import React, { ReactElement } from 'react';
 import { qtMerge } from '@deriv/quill-design';
 import ModalContent from './ModalContent';
 import ModalFooter from './ModalFooter';
 import ModalHeader from './ModalHeader';
 
+/**
+ * Type for the Modal children
+ * @typedef TModalChildren
+ * @property {ReactElement<typeof ModalContent>} ModalContent - Modal content component
+ * @property {ReactElement<typeof ModalFooter>} ModalFooter - Modal footer component
+ * @property {ReactElement<typeof ModalHeader>} ModalHeader - Modal header component
+ */
+type TModalChildren =
+    | ReactElement<typeof ModalContent>
+    | ReactElement<typeof ModalFooter>
+    | ReactElement<typeof ModalHeader>;
+
+/**
+ * Type for the Modal component props
+ * @typedef TModal
+ * @property {TModalChildren | TModalChildren[]} children - Children nodes, should be one of the predefined Modal components (Header, Content, Footer)
+ * @property {string} [className] - Optional CSS class name
+ *
+ * @example
+ * ```tsx
+ * <Modal className="my-modal">
+ *   <Modal.Header>My Modal</Modal.Header>
+ *   <Modal.Content>Modal content goes here</Modal.Content>
+ *   <Modal.Footer>OK</Modal.Footer>
+ * </Modal>
+ * ```
+ */
 type TModal = {
-    children: ReactNode;
+    children: TModalChildren | TModalChildren[];
     className?: string;
 };
 
+/**
+ * Modal component
+ * @param {TModal} props - The properties that define the Modal component.
+ * @returns {JSX.Element} The Modal component.
+ *
+ * @example
+ * ```tsx
+ * <Modal>
+ *   <Modal.Header title="Title"/>
+ *   <Modal.Content>Modal content goes here</Modal.Content>
+ *   <Modal.Footer>
+ *      <Button>Primary Action</Button>
+ *      <Button variant='secondary'>Secondary Action</Button>
+ *   </Modal.Footer>
+ * </Modal>
+ * ```
+ */
 const Modal = ({ children, className }: TModal) => {
     return (
         <div

--- a/packages/tradershub/src/components/Modal/Modal.tsx
+++ b/packages/tradershub/src/components/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 import { qtMerge } from '@deriv/quill-design';
 import ModalContent from './ModalContent';
 import ModalFooter from './ModalFooter';
@@ -21,15 +21,6 @@ type TModalChildren =
  * @typedef TModal
  * @property {TModalChildren | TModalChildren[]} children - Children nodes, should be one of the predefined Modal components (Header, Content, Footer)
  * @property {string} [className] - Optional CSS class name
- *
- * @example
- * ```tsx
- * <Modal className="my-modal">
- *   <Modal.Header>My Modal</Modal.Header>
- *   <Modal.Content>Modal content goes here</Modal.Content>
- *   <Modal.Footer>OK</Modal.Footer>
- * </Modal>
- * ```
  */
 type TModal = {
     children: TModalChildren | TModalChildren[];
@@ -37,21 +28,20 @@ type TModal = {
 };
 
 /**
+ * Generic type for the Modal components
+ * @typedef TModalComponents
+ * @property {ReactNode} children - Children nodes
+ * @property {string} [className] - Optional CSS class name
+ */
+export type TModalComponents = {
+    children: ReactNode;
+    className?: string;
+};
+
+/**
  * Modal component
  * @param {TModal} props - The properties that define the Modal component.
  * @returns {JSX.Element} The Modal component.
- *
- * @example
- * ```tsx
- * <Modal>
- *   <Modal.Header title="Title"/>
- *   <Modal.Content>Modal content goes here</Modal.Content>
- *   <Modal.Footer>
- *      <Button>Primary Action</Button>
- *      <Button variant='secondary'>Secondary Action</Button>
- *   </Modal.Footer>
- * </Modal>
- * ```
  */
 const Modal = ({ children, className }: TModal) => {
     return (

--- a/packages/tradershub/src/components/Modal/ModalContent.tsx
+++ b/packages/tradershub/src/components/Modal/ModalContent.tsx
@@ -1,0 +1,13 @@
+import React, { ReactNode } from 'react';
+import { qtMerge } from '@deriv/quill-design';
+
+type TModalContent = {
+    children: ReactNode;
+    className?: string;
+};
+
+const ModalContent = ({ children, className }: TModalContent) => (
+    <div className={qtMerge('flex-grow p-400 lg:flex-none', className)}>{children}</div>
+);
+
+export default ModalContent;

--- a/packages/tradershub/src/components/Modal/ModalContent.tsx
+++ b/packages/tradershub/src/components/Modal/ModalContent.tsx
@@ -1,23 +1,15 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
 import { qtMerge } from '@deriv/quill-design';
-
-/**
- * Type for the ModalContent component props
- * @typedef TModalContent
- * @property {ReactNode} children - Children nodes
- * @property {string} [className] - Optional CSS class name
- */
-type TModalContent = {
-    children: ReactNode;
-    className?: string;
-};
+import { TModalComponents } from './Modal';
 
 /**
  * ModalContent component
- * @param {TModalContent} props - The properties that define the ModalContent component.
+ * @param {TModalComponents} props - The properties that define the ModalContent component.
+ * @property {ReactNode} children - Children nodes
+ * @property {string} [className] - Optional CSS class name
  * @returns {JSX.Element} The ModalContent component.
  */
-const ModalContent = ({ children, className }: TModalContent) => (
+const ModalContent = ({ children, className }: TModalComponents) => (
     <div className={qtMerge('flex-grow p-400 lg:flex-none', className)}>{children}</div>
 );
 

--- a/packages/tradershub/src/components/Modal/ModalContent.tsx
+++ b/packages/tradershub/src/components/Modal/ModalContent.tsx
@@ -1,11 +1,22 @@
 import React, { ReactNode } from 'react';
 import { qtMerge } from '@deriv/quill-design';
 
+/**
+ * Type for the ModalContent component props
+ * @typedef TModalContent
+ * @property {ReactNode} children - Children nodes
+ * @property {string} [className] - Optional CSS class name
+ */
 type TModalContent = {
     children: ReactNode;
     className?: string;
 };
 
+/**
+ * ModalContent component
+ * @param {TModalContent} props - The properties that define the ModalContent component.
+ * @returns {JSX.Element} The ModalContent component.
+ */
 const ModalContent = ({ children, className }: TModalContent) => (
     <div className={qtMerge('flex-grow p-400 lg:flex-none', className)}>{children}</div>
 );

--- a/packages/tradershub/src/components/Modal/ModalFooter.tsx
+++ b/packages/tradershub/src/components/Modal/ModalFooter.tsx
@@ -1,29 +1,26 @@
 import React, { ReactNode } from 'react';
-import { cva, VariantProps } from 'class-variance-authority';
-import { ExcludeAllNull, qtMerge } from '@deriv/quill-design';
+import { qtMerge } from '@deriv/quill-design';
+import { ModalFooterClass, TModalFooterClass } from './Modal.classnames';
 
-type TModalFooterClass = ExcludeAllNull<VariantProps<typeof ModalFooterClass>>;
-
-interface TModalFooter extends TModalFooterClass {
+/**
+ * Interface for the ModalFooter component props
+ * @interface TModalFooter
+ * @extends {TModalFooterClass}
+ * @property {ReactNode} children - Children nodes
+ * @property {string} [className] - Optional CSS class name
+ */
+export interface TModalFooter extends TModalFooterClass {
     children: ReactNode;
     className?: string;
 }
 
+/**
+ * ModalFooter component
+ * @param {TModalFooter} props - The properties that define the ModalFooter component.
+ * @returns {JSX.Element} The ModalFooter component.
+ */
 const ModalFooter = ({ align = 'right', children, className }: TModalFooter) => (
     <div className={qtMerge(ModalFooterClass({ align }), className)}>{children}</div>
 );
 
 export default ModalFooter;
-
-export const ModalFooterClass = cva(
-    'grid grid-cols-2 gap-400 p-800 border border-solid border-t-100 border-system-light-secondary-background bottom-0 lg:flex lg:items-center lg:px-1200 lg:py-800',
-    {
-        variants: {
-            align: {
-                center: 'lg:justify-center',
-                left: 'lg:justify-start',
-                right: 'lg:justify-end',
-            },
-        },
-    }
-);

--- a/packages/tradershub/src/components/Modal/ModalFooter.tsx
+++ b/packages/tradershub/src/components/Modal/ModalFooter.tsx
@@ -1,0 +1,29 @@
+import React, { ReactNode } from 'react';
+import { cva, VariantProps } from 'class-variance-authority';
+import { ExcludeAllNull, qtMerge } from '@deriv/quill-design';
+
+type TModalFooterClass = ExcludeAllNull<VariantProps<typeof ModalFooterClass>>;
+
+interface TModalFooter extends TModalFooterClass {
+    children: ReactNode;
+    className?: string;
+}
+
+const ModalFooter = ({ align = 'right', children, className }: TModalFooter) => (
+    <div className={qtMerge(ModalFooterClass({ align }), className)}>{children}</div>
+);
+
+export default ModalFooter;
+
+export const ModalFooterClass = cva(
+    'grid grid-cols-2 gap-400 p-800 border border-solid border-t-100 border-system-light-secondary-background bottom-0 lg:flex lg:items-center lg:px-1200 lg:py-800',
+    {
+        variants: {
+            align: {
+                center: 'lg:justify-center',
+                left: 'lg:justify-start',
+                right: 'lg:justify-end',
+            },
+        },
+    }
+);

--- a/packages/tradershub/src/components/Modal/ModalFooter.tsx
+++ b/packages/tradershub/src/components/Modal/ModalFooter.tsx
@@ -1,18 +1,18 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
 import { qtMerge } from '@deriv/quill-design';
+import { TModalComponents } from './Modal';
 import { ModalFooterClass, TModalFooterClass } from './Modal.classnames';
 
 /**
- * Interface for the ModalFooter component props
- * @interface TModalFooter
- * @extends {TModalFooterClass}
+ * Type for the ModalFooter component props
+ * @typedef TModalFooter
+ * @property {string} [align] - Optional alignment for the footer content. Default is 'right'.
  * @property {ReactNode} children - Children nodes
  * @property {string} [className] - Optional CSS class name
+ * @extends TModalComponents
+ * @extends TModalFooterClass
  */
-export interface TModalFooter extends TModalFooterClass {
-    children: ReactNode;
-    className?: string;
-}
+type TModalFooter = TModalComponents & TModalFooterClass;
 
 /**
  * ModalFooter component

--- a/packages/tradershub/src/components/Modal/ModalHeader.tsx
+++ b/packages/tradershub/src/components/Modal/ModalHeader.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Heading, qtMerge } from '@deriv/quill-design';
 import CloseIcon from '../../public/images/ic-close-dark.svg';
 import { useModal } from '../ModalProvider';
+import { TModalComponents } from './Modal';
 
 /**
  * Type for the ModalHeader component props
@@ -9,12 +10,9 @@ import { useModal } from '../ModalProvider';
  * @property {string} [className] - Optional CSS class name
  * @property {boolean} [hideCloseButton] - Optional flag to hide the close button
  * @property {string} [title] - Optional title for the header
+ * @extends TModalComponents
  */
-type TModalHeader = {
-    className?: string;
-    hideCloseButton?: boolean;
-    title?: string;
-};
+type TModalHeader = TModalComponents & { hideCloseButton?: boolean; title?: string };
 
 /**
  * ModalHeader component
@@ -33,7 +31,7 @@ const ModalHeader = ({ className, hideCloseButton = false, title }: TModalHeader
             )}
         >
             {title && <Heading.H3 className='flex-1'>{title}</Heading.H3>}
-            {!hideCloseButton && <CloseIcon className='hover:cursor-pointer' onClick={hide} />}
+            {!hideCloseButton && <CloseIcon className='cursor-pointer' onClick={hide} />}
         </div>
     );
 };

--- a/packages/tradershub/src/components/Modal/ModalHeader.tsx
+++ b/packages/tradershub/src/components/Modal/ModalHeader.tsx
@@ -3,12 +3,24 @@ import { Heading, qtMerge } from '@deriv/quill-design';
 import CloseIcon from '../../public/images/ic-close-dark.svg';
 import { useModal } from '../ModalProvider';
 
+/**
+ * Type for the ModalHeader component props
+ * @typedef TModalHeader
+ * @property {string} [className] - Optional CSS class name
+ * @property {boolean} [hideCloseButton] - Optional flag to hide the close button
+ * @property {string} [title] - Optional title for the header
+ */
 type TModalHeader = {
     className?: string;
     hideCloseButton?: boolean;
     title?: string;
 };
 
+/**
+ * ModalHeader component
+ * @param {TModalHeader} props - The properties that define the ModalHeader component.
+ * @returns {JSX.Element} The ModalHeader component.
+ */
 const ModalHeader = ({ className, hideCloseButton = false, title }: TModalHeader) => {
     const { hide } = useModal();
 

--- a/packages/tradershub/src/components/Modal/ModalHeader.tsx
+++ b/packages/tradershub/src/components/Modal/ModalHeader.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Heading, qtMerge } from '@deriv/quill-design';
+import CloseIcon from '../../public/images/ic-close-dark.svg';
+import { useModal } from '../ModalProvider';
+
+type TModalHeader = {
+    className?: string;
+    hideCloseButton?: boolean;
+    title?: string;
+};
+
+const ModalHeader = ({ className, hideCloseButton = false, title }: TModalHeader) => {
+    const { hide } = useModal();
+
+    return (
+        <div
+            className={qtMerge(
+                'flex items-center pl-800 pr-1200 py-800 lg:px-1200 border border-solid border-b-100 border-system-light-secondary-background w-full',
+                title ? 'justify-between' : 'justify-end',
+                className
+            )}
+        >
+            {title && <Heading.H3 className='flex-1'>{title}</Heading.H3>}
+            {!hideCloseButton && <CloseIcon className='hover:cursor-pointer' onClick={hide} />}
+        </div>
+    );
+};
+
+export default ModalHeader;

--- a/packages/tradershub/src/components/Modal/index.ts
+++ b/packages/tradershub/src/components/Modal/index.ts
@@ -1,0 +1,1 @@
+export { default as Modal } from './Modal';

--- a/packages/tradershub/src/components/index.ts
+++ b/packages/tradershub/src/components/index.ts
@@ -2,6 +2,7 @@ export * from './ContentSwitcher';
 export * from './CurrencySwitcher';
 export * from './Dialog';
 export * from './GetADerivAccountBanner';
+export * from './Modal';
 export * from './ModalProvider';
 export * from './ModalStepWrapper';
 export * from './OptionsAndMultipliersSection';


### PR DESCRIPTION
## Changes:

- Refactored `ModalStepWrapper` to `Modal`.
- Adapt to Desktop and Mobile screens.
- Added TSDocs inside

### Screenshots:
![image](https://github.com/binary-com/deriv-app/assets/103104395/d0b52e2e-9c66-4153-a878-78e6fc3f9366)

![image](https://github.com/binary-com/deriv-app/assets/103104395/8cbdcc82-071f-4201-ac34-d8b7dee88cfd)

![localhost_8443_traders-hub](https://github.com/binary-com/deriv-app/assets/103104395/9b96940c-f5ec-4220-a281-cc28c9253d95)
