### PR TITLE
[WALL] Lubega / WALL-3188 / Fix: Transfer message source account

### DIFF
--- a/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/useTransferMessages.ts
+++ b/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/useTransferMessages.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { useActiveWalletAccount, useAuthorize, usePOI } from '@deriv/api';
+import { useActiveWalletAccount, useAuthorize, usePOI, useWalletAccountsList } from '@deriv/api';
 import { displayMoney as displayMoney_ } from '@deriv/api/src/utils';
 import { THooks } from '../../../../../../types';
 import { TAccount, TInitialTransferFormValues, TMessageFnProps, TTransferMessage } from '../../types';
@@ -29,6 +29,7 @@ const useTransferMessages = ({
 }: TProps) => {
     const { data: authorizeData } = useAuthorize();
     const { data: activeWallet } = useActiveWalletAccount();
+    const { data: walletAccounts } = useWalletAccountsList();
     const { preferred_language: preferredLanguage } = authorizeData;
     const { data: poi } = usePOI();
 
@@ -46,6 +47,8 @@ const useTransferMessages = ({
     );
 
     if (!activeWallet || !fromAccount) return [];
+
+    const fiatAccount = walletAccounts?.find(account => account.account_type === 'doughflow');
 
     const sourceAmount = formData.fromAmount;
 
@@ -67,6 +70,7 @@ const useTransferMessages = ({
             activeWallet,
             activeWalletExchangeRates,
             displayMoney,
+            fiatAccount,
             limits: accountLimits,
             sourceAccount: fromAccount,
             sourceAmount,

--- a/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/utils/transferFeesBetweenWalletsMessageFn.ts
+++ b/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/utils/transferFeesBetweenWalletsMessageFn.ts
@@ -28,12 +28,12 @@ const transferFeesBetweenWalletsMessageFn = ({
     );
 
     const text =
-        'Fee: {{feeMessageText}} ({{feePercentage}}% transfer fee or {{minimumFeeText}}, whichever is higher, applies for fund transfers between your {{targetAccountName}} and cryptocurrency Wallets)';
+        'Fee: {{feeMessageText}} ({{feePercentage}}% transfer fee or {{minimumFeeText}}, whichever is higher, applies for fund transfers between your {{sourceAccountName}} and cryptocurrency Wallets)';
     const values = {
         feeMessageText,
         feePercentage,
         minimumFeeText,
-        targetAccountName: targetAccount.accountName,
+        sourceAccountName: sourceAccount.accountName,
     };
 
     return {

--- a/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/utils/transferFeesBetweenWalletsMessageFn.ts
+++ b/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/utils/transferFeesBetweenWalletsMessageFn.ts
@@ -2,6 +2,7 @@ import { TMessageFnProps } from '../../../types';
 
 const transferFeesBetweenWalletsMessageFn = ({
     displayMoney,
+    fiatAccount,
     sourceAccount,
     sourceAmount,
     targetAccount,
@@ -28,12 +29,12 @@ const transferFeesBetweenWalletsMessageFn = ({
     );
 
     const text =
-        'Fee: {{feeMessageText}} ({{feePercentage}}% transfer fee or {{minimumFeeText}}, whichever is higher, applies for fund transfers between your {{sourceAccountName}} and cryptocurrency Wallets)';
+        'Fee: {{feeMessageText}} ({{feePercentage}}% transfer fee or {{minimumFeeText}}, whichever is higher, applies for fund transfers between your {{fiatAccountName}} and cryptocurrency Wallets)';
     const values = {
         feeMessageText,
         feePercentage,
+        fiatAccountName: fiatAccount?.wallet_currency_type,
         minimumFeeText,
-        sourceAccountName: sourceAccount.accountName,
     };
 
     return {

--- a/packages/wallets/src/features/cashier/modules/Transfer/types/types.ts
+++ b/packages/wallets/src/features/cashier/modules/Transfer/types/types.ts
@@ -35,6 +35,7 @@ export type TMessageFnProps = {
     activeWallet: THooks.ActiveWalletAccount;
     activeWalletExchangeRates?: THooks.ExchangeRate;
     displayMoney?: (amount: number, currency: string, fractionalDigits: number) => string;
+    fiatAccount?: THooks.WalletAccountsList;
     limits?: THooks.AccountLimits;
     sourceAccount: NonNullable<TAccount>;
     sourceAmount: number;


### PR DESCRIPTION
## Changes:

- [x] Updated transfer message to display source account instead of target account

### Screenshots:

<img width="1376" alt="image" src="https://github.com/binary-com/deriv-app/assets/142860499/98243a7d-f44e-47ec-85a8-c4eff17b5061">
