### PR TITLE
[WALL] Lubega / WALL-3211 / Fix: Transfer message missing 'Wallet' in fiat transfer

### DIFF
--- a/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/utils/transferFeesBetweenWalletsMessageFn.ts
+++ b/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/utils/transferFeesBetweenWalletsMessageFn.ts
@@ -33,7 +33,7 @@ const transferFeesBetweenWalletsMessageFn = ({
     const text =
         'Fee: {{feeMessageText}} ({{feePercentage}}% transfer fee or {{minimumFeeText}}, whichever is higher, applies for fund transfers between your {{fiatAccountName}}{{conjunction}} cryptocurrency Wallets)';
     const values = {
-        conjunction: isTransferBetweenCryptoWallets ? '' : ' and ',
+        conjunction: isTransferBetweenCryptoWallets ? '' : ' Wallet and ',
         feeMessageText,
         feePercentage,
         fiatAccountName: isTransferBetweenCryptoWallets ? '' : fiatAccount?.wallet_currency_type,


### PR DESCRIPTION
## Changes:

- [x] Fixed missing 'Wallet' for fiat account in transfer message

### Screenshots:

<img width="646" alt="image" src="https://github.com/binary-com/deriv-app/assets/142860499/c8f2e7e7-7530-4131-8289-bfbeed37a17b">

<img width="646" alt="image" src="https://github.com/binary-com/deriv-app/assets/142860499/41ac0be1-5f52-4921-9474-d68b99f6a394">
