### PR TITLE
[WALL] Lubega / WALL-3137 / Fix: Transaction status mobile ui

### DIFF
--- a/packages/wallets/src/features/cashier/modules/DepositCrypto/DepositCrypto.scss
+++ b/packages/wallets/src/features/cashier/modules/DepositCrypto/DepositCrypto.scss
@@ -30,8 +30,10 @@
         justify-content: flex-end;
 
         .wallets-transaction-status {
-            margin-top: -2.4rem;
-            margin-right: 2.4rem;
+            @include desktop {
+                margin-top: -2.4rem;
+                margin-right: 2.4rem;
+            }
         }
     }
 }


### PR DESCRIPTION
## Changes:

- [x] Fixed responsive design for transaction status

### Screenshots:

Before:
<img width="423" alt="Screenshot 2024-01-02 at 6 36 45 PM" src="https://github.com/binary-com/deriv-app/assets/142860499/0f6e6898-e5c2-44bb-a859-971f9d68afb4">

After:
<img width="423" alt="Screenshot 2024-01-02 at 6 36 45 PM" src="https://github.com/binary-com/deriv-app/assets/142860499/d9a8cdb6-b3ad-47b2-baec-f016a7c275c6">

