### PR TITLE
feat: added error config for duplicate-doc

### DIFF
--- a/packages/shared/src/utils/constants/poi-failure-codes.tsx
+++ b/packages/shared/src/utils/constants/poi-failure-codes.tsx
@@ -352,10 +352,4 @@ export const ONFIDO_ERROR_STATUS: TOnfidoErrorStatus = Object.freeze({
         code: 'VisualAuthenticityTemplate',
         message: <Localize i18n_default_text='Your document appears to be invalid.' />,
     },
-    Default: {
-        code: 'Default',
-        message: (
-            <Localize i18n_default_text='Some details on your document appear to be invalid, missing, or unclear.' />
-        ),
-    },
 });

--- a/packages/shared/src/utils/constants/poi-failure-codes.tsx
+++ b/packages/shared/src/utils/constants/poi-failure-codes.tsx
@@ -171,6 +171,10 @@ export const ONFIDO_ERROR_STATUS: TOnfidoErrorStatus = Object.freeze({
         code: 'DataValidationNoDocumentNumbers',
         message: <Localize i18n_default_text='The serial number of your document couldn’t be verified.' />,
     },
+    DuplicatedDocument: {
+        code: 'DuplicatedDocument',
+        message: <Localize i18n_default_text='Your verification documents were already used for another account.' />,
+    },
     Expired: { code: 'Expired', message: <Localize i18n_default_text='Your document has expired.' /> },
     ImageIntegrityColourPicture: {
         code: 'ImageIntegrityColourPicture',
@@ -347,5 +351,11 @@ export const ONFIDO_ERROR_STATUS: TOnfidoErrorStatus = Object.freeze({
     VisualAuthenticityTemplate: {
         code: 'VisualAuthenticityTemplate',
         message: <Localize i18n_default_text='Your document appears to be invalid.' />,
+    },
+    Default: {
+        code: 'Default',
+        message: (
+            <Localize i18n_default_text='Some details on your document appear to be invalid, missing, or unclear.' />
+        ),
     },
 });

--- a/packages/shared/src/utils/helpers/__tests__/format-response.spec.ts
+++ b/packages/shared/src/utils/helpers/__tests__/format-response.spec.ts
@@ -5,6 +5,7 @@ import {
     isVerificationServiceSupported,
     formatIDVError,
     formatOnfidoError,
+    getOnfidoError,
 } from '../format-response';
 import { LocalStore } from '../../storage';
 import { CONTRACT_TYPES } from '../../contract';
@@ -216,6 +217,10 @@ describe('format-response', () => {
                     'DataValidationExpiryDate',
                 ])
             ).toHaveLength(3);
+        });
+
+        it('should return the rest of error codes if status is not Expired', () => {
+            expect(formatOnfidoError(STATUS_CODES.REJECTED, ['DuplicatedDocument'])).toHaveLength(1);
         });
     });
 });

--- a/packages/shared/src/utils/helpers/__tests__/format-response.spec.ts
+++ b/packages/shared/src/utils/helpers/__tests__/format-response.spec.ts
@@ -5,7 +5,6 @@ import {
     isVerificationServiceSupported,
     formatIDVError,
     formatOnfidoError,
-    getOnfidoError,
 } from '../format-response';
 import { LocalStore } from '../../storage';
 import { CONTRACT_TYPES } from '../../contract';

--- a/packages/shared/src/utils/helpers/format-response.ts
+++ b/packages/shared/src/utils/helpers/format-response.ts
@@ -129,7 +129,7 @@ export const formatOnfidoError = (status_code: string, errors: Array<TOnfidoErro
 };
 
 export const getOnfidoError = (error: TOnfidoErrorStatus) => {
-    return ONFIDO_ERROR_STATUS[error]?.message ?? ONFIDO_ERROR_STATUS.Default.message;
+    return ONFIDO_ERROR_STATUS[error]?.message ?? '';
 };
 
 export const getIDVError = (error: TIDVErrorStatus) => {

--- a/packages/shared/src/utils/helpers/format-response.ts
+++ b/packages/shared/src/utils/helpers/format-response.ts
@@ -129,7 +129,7 @@ export const formatOnfidoError = (status_code: string, errors: Array<TOnfidoErro
 };
 
 export const getOnfidoError = (error: TOnfidoErrorStatus) => {
-    return ONFIDO_ERROR_STATUS[error]?.message ?? '';
+    return ONFIDO_ERROR_STATUS[error]?.message ?? ONFIDO_ERROR_STATUS.Default.message;
 };
 
 export const getIDVError = (error: TIDVErrorStatus) => {


### PR DESCRIPTION
## Changes:

Display `DuplicateDocument` error message when error code is returned in response
