### PR TITLE
[WALL] Farhan/WALL-3067/Metatrader web option is not displayed on mobile

### DIFF
--- a/packages/wallets/src/features/cfd/screens/MT5TradeScreen/MT5TradeScreen.tsx
+++ b/packages/wallets/src/features/cfd/screens/MT5TradeScreen/MT5TradeScreen.tsx
@@ -136,16 +136,20 @@ const MT5TradeScreen: FC<MT5TradeScreenProps> = ({ mt5Account }) => {
                 </div>
             </div>
             <div className='wallets-mt5-trade-screen__links'>
-                {isDesktop && platform === mt5Platform && (
+                {platform === mt5Platform && (
                     <Fragment>
                         <MT5TradeLink
                             app='web'
                             platform={mt5Platform}
                             webtraderUrl={(details as THooks.MT5AccountsList)?.webtrader_url}
                         />
-                        <MT5TradeLink app='windows' platform={mt5Platform} />
-                        <MT5TradeLink app='macos' platform={mt5Platform} />
-                        <MT5TradeLink app='linux' platform={mt5Platform} />
+                        {isDesktop && (
+                            <Fragment>
+                                <MT5TradeLink app='windows' platform={mt5Platform} />
+                                <MT5TradeLink app='macos' platform={mt5Platform} />
+                                <MT5TradeLink app='linux' platform={mt5Platform} />
+                            </Fragment>
+                        )}
                     </Fragment>
                 )}
                 {platform === dxtradePlatform && (


### PR DESCRIPTION
## Changes:

Fix: Metatrader web option is not displayed on mobile

### Screenshots:

![image](https://github.com/binary-com/deriv-app/assets/125247833/c9bb6e34-701f-4c81-ad99-1f54a055c82b)

