### PR TITLE
[WALL] aum/WALL-3340/disable-transfer-button-for-either-amounts-to-be-zero

### DIFF
--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferForm/TransferForm.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferForm/TransferForm.tsx
@@ -52,7 +52,10 @@ const TransferForm = () => {
                             </div>
                         </div>
                         <div className='wallets-transfer__submit-button'>
-                            <WalletButton disabled={!values.toAmount} size={isMobile ? 'md' : 'lg'}>
+                            <WalletButton
+                                disabled={!values.fromAmount || !values.toAmount}
+                                size={isMobile ? 'md' : 'lg'}
+                            >
                                 Transfer
                             </WalletButton>
                         </div>


### PR DESCRIPTION
## Changes:
If either of the transfer amount fields after conversion have 0 as its value, we disable the transfer button.

![image](https://github.com/binary-com/deriv-app/assets/125039206/eb4ea0ee-cf75-495c-a769-b9385fb70d6c)
