### PR TITLE
[BOT] chore: add purchase condition value directly under purchase condition…

### DIFF
--- a/packages/bot-web-ui/src/stores/quick-strategy-store.ts
+++ b/packages/bot-web-ui/src/stores/quick-strategy-store.ts
@@ -157,14 +157,16 @@ export default class QuickStrategyStore implements IQuickStrategyStore {
                 el_block.innerHTML = value;
             });
         };
-        const { unit, action, ...rest_data } = data;
+        const { unit, action, type, ...rest_data } = data;
         const fields_to_update = {
             market,
             submarket,
             tradetypecat: trade_type_cat,
             dalembert_unit: unit,
             oscar_unit: unit,
+            type: 'both',
             ...rest_data,
+            purchase: type,
         };
 
         Object.keys(fields_to_update).forEach(key => {


### PR DESCRIPTION
Set contract type as both when loading a quick strategy. 

- Change `type` to 'both' when adding to XML from QS form
- Update `purchase` value to hold `type` was previously holding