### PR TITLE
refactor: moved advert related hooks to its own entity

### DIFF
--- a/packages/api/src/__tests__/useAdvertList.spec.tsx
+++ b/packages/api/src/__tests__/useAdvertList.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import useInfiniteQuery from '../useInfiniteQuery';
 import { renderHook } from '@testing-library/react-hooks';
-import useAdvertList from '../hooks/p2p/useAdvertList';
+import useAdvertList from '../hooks/p2p/entity/advert/p2p-advert/useAdvertList';
 import APIProvider from '../APIProvider';
 
 jest.mock('../useInfiniteQuery');

--- a/packages/api/src/hooks/p2p/__tests__/useAdvertiserAdverts.spec.tsx
+++ b/packages/api/src/hooks/p2p/__tests__/useAdvertiserAdverts.spec.tsx
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks';
-import useAdvertiserAdverts from '../useAdvertiserAdverts';
+import useAdvertiserAdverts from '../entity/advert/p2p-advertiser-adverts/useAdvertiserAdverts';
 import useInfiniteQuery from '../../../useInfiniteQuery';
 import APIProvider from '../../../APIProvider';
 import React from 'react';

--- a/packages/api/src/hooks/p2p/entity/advert/index.ts
+++ b/packages/api/src/hooks/p2p/entity/advert/index.ts
@@ -1,0 +1,2 @@
+export * as advert from './p2p-advert';
+export * as advertiserAdverts from './p2p-advertiser-adverts';

--- a/packages/api/src/hooks/p2p/entity/advert/p2p-advert/index.ts
+++ b/packages/api/src/hooks/p2p/entity/advert/p2p-advert/index.ts
@@ -1,0 +1,5 @@
+export { default as useGet } from './useAdvertInfo';
+export { default as useGetList } from './useAdvertList';
+export { default as useCreate } from './useAdvertCreate';
+export { default as useUpdate } from './useAdvertUpdate';
+export { default as useDelete } from './useAdvertDelete';

--- a/packages/api/src/hooks/p2p/entity/advert/p2p-advert/useAdvertCreate.ts
+++ b/packages/api/src/hooks/p2p/entity/advert/p2p-advert/useAdvertCreate.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
-import useMutation from '../../useMutation';
-import useInvalidateQuery from '../../useInvalidateQuery';
+import useMutation from '../../../../../useMutation';
+import useInvalidateQuery from '../../../../../useInvalidateQuery';
 
 type TPayload = Parameters<ReturnType<typeof useMutation<'p2p_advert_create'>>['mutate']>[0]['payload'];
 
@@ -19,7 +19,7 @@ type TPayload = Parameters<ReturnType<typeof useMutation<'p2p_advert_create'>>['
     });
  * 
 */
