### PR TITLE
[WALL] Lubega / WALL-3274 / Fix: Display hint message on invalid password input

### DIFF
--- a/packages/wallets/src/features/cfd/screens/EnterPassword/EnterPassword.tsx
+++ b/packages/wallets/src/features/cfd/screens/EnterPassword/EnterPassword.tsx
@@ -53,6 +53,12 @@ const EnterPassword: React.FC<TProps> = ({
                         shouldDisablePasswordMeter
                         showMessage={false}
                     />
+                    {passwordError && (
+                        <WalletText size='sm'>
+                            Hint: You may have entered your Deriv password, which is different from your {title}{' '}
+                            password.
+                        </WalletText>
+                    )}
                 </div>
             </div>
             {isDesktop && (


### PR DESCRIPTION
## Changes:

- [x] Display hint message when invalid password inputted

### Screenshots:

Figma reference:

<img width="408" alt="image" src="https://github.com/binary-com/deriv-app/assets/142860499/b056a500-d3f2-41f3-a9bf-f1de7a05cf27">



Fix:

https://github.com/binary-com/deriv-app/assets/142860499/7b650247-3190-49c1-97a1-e5d7299bb296


