### PR TITLE
[WALL] [Fix] Rostislav / WALL-3345 / Align transfer tab component size with Figma

### DIFF
--- a/packages/wallets/src/components/Base/ATMAmountInput/ATMAmountInput.scss
+++ b/packages/wallets/src/components/Base/ATMAmountInput/ATMAmountInput.scss
@@ -20,6 +20,7 @@
     }
 
     &__input-container {
+        height: 3rem;
         position: relative;
         flex-grow: 1;
     }

--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferForm/TransferForm.scss
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferForm/TransferForm.scss
@@ -25,7 +25,7 @@
         padding: 0.8rem;
 
         @include mobile {
-            height: 9rem;
+            min-height: 9rem;
             grid-template-columns: 60% 40%;
         }
     }

--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferForm/TransferForm.scss
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferForm/TransferForm.scss
@@ -25,6 +25,7 @@
         padding: 0.8rem;
 
         @include mobile {
+            height: 9rem;
             grid-template-columns: 60% 40%;
         }
     }

--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormDropdown/TransferFormDropdown.scss
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormDropdown/TransferFormDropdown.scss
@@ -33,8 +33,7 @@
 
     &__select-account-cta {
         @include mobile {
-            padding-top: 0.5rem;
-            padding-bottom: 0.5rem;
+            padding: 0.5rem 0;
         }
     }
 

--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormDropdown/TransferFormDropdown.scss
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormDropdown/TransferFormDropdown.scss
@@ -15,7 +15,11 @@
         display: flex;
         flex-direction: column;
         flex: 1;
-        gap: 0.4rem;
+        gap: 0.2rem;
+
+        @include mobile {
+            gap: 0.4rem;
+        }
     }
 
     &__header {
@@ -24,6 +28,13 @@
 
         @include mobile {
             justify-content: space-between;
+        }
+    }
+
+    &__select-account-cta {
+        @include mobile {
+            padding-top: 0.5rem;
+            padding-bottom: 0.5rem;
         }
     }
 

--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormDropdown/TransferFormDropdown.scss
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormDropdown/TransferFormDropdown.scss
@@ -33,9 +33,7 @@
 
     &__select-account-cta {
         @include mobile {
-            display: flex;
-            align-items: center;
-            min-height: 5.4rem;
+            padding: 0.5rem 0;
         }
     }
 

--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormDropdown/TransferFormDropdown.scss
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormDropdown/TransferFormDropdown.scss
@@ -33,7 +33,9 @@
 
     &__select-account-cta {
         @include mobile {
-            padding: 0.5rem 0;
+            display: flex;
+            align-items: center;
+            min-height: 5.4rem;
         }
     }
 

--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormDropdown/TransferFormDropdown.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormDropdown/TransferFormDropdown.tsx
@@ -118,9 +118,11 @@ const TransferFormDropdown: React.FC<TProps> = ({ fieldName, mobileAccountsListR
                 {selectedAccount ? (
                     <TransferFormAccountCard account={selectedAccount} activeWallet={activeWallet} type='input' />
                 ) : (
-                    <WalletText size='sm' weight='bold'>
-                        Select a trading account or a Wallet
-                    </WalletText>
+                    <div className='wallets-transfer-form-dropdown__select-account-cta'>
+                        <WalletText size='sm' weight='bold'>
+                            Select a trading account or a Wallet
+                        </WalletText>
+                    </div>
                 )}
             </div>
 


### PR DESCRIPTION
## Changes:

- [x] align transfer tab component size with Figma on desktop and mobile

### Screenshots:

<img width="1263" alt="Screenshot 2024-01-24 at 16 44 45" src="https://github.com/binary-com/deriv-app/assets/119863957/c23cd9d1-05b1-4900-8265-fb553e11fbb8">
<img width="1262" alt="Screenshot 2024-01-24 at 16 45 10" src="https://github.com/binary-com/deriv-app/assets/119863957/db5830cd-d72e-4456-b07a-8e0d2e3219ae">

