### PR TITLE
[BOT] Farabi/bot-974/useComponentVisibility test coverage 

### DIFF
--- a/packages/bot-web-ui/src/components/dashboard/hooks/__tests__/useComponentVisibilty.spec.tsx
+++ b/packages/bot-web-ui/src/components/dashboard/hooks/__tests__/useComponentVisibilty.spec.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useComponentVisibility } from '../useComponentVisibility';
+
+describe('useComponentVisibility', () => {
+    const ref = { current: document.createElement('input') };
+    const Component = () => {
+        const { is_dropdown_visible, setDropdownVisibility } = useComponentVisibility(ref);
+
+        return (
+            <div>
+                <div data-testid='dropdown-status'>{is_dropdown_visible ? 'visible' : 'hidden'}</div>
+                <button onClick={() => setDropdownVisibility(!is_dropdown_visible)}>Toggle Dropdown</button>
+            </div>
+        );
+    };
+
+    it('should render dropdown visibility to be hidden on ESC key press', () => {
+        render(<Component />);
+        const dropdownStatus = screen.getByTestId('dropdown-status');
+        const toggleButton = screen.getByText('Toggle Dropdown');
+
+        expect(dropdownStatus).toHaveTextContent('hidden');
+
+        fireEvent.click(toggleButton);
+        expect(dropdownStatus).toHaveTextContent('visible');
+
+        fireEvent.keyDown(document, { key: 'Escape', code: 'Escape' });
+        expect(dropdownStatus).toHaveTextContent('hidden');
+    });
+
+    it('should render dropdown visibility to be hidden on outside click', () => {
+        render(<Component />);
+        const dropdownStatus = screen.getByTestId('dropdown-status');
+        const toggleButton = screen.getByText('Toggle Dropdown');
+
+        expect(dropdownStatus).toHaveTextContent('hidden');
+
+        fireEvent.click(toggleButton);
+        expect(dropdownStatus).toHaveTextContent('visible');
+
+        fireEvent.click(document.body);
+        expect(dropdownStatus).toHaveTextContent('hidden');
+    });
+});


### PR DESCRIPTION
## Changes:

Added test case for useComponentVisibility hook

### Screenshots:

<img width="1719" alt="Screenshot 2024-01-02 at 4 20 40 PM" src="https://github.com/binary-com/deriv-app/assets/102643568/a8d09bac-5d93-4fe2-bad2-bde08a19b544">


