### PR TITLE
chore: disable crash and boom from bot

### DIFF
--- a/packages/bot-skeleton/src/constants/config.js
+++ b/packages/bot-skeleton/src/constants/config.js
@@ -300,7 +300,7 @@ export const config = {
     },
     default_file_name: localize('Untitled Bot'),
     DISABLED_SYMBOLS: ['frxGBPNOK', 'frxUSDNOK', 'frxUSDNEK', 'frxUSDSEK'],
-    DISABLED_SUBMARKETS: ['energy'],
+    DISABLED_SUBMARKETS: ['energy', 'crash_index'],
     QUICK_STRATEGY: {
         DISABLED: {
             SYMBOLS: ['1HZ150V', '1HZ250V'],


### PR DESCRIPTION
Crash and Boom need to be disabled from the Bot Builder. It was already disabled in the Quick Strategy.

## Changes:

- Added `crash_index` inside the `DISABLED_SUBMARKETS` array of the bot-skeleton config file.

