### PR TITLE
[WALL] aum/bug-fixes-for-pending-transactions-tab

### DIFF
--- a/packages/api/src/hooks/useCryptoTransactions.ts
+++ b/packages/api/src/hooks/useCryptoTransactions.ts
@@ -30,7 +30,7 @@ const getFormattedConfirmations = (transaction: TModifiedTransaction) => {
         case 'ERROR':
             return 'NA';
         default:
-            return transaction.confirmations || 'Pending';
+            return transaction.confirmations ?? 'Pending';
     }
 };
 

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsPendingRow/TransactionsPendingRow.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsPendingRow/TransactionsPendingRow.tsx
@@ -180,7 +180,7 @@ const TransactionsCryptoRow: React.FC<TProps> = ({ transaction }) => {
                 <WalletText color='general' size='sm'>
                     {transaction.status_name}
                 </WalletText>
-                {!isMobile && transaction.is_valid_to_cancel && (
+                {!isMobile && !!transaction.is_valid_to_cancel && (
                     <button
                         className='wallets-transactions-pending-row__transaction-cancel-button'
                         onClick={onCancelButtonClick}


### PR DESCRIPTION
## Changes:

Fixing the following bugs for pending transactions in transactions tab for crypto-wallets:
1. Remove 0 from the end of the transaction status name.
<img width="380" src="https://github.com/binary-com/deriv-app/assets/125039206/fd52317a-b51b-41a5-8169-c0092a8ebc64" />
<img width="380" alt="image" src="https://github.com/binary-com/deriv-app/assets/125039206/f8656d4b-f9de-4bcd-92e6-37938d3b73fa">

2. Show confirmation count when the transaction status is upgraded from `In review` to `In process`.
<img width="380" src="https://github.com/binary-com/deriv-app/assets/125039206/88fa8171-45bb-4ab3-9baa-cde6ee9d5353" /> 
<img width="380" src="https://github.com/binary-com/deriv-app/assets/125039206/6909f192-440e-4801-a727-5da9e6af6c55" />

### Screenshots:

Please provide some screenshots of the change.
