### PR TITLE
[P2PS] / Ameerul / P2PS-2214 Date filters selection in past order tab is not translated to other languages

### DIFF
--- a/packages/p2p/src/components/composite-calendar/composite-calendar.tsx
+++ b/packages/p2p/src/components/composite-calendar/composite-calendar.tsx
@@ -57,43 +57,43 @@ const DateFieldComponent = ({ label, placeholder, showCalendar, value }: TDateFi
     );
 };
 
-const days_duration_list = [
-    {
-        value: 'all_time',
-        label: localize('All time'),
-        duration: 0,
-    },
-    {
-        value: 'today',
-        label: localize('Today'),
-        duration: 1,
-    },
-    {
-        value: 'last_7_days',
-        label: localize('Last 7 days'),
-        duration: 7,
-    },
-    {
-        value: 'last_30_days',
-        label: localize('Last 30 days'),
-        duration: 30,
-    },
-    {
-        value: 'last_60_days',
-        label: localize('Last 60 days'),
-        duration: 60,
-    },
-    {
-        value: 'last_quarter',
-        label: localize('Last quarter'),
-        duration: 90,
-    },
-];
-
 const CompositeCalendar = (props: TCompositeCalendarProps) => {
     const { ui } = useStore();
     const { current_focus, setCurrentFocus } = ui;
     const { from, to, onChange } = props;
+
+    const days_duration_list = [
+        {
+            value: 'all_time',
+            label: localize('All time'),
+            duration: 0,
+        },
+        {
+            value: 'today',
+            label: localize('Today'),
+            duration: 1,
+        },
+        {
+            value: 'last_7_days',
+            label: localize('Last 7 days'),
+            duration: 7,
+        },
+        {
+            value: 'last_30_days',
+            label: localize('Last 30 days'),
+            duration: 30,
+        },
+        {
+            value: 'last_60_days',
+            label: localize('Last 60 days'),
+            duration: 60,
+        },
+        {
+            value: 'last_quarter',
+            label: localize('Last quarter'),
+            duration: 90,
+        },
+    ];
 
     const [show_to, setShowTo] = React.useState(false);
     const [show_from, setShowFrom] = React.useState(false);

--- a/packages/p2p/src/pages/orders/chat/__tests__/chat-messages.spec.jsx
+++ b/packages/p2p/src/pages/orders/chat/__tests__/chat-messages.spec.jsx
@@ -38,9 +38,11 @@ describe('<ChatMessages />', () => {
     it('should render the bot message with appropriate styles', () => {
         render(<ChatMessages />);
         const bot_message = screen.getByText(
-            /Hello! This is where you can chat with the counterparty to confirm the order details. Note: In case of a dispute, we'll use this chat as a reference./
+            /Hello! This is where you can chat with the counterparty to confirm the order details./
         );
+        const bot_message2 = screen.getByText(/Note: In case of a dispute, we'll use this chat as a reference./);
         expect(bot_message).toBeInTheDocument();
+        expect(bot_message2).toBeInTheDocument();
         expect(bot_message).toHaveStyle('--text-lh: var(--text-lh-xl)');
         expect(bot_message).toHaveStyle('--text-size: var(--text-size-xxs)');
     });

--- a/packages/p2p/src/pages/orders/chat/chat-messages.jsx
+++ b/packages/p2p/src/pages/orders/chat/chat-messages.jsx
@@ -8,14 +8,14 @@ import { Localize } from 'Components/i18next';
 import ChatMessageReceipt from 'Pages/orders/chat/chat-message-receipt.jsx';
 import ChatMessageText from 'Pages/orders/chat/chat-message-text.jsx';
 import { useStores } from 'Stores';
-import ChatMessage, { admin_message } from 'Utils/chat-message';
+import ChatMessage from 'Utils/chat-message';
 import { convertToMB, isImageType, isPDFType } from 'Utils/file-uploader';
 import './chat-messages.scss';
 
 const AdminMessage = () => (
     <div className='chat-messages-item chat-messages-item--admin'>
         <ChatMessageText color='general' type='admin'>
-            <Localize i18n_default_text={admin_message} />
+            <Localize i18n_default_text="Hello! This is where you can chat with the counterparty to confirm the order details.<br />Note: In case of a dispute, we'll use this chat as a reference." />
         </ChatMessageText>
     </div>
 );

--- a/packages/p2p/src/utils/chat-message.ts
+++ b/packages/p2p/src/utils/chat-message.ts
@@ -87,7 +87,3 @@ export const convertFromChannelMessage = (channel_message: UserMessage | FileMes
         url: channel_message.isFileMessage() ? channel_message.url : undefined,
     });
 };
-
-export const admin_message = localize(
-    "Hello! This is where you can chat with the counterparty to confirm the order details.\nNote: In case of a dispute, we'll use this chat as a reference."
-);

--- a/packages/p2p/src/utils/chat-message.ts
+++ b/packages/p2p/src/utils/chat-message.ts
@@ -1,5 +1,4 @@
 import { FileMessage, UserMessage } from '@sendbird/chat/message';
-import { localize } from 'Components/i18next';
 
 type TChatMessageArgs = {
     created_at: number;


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- Moved the array into the composite calendar component because when you call localize outside of a component, it doesn't have access to the current locale or the translation messages.
- Due to this discovery, I also fixed the issue with the admin message, as initially the translation wasn't working, but when I move the string to the component itself, it is fixed (after changing the string a little bit and changing the crc32 value). So translation team need to change the text again and it should work

### Screenshots:

Please provide some screenshots of the change.
<img width="467" alt="Screenshot 2024-01-19 at 10 44 51 AM" src="https://github.com/binary-com/deriv-app/assets/103412909/ad45d697-fff6-4e10-a4bf-16e477648c57">
<img width="763" alt="Screenshot 2024-01-19 at 10 45 19 AM" src="https://github.com/binary-com/deriv-app/assets/103412909/53cc5525-2e59-4e81-a254-a839a42f0a61">
<img width="735" alt="Screenshot 2024-01-19 at 10 45 26 AM" src="https://github.com/binary-com/deriv-app/assets/103412909/ec6340ec-eefe-4c42-adc9-33d35442cccb">

