### PR TITLE
[WALL] Lubega / WALL-3243 / Fix: Transactions CTrader completed transfer message

### DIFF
--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/TransactionsCompletedRow.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/TransactionsCompletedRow.tsx
@@ -16,7 +16,7 @@ const TransactionsCompletedRow: React.FC<TProps> = ({ accounts, transaction, wal
     const dxtradeOrCtraderToFrom = useMemo(() => {
         if (transaction?.action_type !== 'transfer' || !transaction.longcode) return null;
         const longcodeMessageTokens = transaction.longcode.split(' ');
-        const direction = longcodeMessageTokens[4] !== 'cTrader' && longcodeMessageTokens[1] === 'from' ? 'from' : 'to';
+        const direction = longcodeMessageTokens[4] === 'cTrader' ? 'to' : longcodeMessageTokens[1];
         const dxtradeOrCtraderLoginid = longcodeMessageTokens.find(
             token => token.startsWith('DX') || token.startsWith('CT')
         );

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/TransactionsCompletedRow.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/TransactionsCompletedRow.tsx
@@ -16,7 +16,7 @@ const TransactionsCompletedRow: React.FC<TProps> = ({ accounts, transaction, wal
     const dxtradeOrCtraderToFrom = useMemo(() => {
         if (transaction?.action_type !== 'transfer' || !transaction.longcode) return null;
         const longcodeMessageTokens = transaction.longcode.split(' ');
-        const direction = longcodeMessageTokens[1];
+        const direction = longcodeMessageTokens[2] === 'cTrader' ? 'to' : longcodeMessageTokens[1];
         const dxtradeOrCtraderLoginid = longcodeMessageTokens.find(
             token => token.startsWith('DX') || token.startsWith('CT')
         );

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/TransactionsCompletedRow.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/TransactionsCompletedRow.tsx
@@ -16,7 +16,7 @@ const TransactionsCompletedRow: React.FC<TProps> = ({ accounts, transaction, wal
     const dxtradeOrCtraderToFrom = useMemo(() => {
         if (transaction?.action_type !== 'transfer' || !transaction.longcode) return null;
         const longcodeMessageTokens = transaction.longcode.split(' ');
-        const direction = longcodeMessageTokens[2] === 'cTrader' ? 'to' : longcodeMessageTokens[1];
+        const direction = longcodeMessageTokens[4] !== 'cTrader' && longcodeMessageTokens[1] === 'from' ? 'from' : 'to';
         const dxtradeOrCtraderLoginid = longcodeMessageTokens.find(
             token => token.startsWith('DX') || token.startsWith('CT')
         );


### PR DESCRIPTION
## Changes:

- [x] Fixed CTrader completed transactions message to show either 'Transfer to' or 'Transfer from' depending on type of transfer
- [x] Updated direction logic based on longcode difference between CTrader and DerivX messages for this temporary workaround before backend adds `to` and `from` for Deriv X and CTrader transfers

### Screenshots:
<img width="1108" alt="image" src="https://github.com/binary-com/deriv-app/assets/142860499/050b1f00-2862-4d63-a1f4-f460a29d3270">

<img width="330" alt="Screenshot 2024-01-10 at 1 43 40 PM" src="https://github.com/binary-com/deriv-app/assets/142860499/6f4ce29c-ede2-4053-9e7a-52561994d4b4">

<img width="415" alt="Screenshot 2024-01-10 at 1 44 13 PM" src="https://github.com/binary-com/deriv-app/assets/142860499/b878de90-0a28-48dc-9aad-14ab807d2465">

