### PR TITLE
[WALL] [Fix] Rostislav / WALL-3387 / Fix navigating from `TransactionStatus` to transactions tab

### DIFF
--- a/packages/wallets/src/features/cashier/modules/TransactionStatus/components/TransactionStatusSuccess/TransactionStatusSuccess.tsx
+++ b/packages/wallets/src/features/cashier/modules/TransactionStatus/components/TransactionStatusSuccess/TransactionStatusSuccess.tsx
@@ -41,7 +41,7 @@ const TransactionStatusSuccess: React.FC<TTransactionStatusSuccess> = ({ transac
                                 // should navigate to transactions page with "Pending transactions" toggle on and filter set to `transactionType`
                                 history.push('/wallets/cashier/transactions', {
                                     showPending: true,
-                                    transactionType: 'withdrawal',
+                                    transactionType,
                                 });
                             }}
                             size='sm'


### PR DESCRIPTION
## Changes:

- [x] account both for withdrawal and deposit instead of just withdrawal

### Screenshots:

code changes are too self-explanatory for this 👀 
