### PR TITLE
[P2PS] / Ameerul P2PS-2176 / Overlap of buy modal when sellers instructions are too long (recurring bug)

### DIFF
--- a/packages/p2p/src/pages/buy-sell/buy-sell-form.scss
+++ b/packages/p2p/src/pages/buy-sell/buy-sell-form.scss
@@ -16,7 +16,7 @@
     &__field {
         margin-bottom: 0 !important;
         flex: 1;
-        height: 4rem;
+        min-height: 4rem;
 
         .dc-input__container {
             width: 91%;


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- changed the height to min-height to fix the issue of the text overlapping with other text inside of buy sell modal

### Screenshots:

Please provide some screenshots of the change.
<img width="530" alt="Screenshot 2024-01-03 at 10 21 00 AM" src="https://github.com/binary-com/deriv-app/assets/103412909/7064cf91-577e-480c-9721-43f4902ee92f">
<img width="525" alt="Screenshot 2024-01-03 at 10 21 05 AM" src="https://github.com/binary-com/deriv-app/assets/103412909/a2362970-4ec4-4c64-8b64-bc3684e0d25d">
