### PR TITLE
[WALL] [Fix] Rostislav / Remove outline for cancel transaction button in `TransactionStatus` when ESC is pressed

### DIFF
--- a/packages/wallets/src/features/cashier/modules/TransactionStatus/components/CryptoTransaction/CryptoTransaction.scss
+++ b/packages/wallets/src/features/cashier/modules/TransactionStatus/components/CryptoTransaction/CryptoTransaction.scss
@@ -57,6 +57,7 @@
         margin-left: 0.3rem;
         padding: 0;
         border: none;
+        outline: none;
         cursor: pointer;
     }
 


### PR DESCRIPTION
## Changes:

- [x] remove cancel button outline in `TransactionStatus` when pressing ESC

### Screenshots:

https://github.com/binary-com/deriv-app/assets/119863957/ff08cd3d-6e57-4859-8708-1845acc46103


