### PR TITLE
[WALL] Lubega / WALL-3173 / Fix: Transactions amount colour

### DIFF
--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/TransactionsCompletedRow.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/TransactionsCompletedRow.tsx
@@ -64,7 +64,7 @@ const TransactionsCompletedRow: React.FC<TProps> = ({ accounts, transaction, wal
                 />
             )}
             <div className='wallets-transactions-completed-row__transaction-details'>
-                <WalletText color={transaction.amount > 0 ? 'success' : 'red'} size='xs' weight='bold'>
+                <WalletText color={transaction.amount > 0 ? 'success' : 'error'} size='xs' weight='bold'>
                     {transaction.amount && transaction.amount > 0 ? '+' : ''}
                     {transaction.display_amount}
                 </WalletText>


### PR DESCRIPTION
## Changes:

- [x] Fix colour of transactions amount to match design

### Screenshots:

<img width="369" alt="Screenshot 2024-01-02 at 6 17 13 PM" src="https://github.com/binary-com/deriv-app/assets/142860499/1509c71c-fa57-48b5-98ad-332b3a62a6d0">

