### PR TITLE
[WALL] [Fix] Rostislav / WALL-3320 / Transaction tab MT5 transactions name & badge

### DIFF
--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/components/TransactionsCompletedRowAccountDetails/TransactionsCompletedRowAccountDetails.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/components/TransactionsCompletedRowAccountDetails/TransactionsCompletedRowAccountDetails.tsx
@@ -54,7 +54,9 @@ const TransactionsCompletedRowAccountDetails: React.FC<TProps> = ({
                     <WalletText color='general' size='xs' weight='bold'>
                         {displayAccountName}
                     </WalletText>
-                    {!isDemo && <WalletListCardBadge isDemo={isDemo} label={mt5LandingCompanyName} />}
+                    {!isDemo && (
+                        <WalletListCardBadge isDemo={isDemo} label={mt5LandingCompanyName ?? landingCompanyName} />
+                    )}
                 </div>
             </div>
         </div>

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/components/TransactionsCompletedRowAccountDetails/TransactionsCompletedRowAccountDetails.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/components/TransactionsCompletedRowAccountDetails/TransactionsCompletedRowAccountDetails.tsx
@@ -19,6 +19,7 @@ type TProps = {
     isInterWallet?: boolean;
     landingCompanyName?: TWalletLandingCompanyName;
     mt5Group?: string;
+    mt5LandingCompanyName?: string;
 };
 
 const TransactionsCompletedRowAccountDetails: React.FC<TProps> = ({
@@ -31,6 +32,7 @@ const TransactionsCompletedRowAccountDetails: React.FC<TProps> = ({
     isInterWallet = false,
     landingCompanyName,
     mt5Group,
+    mt5LandingCompanyName,
 }) => {
     return (
         <div className='wallets-transactions-completed-row-account-details'>
@@ -52,7 +54,7 @@ const TransactionsCompletedRowAccountDetails: React.FC<TProps> = ({
                     <WalletText color='general' size='xs' weight='bold'>
                         {displayAccountName}
                     </WalletText>
-                    {!isDemo && <WalletListCardBadge label={landingCompanyName} />}
+                    {!isDemo && <WalletListCardBadge isDemo={isDemo} label={mt5LandingCompanyName} />}
                 </div>
             </div>
         </div>

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/components/TransactionsCompletedRowAccountDetails/TransactionsCompletedRowAccountDetails.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/components/TransactionsCompletedRowAccountDetails/TransactionsCompletedRowAccountDetails.tsx
@@ -54,9 +54,7 @@ const TransactionsCompletedRowAccountDetails: React.FC<TProps> = ({
                     <WalletText color='general' size='xs' weight='bold'>
                         {displayAccountName}
                     </WalletText>
-                    {!isDemo && (
-                        <WalletListCardBadge isDemo={isDemo} label={mt5LandingCompanyName ?? landingCompanyName} />
-                    )}
+                    {!isDemo && <WalletListCardBadge label={mt5LandingCompanyName ?? landingCompanyName} />}
                 </div>
             </div>
         </div>

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/components/TransactionsCompletedRowTransferAccountDetails/TransactionsCompletedRowTransferAccountDetails.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/components/TransactionsCompletedRowTransferAccountDetails/TransactionsCompletedRowTransferAccountDetails.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import { useActiveWalletAccount } from '@deriv/api';
 import { THooks, TWalletLandingCompanyName } from '../../../../../../../../types';
-import { getAccountName } from '../../../../../../helpers';
+import { getAccountName, getLandingCompanyNameOfMT5Account } from '../../../../../../helpers';
 import { TransactionsCompletedRowAccountDetails } from '../TransactionsCompletedRowAccountDetails';
 
 type TProps = {
@@ -10,6 +11,8 @@ type TProps = {
 };
 
 const TransactionsCompletedRowTransferAccountDetails: React.FC<TProps> = ({ accounts, direction, loginid }) => {
+    const { data: activeWallet } = useActiveWalletAccount();
+
     const wallet = accounts.wallets?.find(account => account.loginid === loginid);
     const dtradeAccount = accounts.dtrade?.find(account => account.loginid === loginid);
     const dxtradeAccount = accounts.dxtrade?.find(account => account.account_id === loginid);
@@ -24,25 +27,29 @@ const TransactionsCompletedRowTransferAccountDetails: React.FC<TProps> = ({ acco
     if (transferAccount) {
         const derivAccountType = transferAccount === wallet ? 'wallet' : 'standard';
         const accountType = transferAccount?.platform !== 'deriv' ? transferAccount.platform : derivAccountType;
+        const mt5LandingCompanyName =
+            transferAccount === mt5Account ? getLandingCompanyNameOfMT5Account(mt5Account.group) : undefined;
         const displayAccountName = getAccountName({
             accountCategory: transferAccount === wallet ? 'wallet' : 'trading',
             //@ts-expect-error this needs backend typing
             accountType,
             displayCurrencyCode: transferAccount.currency_config?.display_code ?? 'USD',
-            landingCompanyName: transferAccount.landing_company_name as TWalletLandingCompanyName,
+            landingCompanyName: activeWallet?.landing_company_name as TWalletLandingCompanyName,
             mt5MarketType: transferAccount === mt5Account ? mt5Account.market_type : undefined,
         });
 
         return (
             <TransactionsCompletedRowAccountDetails
-                accountType={accountType ?? ''}
+                accountType={accountType}
                 actionType='transfer'
                 currency={transferAccount.currency ?? 'USD'}
                 displayAccountName={displayAccountName ?? ''}
                 displayActionType={`Transfer ${direction}`}
                 isDemo={Boolean(transferAccount.is_virtual)}
                 isInterWallet={transferAccount === wallet}
+                landingCompanyName={activeWallet?.landing_company_name as TWalletLandingCompanyName}
                 mt5Group={transferAccount === mt5Account ? mt5Account.group : undefined}
+                mt5LandingCompanyName={mt5LandingCompanyName}
             />
         );
     }

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/components/TransactionsCompletedRowTransferAccountDetails/TransactionsCompletedRowTransferAccountDetails.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/components/TransactionsCompletedRowTransferAccountDetails/TransactionsCompletedRowTransferAccountDetails.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useActiveWalletAccount } from '@deriv/api';
 import { THooks, TWalletLandingCompanyName } from '../../../../../../../../types';
-import { getAccountName, getLandingCompanyNameOfMT5Account } from '../../../../../../helpers';
+import { getAccountName } from '../../../../../../helpers';
 import { TransactionsCompletedRowAccountDetails } from '../TransactionsCompletedRowAccountDetails';
 
 type TProps = {
@@ -27,8 +27,7 @@ const TransactionsCompletedRowTransferAccountDetails: React.FC<TProps> = ({ acco
     if (transferAccount) {
         const derivAccountType = transferAccount === wallet ? 'wallet' : 'standard';
         const accountType = transferAccount?.platform !== 'deriv' ? transferAccount.platform : derivAccountType;
-        const mt5LandingCompanyName =
-            transferAccount === mt5Account ? getLandingCompanyNameOfMT5Account(mt5Account.group) : undefined;
+        const mt5LandingCompanyName = transferAccount === mt5Account ? mt5Account.landing_company_name : undefined;
         const displayAccountName = getAccountName({
             accountCategory: transferAccount === wallet ? 'wallet' : 'trading',
             //@ts-expect-error this needs backend typing


### PR DESCRIPTION
## Changes:

- [x] align name and badge of transactions to/from MT5 trading accs with transfer tab account selection form's list

### Screenshots:

<img width="1273" alt="Screenshot 2024-01-18 at 16 48 54" src="https://github.com/binary-com/deriv-app/assets/119863957/164923e2-2b33-4b93-84c7-0dc07923be59">

