### PR TITLE
[WALL] Aum/WALL-3240/fix-transfer-blue-message-showing-for-small-amount

### DIFF
--- a/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/useTransferMessages.ts
+++ b/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/useTransferMessages.ts
@@ -51,6 +51,7 @@ const useTransferMessages = ({
     const fiatAccount = walletAccounts?.find(account => account.account_type === 'doughflow');
 
     const sourceAmount = formData.fromAmount;
+    const targetAmount = formData.toAmount;
 
     const messageFns: ((props: TMessageFnProps) => TTransferMessage | null)[] = [];
     const messages: TTransferMessage[] = [];
@@ -77,6 +78,7 @@ const useTransferMessages = ({
             sourceAccount: fromAccount,
             sourceAmount,
             targetAccount: toAccount,
+            targetAmount,
             USDExchangeRates,
         });
         if (message) messages.push(message);

--- a/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/utils/transferFeesBetweenWalletsMessageFn.ts
+++ b/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/utils/transferFeesBetweenWalletsMessageFn.ts
@@ -6,8 +6,15 @@ const transferFeesBetweenWalletsMessageFn = ({
     sourceAccount,
     sourceAmount,
     targetAccount,
+    targetAmount,
 }: TMessageFnProps) => {
-    if (!sourceAccount.currency || !sourceAccount.currencyConfig || !sourceAmount || !targetAccount?.currency)
+    if (
+        !sourceAccount.currency ||
+        !sourceAccount.currencyConfig ||
+        !sourceAmount ||
+        !targetAmount ||
+        !targetAccount?.currency
+    )
         return null;
 
     const isTransferBetweenCryptoWallets =

--- a/packages/wallets/src/features/cashier/modules/Transfer/types/types.ts
+++ b/packages/wallets/src/features/cashier/modules/Transfer/types/types.ts
@@ -40,4 +40,5 @@ export type TMessageFnProps = {
     sourceAccount: NonNullable<TAccount>;
     sourceAmount: number;
     targetAccount: TAccount;
+    targetAmount: number;
 };


### PR DESCRIPTION
## Changes:

🐛 Fix for transfer between wallets:
- Hide the blue message for transfer fees when a very small amount is entered for transfer as the amount will be rounded-off to zero for the opposite field after conversion.
- Disable the transfer button if the above scenario is encountered.

[](https://github.com/binary-com/deriv-app/assets/125039206/4e4a3f9f-858b-4bac-b9e1-e9dc760bab8a)
