### PR TITLE
[P2PS] / Ameerul / P2PS-2277 Error message for instruction field is overlapping with the textbox

### DIFF
--- a/packages/p2p/src/components/add-payment-method-form/add-payment-method-form.scss
+++ b/packages/p2p/src/components/add-payment-method-form/add-payment-method-form.scss
@@ -65,6 +65,10 @@
                     padding-right: 0;
                 }
             }
+
+            & .dc-field--error {
+                top: unset;
+            }
         }
     }
 }

--- a/packages/p2p/src/pages/my-ads/edit-ad-form.scss
+++ b/packages/p2p/src/pages/my-ads/edit-ad-form.scss
@@ -79,6 +79,7 @@
                 .dc-input {
                     &__wrapper {
                         margin-top: 2.1rem;
+                        margin-bottom: 3rem;
                     }
                     &__hint {
                         margin-top: 0;

--- a/packages/p2p/src/pages/my-profile/payment-methods/edit-payment-method-form/edit-payment-method-form.scss
+++ b/packages/p2p/src/pages/my-profile/payment-methods/edit-payment-method-form/edit-payment-method-form.scss
@@ -58,6 +58,10 @@
                     padding-right: 0;
                 }
             }
+
+            & .dc-field--error {
+                top: unset;
+            }
         }
     }
 }


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- made the error field unset as it was floating in the div itself

### Screenshots:

Please provide some screenshots of the change.
<img width="946" alt="Screenshot 2024-01-19 at 2 21 26 PM" src="https://github.com/binary-com/deriv-app/assets/103412909/cea730d7-ba07-48c8-a197-aa9b31247348">
<img width="603" alt="Screenshot 2024-01-19 at 2 21 43 PM" src="https://github.com/binary-com/deriv-app/assets/103412909/e1ab5f99-4819-40f1-8bd8-b3e8f89abb20">
<img width="533" alt="Screenshot 2024-01-19 at 2 22 20 PM" src="https://github.com/binary-com/deriv-app/assets/103412909/9a011618-62f8-4923-ba79-fcb95c67e913">
<img width="739" alt="Screenshot 2024-01-19 at 2 22 40 PM" src="https://github.com/binary-com/deriv-app/assets/103412909/7907052b-4da9-4cc4-816e-6cb64e1f22fa">


