### PR TITLE
Akmal / fix: accumulators growth rate is not being updated after refresh

### DIFF
--- a/packages/trader/src/Stores/Modules/Trading/Helpers/__tests__/contract-type.spec.ts
+++ b/packages/trader/src/Stores/Modules/Trading/Helpers/__tests__/contract-type.spec.ts
@@ -6,86 +6,84 @@ import { mockStore } from '@deriv/stores';
 jest.mock('@deriv/shared', () => ({
     ...jest.requireActual('@deriv/shared'),
     WS: {
-        storage: {
-            contractsFor: jest.fn(() =>
-                Promise.resolve({
-                    contracts_for: {
-                        available: [
-                            {
-                                barrier_category: 'euro_atm',
-                                barriers: 0,
-                                contract_category: 'callput',
-                                contract_category_display: 'Up/Down',
-                                contract_display: 'Higher',
-                                contract_type: 'CALL',
-                                exchange_name: 'FOREX',
-                                expiry_type: 'daily',
-                                market: 'forex',
-                                max_contract_duration: '365d',
-                                min_contract_duration: '1d',
-                                sentiment: 'up',
-                                start_type: 'spot',
-                                submarket: 'major_pairs',
-                                underlying_symbol: 'frxAUDJPY',
-                            },
-                            {
-                                barrier_category: 'euro_non_atm',
-                                barriers: 2,
-                                contract_category: 'endsinout',
-                                contract_category_display: 'Ends Between/Ends Outside',
-                                contract_display: 'Ends Outside',
-                                contract_type: 'EXPIRYMISS',
-                                exchange_name: 'FOREX',
-                                expiry_type: 'daily',
-                                forward_starting_options: [
-                                    {
-                                        close: '1701302399',
-                                        date: '1701216000',
-                                        open: '1701216000',
-                                    },
-                                    {
-                                        close: '1701388799',
-                                        date: '1701302400',
-                                        open: '1701302400',
-                                    },
-                                    {
-                                        close: '1701475199',
-                                        date: '1701388800',
-                                        open: '1701388800',
-                                    },
-                                ],
-                                high_barrier: '98.745',
-                                low_barrier: '97.672',
-                                market: 'forex',
-                                max_contract_duration: '365d',
-                                min_contract_duration: '1d',
-                                sentiment: 'high_vol',
-                                start_type: 'spot',
-                                submarket: 'major_pairs',
-                                underlying_symbol: 'frxAUDJPY',
-                            },
-                        ],
-                        close: 1701215999,
-                        feed_license: 'realtime',
-                        hit_count: 22,
-                        non_available: [
-                            {
-                                contract_category: 'accumulator',
-                                contract_display_name: 'Accumulator Up',
-                                contract_type: 'ACCU',
-                            },
-                            {
-                                contract_category: 'asian',
-                                contract_display_name: 'Asian Down',
-                                contract_type: 'ASIAND',
-                            },
-                        ],
-                        open: 1701129600,
-                        spot: 98.076,
-                    },
-                })
-            ),
-        },
+        contractsFor: jest.fn(() =>
+            Promise.resolve({
+                contracts_for: {
+                    available: [
+                        {
+                            barrier_category: 'euro_atm',
+                            barriers: 0,
+                            contract_category: 'callput',
+                            contract_category_display: 'Up/Down',
+                            contract_display: 'Higher',
+                            contract_type: 'CALL',
+                            exchange_name: 'FOREX',
+                            expiry_type: 'daily',
+                            market: 'forex',
+                            max_contract_duration: '365d',
+                            min_contract_duration: '1d',
+                            sentiment: 'up',
+                            start_type: 'spot',
+                            submarket: 'major_pairs',
+                            underlying_symbol: 'frxAUDJPY',
+                        },
+                        {
+                            barrier_category: 'euro_non_atm',
+                            barriers: 2,
+                            contract_category: 'endsinout',
+                            contract_category_display: 'Ends Between/Ends Outside',
+                            contract_display: 'Ends Outside',
+                            contract_type: 'EXPIRYMISS',
+                            exchange_name: 'FOREX',
+                            expiry_type: 'daily',
+                            forward_starting_options: [
+                                {
+                                    close: '1701302399',
+                                    date: '1701216000',
+                                    open: '1701216000',
+                                },
+                                {
+                                    close: '1701388799',
+                                    date: '1701302400',
+                                    open: '1701302400',
+                                },
+                                {
+                                    close: '1701475199',
+                                    date: '1701388800',
+                                    open: '1701388800',
+                                },
+                            ],
+                            high_barrier: '98.745',
+                            low_barrier: '97.672',
+                            market: 'forex',
+                            max_contract_duration: '365d',
+                            min_contract_duration: '1d',
+                            sentiment: 'high_vol',
+                            start_type: 'spot',
+                            submarket: 'major_pairs',
+                            underlying_symbol: 'frxAUDJPY',
+                        },
+                    ],
+                    close: 1701215999,
+                    feed_license: 'realtime',
+                    hit_count: 22,
+                    non_available: [
+                        {
+                            contract_category: 'accumulator',
+                            contract_display_name: 'Accumulator Up',
+                            contract_type: 'ACCU',
+                        },
+                        {
+                            contract_category: 'asian',
+                            contract_display_name: 'Asian Down',
+                            contract_type: 'ASIAND',
+                        },
+                    ],
+                    open: 1701129600,
+                    spot: 98.076,
+                },
+            })
+        ),
         tradingTimes: jest.fn(() =>
             Promise.resolve({
                 trading_times: {

--- a/packages/trader/src/Stores/Modules/Trading/Helpers/contract-type.ts
+++ b/packages/trader/src/Stores/Modules/Trading/Helpers/contract-type.ts
@@ -88,7 +88,7 @@ export const ContractType = (() => {
     let has_only_forward_starting_contracts = false;
 
     const buildContractTypesConfig = (symbol: string): Promise<void> =>
-        WS.storage.contractsFor(symbol).then((r: Required<ContractsForSymbolResponse>) => {
+        WS.contractsFor(symbol).then((r: Required<ContractsForSymbolResponse>) => {
             const has_contracts = getPropertyValue(r, ['contracts_for']);
             has_only_forward_starting_contracts =
                 has_contracts && !r.contracts_for.available.find(contract => contract.start_type !== 'forward');

--- a/packages/trader/src/Stores/Modules/Trading/trade-store.ts
+++ b/packages/trader/src/Stores/Modules/Trading/trade-store.ts
@@ -552,9 +552,13 @@ export default class TradeStore extends BaseStore {
                 }
             }
         );
-        when(
-            () => !!this.accumulator_range_list.length,
-            () => this.setDefaultGrowthRate()
+        reaction(
+            () => this.accumulator_range_list.length,
+            () => {
+                if (this.accumulator_range_list.length) {
+                    this.setDefaultGrowthRate();
+                }
+            }
         );
     }
 

--- a/packages/trader/src/sass/app/_common/components/number-selector.scss
+++ b/packages/trader/src/sass/app/_common/components/number-selector.scss
@@ -37,8 +37,8 @@
             margin-right: 0;
         }
         &--percentage {
-            width: 20%;
             border-radius: unset;
+            flex: 1;
             height: 3.2rem;
 
             &:not(:first-child) {

--- a/packages/trader/src/sass/app/modules/trading.scss
+++ b/packages/trader/src/sass/app/modules/trading.scss
@@ -178,6 +178,7 @@
         }
         &.accumulator {
             .number-selector__row {
+                display: flex;
                 margin-bottom: 0;
             }
         }


### PR DESCRIPTION
## Changes:

This change addresses an issue where the accumulators' growth rate fails to update correctly after a refresh. The previous implementation did not properly handle the recalculation of growth rates following a refresh action, leading to inaccurate or stagnant values in the accumulators. This fix ensures that the growth rate is appropriately updated, maintaining the integrity and accuracy of the accumulators' data. Users can now rely on the system to reflect real-time changes in growth rates, providing a more reliable and consistent experience when working with accumulators.
