### PR TITLE
[WALL] [Fix] Rostislav / WALL-3380 & WALL-3381 / Fix daily limits messages values conversion

### DIFF
--- a/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/utils/cumulativeAccountLimitsMessageFn.ts
+++ b/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/utils/cumulativeAccountLimitsMessageFn.ts
@@ -80,9 +80,14 @@ const cumulativeAccountLimitsMessageFn = ({
     )
         return null;
 
-    const sourceCurrencyLimit = allowedSumUSD * (activeWalletExchangeRates?.rates?.[sourceAccount.currency] ?? 1);
+    const USDToSourceRate =
+        activeWallet.currency === sourceAccount.currency
+            ? 1 / (activeWalletExchangeRates?.rates?.USD ?? 1)
+            : (activeWalletExchangeRates?.rates?.[sourceAccount.currency] ?? 1) /
+              (activeWalletExchangeRates?.rates?.USD ?? 1);
 
-    const sourceCurrencyRemainder = availableSumUSD * (activeWalletExchangeRates?.rates?.[sourceAccount.currency] ?? 1);
+    const sourceCurrencyLimit = allowedSumUSD * USDToSourceRate;
+    const sourceCurrencyRemainder = availableSumUSD * USDToSourceRate;
 
     const formattedSourceCurrencyLimit = displayMoney?.(
         sourceCurrencyLimit,

--- a/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/utils/cumulativeAccountLimitsMessageFn.ts
+++ b/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/utils/cumulativeAccountLimitsMessageFn.ts
@@ -84,7 +84,7 @@ const cumulativeAccountLimitsMessageFn = ({
         activeWallet.currency === sourceAccount.currency
             ? 1 / (activeWalletExchangeRates?.rates?.USD ?? 1)
             : // if the source ("from") account is not the active wallet,
-              // compute sourceCurrency -> USD rate as activeWalletCurrency -> sourceCurrency rate,
+              // compute USD -> sourceCurrency rate as activeWalletCurrency -> sourceCurrency rate,
               // divided by activeWalletCurrency -> USD rate
               (activeWalletExchangeRates?.rates?.[sourceAccount.currency] ?? 1) /
               (activeWalletExchangeRates?.rates?.USD ?? 1);

--- a/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/utils/cumulativeAccountLimitsMessageFn.ts
+++ b/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/utils/cumulativeAccountLimitsMessageFn.ts
@@ -83,7 +83,10 @@ const cumulativeAccountLimitsMessageFn = ({
     const USDToSourceRate =
         activeWallet.currency === sourceAccount.currency
             ? 1 / (activeWalletExchangeRates?.rates?.USD ?? 1)
-            : (activeWalletExchangeRates?.rates?.[sourceAccount.currency] ?? 1) /
+            : // if the source ("from") account is not the active wallet,
+              // compute sourceCurrency -> USD rate as activeWalletCurrency -> sourceCurrency rate,
+              // divided by activeWalletCurrency -> USD rate
+              (activeWalletExchangeRates?.rates?.[sourceAccount.currency] ?? 1) /
               (activeWalletExchangeRates?.rates?.USD ?? 1);
 
     const sourceCurrencyLimit = allowedSumUSD * USDToSourceRate;


### PR DESCRIPTION
## Changes:

- [x] fix the issue of USD limits values being displayed in the transfer messages as non-USD currencies (e.g. 100,000.00000000 BTC (actually $100,000.00, so roughly 2.4 BTC))

### Screenshots:

https://github.com/binary-com/deriv-app/assets/119863957/6101b778-8d96-4c2d-aaa6-3e9f6206891c
