### PR TITLE
[WALL]Aum/WALL-3189/fix blue message for transfer between crypto wallets

### DIFF
--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferReceipt/TransferReceipt.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferReceipt/TransferReceipt.tsx
@@ -81,7 +81,7 @@ const TransferReceipt = () => {
                 <ReceiptCard
                     account={fromAccount}
                     activeWallet={activeWallet}
-                    balance={`+ ${displayTransferredFromAmount}`}
+                    balance={`- ${displayTransferredFromAmount}`}
                 />
                 <div className='wallets-transfer-receipt__arrow-icon'>
                     <Arrow />
@@ -89,7 +89,7 @@ const TransferReceipt = () => {
                 <ReceiptCard
                     account={toAccount}
                     activeWallet={activeWallet}
-                    balance={`- ${displayTransferredToAmount}`}
+                    balance={`+ ${displayTransferredToAmount}`}
                 />
             </div>
             <div

--- a/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/utils/transferFeesBetweenWalletsMessageFn.ts
+++ b/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/utils/transferFeesBetweenWalletsMessageFn.ts
@@ -10,6 +10,8 @@ const transferFeesBetweenWalletsMessageFn = ({
     if (!sourceAccount.currency || !sourceAccount.currencyConfig || !sourceAmount || !targetAccount?.currency)
         return null;
 
+    const isTransferBetweenCryptoWallets =
+        sourceAccount.account_type === 'crypto' && targetAccount.account_type === 'crypto';
     const minimumFeeAmount = 1 / Math.pow(10, sourceAccount.currencyConfig.fractional_digits);
 
     const minimumFeeText = displayMoney?.(
@@ -29,11 +31,12 @@ const transferFeesBetweenWalletsMessageFn = ({
     );
 
     const text =
-        'Fee: {{feeMessageText}} ({{feePercentage}}% transfer fee or {{minimumFeeText}}, whichever is higher, applies for fund transfers between your {{fiatAccountName}} and cryptocurrency Wallets)';
+        'Fee: {{feeMessageText}} ({{feePercentage}}% transfer fee or {{minimumFeeText}}, whichever is higher, applies for fund transfers between your {{fiatAccountName}}{{conjunction}} cryptocurrency Wallets)';
     const values = {
+        conjunction: isTransferBetweenCryptoWallets ? '' : ' and ',
         feeMessageText,
         feePercentage,
-        fiatAccountName: fiatAccount?.wallet_currency_type,
+        fiatAccountName: isTransferBetweenCryptoWallets ? '' : fiatAccount?.wallet_currency_type,
         minimumFeeText,
     };
 


### PR DESCRIPTION
## Changes:

1. 🐛 Fix the blue transfer fees message when the transfer is happening between `crypto-wallets`,

from: Fee: 0.00003200 LTC (2% transfer fee or 0.00000001 LTC, whichever is higher, applies for fund transfers between your `{{active_wallet_name}} Wallet and cryptocurrency Wallets`)

to: Fee: 0.00003200 LTC (2% transfer fee or 0.00000001 LTC, whichever is higher, applies for fund transfers between your `cryptocurrency Wallets`)
![image](https://github.com/binary-com/deriv-app/assets/125039206/fa9eceb9-e81a-4d2e-b125-a663adf68097)

2. 🐛 Fixed the signs of the transferred amount in wallet-cards in the TransferReceipt screen.
<img width="1193" alt="Screenshot 2024-01-02 at 5 00 18 PM" src="https://github.com/binary-com/deriv-app/assets/125039206/b900fa1a-ebbd-456a-a268-addb96e0bf41">