### PR TITLE
[BOT] Farabi/bot-1290/fix incorrect tooltips on quick strategy modal

### DIFF
--- a/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/config.ts
+++ b/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/config.ts
@@ -119,11 +119,19 @@ const LOSS: TConfigItem = {
     validation: ['number', 'required', 'ceil', NUMBER_DEFAULT_VALIDATION],
 };
 
-const LABEL_SIZE: TConfigItem = {
+const LABEL_MARTINGALE_SIZE: TConfigItem = {
     type: 'label',
     label: localize('Size'),
     description: localize(
         'The multiplier amount used to increase your stake if you’re losing a trade. Value must be higher than 1.'
+    ),
+};
+
+const LABEL_REVERSE_MARTINGALE_SIZE: TConfigItem = {
+    type: 'label',
+    label: localize('Size'),
+    description: localize(
+        'The multiplier amount used to increase your stake after a successful trade. Value must be higher than 1.'
     ),
 };
 
@@ -147,6 +155,12 @@ const LABEL_DALEMBERT_UNIT: TConfigItem = {
     type: 'label',
     label: localize('Unit'),
     description: localize("The amount that you may add to your stake if you're losing a trade."),
+};
+
+const LABEL_REVERSE_DALEMBERT_UNIT: TConfigItem = {
+    type: 'label',
+    label: localize('Unit'),
+    description: localize('The amount that you may add to your stake after a successful trade.'),
 };
 
 const UNIT: TConfigItem = {
@@ -209,7 +223,7 @@ export const STRATEGIES: TStrategies = {
                 DURATION_TYPE,
                 DURATION,
             ],
-            [LABEL_PROFIT, PROFIT, LABEL_LOSS, LOSS, LABEL_SIZE, SIZE, CHECKBOX_MAX_STAKE, MAX_STAKE],
+            [LABEL_PROFIT, PROFIT, LABEL_LOSS, LOSS, LABEL_MARTINGALE_SIZE, SIZE, CHECKBOX_MAX_STAKE, MAX_STAKE],
         ],
     },
     D_ALEMBERT: {
@@ -278,7 +292,16 @@ export const STRATEGIES: TStrategies = {
                 DURATION_TYPE,
                 DURATION,
             ],
-            [LABEL_PROFIT, PROFIT, LABEL_LOSS, LOSS, LABEL_SIZE, SIZE, CHECKBOX_MAX_STAKE, MAX_STAKE],
+            [
+                LABEL_PROFIT,
+                PROFIT,
+                LABEL_LOSS,
+                LOSS,
+                LABEL_REVERSE_MARTINGALE_SIZE,
+                SIZE,
+                CHECKBOX_MAX_STAKE,
+                MAX_STAKE,
+            ],
         ],
     },
     REVERSE_D_ALEMBERT: {
@@ -301,7 +324,7 @@ export const STRATEGIES: TStrategies = {
                 DURATION_TYPE,
                 DURATION,
             ],
-            [LABEL_PROFIT, PROFIT, LABEL_LOSS, LOSS, LABEL_DALEMBERT_UNIT, UNIT, CHECKBOX_MAX_STAKE, MAX_STAKE],
+            [LABEL_PROFIT, PROFIT, LABEL_LOSS, LOSS, LABEL_REVERSE_DALEMBERT_UNIT, UNIT, CHECKBOX_MAX_STAKE, MAX_STAKE],
         ],
     },
     STRATEGY_1_3_2_6: {


### PR DESCRIPTION
## Changes:

- Fixed incorrect tooltips for reverse martingale and reverse d'alembert strategy on quick strategy modal
- Size field for reverse martingale strategy
- Unit field for reverse d'alembert strategy

### Screenshots:

<img width="719" alt="Screenshot 2024-01-30 at 7 29 26 PM" src="https://github.com/binary-com/deriv-app/assets/102643568/65d0cc29-1821-44a5-be54-f74523f245e9">
