### PR TITLE
[WALL] [Fix] Rostislav / WALL-3368 / Address mobile `TransactionStatus` inconsistencies

### DIFF
--- a/packages/wallets/src/features/cashier/modules/TransactionStatus/components/CryptoTransaction/CryptoTransaction.tsx
+++ b/packages/wallets/src/features/cashier/modules/TransactionStatus/components/CryptoTransaction/CryptoTransaction.tsx
@@ -63,7 +63,10 @@ const CryptoTransaction: React.FC<TCryptoTransaction> = ({ currencyDisplayCode: 
                                         description='Are you sure you want to cancel this transaction?'
                                         hideCloseButton={true}
                                         title='Cancel transaction'
-                                    />
+                                    />,
+                                    {
+                                        defaultRootId: 'wallets_modal_root',
+                                    }
                                 )
                             }
                         >


### PR DESCRIPTION
## Changes:

- [x] fix "Cancel transaction" modal opening incorrectly on mobile

### Screenshots:

(including desktop as well just to show that the changes don't break that)

https://github.com/binary-com/deriv-app/assets/119863957/7e659da6-91e9-4033-86f3-18153bcfd39b

https://github.com/binary-com/deriv-app/assets/119863957/b08c64a3-1143-4139-b51e-a9d9440fe184

