### PR TITLE
Rostislav / WEBREL-1858 / Suppress console error in "Payment agents" withdrawal tab

### DIFF
--- a/packages/cashier/src/pages/payment-agent-transfer/payment-agent-transfer-confirm/payment-agent-transfer-confirm.tsx
+++ b/packages/cashier/src/pages/payment-agent-transfer/payment-agent-transfer-confirm/payment-agent-transfer-confirm.tsx
@@ -19,18 +19,18 @@ const PaymentAgentTransferConfirm = observer(() => {
     return (
         <TransferConfirm
             data={[
-                { label: localize('From account number'), value: loginid || '', key: 'transfer_from' },
+                { label: localize('From account number'), value: loginid || '', item_key: 'transfer_from' },
                 {
                     label: [localize('To account number'), localize('Account holder name')],
                     value: [transfer_to?.toUpperCase() || '', transfer_to_name || ''],
-                    key: 'transfer_to',
+                    item_key: 'transfer_to',
                 },
                 {
                     label: localize('Amount'),
                     value: <Money currency={currency} amount={amount} show_currency />,
-                    key: 'amount',
+                    item_key: 'amount',
                 },
-                { label: localize('Description'), value: description || '', key: 'description' },
+                { label: localize('Description'), value: description || '', item_key: 'description' },
             ]}
             error={error}
             onClickBack={() => {

--- a/packages/cashier/src/pages/payment-agent/payment-agent-withdraw-confirm/payment-agent-withdraw-confirm.tsx
+++ b/packages/cashier/src/pages/payment-agent/payment-agent-withdraw-confirm/payment-agent-withdraw-confirm.tsx
@@ -19,16 +19,16 @@ const PaymentAgentWithdrawConfirm = observer(() => {
     return (
         <TransferConfirm
             data={[
-                { label: localize('From account number'), value: client_loginid || '', key: 'transfer_from' },
+                { label: localize('From account number'), value: client_loginid || '', item_key: 'transfer_from' },
                 {
                     label: [localize('To account number'), localize('Account holder name')],
                     value: [loginid.toUpperCase(), payment_agent_name],
-                    key: 'transfer_to',
+                    item_key: 'transfer_to',
                 },
                 {
                     label: localize('Amount'),
                     value: <Money currency={currency} amount={amount} show_currency />,
-                    key: 'amount',
+                    item_key: 'amount',
                 },
             ]}
             error={error}


### PR DESCRIPTION
## Changes:

- [x] suppress API error logging by a 3rd party library for a hook's uses

### Screenshots:

Previously:

<img width="1792" alt="Screenshot 2024-01-03 at 14 53 00" src="https://github.com/binary-com/deriv-app/assets/119863957/d322dced-a2ff-4e62-8b5f-9d60827efb9a">
<img width="526" alt="Screenshot 2024-01-03 at 14 53 15" src="https://github.com/binary-com/deriv-app/assets/119863957/70164e14-0dfa-4a46-9c86-e3a9b4936911">


Now:

<img width="1792" alt="Screenshot 2024-01-03 at 14 50 01" src="https://github.com/binary-com/deriv-app/assets/119863957/5ac437e7-96ff-4da2-bcd3-b3ee6c7f8949">
