### PR TITLE
Ako/ remove datadog session replay

### DIFF
--- a/packages/core/src/Utils/Datadog/index.ts
+++ b/packages/core/src/Utils/Datadog/index.ts
@@ -69,6 +69,4 @@ if (isProduction || isStaging) {
             }
         },
     });
-
-    datadogRum.startSessionReplayRecording();
 }


### PR DESCRIPTION
## Changes:

This is to ensure that we are not running datadog session replay on the repo.

### Screenshots:

Please provide some screenshots of the change.
