### PR TITLE
[WALL] Farhan/WALL-3040/Not selected corresponding accounts in Transfer modal

### DIFF
--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormDropdown/TransferFormDropdown.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormDropdown/TransferFormDropdown.tsx
@@ -1,11 +1,11 @@
-import React, { RefObject, useCallback, useMemo } from 'react';
+import React, { RefObject, useCallback, useEffect, useMemo } from 'react';
 import { useFormikContext } from 'formik';
 import { WalletListCardBadge, WalletText } from '../../../../../../components';
 import { useModal } from '../../../../../../components/ModalProvider';
 import useDevice from '../../../../../../hooks/useDevice';
 import IcDropdown from '../../../../../../public/images/ic-dropdown.svg';
 import { useTransfer } from '../../provider';
-import { TInitialTransferFormValues } from '../../types';
+import { TInitialTransferFormValues, TToAccount } from '../../types';
 import { TransferFormAccountCard } from '../TransferFormAccountCard';
 import { TransferFormAccountSelection } from '../TransferFormAccountSelection';
 import './TransferFormDropdown.scss';
@@ -38,6 +38,25 @@ const TransferFormDropdown: React.FC<TProps> = ({ fieldName, mobileAccountsListR
     const accountsList = isFromAccountDropdown ? accounts : toAccountList;
     const label = isFromAccountDropdown ? 'Transfer from' : 'Transfer to';
     const badgeLabel = selectedAccount?.demo_account ? 'virtual' : selectedAccount?.landingCompanyName;
+    const queryParamToAccount = new URLSearchParams(window.location.search).get('to-account');
+
+    useEffect(() => {
+        const toAccount: TToAccount = Object.values(accounts)
+            .flatMap(account => account)
+            .find(account => account.loginid === queryParamToAccount);
+
+        if (queryParamToAccount && toAccount) {
+            setValues(prev => ({
+                ...prev,
+                toAccount,
+            }));
+        }
+
+        // remove 'to-account' query param from url
+        const url = new URL(window.location.href);
+        url.searchParams.delete('to-account');
+        window.history.replaceState({}, document.title, url.toString());
+    }, [accounts, queryParamToAccount, setValues]);
 
     const handleSelect = useCallback(
         (account: TInitialTransferFormValues['fromAccount']) => {

--- a/packages/wallets/src/features/cashier/modules/Transfer/types/types.ts
+++ b/packages/wallets/src/features/cashier/modules/Transfer/types/types.ts
@@ -3,12 +3,13 @@ import type { TTransferContext } from '../provider';
 
 export type TAccount = TTransferContext['activeWallet'];
 export type TAccountsList = TTransferContext['accounts'];
+export type TToAccount = TAccountsList[keyof TAccountsList][number] | undefined;
 
 export type TInitialTransferFormValues = {
     activeAmountFieldName?: 'fromAmount' | 'toAmount';
     fromAccount?: TAccount;
     fromAmount: number;
-    toAccount?: TAccount;
+    toAccount?: TToAccount;
     toAmount: number;
 };
 

--- a/packages/wallets/src/features/cfd/flows/CTrader/AddedCTraderAccountsList/AddedCTraderAccountsList.tsx
+++ b/packages/wallets/src/features/cfd/flows/CTrader/AddedCTraderAccountsList/AddedCTraderAccountsList.tsx
@@ -32,11 +32,11 @@ const AddedCTraderAccountsList: React.FC = () => {
         </div>
     );
 
-    const trailing = () => (
+    const trailing = (loginid?: string) => (
         <div className='wallets-added-ctrader__actions'>
             <WalletButton
                 onClick={() => {
-                    history.push('/wallets/cashier/transfer');
+                    history.push(`/wallets/cashier/transfer?to-account=${loginid}`);
                 }}
                 variant='outlined'
             >
@@ -50,21 +50,23 @@ const AddedCTraderAccountsList: React.FC = () => {
 
     return (
         <div className='wallets-added-ctrader'>
-            <TradingAccountCard leading={leading} trailing={trailing}>
-                <div className='wallets-added-ctrader__details'>
-                    {cTraderAccounts?.map(account => (
-                        <React.Fragment key={`added-ctrader-${account.login}`}>
-                            <WalletText size='sm'>{PlatformDetails.ctrader.title}</WalletText>
-                            <WalletText size='sm' weight='bold'>
-                                {account?.formatted_balance}
-                            </WalletText>
-                            <WalletText color='primary' size='sm' weight='bold'>
-                                {account.login}
-                            </WalletText>
-                        </React.Fragment>
-                    ))}
-                </div>
-            </TradingAccountCard>
+            {cTraderAccounts?.map(account => (
+                <TradingAccountCard
+                    key={`added-ctrader-${account.login}`}
+                    leading={leading}
+                    trailing={() => trailing(account.id)}
+                >
+                    <div className='wallets-added-ctrader__details'>
+                        <WalletText size='sm'>{PlatformDetails.ctrader.title}</WalletText>
+                        <WalletText size='sm' weight='bold'>
+                            {account?.formatted_balance}
+                        </WalletText>
+                        <WalletText color='primary' size='sm' weight='bold'>
+                            {account.login}
+                        </WalletText>
+                    </div>
+                </TradingAccountCard>
+            ))}
         </div>
     );
 };

--- a/packages/wallets/src/features/cfd/flows/CTrader/AddedCTraderAccountsList/__tests__/AddedCTraderAccountsList.spec.tsx
+++ b/packages/wallets/src/features/cfd/flows/CTrader/AddedCTraderAccountsList/__tests__/AddedCTraderAccountsList.spec.tsx
@@ -76,8 +76,8 @@ describe('AddedCTraderAccountsList', () => {
             </Router>
         );
 
-        const icon = screen.getByText('CTrader');
-        fireEvent.click(icon);
+        const icon = screen.getAllByText('CTrader');
+        fireEvent.click(icon[0]);
         expect(mockWindowOpen).toHaveBeenCalledWith('https://deriv.com/deriv-ctrader');
     });
 
@@ -91,8 +91,8 @@ describe('AddedCTraderAccountsList', () => {
             </Router>
         );
 
-        const icon = screen.getByText('CTrader');
-        fireEvent.keyDown(icon, { code: 'Enter', key: 'Enter' });
+        const icon = screen.getAllByText('CTrader');
+        fireEvent.keyDown(icon[0], { code: 'Enter', key: 'Enter' });
         expect(mockWindowOpen).toHaveBeenCalledWith('https://deriv.com/deriv-ctrader');
     });
 
@@ -103,8 +103,8 @@ describe('AddedCTraderAccountsList', () => {
             </Router>
         );
 
-        const transferButton = screen.getByText('Transfer');
-        fireEvent.click(transferButton);
+        const transferButton = screen.getAllByText('Transfer');
+        fireEvent.click(transferButton[0]);
         expect(history.location.pathname).toEqual('/wallets/cashier/transfer');
     });
 
@@ -115,8 +115,8 @@ describe('AddedCTraderAccountsList', () => {
             </Router>
         );
 
-        const openButton = screen.getByText('Open');
-        fireEvent.click(openButton);
+        const openButton = screen.getAllByText('Open');
+        fireEvent.click(openButton[0]);
         expect(mockShow).toHaveBeenCalled();
     });
 });

