### PR TITLE
[WALL] george / WALL-3289 / Cashier Locked message is not aligned properly in transfer page

### DIFF
--- a/packages/cashier/src/containers/cashier/cashier.scss
+++ b/packages/cashier/src/containers/cashier/cashier.scss
@@ -323,6 +323,15 @@
                 padding: 0 1rem;
             }
         }
+
+        &-padding {
+            padding: 0 2.4rem 2.4rem;
+            max-width: 61.8rem;
+
+            @include mobile {
+                padding: 1.6rem;
+            }
+        }
     }
 
     .dc-vertical-tab__tab--floating {

--- a/packages/cashier/src/pages/account-transfer/account-transfer.tsx
+++ b/packages/cashier/src/pages/account-transfer/account-transfer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Loading } from '@deriv/components';
+import { useCashierLocked } from '@deriv/hooks';
 import { WS } from '@deriv/shared';
 import { useStore, observer } from '@deriv/stores';
 import Error from '../../components/error';
@@ -10,7 +11,6 @@ import AccountTransferForm from './account-transfer-form';
 import AccountTransferNoAccount from './account-transfer-no-account';
 import AccountTransferLocked from './account-transfer-locked';
 import { useCashierStore } from '../../stores/useCashierStores';
-import { useCashierLocked } from '@deriv/hooks';
 
 type TAccountTransferProps = {
     onClickDeposit?: VoidFunction;
@@ -68,7 +68,11 @@ const AccountTransfer = observer(({ onClickDeposit, onClickNotes, onClose, setSi
     }
 
     if (is_cashier_locked) {
-        return <CashierLocked />;
+        return (
+            <div className='cashier-locked-padding'>
+                <CashierLocked />
+            </div>
+        );
     }
     if (is_transfer_locked) {
         return <AccountTransferLocked />;

--- a/packages/cashier/src/pages/on-ramp/on-ramp.tsx
+++ b/packages/cashier/src/pages/on-ramp/on-ramp.tsx
@@ -104,7 +104,11 @@ const OnRamp = observer(({ menu_options, setSideNotes }: TOnRampProps) => {
     if (is_switching || is_loading) return <Loading className='cashier-onboarding__loader' is_fullscreen />;
 
     if (is_deposit_locked || is_cashier_locked) {
-        return <CashierLocked />;
+        return (
+            <div className='cashier-locked-padding'>
+                <CashierLocked />
+            </div>
+        );
     }
 
     return (

--- a/packages/cashier/src/pages/payment-agent-transfer/payment-agent-transfer.tsx
+++ b/packages/cashier/src/pages/payment-agent-transfer/payment-agent-transfer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Loading } from '@deriv/components';
+import { useCashierLocked } from '@deriv/hooks';
 import { observer, useStore } from '@deriv/stores';
 import CashierLocked from 'Components/cashier-locked';
 import Error from 'Components/error';
@@ -9,7 +10,6 @@ import PaymentAgentTransferConfirm from './payment-agent-transfer-confirm';
 import PaymentAgentTransferForm from './payment-agent-transfer-form';
 import PaymentAgentTransferReceipt from './payment-agent-transfer-receipt';
 import { useCashierStore } from '../../stores/useCashierStores';
-import { useCashierLocked } from '@deriv/hooks';
 
 const PaymentAgentTransfer = observer(() => {
     const { client } = useStore();
@@ -44,7 +44,11 @@ const PaymentAgentTransfer = observer(() => {
         return <Loading className='cashier__loader' />;
     }
     if (is_cashier_locked) {
-        return <CashierLocked />;
+        return (
+            <div className='cashier-locked-padding'>
+                <CashierLocked />
+            </div>
+        );
     }
     if (error.is_show_full_page) {
         // for errors with CTA hide the form and show the error,

--- a/packages/cashier/src/pages/payment-agent/payment-agent.tsx
+++ b/packages/cashier/src/pages/payment-agent/payment-agent.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Loading } from '@deriv/components';
+import { useCashierLocked } from '@deriv/hooks';
 import { observer, useStore } from '@deriv/stores';
 import CashierLocked from 'Components/cashier-locked';
 import { Virtual } from 'Components/cashier-container';
 import PaymentAgentList from './payment-agent-list';
 import { useCashierStore } from '../../stores/useCashierStores';
-import { useCashierLocked } from '@deriv/hooks';
 
 type TPaymentAgent = {
     setSideNotes?: (notes: React.ReactNode[]) => void;
@@ -46,7 +46,11 @@ const PaymentAgent = observer(({ setSideNotes }: TPaymentAgent) => {
     }
 
     if (is_cashier_locked) {
-        return <CashierLocked />;
+        return (
+            <div className='cashier-locked-padding'>
+                <CashierLocked />
+            </div>
+        );
     }
 
     return <PaymentAgentList setSideNotes={setSideNotes} />;


### PR DESCRIPTION
## Changes:

- fix cashier locked message alignment in PA, Account transfer, PA Transfer, FiatOnRamp

### Screenshots:

![Screenshot 2024-01-29 at 13 46 46](https://github.com/binary-com/deriv-app/assets/103181646/c6f60292-e0fa-469a-bedd-fa48d1986dcd)

