### PR TITLE
fix: handle google drive error response

### DIFF
--- a/packages/bot-web-ui/src/stores/google-drive-store.js
+++ b/packages/bot-web-ui/src/stores/google-drive-store.js
@@ -51,9 +51,11 @@ export default class GoogleDriveStore {
             client_id: this.client_id,
             scope: this.scope,
             callback: response => {
-                this.access_token = response.access_token;
-                this.updateSigninStatus(true);
-                localStorage.setItem('google_access_token', response.access_token);
+                if (response?.access_token && !response?.error) {
+                    this.access_token = response.access_token;
+                    this.updateSigninStatus(true);
+                    localStorage.setItem('google_access_token', response.access_token);
+                }
             },
         });
     };


### PR DESCRIPTION
## Changes:

Handle Google Drive error response. Currently, if users cancel the sign-in flow, it is showing connected in the app.

- Added a response check to see if there is a token with no error, only then proceed to sign in the user.
