### PR TITLE
[WALL] george / WALL-3237 / Bouncing of the header when scrolling up and down on IPhone device

### DIFF
--- a/packages/wallets/src/components/Base/ATMAmountInput/ATMAmountInput.tsx
+++ b/packages/wallets/src/components/Base/ATMAmountInput/ATMAmountInput.tsx
@@ -64,6 +64,7 @@ const WalletTransferFormInputField: React.FC<TProps> = ({
                     <input
                         className='wallets-atm-amount-input__input'
                         disabled={disabled || isFocused}
+                        readOnly
                         value={`${formattedValue} ${currency || ''}`}
                     />
                     <input

--- a/packages/wallets/src/features/cashier/WalletCashier.scss
+++ b/packages/wallets/src/features/cashier/WalletCashier.scss
@@ -17,6 +17,8 @@
     padding: 4.8rem 1.6rem 0;
     background-color: #ffffff;
     overflow: scroll;
+    //prevent content bouncing on scroll on iPhone devices
+    overscroll-behavior: none;
 
     @include mobile {
         padding: 2.4rem 1.6rem;

--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormAccountSelection/TransferFormAccountSelection.scss
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormAccountSelection/TransferFormAccountSelection.scss
@@ -16,7 +16,6 @@
         height: 100%;
         border-radius: 0;
         box-shadow: none;
-        z-index: 100;
     }
 
     &__loader {

--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormAccountSelection/TransferFormAccountSelection.scss
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormAccountSelection/TransferFormAccountSelection.scss
@@ -33,6 +33,8 @@
             padding: 0 1.6rem 1.6rem;
             gap: 1.6rem;
             overflow-y: unset;
+            //prevent content bouncing on scroll on iPhone devices
+            overscroll-behavior: none;
         }
     }
 


### PR DESCRIPTION
## Changes:

- fix bouncing when scroll up/down on iPhone devices
- fix overlapping side navigation menu by dropdown transfer

### Screenshots:
bug:
https://github.com/binary-com/deriv-app/assets/103181646/d43b051a-7eb7-428e-b4cb-741eafa1582b
fix:
https://github.com/binary-com/deriv-app/assets/103181646/5bd6b503-b76f-4bb4-a3fb-b75dd52a2fee

Bug overlapping:
<img width="750" alt="Screenshot 2024-01-06 at 12 27 41" src="https://github.com/binary-com/deriv-app/assets/103181646/a49821a4-635d-4a24-a301-2e2f94cc79cc">
Fix overlapping
<img width="664" alt="Screenshot 2024-01-06 at 12 29 29" src="https://github.com/binary-com/deriv-app/assets/103181646/069ca356-db20-4f0e-81c6-b51d0d3fdb25">




