### PR TITLE
fix: updated mt5 account error message display

### DIFF
--- a/packages/account/src/Sections/Verification/ProofOfAddress/proof-of-address-form.tsx
+++ b/packages/account/src/Sections/Verification/ProofOfAddress/proof-of-address-form.tsx
@@ -347,7 +347,6 @@ const ProofOfAddressForm = observer(
                                             label={localize('Continue')}
                                             is_absolute={is_mobile}
                                             is_loading={isSubmitting}
-                                            form_error={status?.msg}
                                         />
                                     </Modal.Footer>
                                 ) : (


### PR DESCRIPTION
## Changes:

Got two error messages for the Duplicate File upload error in MT5 account creation page. 

Remove the message in the footer
