### PR TITLE
[WALL] george / WALL-3220 / The padding size between cards in the success page does not align with design.(Mobile view)

### DIFF
--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferReceipt/TransferReceipt.scss
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferReceipt/TransferReceipt.scss
@@ -8,7 +8,7 @@
         display: flex;
         flex-direction: row;
         align-items: center;
-        gap: 1.7rem;
+        gap: 1.6rem;
 
         & .wallets-card__details {
             padding: 1.6rem;

--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferReceipt/TransferReceipt.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferReceipt/TransferReceipt.tsx
@@ -81,7 +81,7 @@ const TransferReceipt = () => {
                 <ReceiptCard
                     account={fromAccount}
                     activeWallet={activeWallet}
-                    balance={`- ${displayTransferredFromAmount}`}
+                    balance={`-${displayTransferredFromAmount}`}
                 />
                 <div className='wallets-transfer-receipt__arrow-icon'>
                     <Arrow />
@@ -89,7 +89,7 @@ const TransferReceipt = () => {
                 <ReceiptCard
                     account={toAccount}
                     activeWallet={activeWallet}
-                    balance={`+ ${displayTransferredToAmount}`}
+                    balance={`+${displayTransferredToAmount}`}
                 />
             </div>
             <div


### PR DESCRIPTION
## Changes:

- fix gap
- fix content (remove space in card balance)

### Screenshots:

![Screenshot 2024-01-05 at 11 34 17](https://github.com/binary-com/deriv-app/assets/103181646/8671eede-831d-421b-b22b-40424a14e2cf)
![Screenshot 2024-01-05 at 12 42 35](https://github.com/binary-com/deriv-app/assets/103181646/c3b5932b-c1ae-4913-863b-1c8e1bd38ef2)

