### PR TITLE
[WALL] george / WALL-3216 / The colour of the wallet name, the balance and the badge does not align with the design

### DIFF
--- a/packages/wallets/src/components/WalletCard/WalletCard.tsx
+++ b/packages/wallets/src/components/WalletCard/WalletCard.tsx
@@ -34,7 +34,7 @@ const WalletCard: React.FC<TProps> = ({ balance, currency, iconSize = 'lg', isDe
                         </div>
                     </div>
                     <div className='wallets-card__details__bottom'>
-                        <WalletText color={isDemo ? 'white' : 'black'} size='2xs'>
+                        <WalletText color={isDemo ? 'white' : 'general'} size='2xs'>
                             {currency} Wallet
                         </WalletText>
                         {isLoading ? (
@@ -43,7 +43,7 @@ const WalletCard: React.FC<TProps> = ({ balance, currency, iconSize = 'lg', isDe
                                 data-testid='dt_wallet_card_balance_loader'
                             />
                         ) : (
-                            <WalletText color={isDemo ? 'white' : 'black'} size='sm' weight='bold'>
+                            <WalletText color={isDemo ? 'white' : 'general'} size='sm' weight='bold'>
                                 {balance}
                             </WalletText>
                         )}

--- a/packages/wallets/src/components/WalletListCardBadge/WalletListCardBadge.tsx
+++ b/packages/wallets/src/components/WalletListCardBadge/WalletListCardBadge.tsx
@@ -18,7 +18,7 @@ const WalletListCardBadge: React.FC<TProps> = ({ isDemo, label }) => {
 
     return (
         <div className={className}>
-            <WalletText color={isDemo ? 'white' : 'black'} size='2xs' weight='bold'>
+            <WalletText color={isDemo ? 'white' : 'general'} size='2xs' weight='bold'>
                 {formattedLabel}
             </WalletText>
         </div>

--- a/packages/wallets/src/components/WalletListCardBadge/__tests__/WalletListCardBadge.spec.tsx
+++ b/packages/wallets/src/components/WalletListCardBadge/__tests__/WalletListCardBadge.spec.tsx
@@ -19,6 +19,6 @@ describe('WalletListCardBadge', () => {
         render(<WalletListCardBadge label='malta' />);
         const badge = screen.getByText('MALTA');
         expect(badge).toBeInTheDocument();
-        expect(badge).toHaveClass('wallets-text__color--black');
+        expect(badge).toHaveClass('wallets-text__color--general');
     });
 });


### PR DESCRIPTION
## Changes:

- fix text color

### Screenshots:

![Screenshot 2024-01-05 at 10 38 22](https://github.com/binary-com/deriv-app/assets/103181646/d2f94d35-9c85-4919-bd6c-5e9d0be614e9)
