### PR TITLE
[TRAH] shontzu/TRAH-2644/you-need-a-d3r1v-account-dialog

### DIFF
--- a/packages/tradershub/src/components/Dialog/DialogHeader.tsx
+++ b/packages/tradershub/src/components/Dialog/DialogHeader.tsx
@@ -12,6 +12,7 @@ import CloseIcon from '../../public/images/ic-close-dark.svg';
  */
 type TDialogHeader = {
     className?: string;
+    heading?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
     hideCloseButton?: boolean;
     title?: string;
 };
@@ -21,12 +22,23 @@ type TDialogHeader = {
  * @param {TDialogHeader} props - The properties that define the DialogHeader component.
  * @returns {JSX.Element} The DialogHeader component.
  */
-const DialogHeader = ({ className, hideCloseButton = false, title }: TDialogHeader) => {
+const DialogHeader = ({ className, heading = 'h3', hideCloseButton = false, title }: TDialogHeader) => {
+    const headingSizes = {
+        h1: Heading.H1,
+        h2: Heading.H2,
+        h3: Heading.H3,
+        h4: Heading.H4,
+        h5: Heading.H5,
+        h6: Heading.H6,
+    };
+
+    const HeadingSize = headingSizes[heading];
+
     const { hide } = Provider.useModal();
 
     return (
         <div className={qtMerge('flex items-start', title ? 'justify-between' : 'justify-end', className)}>
-            {title && <Heading.H3 className='flex-1'>{title}</Heading.H3>}
+            {title && <HeadingSize className='flex-1'>{title}</HeadingSize>}
             {!hideCloseButton && <CloseIcon className='hover:cursor-pointer' onClick={hide} />}
         </div>
     );

--- a/packages/tradershub/src/components/GetADerivAccountBanner/GetADerivAccountDialog.tsx
+++ b/packages/tradershub/src/components/GetADerivAccountBanner/GetADerivAccountDialog.tsx
@@ -11,15 +11,15 @@ import { Dialog } from '../Dialog';
 const GetADerivAccountDialog = () => {
     return (
         <Dialog className='lg:w-[440px]'>
-            <Dialog.Header heading='h6' hideCloseButton title="You'll need a Deriv account" />
+            <Dialog.Header heading='h5' hideCloseButton title="You'll need a Deriv account" />
             <Dialog.Content>
                 <Text size='sm'>A Deriv account will allow you to fund (and withdraw from) your MT5 account(s). </Text>
             </Dialog.Content>
             <Dialog.Action align='right'>
-                <Button className='rounded-200 py-800 px-500' colorStyle='black' size='md' variant='secondary'>
+                <Button className='rounded-200 h-2000 px-500' colorStyle='black' size='md' variant='secondary'>
                     Cancel
                 </Button>
-                <Button className='rounded-200 py-800 px-500' colorStyle='coral' size='md' variant='primary'>
+                <Button className='rounded-200 h-2000 px-500' colorStyle='coral' size='md' variant='primary'>
                     Add a Deriv account
                 </Button>
             </Dialog.Action>

--- a/packages/tradershub/src/components/GetADerivAccountBanner/GetADerivAccountDialog.tsx
+++ b/packages/tradershub/src/components/GetADerivAccountBanner/GetADerivAccountDialog.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Button, Text } from '@deriv/quill-design';
+import { Dialog } from '../Dialog';
+
+/**
+ * `GetADerivAccountDialog`  is opened when user tried to create a CFD account without a Deriv account
+ * It includes a button that leads the user to a modal where they can create a Deriv account.
+ *
+ * @returns {React.ReactElement} A `<Dialog>` component containing the dialog message and action button.
+ */
+const GetADerivAccountDialog = () => {
+    return (
+        <Dialog className='lg:w-[440px]'>
+            <Dialog.Header heading='h6' hideCloseButton title="You'll need a Deriv account" />
+            <Dialog.Content>
+                <Text size='sm'>A Deriv account will allow you to fund (and withdraw from) your MT5 account(s). </Text>
+            </Dialog.Content>
+            <Dialog.Action align='right'>
+                <Button className='rounded-200 py-800 px-500' colorStyle='black' size='md' variant='secondary'>
+                    Cancel
+                </Button>
+                <Button className='rounded-200 py-800 px-500' colorStyle='coral' size='md' variant='primary'>
+                    Add a Deriv account
+                </Button>
+            </Dialog.Action>
+        </Dialog>
+    );
+};
+
+export default GetADerivAccountDialog;

--- a/packages/tradershub/src/components/GetADerivAccountBanner/index.ts
+++ b/packages/tradershub/src/components/GetADerivAccountBanner/index.ts
@@ -1,1 +1,2 @@
 export { default as GetADerivAccountBanner } from './GetADerivAccountBanner';
+export { default as GetADerivAccountDialog } from './GetADerivAccountDialog';


### PR DESCRIPTION
## Changes:

- **You Need A Deriv Account** dialog  ([CU](https://app.clickup.com/t/20696747/TRAH-2644))
- extended `DialogHeader` component to have more than one type of heading and default it as H3

### Screenshots:
<img width="437" alt="image" src="https://github.com/binary-com/deriv-app/assets/108507236/ce4628a1-f3bc-4917-ae18-7a981411db28">


