### PR TITLE
[TRAH] Aizad/TRAH-2651/Trading App Card improvements

### DIFF
--- a/packages/tradershub/src/components/OptionsAndMultipliersSection/OptionsAndMultipliersContent/OptionsAndMultipliersContent.tsx
+++ b/packages/tradershub/src/components/OptionsAndMultipliersSection/OptionsAndMultipliersContent/OptionsAndMultipliersContent.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 import { useActiveTradingAccount, useIsEuRegion } from '@deriv/api';
-import { Button, Text, useBreakpoint } from '@deriv/quill-design';
+import { Button, useBreakpoint } from '@deriv/quill-design';
 import { optionsAndMultipliersContent } from '../../../constants/constants';
 import { getStaticUrl, getUrlBinaryBot, getUrlSmartTrader } from '../../../helpers/urls';
 import { TradingAppCardLoader } from '../../Loaders';
-import { TradingAccountCard } from '../../TradingAccountCard';
+import { TradingAccountCard, TradingAccountCardContent } from '../../TradingAccountCard';
 
 type OptionsAndMultipliersContentItem = {
     description: string;
@@ -112,28 +112,22 @@ const OptionsAndMultipliersContent = () => {
     return (
         <div className='grid w-full grid-cols-1 gap-200 lg:grid-cols-3 lg:gap-x-1200 lg:gap-y-200'>
             {filteredContent.map(account => {
-                const trailingComponent = () => (
-                    <ShowOpenButton isExternal={account.isExternal} redirect={account.redirect} />
-                );
+                const { description, icon, isExternal, redirect, smallIcon, title } = account;
+
+                const trailingComponent = () => <ShowOpenButton isExternal={isExternal} redirect={redirect} />;
 
                 const leadingComponent = () => (
-                    <LinkTitle icon={data?.loginid || !isMobile ? account.icon : account.smallIcon} title={title} />
+                    <LinkTitle icon={data?.loginid || !isMobile ? icon : smallIcon} title={title} />
                 );
 
-                const title = account.title;
                 return (
                     <TradingAccountCard
                         {...account}
-                        key={`trading-account-card-${account.title}`}
+                        key={`trading-account-card-${title}`}
                         leading={leadingComponent}
                         trailing={trailingComponent}
                     >
-                        <div className='flex flex-col flex-grow'>
-                            <Text bold size='sm'>
-                                {account.title}
-                            </Text>
-                            <Text className='text-[12px]'>{account.description}</Text>
-                        </div>
+                        <TradingAccountCardContent title={title}>{description}</TradingAccountCardContent>
                     </TradingAccountCard>
                 );
             })}

--- a/packages/tradershub/src/components/TradingAccountCard/TradingAccountCardComponent.tsx
+++ b/packages/tradershub/src/components/TradingAccountCard/TradingAccountCardComponent.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Button, ButtonProps, Text } from '@deriv/quill-design';
+
+type TTradingAccountCardContent = {
+    children: string;
+    title: string;
+};
+
+export const TradingAccountCardContent = ({ children, title }: TTradingAccountCardContent) => (
+    <div className='grow'>
+        <Text bold className='leading-200' size='sm'>
+            {title}
+        </Text>
+        <Text className='text-[12px] leading-100 w-5/6 lg:w-full'>{children}</Text>
+    </div>
+);
+
+type TTradingAccountCardButton = {
+    onSubmit?: ButtonProps['onClick'];
+};
+
+export const TradingAccountCardLightButton = ({ onSubmit }: TTradingAccountCardButton) => (
+    <Button
+        className='rounded-200 bg-solid-coral-100 text-solid-coral-700 enabled:hover:bg-solid-red-200'
+        onClick={onSubmit}
+        variant='primary'
+    >
+        Get
+    </Button>
+);

--- a/packages/tradershub/src/components/TradingAccountCard/index.ts
+++ b/packages/tradershub/src/components/TradingAccountCard/index.ts
@@ -1,1 +1,2 @@
 export { default as TradingAccountCard } from './TradingAccountCard';
+export * from './TradingAccountCardComponent';

--- a/packages/tradershub/src/features/cfd/flows/CTrader/AvailableCTraderAccountsList/AvailableCTraderAccountsList.tsx
+++ b/packages/tradershub/src/features/cfd/flows/CTrader/AvailableCTraderAccountsList/AvailableCTraderAccountsList.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { useActiveTradingAccount, useCreateOtherCFDAccount } from '@deriv/api';
-import { Button, Text } from '@deriv/quill-design';
-import { TradingAccountCard } from '../../../../../components';
+import {
+    TradingAccountCard,
+    TradingAccountCardContent,
+    TradingAccountCardLightButton,
+} from '../../../../../components/TradingAccountCard';
 import { getStaticUrl } from '../../../../../helpers/urls';
 import CTrader from '../../../../../public/images/cfd/ctrader.svg';
 import { PlatformDetails } from '../../../constants';
@@ -39,23 +42,14 @@ const AvailableCTraderAccountsList = () => {
         </div>
     );
 
-    const TrailingButton = () => (
-        <Button className='rounded-200' colorStyle='coral' onClick={onSubmit} variant='primary'>
-            Get
-        </Button>
-    );
+    const TrailingButton = () => <TradingAccountCardLightButton onSubmit={onSubmit} />;
 
     return (
         <div>
             <TradingAccountCard leading={LeadingIcon} trailing={TrailingButton}>
-                <div className='grow user-select-none'>
-                    <Text bold className='leading-200' size='sm'>
-                        {PlatformDetails.ctrader.title}
-                    </Text>
-                    <Text className='text-[12px] leading-100 w-5/6 lg:w-full'>
-                        This account offers CFDs on a feature-rich trading platform.
-                    </Text>
-                </div>
+                <TradingAccountCardContent title={PlatformDetails.ctrader.title}>
+                    This account offers CFDs on a feature-rich trading platform.
+                </TradingAccountCardContent>
             </TradingAccountCard>
         </div>
     );

--- a/packages/tradershub/src/features/cfd/flows/CTrader/AvailableCTraderAccountsList/AvailableCTraderAccountsList.tsx
+++ b/packages/tradershub/src/features/cfd/flows/CTrader/AvailableCTraderAccountsList/AvailableCTraderAccountsList.tsx
@@ -22,7 +22,7 @@ const AvailableCTraderAccountsList = () => {
         });
     };
 
