### PR TITLE
fix: issue with package-lock caching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3040,9 +3040,9 @@
             }
         },
         "node_modules/@deriv/quill-icons": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/@deriv/quill-icons/-/quill-icons-1.1.11.tgz",
-            "integrity": "sha512-bgX8XS8mKhtj6gVdZJNOg9IlSqvC23+OFbArChiHuBYYWvN06o3iCPyT/FLwCoWAsmE73T/onPSKhTLJvjLDiQ==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/@deriv/quill-icons/-/quill-icons-1.1.12.tgz",
+            "integrity": "sha512-goZG0+ER6DKCwnP2Ylku11hNfxeXIQOIT0rRngMxE2qaCPj5qCBMlP+0XWtBJvQMVFTufTacYfR2IkTfS1X4/w==",
             "peerDependencies": {
                 "react": ">= 16",
                 "react-dom": ">= 16"
@@ -9736,9 +9736,9 @@
             "integrity": "sha512-h4lTMgMJctJybDp8CQrxTUiiYmedihHWkjnF/8Pxseu2S6Nlfcy8kwboQ8yejh456rP2yWoEVm1sS/FVsfM48w=="
         },
         "node_modules/@storybook/builder-webpack4/node_modules/@types/node": {
-            "version": "16.18.70",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.70.tgz",
-            "integrity": "sha512-8eIk20G5VVVQNZNouHjLA2b8utE2NvGybLjMaF4lyhA9uhGwnmXF8o+icdXKGSQSNANJewXva/sFUoZLwAaYAg=="
+            "version": "16.18.71",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.71.tgz",
+            "integrity": "sha512-ARO+458bNJQeNEFuPyT6W+q9ULotmsQzhV3XABsFSxEvRMUYENcBsNAHWYPlahU+UHa5gCVwyKT1Z3f1Wwr26Q=="
         },
         "node_modules/@storybook/builder-webpack4/node_modules/@types/webpack": {
             "version": "4.41.38",
@@ -11065,9 +11065,9 @@
             }
         },
         "node_modules/@storybook/builder-webpack5/node_modules/@types/node": {
-            "version": "16.18.70",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.70.tgz",
-            "integrity": "sha512-8eIk20G5VVVQNZNouHjLA2b8utE2NvGybLjMaF4lyhA9uhGwnmXF8o+icdXKGSQSNANJewXva/sFUoZLwAaYAg=="
+            "version": "16.18.71",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.71.tgz",
+            "integrity": "sha512-ARO+458bNJQeNEFuPyT6W+q9ULotmsQzhV3XABsFSxEvRMUYENcBsNAHWYPlahU+UHa5gCVwyKT1Z3f1Wwr26Q=="
         },
         "node_modules/@storybook/builder-webpack5/node_modules/colorette": {
             "version": "1.4.0",
@@ -11492,9 +11492,9 @@
             }
         },
         "node_modules/@storybook/core-common/node_modules/@types/node": {
-            "version": "16.18.70",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.70.tgz",
-            "integrity": "sha512-8eIk20G5VVVQNZNouHjLA2b8utE2NvGybLjMaF4lyhA9uhGwnmXF8o+icdXKGSQSNANJewXva/sFUoZLwAaYAg=="
+            "version": "16.18.71",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.71.tgz",
+            "integrity": "sha512-ARO+458bNJQeNEFuPyT6W+q9ULotmsQzhV3XABsFSxEvRMUYENcBsNAHWYPlahU+UHa5gCVwyKT1Z3f1Wwr26Q=="
         },
         "node_modules/@storybook/core-common/node_modules/@webassemblyjs/ast": {
             "version": "1.9.0",
@@ -12316,9 +12316,9 @@
             }
         },
         "node_modules/@storybook/core-server/node_modules/@types/node": {
-            "version": "16.18.70",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.70.tgz",
-            "integrity": "sha512-8eIk20G5VVVQNZNouHjLA2b8utE2NvGybLjMaF4lyhA9uhGwnmXF8o+icdXKGSQSNANJewXva/sFUoZLwAaYAg=="
+            "version": "16.18.71",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.71.tgz",
+            "integrity": "sha512-ARO+458bNJQeNEFuPyT6W+q9ULotmsQzhV3XABsFSxEvRMUYENcBsNAHWYPlahU+UHa5gCVwyKT1Z3f1Wwr26Q=="
         },
         "node_modules/@storybook/core-server/node_modules/@types/webpack": {
             "version": "4.41.38",
@@ -13252,9 +13252,9 @@
             "integrity": "sha512-h4lTMgMJctJybDp8CQrxTUiiYmedihHWkjnF/8Pxseu2S6Nlfcy8kwboQ8yejh456rP2yWoEVm1sS/FVsfM48w=="
         },
         "node_modules/@storybook/manager-webpack4/node_modules/@types/node": {
-            "version": "16.18.70",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.70.tgz",
-            "integrity": "sha512-8eIk20G5VVVQNZNouHjLA2b8utE2NvGybLjMaF4lyhA9uhGwnmXF8o+icdXKGSQSNANJewXva/sFUoZLwAaYAg=="
+            "version": "16.18.71",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.71.tgz",
+            "integrity": "sha512-ARO+458bNJQeNEFuPyT6W+q9ULotmsQzhV3XABsFSxEvRMUYENcBsNAHWYPlahU+UHa5gCVwyKT1Z3f1Wwr26Q=="
         },
         "node_modules/@storybook/manager-webpack4/node_modules/@types/webpack": {
             "version": "4.41.38",
@@ -14545,9 +14545,9 @@
             }
         },
         "node_modules/@storybook/manager-webpack5/node_modules/@types/node": {
-            "version": "16.18.70",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.70.tgz",
-            "integrity": "sha512-8eIk20G5VVVQNZNouHjLA2b8utE2NvGybLjMaF4lyhA9uhGwnmXF8o+icdXKGSQSNANJewXva/sFUoZLwAaYAg=="
+            "version": "16.18.71",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.71.tgz",
+            "integrity": "sha512-ARO+458bNJQeNEFuPyT6W+q9ULotmsQzhV3XABsFSxEvRMUYENcBsNAHWYPlahU+UHa5gCVwyKT1Z3f1Wwr26Q=="
         },
         "node_modules/@storybook/manager-webpack5/node_modules/ansi-styles": {
             "version": "4.3.0",
@@ -15059,9 +15059,9 @@
             "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ=="
         },
         "node_modules/@storybook/react/node_modules/@types/node": {
-            "version": "16.18.70",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.70.tgz",
-            "integrity": "sha512-8eIk20G5VVVQNZNouHjLA2b8utE2NvGybLjMaF4lyhA9uhGwnmXF8o+icdXKGSQSNANJewXva/sFUoZLwAaYAg=="
+            "version": "16.18.71",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.71.tgz",
+            "integrity": "sha512-ARO+458bNJQeNEFuPyT6W+q9ULotmsQzhV3XABsFSxEvRMUYENcBsNAHWYPlahU+UHa5gCVwyKT1Z3f1Wwr26Q=="
         },
         "node_modules/@storybook/react/node_modules/acorn": {
             "version": "7.4.1",
@@ -20217,9 +20217,9 @@
             }
         },
         "node_modules/chai": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.0.tgz",
