### PR TITLE
[COJ]/likhith/coj-531/fix fianncial assessment form submission

### DIFF
--- a/packages/account/src/Sections/Assessment/FinancialAssessment/__tests__/financial-assessment.spec.tsx
+++ b/packages/account/src/Sections/Assessment/FinancialAssessment/__tests__/financial-assessment.spec.tsx
@@ -3,10 +3,10 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { StoreProvider, mockStore } from '@deriv/stores';
 import FinancialAssessment from '../financial-assessment';
+import { WS } from '@deriv/shared';
 
-jest.mock('@deriv/shared/src/services/ws-methods', () => ({
-    __esModule: true,
-    default: 'mockedDefaultExport',
+jest.mock('@deriv/shared', () => ({
+    ...jest.requireActual('@deriv/shared'),
     WS: {
         wait: jest.fn(() => Promise.resolve()),
         setSettings: jest.fn(() => Promise.resolve({ error: '' })),
@@ -70,6 +70,34 @@ describe('<FinancialAssessment/>', () => {
             expect(screen.getByText('Source of wealth')).toBeInTheDocument();
             expect(screen.getByText('Estimated net worth')).toBeInTheDocument();
             expect(screen.getByText('Anticipated account turnover')).toBeInTheDocument();
+        });
+    });
+
+    it('should render FinancialAssessment component without occupation field when Employment status is self employed', async () => {
+        WS.authorized.storage.getFinancialAssessment = jest.fn(() =>
+            Promise.resolve({
+                get_financial_assessment: {
+                    account_turnover: '',
+                    cfd_score: 0,
+                    education_level: '',
+                    employment_industry: '',
+                    employment_status: 'Self-Employed',
+                    estimated_worth: '',
+                    financial_information_score: '',
+                    income_source: '',
+                    net_income: '',
+                    occupation: '',
+                    source_of_wealth: '',
+                    total_score: '',
+                    trading_score: '',
+                },
+            })
+        );
+        rendercomponent();
+        await waitFor(() => {
+            expect(screen.getByText('Employment status')).toBeInTheDocument();
+            expect(screen.getByText('Industry of employment')).toBeInTheDocument();
+            expect(screen.queryByText('Occupation')).not.toBeInTheDocument();
         });
     });
 });

--- a/packages/account/src/Sections/Assessment/FinancialAssessment/financial-assessment.tsx
+++ b/packages/account/src/Sections/Assessment/FinancialAssessment/financial-assessment.tsx
@@ -315,6 +315,9 @@ const FinancialAssessment = observer(() => {
                 errors[field] = localize('This field is required');
             }
         });
+        if (shouldHideOccupationField(values?.employment_status || employment_status)) {
+            delete errors.occupation;
+        }
         return errors;
     };
 


### PR DESCRIPTION
## Changes:

When Self-Employed or Unemployed is selected for Employment status, client is not able to save their Financial Information.

Fixed the validation condition used for form submission
