### PR TITLE
thisyahlen/chore: filter mt5 accounts for eu and non-eu for financial markettype

### DIFF
--- a/packages/api/src/hooks/useSortedMT5Accounts.ts
+++ b/packages/api/src/hooks/useSortedMT5Accounts.ts
@@ -12,9 +12,9 @@ const useSortedMT5Accounts = () => {
     const modified_data = useMemo(() => {
         if (!all_available_mt5_accounts || !mt5_accounts) return;
 
-        const filtered_available_accounts = isEU
-            ? all_available_mt5_accounts.filter(account => account.shortcode === 'maltainvest')
-            : all_available_mt5_accounts;
+        const filtered_available_accounts = all_available_mt5_accounts.filter(account =>
+            isEU ? account.shortcode === 'maltainvest' : account.shortcode !== 'maltainvest'
+        );
 
         return filtered_available_accounts?.map(available_account => {
             const created_account = mt5_accounts?.find(account => {
@@ -43,7 +43,14 @@ const useSortedMT5Accounts = () => {
     const filtered_data = useMemo(() => {
         if (!modified_data) return;
 
-        const added_accounts = modified_data.filter(account => account.is_added);
+        // const added_accounts = modified_data.filter(account => account.is_added);
+        const added_accounts = modified_data.filter(
+            account =>
+                account.is_added &&
+                (isEU
+                    ? account.landing_company_short === 'maltainvest'
+                    : account.landing_company_short !== 'maltainvest')
+        );
         const non_added_accounts = modified_data.filter(account => !account.is_added);
 
         const filtered_non_added_accounts = non_added_accounts.reduce((acc, account) => {
@@ -55,7 +62,7 @@ const useSortedMT5Accounts = () => {
         }, [] as typeof non_added_accounts);
 
         return [...added_accounts, ...filtered_non_added_accounts];
-    }, [modified_data]);
+    }, [isEU, modified_data]);
 
     // Sort the data by market_type to make sure the order is 'synthetic', 'financial', 'all'
     const sorted_data = useMemo(() => {

--- a/packages/api/src/hooks/useSortedMT5Accounts.ts
+++ b/packages/api/src/hooks/useSortedMT5Accounts.ts
@@ -43,7 +43,6 @@ const useSortedMT5Accounts = () => {
     const filtered_data = useMemo(() => {
         if (!modified_data) return;
 
-        // const added_accounts = modified_data.filter(account => account.is_added);
         const added_accounts = modified_data.filter(
             account =>
                 account.is_added &&

--- a/packages/tradershub/src/components/RegulationSwitcher/RegulationSwitcherDesktop.tsx
+++ b/packages/tradershub/src/components/RegulationSwitcher/RegulationSwitcherDesktop.tsx
@@ -26,8 +26,8 @@ const RegulationSwitcherDesktop = () => {
     return (
         <div className='flex items-center gap-400'>
             <div className='flex items-center gap-400'>
-                <Text size='sm'>Regulation</Text>
-                <LabelPairedCircleInfoMdRegularIcon />
+                <Text size='sm'>Regulation:</Text>
+                <LabelPairedCircleInfoMdRegularIcon className='cursor-pointer' />
             </div>
             <div className='flex bg-system-light-secondary-background rounded-400 p-200 gap-200 w-[200px] h-2000'>
                 {buttons.map(button => (

--- a/packages/tradershub/src/features/cfd/components/MT5PlatformsList/MT5PlatformsList.tsx
+++ b/packages/tradershub/src/features/cfd/components/MT5PlatformsList/MT5PlatformsList.tsx
@@ -1,5 +1,11 @@
 import React, { useEffect, useMemo } from 'react';
-import { useActiveTradingAccount, useAuthorize, useInvalidateQuery, useSortedMT5Accounts } from '@deriv/api';
+import {
+    useActiveTradingAccount,
+    useAuthorize,
+    useInvalidateQuery,
+    useIsEuRegion,
+    useSortedMT5Accounts,
+} from '@deriv/api';
 import { TradingAppCardLoader } from '../../../../components/Loaders/TradingAppCardLoader';
 import { THooks } from '../../../../types';
 import { PlatformDetails } from '../../constants';
@@ -16,6 +22,7 @@ const MT5PlatformsList = ({ onMT5PlatformListLoaded }: TMT5PlatformsListProps) =
     const { areAllAccountsCreated, data, isFetchedAfterMount } = useSortedMT5Accounts();
     const { data: activeTradingAccount } = useActiveTradingAccount();
     const invalidate = useInvalidateQuery();
+    const { isEU } = useIsEuRegion();
 
     const hasMT5Account = useMemo(() => {
         return data?.some(account => account.is_added);
@@ -32,6 +39,9 @@ const MT5PlatformsList = ({ onMT5PlatformListLoaded }: TMT5PlatformsListProps) =
         return () => onMT5PlatformListLoaded?.(false);
     }, [isFetchedAfterMount, onMT5PlatformListLoaded]);
 
+    const showGetMoreMT5Accounts =
+        hasMT5Account && !activeTradingAccount?.is_virtual && !areAllAccountsCreated && !isEU && isFetchedAfterMount;
+
     return (
         <CFDPlatformLayout title={PlatformDetails.mt5.title}>
             {!isFetchedAfterMount && <TradingAppCardLoader />}
@@ -47,7 +57,7 @@ const MT5PlatformsList = ({ onMT5PlatformListLoaded }: TMT5PlatformsListProps) =
                         />
                     );
                 })}
-            {hasMT5Account && !activeTradingAccount?.is_virtual && !areAllAccountsCreated && <GetMoreMT5Accounts />}
+            {showGetMoreMT5Accounts && <GetMoreMT5Accounts />}
         </CFDPlatformLayout>
     );
 };


### PR DESCRIPTION
## Changes:
1. For eu region filter landing_company_short maltainvest, for non-eu use everything except maltainvest

## Screenshots

https://github.com/binary-com/deriv-app/assets/104053934/038763f7-dcc9-4a40-a2ea-5a3f72c40ad4


