### PR TITLE
[WALL] wojtek/disabled refetching every 30s as it caused problems and to limit the possibility of race hazards 

### DIFF
--- a/packages/api/src/hooks/useBalance.ts
+++ b/packages/api/src/hooks/useBalance.ts
@@ -9,7 +9,6 @@ const useBalance = () => {
         payload: { account: 'all' },
         options: {
             enabled: isSuccess,
-            refetchInterval: 30000, // Refetch every 30 seconds to simulate subscription.
         },
     });
 


### PR DESCRIPTION
## Changes:

Disabled balances refetching every 30s, as with new upcoming designs it won't be needed anyway, while at the moment its contributing to some of the bugs we have.