-            "integrity": "sha512-x9cHNq1uvkCdU+5xTkNh5WtgD4e4yDFCsp9jVc7N7qVeKeftv3gO/ZrviX5d+3ZfxdYnZXZYujjRInu1RogU6A==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
+            "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
             "peer": true,
             "dependencies": {
                 "assertion-error": "^1.1.0",
@@ -47849,10 +47849,9 @@
             }
         },
         "node_modules/usehooks-ts": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.9.2.tgz",
-            "integrity": "sha512-fOzPeG01rs51CGYzqgioP/zs9v1Cgpe+zcXeqJPlDHYfdfG/wjsdjBWHJi+Ph1JgQAGUrDo5sJbPlaZd+Z9lxw==",
-            "hasInstallScript": true,
+            "version": "2.9.4",
+            "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.9.4.tgz",
+            "integrity": "sha512-VOSEbA+BGGORLttsICowNb5CG0D2/IEoVvMEl9OuuOoQi99W6XuNipo3SPFhWo3Bhdwi0Swj1D+IMQDQB9KrwQ==",
             "engines": {
                 "node": ">=16.15.0"
             },
@@ -52091,9 +52090,9 @@
             "requires": {}
         },
         "@deriv/quill-icons": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/@deriv/quill-icons/-/quill-icons-1.1.11.tgz",
