### PR TITLE
[P2PS] farrah/P2PS-2302/fix: ios redirection

### DIFF
--- a/packages/core/src/public/.well-known/apple-app-site-association
+++ b/packages/core/src/public/.well-known/apple-app-site-association
@@ -24,6 +24,7 @@
                 "paths": [
                     "/cashier/p2p",
                     "/cashier/p2p/advertiser",
+                    "/redirect",
                     "/redirect/p2p"
                 ]
             },


### PR DESCRIPTION
## Changes:

Added the `/redirect` path to open the p2p mobile application via a link to reset the password.

### Screenshots:

Please provide some screenshots of the change.
