### PR TITLE
[WALL] Lubega / WALL-3187 / Fix: Transfer message padding update

### DIFF
--- a/packages/wallets/src/components/Base/WalletAlertMessage/WalletAlertMessage.scss
+++ b/packages/wallets/src/components/Base/WalletAlertMessage/WalletAlertMessage.scss
@@ -1,7 +1,7 @@
 .wallets-alert-message {
     display: flex;
     flex-direction: row;
-    column-gap: 0.8rem;
+    column-gap: 0.4rem;
     justify-content: flex-start;
 
     @include mobile {
@@ -34,7 +34,11 @@
     }
 
     &__message-container {
-        padding: 0.6rem 0;
+        padding: 0.7rem 0;
+
+        @include mobile {
+            padding: 0.9rem 0;
+        }
     }
 
     &__button-container {


### PR DESCRIPTION
## Changes:

- [x] Fixed transfer message padding according to figma design:
The top and bottom of the message changed to 7 px for desktop and 9 px for mobile
The right gap between the message and icons changed to 4 px for both mobile and desktop

### Screenshots:

<img width="425" alt="Screenshot 2023-12-29 at 4 11 22 PM" src="https://github.com/binary-com/deriv-app/assets/142860499/3355541b-c637-4b7b-abbe-1a3ae4f44a12">

<img width="1379" alt="Screenshot 2023-12-29 at 4 12 34 PM" src="https://github.com/binary-com/deriv-app/assets/142860499/c15931c9-7592-4e95-a42b-4b6896965935">

<img width="425" alt="Screenshot 2023-12-29 at 4 11 49 PM" src="https://github.com/binary-com/deriv-app/assets/142860499/a9ee2da9-df95-4042-9b8f-dc8e1291abb8">

<img width="1379" alt="Screenshot 2023-12-29 at 4 12 40 PM" src="https://github.com/binary-com/deriv-app/assets/142860499/83561bd9-b216-4cd5-8c5f-d7fac13c9535">