-            "integrity": "sha512-bgX8XS8mKhtj6gVdZJNOg9IlSqvC23+OFbArChiHuBYYWvN06o3iCPyT/FLwCoWAsmE73T/onPSKhTLJvjLDiQ==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/@deriv/quill-icons/-/quill-icons-1.1.12.tgz",
+            "integrity": "sha512-goZG0+ER6DKCwnP2Ylku11hNfxeXIQOIT0rRngMxE2qaCPj5qCBMlP+0XWtBJvQMVFTufTacYfR2IkTfS1X4/w==",
             "requires": {}
         },
         "@deriv/react-joyride": {
@@ -56750,9 +56749,9 @@
                     "integrity": "sha512-h4lTMgMJctJybDp8CQrxTUiiYmedihHWkjnF/8Pxseu2S6Nlfcy8kwboQ8yejh456rP2yWoEVm1sS/FVsfM48w=="
                 },
                 "@types/node": {
-                    "version": "16.18.70",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.70.tgz",
-                    "integrity": "sha512-8eIk20G5VVVQNZNouHjLA2b8utE2NvGybLjMaF4lyhA9uhGwnmXF8o+icdXKGSQSNANJewXva/sFUoZLwAaYAg=="
+                    "version": "16.18.71",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.71.tgz",
+                    "integrity": "sha512-ARO+458bNJQeNEFuPyT6W+q9ULotmsQzhV3XABsFSxEvRMUYENcBsNAHWYPlahU+UHa5gCVwyKT1Z3f1Wwr26Q=="
                 },
                 "@types/webpack": {
                     "version": "4.41.38",
@@ -57800,9 +57799,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "16.18.70",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.70.tgz",
-                    "integrity": "sha512-8eIk20G5VVVQNZNouHjLA2b8utE2NvGybLjMaF4lyhA9uhGwnmXF8o+icdXKGSQSNANJewXva/sFUoZLwAaYAg=="
+                    "version": "16.18.71",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.71.tgz",
+                    "integrity": "sha512-ARO+458bNJQeNEFuPyT6W+q9ULotmsQzhV3XABsFSxEvRMUYENcBsNAHWYPlahU+UHa5gCVwyKT1Z3f1Wwr26Q=="
                 },
                 "colorette": {
                     "version": "1.4.0",
@@ -58098,9 +58097,9 @@
                     }
                 },
                 "@types/node": {
-                    "version": "16.18.70",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.70.tgz",
-                    "integrity": "sha512-8eIk20G5VVVQNZNouHjLA2b8utE2NvGybLjMaF4lyhA9uhGwnmXF8o+icdXKGSQSNANJewXva/sFUoZLwAaYAg=="
+                    "version": "16.18.71",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.71.tgz",
+                    "integrity": "sha512-ARO+458bNJQeNEFuPyT6W+q9ULotmsQzhV3XABsFSxEvRMUYENcBsNAHWYPlahU+UHa5gCVwyKT1Z3f1Wwr26Q=="
                 },
                 "@webassemblyjs/ast": {
                     "version": "1.9.0",
@@ -58773,9 +58772,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "16.18.70",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.70.tgz",
-                    "integrity": "sha512-8eIk20G5VVVQNZNouHjLA2b8utE2NvGybLjMaF4lyhA9uhGwnmXF8o+icdXKGSQSNANJewXva/sFUoZLwAaYAg=="
+                    "version": "16.18.71",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.71.tgz",
+                    "integrity": "sha512-ARO+458bNJQeNEFuPyT6W+q9ULotmsQzhV3XABsFSxEvRMUYENcBsNAHWYPlahU+UHa5gCVwyKT1Z3f1Wwr26Q=="
                 },
                 "@types/webpack": {
                     "version": "4.41.38",
@@ -59543,9 +59542,9 @@
                     "integrity": "sha512-h4lTMgMJctJybDp8CQrxTUiiYmedihHWkjnF/8Pxseu2S6Nlfcy8kwboQ8yejh456rP2yWoEVm1sS/FVsfM48w=="
                 },
                 "@types/node": {
-                    "version": "16.18.70",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.70.tgz",
-                    "integrity": "sha512-8eIk20G5VVVQNZNouHjLA2b8utE2NvGybLjMaF4lyhA9uhGwnmXF8o+icdXKGSQSNANJewXva/sFUoZLwAaYAg=="
+                    "version": "16.18.71",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.71.tgz",
+                    "integrity": "sha512-ARO+458bNJQeNEFuPyT6W+q9ULotmsQzhV3XABsFSxEvRMUYENcBsNAHWYPlahU+UHa5gCVwyKT1Z3f1Wwr26Q=="
                 },
                 "@types/webpack": {
                     "version": "4.41.38",
@@ -60568,9 +60567,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "16.18.70",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.70.tgz",
-                    "integrity": "sha512-8eIk20G5VVVQNZNouHjLA2b8utE2NvGybLjMaF4lyhA9uhGwnmXF8o+icdXKGSQSNANJewXva/sFUoZLwAaYAg=="
+                    "version": "16.18.71",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.71.tgz",
+                    "integrity": "sha512-ARO+458bNJQeNEFuPyT6W+q9ULotmsQzhV3XABsFSxEvRMUYENcBsNAHWYPlahU+UHa5gCVwyKT1Z3f1Wwr26Q=="
                 },
                 "ansi-styles": {
                     "version": "4.3.0",
@@ -60901,9 +60900,9 @@
                     "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ=="
                 },
                 "@types/node": {
-                    "version": "16.18.70",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.70.tgz",
-                    "integrity": "sha512-8eIk20G5VVVQNZNouHjLA2b8utE2NvGybLjMaF4lyhA9uhGwnmXF8o+icdXKGSQSNANJewXva/sFUoZLwAaYAg=="
+                    "version": "16.18.71",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.71.tgz",
+                    "integrity": "sha512-ARO+458bNJQeNEFuPyT6W+q9ULotmsQzhV3XABsFSxEvRMUYENcBsNAHWYPlahU+UHa5gCVwyKT1Z3f1Wwr26Q=="
                 },
                 "acorn": {
                     "version": "7.4.1",
@@ -64767,9 +64766,9 @@
             "integrity": "sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg=="
         },
         "chai": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.0.tgz",