-const useP2PAdvertCreate = () => {
+const useAdvertCreate = () => {
     const invalidate = useInvalidateQuery();
     const {
         data,
@@ -58,4 +58,4 @@ const useP2PAdvertCreate = () => {
     };
 };
 
-export default useP2PAdvertCreate;
+export default useAdvertCreate;

--- a/packages/api/src/hooks/p2p/entity/advert/p2p-advert/useAdvertDelete.ts
+++ b/packages/api/src/hooks/p2p/entity/advert/p2p-advert/useAdvertDelete.ts
@@ -1,20 +1,20 @@
 import { useCallback, useMemo } from 'react';
-import useMutation from '../../useMutation';
-import useInvalidateQuery from '../../useInvalidateQuery';
+import useMutation from '../../../../../useMutation';
+import useInvalidateQuery from '../../../../../useInvalidateQuery';
 
 type TPayload = Parameters<ReturnType<typeof useMutation<'p2p_advert_update'>>['mutate']>[0]['payload'];
 
-/** A custom hook that updates a P2P advert. This can only be used by an approved P2P advertiser.
+/** A custom hook that deletes a P2P advert. This can only be used by an approved P2P advertiser.
  * 
- * To update an advert, specify the payload arguments that should be updated, for instance:
+ * To delete an advert, specify the advert ID to delete, for instance:
  * @example
  *  mutate({
-        "id": 1234, // required
-        "is_active": 0 // optional
+        "id": 1234
     });
- * 
+ *
+ * Once this is mutated, the advert with ID of 1234 will be deleted.
 */
-const useAdvertUpdate = () => {
+const useAdvertDelete = () => {
     const invalidate = useInvalidateQuery();
     const {
         data,
@@ -26,10 +26,20 @@ const useAdvertUpdate = () => {
         },
     });
 
-    const mutate = useCallback((payload: TPayload) => _mutate({ payload }), [_mutate]);
+    const mutate = useCallback(
+        (payload: Omit<TPayload, 'delete'>) =>
+            _mutate({
+                payload: {
+                    ...payload,
+                    delete: 1,
+                },
+            }),
+        [_mutate]
+    );
 
     const modified_data = useMemo(() => {
         const p2p_advert_update = data?.p2p_advert_update;
+
         if (!p2p_advert_update) return undefined;
 
         return {
@@ -52,4 +62,4 @@ const useAdvertUpdate = () => {
     };
 };
 
-export default useAdvertUpdate;
+export default useAdvertDelete;

--- a/packages/api/src/hooks/p2p/entity/advert/p2p-advert/useAdvertInfo.ts
+++ b/packages/api/src/hooks/p2p/entity/advert/p2p-advert/useAdvertInfo.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import useQuery from '../../useQuery';
+import useQuery from '../../../../../useQuery';
 
 /**
  * This custom hook returns the advert information about the given advert ID.

--- a/packages/api/src/hooks/p2p/entity/advert/p2p-advert/useAdvertList.ts
+++ b/packages/api/src/hooks/p2p/entity/advert/p2p-advert/useAdvertList.ts
@@ -1,6 +1,6 @@
 import React from 'react';
-import useInfiniteQuery from '../../useInfiniteQuery';
-import useAuthorize from '../useAuthorize';
+import useInfiniteQuery from '../../../../../useInfiniteQuery';
+import useAuthorize from '../../../../useAuthorize';
 
 /**
  * This custom hook returns available adverts for use with 'p2p_order_create' by calling 'p2p_advert_list' endpoint

--- a/packages/api/src/hooks/p2p/entity/advert/p2p-advert/useAdvertUpdate.ts
+++ b/packages/api/src/hooks/p2p/entity/advert/p2p-advert/useAdvertUpdate.ts
@@ -1,20 +1,20 @@
 import { useCallback, useMemo } from 'react';
-import useMutation from '../../useMutation';
-import useInvalidateQuery from '../../useInvalidateQuery';
+import useMutation from '../../../../../useMutation';
+import useInvalidateQuery from '../../../../../useInvalidateQuery';
 
 type TPayload = Parameters<ReturnType<typeof useMutation<'p2p_advert_update'>>['mutate']>[0]['payload'];
 
-/** A custom hook that deletes a P2P advert. This can only be used by an approved P2P advertiser.
+/** A custom hook that updates a P2P advert. This can only be used by an approved P2P advertiser.
  * 
- * To delete an advert, specify the advert ID to delete, for instance:
+ * To update an advert, specify the payload arguments that should be updated, for instance:
  * @example
  *  mutate({
-        "id": 1234
+        "id": 1234, // required
+        "is_active": 0 // optional
     });
- *
- * Once this is mutated, the advert with ID of 1234 will be deleted.
+ * 
 */
-const useAdvertDelete = () => {
+const useAdvertUpdate = () => {
     const invalidate = useInvalidateQuery();
     const {
         data,
@@ -26,20 +26,10 @@ const useAdvertDelete = () => {
         },
     });
 
-    const mutate = useCallback(
-        (payload: Omit<TPayload, 'delete'>) =>
-            _mutate({
-                payload: {
-                    ...payload,
-                    delete: 1,
-                },
-            }),
-        [_mutate]
-    );
+    const mutate = useCallback((payload: TPayload) => _mutate({ payload }), [_mutate]);
 
     const modified_data = useMemo(() => {
         const p2p_advert_update = data?.p2p_advert_update;
-
         if (!p2p_advert_update) return undefined;
 
         return {
@@ -62,4 +52,4 @@ const useAdvertDelete = () => {
     };
 };
 
-export default useAdvertDelete;
+export default useAdvertUpdate;

--- a/packages/api/src/hooks/p2p/entity/advert/p2p-advertiser-adverts/index.ts
+++ b/packages/api/src/hooks/p2p/entity/advert/p2p-advertiser-adverts/index.ts
@@ -1,0 +1,1 @@
+export { default as useGet } from './useAdvertiserAdverts';

--- a/packages/api/src/hooks/p2p/entity/advert/p2p-advertiser-adverts/useAdvertiserAdverts.ts
+++ b/packages/api/src/hooks/p2p/entity/advert/p2p-advertiser-adverts/useAdvertiserAdverts.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
-import useInfiniteQuery from '../../useInfiniteQuery';
-import useAuthorize from '../useAuthorize';
+import useInfiniteQuery from '../../../../../useInfiniteQuery';
+import useAuthorize from '../../../../useAuthorize';
 
 /** This custom hook returns a list of adverts under the current active client. */
 const useAdvertiserAdverts = (

--- a/packages/api/src/hooks/p2p/entity/index.ts
+++ b/packages/api/src/hooks/p2p/entity/index.ts
@@ -1,1 +1,2 @@
 export * from './payment-method';
+export * from './advert';


### PR DESCRIPTION
## Changes:

Moved advert related hooks to advert entity - create, update, list, info, delete, advertiser, adverts

### Screenshots:

Please provide some screenshots of the change.