--- a/packages/wallets/src/features/cfd/flows/MT5/AddedMT5AccountsList/AddedMT5AccountsList.tsx
+++ b/packages/wallets/src/features/cfd/flows/MT5/AddedMT5AccountsList/AddedMT5AccountsList.tsx
@@ -47,7 +47,7 @@ const AddedMT5AccountsList: React.FC<TProps> = ({ account }) => {
                     <WalletButton
                         disabled={jurisdictionStatus.is_failed || jurisdictionStatus.is_pending}
                         onClick={() => {
-                            history.push('/wallets/cashier/transfer');
+                            history.push(`/wallets/cashier/transfer?to-account=${account.loginid}`);
                         }}
                         variant='outlined'
                     >

--- a/packages/wallets/src/features/cfd/flows/OtherCFDs/Dxtrade/AddedDxtradeAccountsList/AddedDxtradeAccountsList.tsx
+++ b/packages/wallets/src/features/cfd/flows/OtherCFDs/Dxtrade/AddedDxtradeAccountsList/AddedDxtradeAccountsList.tsx
@@ -32,11 +32,11 @@ const AddedDxtradeAccountsList: React.FC = () => {
         </div>
     );
 
-    const trailingComponent = () => (
+    const trailingComponent = (loginid?: string) => (
         <div className='wallets-available-derivx__actions'>
             <WalletButton
                 onClick={() => {
-                    history.push('/wallets/cashier/transfer');
+                    history.push(`/wallets/cashier/transfer?to-account=${loginid}`);
                 }}
                 variant='outlined'
             >
@@ -49,10 +49,14 @@ const AddedDxtradeAccountsList: React.FC = () => {
     );
 
     return (
-        <TradingAccountCard leading={leadingComponent} trailing={trailingComponent}>
-            <div className='wallets-available-derivx__details'>
-                {data?.map(account => (
-                    <React.Fragment key={account?.account_id}>
+        <React.Fragment>
+            {data?.map(account => (
+                <TradingAccountCard
+                    key={account?.account_id}
+                    leading={leadingComponent}
+                    trailing={() => trailingComponent(account.account_id)}
+                >
+                    <div className='wallets-available-derivx__details'>
                         <WalletText size='sm'>{PlatformDetails.dxtrade.title}</WalletText>
                         <WalletText size='sm' weight='bold'>
                             {account?.display_balance}
@@ -60,10 +64,10 @@ const AddedDxtradeAccountsList: React.FC = () => {
                         <WalletText color='primary' size='xs' weight='bold'>
                             {account?.login}
                         </WalletText>
-                    </React.Fragment>
-                ))}
-            </div>
-        </TradingAccountCard>
+                    </div>
+                </TradingAccountCard>
+            ))}
+        </React.Fragment>
     );
 };
 


### PR DESCRIPTION
## Changes:

- Add account loginid to query param when redirecting from the account listing
- Set `toAccount` value if query param and account with given loginid exist

### Screenshots:


https://github.com/binary-com/deriv-app/assets/125247833/793599d5-0a26-4b9e-ab72-7f4bdc5d8245


