### PR TITLE
[WALL] Lubega / WALL-3245 / Fix: Enter/create password modal ui issues

### DIFF
--- a/packages/wallets/src/components/Base/WalletTextField/WalletTextField.scss
+++ b/packages/wallets/src/components/Base/WalletTextField/WalletTextField.scss
@@ -20,17 +20,12 @@
             border: 1px solid var(--brand-blue, #ec3f3f);
         }
 
-        .wallets-textfield__field,
         .wallets-textfield__label {
             color: #ec3f3f;
         }
+
         .wallets-textfield__field:focus ~ .wallets-textfield__label {
             color: #ec3f3f;
-        }
-
-        .wallets-textfield__icon-left,
-        .wallets-textfield__icon-right {
-            filter: invert(37%) sepia(87%) saturate(4597%) hue-rotate(343deg) brightness(98%) contrast(87%); //#ec3f3f for svg icon
         }
     }
 

--- a/packages/wallets/src/features/cfd/screens/EnterPassword/EnterPassword.scss
+++ b/packages/wallets/src/features/cfd/screens/EnterPassword/EnterPassword.scss
@@ -35,6 +35,8 @@
         @include mobile {
             text-align: center;
             gap: 1.6rem;
+            width: 100%;
+            align-items: center;
         }
     }
 


### PR DESCRIPTION
## Changes:

- [x] Changed text and icon in password field to match design colour
- [x] Fixed issue where password field length changing depending on error message

### Screenshots:
Before:
![image](https://github.com/binary-com/deriv-app/assets/142860499/6cf32157-7a86-461e-b187-36be2ed81e4e)

https://github.com/binary-com/deriv-app/assets/142860499/eaec6e49-eacd-4518-9253-99d145f38edc


After:
![image](https://github.com/binary-com/deriv-app/assets/142860499/c6fbba6d-bbf1-45bd-bbec-72580499ce01)

https://github.com/binary-com/deriv-app/assets/142860499/436ac9e3-59a2-4559-a7c4-6ae580c99896

