### PR TITLE
thisyahlen/TRAH-2664/chore: swap the order of cfd and deriv platform section and hide ctrader and derivx for eu

### DIFF
--- a/packages/tradershub/src/components/CFDSection/CFDContent/CFDContent.tsx
+++ b/packages/tradershub/src/components/CFDSection/CFDContent/CFDContent.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
+import { useIsEuRegion } from '@deriv/api';
 import { CTraderList, MT5PlatformsList, OtherCFDPlatformsList } from '../../../features/cfd/components';
 
-const CFDContent = () => (
-    <div className='space-y-800 pt-800 lg:space-y-1200 lg:pt-1200'>
-        <MT5PlatformsList />
-        <CTraderList />
-        <OtherCFDPlatformsList />
-    </div>
-);
+const CFDContent = () => {
+    const { isEU } = useIsEuRegion();
+    return (
+        <div className='space-y-800 pt-800 lg:space-y-1200 lg:pt-1200'>
+            <MT5PlatformsList />
+            {!isEU && <CTraderList />}
+            {!isEU && <OtherCFDPlatformsList />}
+        </div>
+    );
+};
 
 export default CFDContent;

--- a/packages/tradershub/src/components/TradersHubContent/TradersHubContent.tsx
+++ b/packages/tradershub/src/components/TradersHubContent/TradersHubContent.tsx
@@ -1,0 +1,25 @@
+import React, { Fragment } from 'react';
+import { useIsEuRegion } from '@deriv/api';
+import { CFDSection, OptionsAndMultipliersSection } from '..';
+
+const TradersHubContent = () => {
+    const { isEU } = useIsEuRegion();
+
+    if (isEU) {
+        return (
+            <Fragment>
+                <CFDSection />
+                <OptionsAndMultipliersSection />
+            </Fragment>
+        );
+    }
+
+    return (
+        <Fragment>
+            <OptionsAndMultipliersSection />
+            <CFDSection />
+        </Fragment>
+    );
+};
+
+export default TradersHubContent;

--- a/packages/tradershub/src/components/TradersHubContent/index.ts
+++ b/packages/tradershub/src/components/TradersHubContent/index.ts
@@ -1,0 +1,1 @@
+export { default as TradersHubContent } from './TradersHubContent';

--- a/packages/tradershub/src/components/index.ts
+++ b/packages/tradershub/src/components/index.ts
@@ -14,5 +14,6 @@ export * from './SentEmailContent';
 export * from './StaticLink';
 export * from './Tooltip';
 export * from './TotalAssets';
+export * from './TradersHubContent';
 export * from './TradingAccountCard';
 export * from './TradingAccountsList';

--- a/packages/tradershub/src/routes/TradersHubRoute/TradersHubRoute.tsx
+++ b/packages/tradershub/src/routes/TradersHubRoute/TradersHubRoute.tsx
@@ -9,6 +9,7 @@ import {
     RegulationSwitcherDesktop,
     RegulationSwitcherMobile,
     TotalAssets,
+    TradersHubContent,
 } from '../../components';
 
 const TradersHubRoute = () => {
@@ -56,8 +57,7 @@ const TradersHubRoute = () => {
                 {isSwitcherVisible && <RegulationSwitcherDesktop />}
                 <TotalAssets />
             </div>
-            <OptionsAndMultipliersSection />
-            <CFDSection />
+            <TradersHubContent />
         </div>
     );
 };


### PR DESCRIPTION
## Changes:
1. Dont show ctrader and derivx in eu countries
2. Show CFD section on top in eu countrues

### Screenshots:

https://github.com/binary-com/deriv-app/assets/104053934/aafe8dfe-1141-48c0-b4f9-11dac989df64


