### PR TITLE
[WALL] Lubega / WALL-3257 / Fix: Remove EU/Non-EU label

### DIFF
--- a/packages/cashier/src/modules/cashier-onboarding/components/cashier-onboarding-account-identifier-message/__test__/cashier-onboarding-account-identifier-message.test.tsx
+++ b/packages/cashier/src/modules/cashier-onboarding/components/cashier-onboarding-account-identifier-message/__test__/cashier-onboarding-account-identifier-message.test.tsx
@@ -18,35 +18,7 @@ jest.mock('@deriv/api', () => ({
 }));
 
 describe('CashierOnboardingAccountIdentifierMessage', () => {
-    test('should not show regulation for crypto accounts', () => {
-        const mock = mockStore({
-            client: { currency: 'BTC' },
-        });
-
-        const wrapper = ({ children }: { children: JSX.Element }) => (
-            <StoreProvider store={mock}>{children}</StoreProvider>
-        );
-        render(<CashierOnboardingAccountIdentifierMessage />, { wrapper });
-
-        expect(screen.queryByText(/EU/)).not.toBeInTheDocument();
-        expect(screen.queryByText(/non-EU/)).not.toBeInTheDocument();
-    });
-
-    test('should not show regulation for low risk account', () => {
-        const mock = mockStore({
-            client: { currency: 'USD', is_low_risk: true },
-        });
-
-        const wrapper = ({ children }: { children: JSX.Element }) => (
-            <StoreProvider store={mock}>{children}</StoreProvider>
-        );
-        render(<CashierOnboardingAccountIdentifierMessage />, { wrapper });
-
-        expect(screen.queryByText(/EU/)).not.toBeInTheDocument();
-        expect(screen.queryByText(/non-EU/)).not.toBeInTheDocument();
-    });
-
-    test('should show regulation for fiat currency', () => {
+    test('should show fiat currency in identfier message for active fiat account', () => {
         const mock = mockStore({
             client: { currency: 'USD' },
         });
@@ -56,6 +28,20 @@ describe('CashierOnboardingAccountIdentifierMessage', () => {
         );
         render(<CashierOnboardingAccountIdentifierMessage />, { wrapper });
 
-        expect(screen.queryByText(/non-EU/)).toBeInTheDocument();
+        expect(screen.queryByText('USD')).toBeInTheDocument();
+    });
+
+    test('should show crypto currency in identfier message for active crypto account', () => {
+        const mock = mockStore({
+            client: { currency: 'BTC' },
+        });
+
+        const wrapper = ({ children }: { children: JSX.Element }) => (
+            <StoreProvider store={mock}>{children}</StoreProvider>
+        );
+        render(<CashierOnboardingAccountIdentifierMessage />, { wrapper });
+
+        expect(screen.queryByText('USD')).not.toBeInTheDocument();
+        expect(screen.queryByText('BTC')).toBeInTheDocument();
     });
 });

--- a/packages/cashier/src/modules/cashier-onboarding/components/cashier-onboarding-account-identifier-message/cashier-onboarding-account-identifier-message.tsx
+++ b/packages/cashier/src/modules/cashier-onboarding/components/cashier-onboarding-account-identifier-message/cashier-onboarding-account-identifier-message.tsx
@@ -6,10 +6,8 @@ import { Localize } from '@deriv/translations';
 
 const CashierOnboardingAccountIdentifierMessage: React.FC = observer(() => {
     const { client } = useStore();
-    const { loginid, is_eu, is_low_risk } = client;
+    const { loginid } = client;
     const currency_config = useCurrentCurrencyConfig();
-    const regulation_text = is_eu ? 'EU ' : 'non-EU ';
-    const regulation = currency_config.is_crypto || is_low_risk ? '' : regulation_text;
 
     return (
         <InlineMessage
@@ -17,8 +15,8 @@ const CashierOnboardingAccountIdentifierMessage: React.FC = observer(() => {
             size='sm'
             message={
                 <Localize
-                    i18n_default_text='This is your <0>{{regulation}}{{currency}}</0> account {{loginid}}.'
-                    values={{ regulation, currency: currency_config.display_code, loginid }}
+                    i18n_default_text='This is your <0>{{currency}}</0> account {{loginid}}.'
+                    values={{ currency: currency_config.display_code, loginid }}
                     components={[<strong key={0} />]}
                 />
             }


### PR DESCRIPTION
## Changes:

- [x] Remove EU/Non-EU label in cashier onboarding identifier message
- [x] Updated identifier message to test for currency instead of regulation

### Screenshots:

<img width="1221" alt="Screenshot 2024-01-09 at 6 13 04 PM" src="https://github.com/binary-com/deriv-app/assets/142860499/fefee3eb-4647-45f2-8f91-c30f24211f43">

<img width="1728" alt="Screenshot 2024-01-09 at 5 28 38 PM" src="https://github.com/binary-com/deriv-app/assets/142860499/9af6e1c2-9202-432e-919a-ec4a6733c749">