-            "integrity": "sha512-x9cHNq1uvkCdU+5xTkNh5WtgD4e4yDFCsp9jVc7N7qVeKeftv3gO/ZrviX5d+3ZfxdYnZXZYujjRInu1RogU6A==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
+            "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
             "peer": true,
             "requires": {
                 "assertion-error": "^1.1.0",
@@ -83991,9 +83990,9 @@
             "requires": {}
         },
         "usehooks-ts": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.9.2.tgz",
-            "integrity": "sha512-fOzPeG01rs51CGYzqgioP/zs9v1Cgpe+zcXeqJPlDHYfdfG/wjsdjBWHJi+Ph1JgQAGUrDo5sJbPlaZd+Z9lxw==",
+            "version": "2.9.4",
+            "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.9.4.tgz",
+            "integrity": "sha512-VOSEbA+BGGORLttsICowNb5CG0D2/IEoVvMEl9OuuOoQi99W6XuNipo3SPFhWo3Bhdwi0Swj1D+IMQDQB9KrwQ==",
             "requires": {}
         },
         "util": {


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- There is an issue where the incorrect generated package-lock.json with the key `Linux-build-master-cache-07a6a705c020ca99227651a244f241dd22d2af64af3dd693979dabf27fbbc533` was pushed to `master` branch and is cached to all PR builds, causing all other workflows to reuse this failed cache
- Regenerated a new package-lock.json based on a new repository clone of `deriv-app` through `npm i && npm run bootstrap:dev`

### Screenshots:

Please provide some screenshots of the change.
