### PR TITLE
[WALL] Farhan/WALL-3111/Arrow button in the Compare accounts modal is not same as in design

### DIFF
--- a/packages/wallets/src/features/cfd/components/CompareAccountsCarousel/CompareAccountsCarouselButton.scss
+++ b/packages/wallets/src/features/cfd/components/CompareAccountsCarousel/CompareAccountsCarouselButton.scss
@@ -13,24 +13,20 @@
     border: 1px solid var(--general-background-main);
     border-radius: 50%;
     box-shadow: 0px 0px 24px rgba(0, 0, 0, 0.08), 0px 24px 24px rgba(0, 0, 0, 0.08);
+
     &--prev {
         left: 1.6rem;
     }
+
     &--next {
         right: 1.6rem;
     }
+
     &:disabled {
         opacity: 0.3;
         display: none;
     }
-    &__svg {
-        width: 50%;
-        height: 35%;
 
-        &--next {
-            transform: rotateY(180deg);
-        }
-    }
     @include mobile {
         display: none;
     }

--- a/packages/wallets/src/features/cfd/components/CompareAccountsCarousel/CompareAccountsCarouselButton.tsx
+++ b/packages/wallets/src/features/cfd/components/CompareAccountsCarousel/CompareAccountsCarouselButton.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import classNames from 'classnames';
-import ArrowIcon from '../../../../public/images/ic-back-arrow.svg';
+import { IconButton } from '../../../../components/Base';
+import LeftArrow from '../../../../public/images/left-arrow.svg';
+import RightArrow from '../../../../public/images/right-arrow.svg';
 import './CompareAccountsCarouselButton.scss';
 
 type TPrevNextButtonProps = {
@@ -13,20 +15,18 @@ const CFDCompareAccountsCarouselButton = (props: TPrevNextButtonProps) => {
     const { enabled, isNext, onClick } = props;
 
     return (
-        <button
+        <IconButton
             className={classNames('wallets-compare-accounts-carousel-button', {
                 'wallets-compare-accounts-carousel-button--next': isNext,
                 'wallets-compare-accounts-carousel-button--prev': !isNext,
             })}
+            color='white'
             disabled={!enabled}
+            icon={isNext ? <RightArrow /> : <LeftArrow />}
+            isRound
             onClick={onClick}
-        >
-            <ArrowIcon
-                className={classNames('wallets-compare-accounts-carousel-button__svg', {
-                    'wallets-compare-accounts-carousel-button__svg--next': isNext,
-                })}
-            />
-        </button>
+            size='md'
+        />
     );
 };
 export default CFDCompareAccountsCarouselButton;


### PR DESCRIPTION
## Changes:

Change compare account arrow icon

### Screenshots:

![image](https://github.com/binary-com/deriv-app/assets/125247833/bb395de2-9459-49d9-9b00-bcb96b1fdfa4)

