### PR TITLE
[COJ]/likhith/COJ-563/fix poa pending error on MT5

### DIFF
--- a/packages/shared/src/utils/cfd/cfd.ts
+++ b/packages/shared/src/utils/cfd/cfd.ts
@@ -511,12 +511,13 @@ export const getMT5AccountTitle = ({ account_type, jurisdiction }: TGetMT5Accoun
 export const isPOARequiredForMT5 = (account_status: GetAccountStatus, jurisdiction_shortcode: string) => {
     const { authentication } = account_status;
 
-    if (!['pending', 'verified'].includes(authentication?.document?.status ?? '')) {
-        if (authentication?.attempts?.latest?.service === 'idv') {
-            // @ts-expect-error as the prop authenticated_with_idv is not yet present in GetAccountStatus
-            return !authentication?.document?.authenticated_with_idv[jurisdiction_shortcode];
+    if (authentication?.attempts?.latest?.service === 'idv') {
+        if (authentication?.document?.status === 'pending') {
+            return false;
         }
-        return true;
+        // @ts-expect-error as the prop authenticated_with_idv is not yet present in GetAccountStatus
+        return !authentication?.document?.authenticated_with_idv[jurisdiction_shortcode];
     }
-    return false;
+
+    return !['pending', 'verified'].includes(authentication?.document?.status ?? '');
 };

--- a/packages/shared/src/utils/cfd/cfd.ts
+++ b/packages/shared/src/utils/cfd/cfd.ts
@@ -511,10 +511,12 @@ export const getMT5AccountTitle = ({ account_type, jurisdiction }: TGetMT5Accoun
 export const isPOARequiredForMT5 = (account_status: GetAccountStatus, jurisdiction_shortcode: string) => {
     const { authentication } = account_status;
 
-    if (authentication?.attempts?.latest?.service !== 'idv') {
-        return !['pending', 'verified'].includes(authentication?.document?.status ?? '');
+    if (!['pending', 'verified'].includes(authentication?.document?.status ?? '')) {
+        if (authentication?.attempts?.latest?.service === 'idv') {
+            // @ts-expect-error as the prop authenticated_with_idv is not yet present in GetAccountStatus
+            return !authentication?.document?.authenticated_with_idv[jurisdiction_shortcode];
+        }
+        return true;
     }
-
-    // @ts-expect-error as the prop authenticated_with_idv is not yet present in GetAccountStatus
-    return !authentication?.document?.authenticated_with_idv[jurisdiction_shortcode];
+    return false;
 };


### PR DESCRIPTION
## Changes:

For IDV supp. countries, if the IDV POI fails while the POA is submitted but still in pending status, when client attempt to create regulated MT5 account, Still asks for POA

So fixed the condition that will trigger POA for MT5 account creation
