### PR TITLE
thisyahlen/TRAH-2680/fix: mt5 account type screen not showing in modal

### DIFF
--- a/packages/library/src/providers/CFDProvider/CFDProvider.tsx
+++ b/packages/library/src/providers/CFDProvider/CFDProvider.tsx
@@ -43,7 +43,7 @@ export const CFDProvider = ({ children }: { children: React.ReactNode }) => {
         [setCfdState]
     );
 
-    const providerValue = useMemo(() => ({ getCFDState, setCfdState: updateCFDState }), [getCFDState]);
+    const providerValue = useMemo(() => ({ getCFDState, setCfdState: updateCFDState }), [getCFDState, updateCFDState]);
 
     return <CFDContext.Provider value={providerValue}>{children}</CFDContext.Provider>;
 };

--- a/packages/tradershub/src/features/cfd/screens/MT5AccountType/MT5AccountType.tsx
+++ b/packages/tradershub/src/features/cfd/screens/MT5AccountType/MT5AccountType.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+import useRegulationFlags from '../../../../hooks/useRegulationFlags';
 import { MarketTypeDetails } from '../../constants';
 import { MT5AccountTypeCard } from '../MT5AccountTypeCard';
 
@@ -8,10 +9,13 @@ type TProps = {
 };
 
 const MT5AccountType: FC<TProps> = ({ onMarketTypeSelect, selectedMarketType }) => {
-    const sortedMarketTypeEntries = Object.entries(MarketTypeDetails).sort(([keyA], [keyB]) => {
+    const { isEU } = useRegulationFlags();
+    const marketTypeDetails = MarketTypeDetails(isEU);
+    const sortedMarketTypeEntries = Object.entries(marketTypeDetails).sort(([keyA], [keyB]) => {
         const order = ['synthetic', 'financial', 'all'];
         return order.indexOf(keyA) - order.indexOf(keyB);
     });
+
     return (
         <div className='flex items-center flex-shrink-0 bg-system-light-primary-background rounded-xl h-[70vh] w-[80vw] justify-center p-1200 flex-1 gap-1200'>
             {sortedMarketTypeEntries.map(([key, value]) => (


### PR DESCRIPTION
## Changes:
1. Fix mt5 account type screen not showing in modal

### Screenshots:

Please provide some screenshots of the change.
![Screenshot 2024-01-18 at 10 25 22 AM](https://github.com/binary-com/deriv-app/assets/104053934/3f1aa5e7-7ee7-4427-a61b-1f8c271d2a34)
