### PR TITLE
feat: implemented useKycAuthStatus hook

### DIFF
--- a/packages/api/src/hooks/__tests__/useKycAuthStatus.spec.ts
+++ b/packages/api/src/hooks/__tests__/useKycAuthStatus.spec.ts
@@ -1,0 +1,30 @@
+import { renderHook } from '@testing-library/react-hooks';
+import useKycAuthStatus from '../useKycAuthStatus';
+import useQuery from '../../useQuery';
+
+jest.mock('../../useQuery');
+
+describe('useKycAuthStatus', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should return kyc_auth_status', () => {
+        const mock_response = {
+            data: {
+                kyc_auth_status: {
+                    identity: {
+                        status: 'none',
+                    },
+                    document: {
+                        status: 'none',
+                    },
+                },
+            },
+        };
+        (useQuery as jest.Mock).mockReturnValue(mock_response);
+
+        const { result } = renderHook(() => useKycAuthStatus({ country: 'in' }));
+        expect(result.current.kyc_auth_status).toEqual(mock_response.data.kyc_auth_status);
+    });
+});

--- a/packages/api/src/hooks/useKycAuthStatus.ts
+++ b/packages/api/src/hooks/useKycAuthStatus.ts
@@ -1,0 +1,19 @@
+import { TSocketRequestPayload } from '../../types';
+import useQuery from '../useQuery';
+
+type TKycAuthStatusPayload = TSocketRequestPayload<'kyc_auth_status'>['payload'];
+
+/** Custom hook that returns Proof of Identity (POI) and Proof of Address (POA) authentication status details. */
+const useKycAuthStatus = (payload: TKycAuthStatusPayload) => {
+    const { data, ...kyc_auth_status_rest } = useQuery('kyc_auth_status', {
+        payload,
+    });
+
+    return {
+        /** The KYC auth status */
+        kyc_auth_status: data?.kyc_auth_status,
+        ...kyc_auth_status_rest,
+    };
+};
+
+export default useKycAuthStatus;

--- a/packages/api/types.ts
+++ b/packages/api/types.ts
@@ -228,6 +228,143 @@ import type {
 } from '@deriv/api-types';
 import type { useInfiniteQuery, useMutation, useQuery } from '@tanstack/react-query';
 
+/**
+ * Proof of Identity (POI) and Proof of Address (POA) authentication status details.
+ */
+type KycAuthStatus =
+    | {
+          /**
+           * POA authentication status details.
+           */
+          address: {
+              /**
+               * Current POA status.
+               */
+              status?: 'none' | 'pending' | 'rejected' | 'verified' | 'expired';
+          };
+          /**
+           * POI authentication status details.
+           */
+          identity: {
+              /**
+               * Available services for the next POI attempt.
+               */
+              available_services?: string[];
+              /**
+               * Details on the rejected POI attempt.
+               */
+              last_rejected?: {
+                  /**
+                   * Document type of the rejected POI attempt (IDV only).
+                   */
+                  document_type?: null | string;
+                  /**
+                   * Reason(s) for the rejected POI attempt.
+                   */
+                  rejected_reasons?: string[];
+              };
+              /**
+               * Service used for the current POI status.
+               */
+              service?: 'none' | 'idv' | 'onfido' | 'manual';
+              /**
+               * Current POI status.
+               */
+              status?: 'none' | 'pending' | 'rejected' | 'verified' | 'expired' | 'suspected';
+              /**
+               * Supported documents per service.
+               */
+              supported_documents?: {
+                  idv?: {
+                      [k: string]: {
+                          additional?: {
+                              display_name?: string;
+                              format?: string;
+                              [k: string]: unknown;
+                          };
+                          display_name?: string;
+                          format?: string;
+                          [k: string]: unknown;
+                      };
+                  };
+                  onfido?: {
+                      [k: string]: {
+                          display_name?: string;
+                          [k: string]: unknown;
+                      };
+                  };
+                  [k: string]: unknown;
+              };
+          };
+      }
+    | {
+          [k: string]: {
+              /**
+               * POA authentication status details.
+               */
+              address: {
+                  /**
+                   * Current POA status.
+                   */
+                  status?: 'none' | 'pending' | 'rejected' | 'verified' | 'expired';
+              };
+              /**
+               * POI authentication status details.
+               */
+              identity: {
+                  /**
+                   * Available services for the next POI attempt.
+                   */
+                  available_services?: string[];
+                  /**
+                   * Details on the rejected POI attempt.
+                   */
+                  last_rejected?: {
+                      /**
+                       * Document type of the rejected POI attempt (IDV only).
+                       */
+                      document_type?: null | string;
+                      /**
+                       * Reason(s) for the rejected POI attempt.
+                       */
+                      rejected_reasons?: string[];
+                  };
+                  /**
+                   * Service used for the current POI status.
+                   */
+                  service?: 'none' | 'idv' | 'onfido' | 'manual';
+                  /**
+                   * Current POI status.
+                   */
+                  status?: 'none' | 'pending' | 'rejected' | 'verified' | 'expired' | 'suspected';
+                  /**
+                   * Supported documents per service.
+                   */
+                  supported_documents?: {
+                      idv?: {
+                          [k: string]: {
+                              additional?: {
+                                  display_name?: string;
+                                  format?: string;
+                                  [k: string]: unknown;
+                              };
+                              display_name?: string;
+                              format?: string;
+                              [k: string]: unknown;
+                          };
+                      };
+                      onfido?: {
+                          [k: string]: {
+                              display_name?: string;
+                              [k: string]: unknown;
+                          };
+                      };
+                      [k: string]: unknown;
+                  };
+              };
+          };
+      };
+
 type TPrivateSocketEndpoints = {
     available_accounts: {
         request: {
@@ -1864,6 +2001,66 @@ type TPrivateSocketEndpoints = {
          */
         req_id?: number;
         [k: string]: unknown;
+    };
+    kyc_auth_status: {
+        request: {
+            /**
+             * Must be `1`
+             */
+            kyc_auth_status: 1;
+            /**
+             * The country for which service availability is being verified, 2-letter country code
+             */
+            country?: string;
+            /**
+             * Indicates which landing companies to get the KYC authentication status for.
+             */
+            landing_companies?: (
+                | 'iom'
+                | 'malta'
+                | 'maltainvest'
+                | 'svg'
+                | 'virtual'
+                | 'vanuatu'
+                | 'labuan'
+                | 'samoa'
+                | 'samoa-virtual'
+                | 'bvi'
+                | 'dsl'
+            )[];
+            /**
+             * [Optional] The login id of the user. If left unspecified, it defaults to the initial authorized token's login id.
+             */
+            loginid?: string;
+            /**
+             * [Optional] Used to pass data through the websocket, which may be retrieved via the `echo_req` output field.
+             */
+            passthrough?: {
+                [k: string]: unknown;
+            };
+            /**
+             * [Optional] Used to map request to response.
+             */
+            req_id?: number;
+        };
+        response: {
+            kyc_auth_status?: KycAuthStatus;
+            /**
+             * Echo of the request made.
+             */
+            echo_req: {
+                [k: string]: unknown;
+            };
+            /**
+             * Action name of the request made.
+             */
+            msg_type: 'kyc_auth_status';
+            /**
+             * Optional field sent in request to map to response, present only when request contains `req_id`.
+             */
+            req_id?: number;
+            [k: string]: unknown;
+        };
     };
 };
 


### PR DESCRIPTION
## Changes:

Created a new hook that uses `useKycAuthStatus` API call.
This will replace usePOI hook as most of the business logic is moved to the BE which will control the POI and POA flow
