### PR TITLE
[BOT]Maryia/fix: For Reverse D'Alembert strategy, the dropdown is present for description section as well

### DIFF
--- a/packages/bot-web-ui/src/components/quick-strategy/descriptions/reverse_dalembert.ts
+++ b/packages/bot-web-ui/src/components/quick-strategy/descriptions/reverse_dalembert.ts
@@ -6,6 +6,8 @@ export const REVERSE_D_ALEMBERT: TDescriptionItem[] = [
     {
         type: 'subtitle',
         content: [localize('Exploring the Reverse D’Alembert strategy in Deriv Bot')],
+        expanded: true,
+        no_collapsible: false,
     },
     {
         type: 'text',
@@ -15,6 +17,14 @@ export const REVERSE_D_ALEMBERT: TDescriptionItem[] = [
             ),
             localize('These are the trade parameters used for the Reverse D’Alembert strategy in Deriv Bot.'),
         ],
+    },
+    {
+        type: 'subtitle',
+        content: [localize('Key Parameters')],
+    },
+    {
+        type: 'text',
+        content: [localize(`These are the trade parameters used in Deriv Bot with Reverse D'Alembert strategy.`)],
     },
     {
         type: 'text',


### PR DESCRIPTION
## Changes:

fix: For the Reverse D'Alembert strategy, the dropdown is present for the description section as well

### Screenshots:

<img width="1115" alt="Screenshot 2024-01-04 at 19 02 52" src="https://github.com/binary-com/deriv-app/assets/103181650/37b6f2f1-51c6-4268-8236-9ff02c53dc1a">

