### PR TITLE
[WALL] [Fix] Rostislav / WALL-3343 (again) / Fix non-updating transfer form field when exiting from an input amount field before debounce function is called

### DIFF
--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormAmountInput/TransferFormAmountInput.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormAmountInput/TransferFormAmountInput.tsx
@@ -136,13 +136,23 @@ const TransferFormAmountInput: React.FC<TProps> = ({ fieldName }) => {
             const fromRate = newRates.rates[fromAccount.currency];
             const toRate = newRates.rates[toAccount.currency];
 
+            const convertedFromAmount = Number(
+                (fromRate ? toAmount * fromRate : toAmount / toRate).toFixed(
+                    fromAccount?.currencyConfig?.fractional_digits
+                )
+            );
             const convertedToAmount = Number(
                 (toRate ? fromAmount * toRate : fromAmount / fromRate).toFixed(
                     toAccount?.currencyConfig?.fractional_digits
                 )
             );
 
-            setFieldValue('toAmount', convertedToAmount);
+            // if focused into the receiving account amount field, change the other ("from") field value
+            if (values.activeAmountFieldName === 'toAmount') {
+                setFieldValue('fromAmount', convertedFromAmount);
+            } else {
+                setFieldValue('toAmount', convertedToAmount);
+            }
         });
     }, [
         fromAmount,

--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormAmountInput/TransferFormAmountInput.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormAmountInput/TransferFormAmountInput.tsx
@@ -13,6 +13,7 @@ type TProps = {
 
 const MAX_DIGITS = 12;
 const USD_MAX_POSSIBLE_TRANSFER_AMOUNT = 100_000;
+const DEBOUNCE_DELAY_MS = 500;
 
 const TransferFormAmountInput: React.FC<TProps> = ({ fieldName }) => {
     const { setFieldValue, setValues, values } = useFormikContext<TInitialTransferFormValues>();
@@ -41,7 +42,7 @@ const TransferFormAmountInput: React.FC<TProps> = ({ fieldName }) => {
     const isTimerVisible = !isFromAmountField && toAccount && !isSameCurrency && fromAmount > 0 && toAmount > 0;
 
     const amountValue = isFromAmountField ? fromAmount : toAmount;
-    const debouncedAmountValue = useDebounce(amountValue, 500);
+    const debouncedAmountValue = useDebounce(amountValue, DEBOUNCE_DELAY_MS);
 
     const toAmountLabel = isSameCurrency || !toAccount ? 'Amount you receive' : 'Estimated amount';
     const amountLabel = isFromAmountField ? 'Amount you send' : toAmountLabel;
@@ -103,6 +104,13 @@ const TransferFormAmountInput: React.FC<TProps> = ({ fieldName }) => {
         }
     }, [amountConverterHandler, debouncedAmountValue, isSameCurrency]);
 
+    const onBlurHandler = useCallback(() => {
+        if (!isSameCurrency) {
+            amountConverterHandler(amountValue);
+        }
+        setFieldValue('activeAmountFieldName', undefined);
+    }, [amountValue, isSameCurrency, setFieldValue]);
+
     const onChangeHandler = useCallback(
         (value: number) => {
             if (!isAmountFieldActive) return;
@@ -154,7 +162,7 @@ const TransferFormAmountInput: React.FC<TProps> = ({ fieldName }) => {
                 label={amountLabel}
                 locale={preferredLanguage}
                 maxDigits={maxDigits}
-                onBlur={() => setFieldValue('activeAmountFieldName', undefined)}
+                onBlur={onBlurHandler}
                 onChange={onChangeHandler}
                 onFocus={() => setFieldValue('activeAmountFieldName', fieldName)}
                 value={amountValue}

--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormAmountInput/TransferFormAmountInput.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormAmountInput/TransferFormAmountInput.tsx
@@ -109,7 +109,7 @@ const TransferFormAmountInput: React.FC<TProps> = ({ fieldName }) => {
             amountConverterHandler(amountValue);
         }
         setFieldValue('activeAmountFieldName', undefined);
-    }, [amountValue, isSameCurrency, setFieldValue]);
+    }, [amountConverterHandler, amountValue, isSameCurrency, setFieldValue]);
 
     const onChangeHandler = useCallback(
         (value: number) => {


### PR DESCRIPTION
## Changes:

Addressing a non-covered scenario of the bug described in the WALL-3343 card

- [x] change `onBlur` logic to fix the non-changing values issue

### Screenshots:

https://github.com/binary-com/deriv-app/assets/119863957/70b4483c-288b-4793-aa47-2bad2d672158
