### PR TITLE
[WALL] [Fix] Rostislav / WALL-3161 / `TransactionStatus` in mobile withdrawal

### DIFF
--- a/packages/wallets/src/features/cashier/modules/WithdrawalCrypto/WithdrawalCrypto.scss
+++ b/packages/wallets/src/features/cashier/modules/WithdrawalCrypto/WithdrawalCrypto.scss
@@ -6,6 +6,7 @@
     gap: 2.4rem;
 
     @include mobile {
+        height: fit-content;
         flex-direction: column;
         align-items: center;
         justify-content: center;
@@ -35,9 +36,17 @@
         flex: 1 1 0;
         justify-content: flex-end;
 
+        @include mobile {
+            width: 100%;
+        }
+
         .wallets-transaction-status {
             margin-top: -2.4rem;
             margin-right: 2.4rem;
+
+            @include mobile {
+                margin: 0;
+            }
         }
     }
 }


### PR DESCRIPTION
## Changes:

- [x] fix `TransactionStatus` in mobile withdrawal

### Screenshots:

<img width="592" alt="Screenshot 2023-12-29 at 03 47 20" src="https://github.com/binary-com/deriv-app/assets/119863957/f2818720-f42c-464e-b3ba-07eb4d5f5c81">
