### PR TITLE
[BOT]/Maryia/WEBREL-1870/fix: Responsive/ On Quick strategy modal, the dropdown in overlapping with the text

### DIFF
--- a/packages/bot-web-ui/src/components/quick-strategy/quick-strategy.scss
+++ b/packages/bot-web-ui/src/components/quick-strategy/quick-strategy.scss
@@ -16,6 +16,7 @@
         --footer-height: 4.2rem;
         --input-action-height: 3rem;
         --input-action-width: 3rem;
+        width: 100%;
     }
 
     .xy-center {
@@ -232,7 +233,6 @@
 
             @include mobile() {
                 margin-bottom: 0;
-                padding: 0 1.9rem 1.6rem;
                 max-height: calc(100% - 12.2rem) !important;
             }
 


### PR DESCRIPTION
## Changes:

fix: Responsive/ On Quick strategy modal, the dropdown in overlapping with the text

### Screenshots:

Please provide some screenshots of the change.
<img width="487" alt="Screenshot 2024-01-05 at 11 05 54" src="https://github.com/binary-com/deriv-app/assets/103181650/0fc97b7f-73ed-4d7e-8e64-93f4251c39a1">

