### PR TITLE
[WALL] aum/WALL-3357/blue-transfer-disappear-and-button-disabled-wallets

### DIFF
--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormAmountInput/TransferFormAmountInput.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormAmountInput/TransferFormAmountInput.tsx
@@ -123,15 +123,22 @@ const TransferFormAmountInput: React.FC<TProps> = ({ fieldName }) => {
     const onTimerCompleteHandler = useCallback(() => {
         refetchExchangeRatesAndLimits().then(res => {
             const newRates = res.data?.exchange_rates;
-            if (!newRates?.rates || !toAccount?.currency) return;
+            if (!newRates?.rates || !fromAccount?.currency || !toAccount?.currency) return;
+
+            const fromRate = newRates.rates[fromAccount.currency];
             const toRate = newRates.rates[toAccount.currency];
+
             const convertedToAmount = Number(
-                (fromAmount * toRate).toFixed(toAccount?.currencyConfig?.fractional_digits)
+                (toRate ? fromAmount * toRate : fromAmount / fromRate).toFixed(
+                    toAccount?.currencyConfig?.fractional_digits
+                )
             );
+
             setFieldValue('toAmount', convertedToAmount);
         });
     }, [
         fromAmount,
+        fromAccount?.currency,
         refetchExchangeRatesAndLimits,
         setFieldValue,
         toAccount?.currency,


### PR DESCRIPTION
## Changes:

Fix the hiding of transfer blue message and disabling of the transfer button once the timer expires and target amount is not updated with the new exchange rate.


https://github.com/binary-com/deriv-app/assets/125039206/00ac5306-7902-4728-8806-12a3823f9ccf

