### PR TITLE
[WALL] Farhan/WALL-3163/MT5 login id format in MT5 trade popup is different from the design

### DIFF
--- a/packages/wallets/src/features/cfd/screens/MT5TradeScreen/MT5TradeScreen.tsx
+++ b/packages/wallets/src/features/cfd/screens/MT5TradeScreen/MT5TradeScreen.tsx
@@ -54,7 +54,7 @@ const MT5TradeScreen: FC<MT5TradeScreenProps> = ({ mt5Account }) => {
 
     const loginId = useMemo(() => {
         if (platform === mt5Platform) {
-            return (details as THooks.MT5AccountsList)?.loginid;
+            return (details as THooks.MT5AccountsList)?.display_login;
         } else if (platform === dxtradePlatform) {
             return (details as THooks.DxtradeAccountsList)?.account_id;
         }


### PR DESCRIPTION
## Changes:

Change MT5 login id format in MT5 trade popup

### Screenshots:

![image](https://github.com/binary-com/deriv-app/assets/125247833/703aa069-41a7-43ba-a756-f6c744a62f1a)