-    const leadingIcon = () => (
+    const LeadingIcon = () => (
         <div
             className='cursor-pointer'
             onClick={() => {
@@ -39,7 +39,7 @@ const AvailableCTraderAccountsList = () => {
         </div>
     );
 
-    const trailingButton = () => (
+    const TrailingButton = () => (
         <Button className='rounded-200' colorStyle='coral' onClick={onSubmit} variant='primary'>
             Get
         </Button>
@@ -47,12 +47,14 @@ const AvailableCTraderAccountsList = () => {
 
     return (
         <div>
-            <TradingAccountCard leading={leadingIcon} trailing={trailingButton}>
-                <div className='flex flex-col flex-grow'>
-                    <Text bold size='sm'>
+            <TradingAccountCard leading={LeadingIcon} trailing={TrailingButton}>
+                <div className='grow user-select-none'>
+                    <Text bold className='leading-200' size='sm'>
                         {PlatformDetails.ctrader.title}
                     </Text>
-                    <Text className='text-[12px]'>This account offers CFDs on a feature-rich trading platform.</Text>
+                    <Text className='text-[12px] leading-100 w-5/6 lg:w-full'>
+                        This account offers CFDs on a feature-rich trading platform.
+                    </Text>
                 </div>
             </TradingAccountCard>
         </div>

--- a/packages/tradershub/src/features/cfd/flows/MT5/AvailableMT5AccountsList/AvailableMT5AccountsList.tsx
+++ b/packages/tradershub/src/features/cfd/flows/MT5/AvailableMT5AccountsList/AvailableMT5AccountsList.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
-import { Button, Text } from '@deriv/quill-design';
-import { TradingAccountCard } from '../../../../../components';
+import {
+    TradingAccountCard,
+    TradingAccountCardContent,
+    TradingAccountCardLightButton,
+} from '../../../../../components';
 import { THooks } from '../../../../../types';
 import { MarketTypeDetails } from '../../../constants';
 import { MT5AccountIcon } from '../MT5AccountIcon';
@@ -10,20 +13,11 @@ const AvailableMT5AccountsList = ({ account }: { account: THooks.MT5AccountsList
 
     const LeadingIcon = () => <MT5AccountIcon account={account} />;
 
-    const TrailingButton = () => (
-        <Button className='rounded-200' colorStyle='coral' variant='primary'>
-            Get
-        </Button>
-    );
+    const TrailingButton = () => <TradingAccountCardLightButton />;
 
     return (
         <TradingAccountCard leading={LeadingIcon} trailing={TrailingButton}>
-            <div className='grow user-select-none'>
-                <Text bold className='leading-200' size='sm'>
-                    {title}
-                </Text>
-                <Text className='text-[12px] leading-100 w-5/6 lg:w-full'>{description}</Text>
-            </div>
+            <TradingAccountCardContent title={title}>{description}</TradingAccountCardContent>
         </TradingAccountCard>
     );
 };

--- a/packages/tradershub/src/features/cfd/flows/MT5/AvailableMT5AccountsList/AvailableMT5AccountsList.tsx
+++ b/packages/tradershub/src/features/cfd/flows/MT5/AvailableMT5AccountsList/AvailableMT5AccountsList.tsx
@@ -8,24 +8,21 @@ import { MT5AccountIcon } from '../MT5AccountIcon';
 const AvailableMT5AccountsList = ({ account }: { account: THooks.MT5AccountsList }) => {
     const { description, title } = MarketTypeDetails[account.market_type || 'all'];
 
+    const LeadingIcon = () => <MT5AccountIcon account={account} />;
+
+    const TrailingButton = () => (
+        <Button className='rounded-200' colorStyle='coral' variant='primary'>
+            Get
+        </Button>
+    );
+
     return (
-        <TradingAccountCard
-            leading={() => <MT5AccountIcon account={account} />}
-            trailing={() => (
-                <Button
-                    className='rounded-200'
-                    colorStyle='coral'
-                    variant='primary' /* onClick show MT5PasswordModal : JurisdictionModal */
-                >
-                    Get
-                </Button>
-            )}
-        >
-            <div className='flex-grow user-select-none'>
-                <Text bold className='leading-[20px]' size='md'>
+        <TradingAccountCard leading={LeadingIcon} trailing={TrailingButton}>
+            <div className='grow user-select-none'>
+                <Text bold className='leading-200' size='sm'>
                     {title}
                 </Text>
-                <Text className='leading-[14px] text-[12px]'>{description}</Text>
+                <Text className='text-[12px] leading-100 w-5/6 lg:w-full'>{description}</Text>
             </div>
         </TradingAccountCard>
     );

--- a/packages/tradershub/src/features/cfd/flows/OtherCFDs/Dxtrade/AvailableDxtradeAccountsList/AvailableDxtradeAccountsList.tsx
+++ b/packages/tradershub/src/features/cfd/flows/OtherCFDs/Dxtrade/AvailableDxtradeAccountsList/AvailableDxtradeAccountsList.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
-import { Button, Text } from '@deriv/quill-design';
-import { TradingAccountCard } from '../../../../../../components';
+import {
+    TradingAccountCard,
+    TradingAccountCardContent,
+    TradingAccountCardLightButton,
+} from '../../../../../../components/TradingAccountCard';
 import { getStaticUrl } from '../../../../../../helpers/urls';
 import DerivX from '../../../../../../public/images/cfd/derivx.svg';
+import { PlatformDetails } from '../../../../constants';
 
 const LeadingIcon = () => (
     <div
@@ -21,22 +25,13 @@ const LeadingIcon = () => (
     </div>
 );
 
-const TrailingButton = () => (
-    <Button className='rounded-200' colorStyle='coral' variant='primary'>
-        Get
-    </Button>
-);
+const TrailingButton = () => <TradingAccountCardLightButton />;
 
 const AvailableDxtradeAccountsList = () => (
     <TradingAccountCard leading={LeadingIcon} trailing={TrailingButton}>
-        <div className='grow user-select-none'>
-            <Text bold className='leading-200' size='sm'>
-                Deriv X
-            </Text>
-            <Text className='text-[12px] leading-100 w-5/6 lg:w-full'>
-                This account offers CFDs on a highly customisable CFD trading platform.
-            </Text>
-        </div>
+        <TradingAccountCardContent title={PlatformDetails.dxtrade.title}>
+            This account offers CFDs on a highly customisable CFD trading platform.
+        </TradingAccountCardContent>
     </TradingAccountCard>
 );
 

--- a/packages/tradershub/src/features/cfd/flows/OtherCFDs/Dxtrade/AvailableDxtradeAccountsList/AvailableDxtradeAccountsList.tsx
+++ b/packages/tradershub/src/features/cfd/flows/OtherCFDs/Dxtrade/AvailableDxtradeAccountsList/AvailableDxtradeAccountsList.tsx
@@ -4,46 +4,40 @@ import { TradingAccountCard } from '../../../../../../components';
 import { getStaticUrl } from '../../../../../../helpers/urls';
 import DerivX from '../../../../../../public/images/cfd/derivx.svg';
 
-const leading = () => {
-    return (
-        <div
-            className='cursor-pointer'
-            onClick={() => {
+const LeadingIcon = () => (
+    <div
+        className='cursor-pointer'
+        onClick={() => {
+            window.open(getStaticUrl('/derivx'));
+        }}
+        onKeyDown={e => {
+            if (e.key === 'Enter') {
                 window.open(getStaticUrl('/derivx'));
-            }}
-            onKeyDown={e => {
-                if (e.key === 'Enter') {
-                    window.open(getStaticUrl('/derivx'));
-                }
-            }}
-            role='button'
-        >
-            <DerivX />
+            }
+        }}
+        role='button'
+    >
+        <DerivX />
+    </div>
+);
+
+const TrailingButton = () => (
+    <Button className='rounded-200' colorStyle='coral' variant='primary'>
+        Get
+    </Button>
+);
+
+const AvailableDxtradeAccountsList = () => (
+    <TradingAccountCard leading={LeadingIcon} trailing={TrailingButton}>
+        <div className='grow user-select-none'>
+            <Text bold className='leading-200' size='sm'>
+                Deriv X
+            </Text>
+            <Text className='text-[12px] leading-100 w-5/6 lg:w-full'>
+                This account offers CFDs on a highly customisable CFD trading platform.
+            </Text>
         </div>
-    );
-};
-
-const trailing = () => {
-    return (
-        <Button className='rounded-200' colorStyle='coral' variant='primary'>
-            Get
-        </Button>
-    );
-};
-
-const AvailableDxtradeAccountsList = () => {
-    return (
-        <TradingAccountCard leading={leading} trailing={trailing}>
-            <div className='flex flex-col flex-grow'>
-                <Text bold size='sm'>
-                    Deriv X
-                </Text>
-                <Text className='text-[12px]'>
-                    This account offers CFDs on a highly customisable CFD trading platform.
-                </Text>
-            </div>
-        </TradingAccountCard>
-    );
-};
+    </TradingAccountCard>
+);
 
 export default AvailableDxtradeAccountsList;


### PR DESCRIPTION
## Changes:

- Created a reusable component layout within the `TradingAccountCardComponent` and used across Options and Multipliers, MT5, Deriv X and CTrader accounts.
- Created a coral light button
- Fix alignment issues and some other minor tweaks
- All of the changes above supports different screen sizes

### Screenshots:

https://github.com/binary-com/deriv-app/assets/103104395/45d6a2e0-1794-4786-8924-16b10f1d3c50



