### PR TITLE
[TRAH] shontzu/TRAH-2704/Rename-TProps

### DIFF
--- a/packages/tradershub/src/components/ActionScreen/ActionScreen.tsx
+++ b/packages/tradershub/src/components/ActionScreen/ActionScreen.tsx
@@ -1,7 +1,7 @@
-import React, { ComponentProps, isValidElement, PropsWithChildren, ReactNode } from 'react';
+import React, { ComponentProps, isValidElement, ReactNode } from 'react';
 import { qtMerge, Text } from '@deriv/quill-design';
 
-type TProps = {
+type TActionScreenProps = {
     className?: string;
     description: ReactNode;
     descriptionSize?: ComponentProps<typeof Text>['size'];
@@ -16,7 +16,7 @@ type TProps = {
  * As its common and repeated in many places,
  * at the moment of writing this, there are already 3 different patterns use to display ex
  */
-const ActionScreen: React.FC<PropsWithChildren<TProps>> = ({
+const ActionScreen = ({
     className,
     description,
     descriptionSize = 'md',
@@ -24,7 +24,7 @@ const ActionScreen: React.FC<PropsWithChildren<TProps>> = ({
     renderButtons,
     title,
     titleSize = 'md',
-}) => {
+}: TActionScreenProps) => {
     return (
         <div
             className={qtMerge([

--- a/packages/tradershub/src/components/SentEmailContent/SentEmailContent.tsx
+++ b/packages/tradershub/src/components/SentEmailContent/SentEmailContent.tsx
@@ -1,4 +1,4 @@
-import React, { FC, Fragment, useEffect, useState } from 'react';
+import React, { Fragment, useEffect, useState } from 'react';
 import { useCountdown } from 'usehooks-ts';
 import { useActiveTradingAccount, useSettings, useVerifyEmail } from '@deriv/api';
 import { Button, useBreakpoint } from '@deriv/quill-design';
@@ -8,13 +8,13 @@ import { TPlatforms } from '../../types';
 import { platformPasswordResetRedirectLink } from '../../utils/cfd';
 import { ActionScreen } from '../ActionScreen';
 
-type TProps = {
+type TSentEmailContentProps = {
     description?: string;
     isInvestorPassword?: boolean;
     platform?: TPlatforms.All;
 };
 
-const SentEmailContent: FC<TProps> = ({ description, isInvestorPassword = false, platform }) => {
+const SentEmailContent = ({ description, isInvestorPassword = false, platform }: TSentEmailContentProps) => {
     const [shouldShowResendEmailReasons, setShouldShowResendEmailReasons] = useState(false);
     const [hasCountdownStarted, setHasCountdownStarted] = useState(false);
     const { data } = useSettings();

--- a/packages/tradershub/src/components/Tooltip/Tooltip.tsx
+++ b/packages/tradershub/src/components/Tooltip/Tooltip.tsx
@@ -1,16 +1,16 @@
-import React, { FC, ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 import { qtMerge, Text } from '@deriv/quill-design';
 import { TooltipClass, TooltipPointerClass } from './Tooltip.classnames';
 
 /**
  * Props for the Tooltip component.
- * @typedef {Object} TProps
+ * @typedef {Object} TTooltipProps
  * @property {'bottom' | 'left' | 'right' | 'top'} [alignment='left'] - The alignment of the tooltip.
  * @property {ReactNode} children - The content that triggers the tooltip.
  * @property {string} [className] - Additional CSS class for styling.
  * @property {string} message - The message to be displayed in the tooltip.
  */
-type TProps = {
+type TTooltipProps = {
     alignment: 'bottom' | 'left' | 'right' | 'top';
     children: ReactNode;
     className?: string;
@@ -20,7 +20,7 @@ type TProps = {
 
 /**
  * Tooltip component for displaying additional information.
- * @param {TProps} props - The properties that define the Tooltip component.
+ * @param {TTooltipProps} props - The properties that define the Tooltip component.
  * @returns {JSX.Element}
  *
  * @example
@@ -30,7 +30,7 @@ type TProps = {
  * </Tooltip>
  * ```
  */
-const Tooltip: FC<TProps> = ({ alignment = 'bottom', children, className, message }) => {
+const Tooltip = ({ alignment = 'bottom', children, className, message }: TTooltipProps) => {
     return (
         <div className='relative w-max h-max group z-1'>
             <div className='border rounded-md border-neutral-600'>{children}</div>

--- a/packages/tradershub/src/components/TradingAccountCard/TradingAccountCard.tsx
+++ b/packages/tradershub/src/components/TradingAccountCard/TradingAccountCard.tsx
@@ -1,12 +1,13 @@
-import React, { FC, PropsWithChildren, ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 import './TradingAccountCard.scss';
 
-type TProps = {
+type TTradingAccountCardProps = {
+    children: ReactNode;
     leading?: () => ReactNode;
     trailing?: () => ReactNode;
 };
 
-const TradingAccountCard: FC<PropsWithChildren<TProps>> = ({ children, leading, trailing }) => {
+const TradingAccountCard = ({ children, leading, trailing }: TTradingAccountCardProps) => {
     return (
         <div className='wallets-trading-account-card'>
             {leading?.()}

--- a/packages/tradershub/src/features/cfd/screens/CFDSuccess/CFDSuccess.tsx
+++ b/packages/tradershub/src/features/cfd/screens/CFDSuccess/CFDSuccess.tsx
@@ -8,7 +8,7 @@ import MT5SwapFreeSuccess from '../../../../public/images/cfd/mt5-swap-free-succ
 import CheckMark from '../../../../public/images/checkmark.svg';
 import { TMarketTypes, TPlatforms } from '../../../../types';
 
-type TProps = {
+type TCFDSuccessProps = {
     description: string;
     renderButtons?: () => React.ReactNode;
 } & (
@@ -49,7 +49,7 @@ const marketTypeToDetailsMapper: Record<TPlatforms.All, PlatformDetails> = {
     },
 };
 
-const CFDSuccess = ({ description, marketType, platform, renderButtons }: TProps) => {
+const CFDSuccess = ({ description, marketType, platform, renderButtons }: TCFDSuccessProps) => {
     let icon: React.ReactNode;
     if (platform === 'mt5') {
         icon = marketTypeToDetailsMapper[platform][marketType]?.icon;

--- a/packages/tradershub/src/features/cfd/screens/CreatePassword/CreatePassword.tsx
+++ b/packages/tradershub/src/features/cfd/screens/CreatePassword/CreatePassword.tsx
@@ -1,10 +1,10 @@
-import React, { FC } from 'react';
+import React from 'react';
 import { Button, Text, TextField, useBreakpoint } from '@deriv/quill-design';
 import { TPlatforms } from '../../../../types';
 import { validPassword } from '../../../../utils/password';
 import { PlatformDetails } from '../../constants';
 
-type TProps = {
+type TCreatePasswordProps = {
     icon: React.ReactNode;
     isLoading?: boolean;
     onPasswordChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -23,7 +23,14 @@ type TProps = {
  * @param platform MT5 or Deriv X
  * @returns
  */
-const CreatePassword: FC<TProps> = ({ icon, isLoading, onPasswordChange, onPrimaryClick, password, platform }) => {
+const CreatePassword = ({
+    icon,
+    isLoading,
+    onPasswordChange,
+    onPrimaryClick,
+    password,
+    platform,
+}: TCreatePasswordProps) => {
     const { isMobile } = useBreakpoint();
 
     const { title } = PlatformDetails[platform];

--- a/packages/tradershub/src/features/cfd/screens/EnterPassword/EnterPassword.tsx
+++ b/packages/tradershub/src/features/cfd/screens/EnterPassword/EnterPassword.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React from 'react';
 import { useActiveTradingAccount } from '@deriv/api';
 import { Button, Text, TextField, useBreakpoint } from '@deriv/quill-design';
 import { useUIContext } from '../../../../components';
@@ -31,7 +31,7 @@ type TEnterPasswordProps = {
  * @returns {React.ReactNode} - returns the enter password screen component
  */
 
-const EnterPassword: FC<TEnterPasswordProps> = ({
+const EnterPassword = ({
     isLoading,
     marketType,
     onPasswordChange,
@@ -40,7 +40,7 @@ const EnterPassword: FC<TEnterPasswordProps> = ({
     password,
     passwordError,
     platform,
-}) => {
+}: TEnterPasswordProps) => {
     const { isDesktop } = useBreakpoint();
     const title = PlatformDetails[platform].title;
     const { getUIState } = useUIContext();

--- a/packages/tradershub/src/features/cfd/screens/EnterPassword/EnterPassword.tsx
+++ b/packages/tradershub/src/features/cfd/screens/EnterPassword/EnterPassword.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 import { useActiveTradingAccount } from '@deriv/api';
 import { Button, Text, TextField, useBreakpoint } from '@deriv/quill-design';
 import { useUIContext } from '../../../../components';
@@ -7,7 +7,7 @@ import { TMarketTypes, TPlatforms } from '../../../../types';
 import { validPassword } from '../../../../utils/password';
 import { MarketTypeDetails, PlatformDetails } from '../../constants';
 
-type TProps = {
+type TEnterPasswordProps = {
     isLoading?: boolean;
     marketType: TMarketTypes.CreateOtherCFDAccount;
     onPasswordChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -31,7 +31,7 @@ type TProps = {
  * @returns {React.ReactNode} - returns the enter password screen component
  */
 
-const EnterPassword: React.FC<TProps> = ({
+const EnterPassword: FC<TEnterPasswordProps> = ({
     isLoading,
     marketType,
     onPasswordChange,

--- a/packages/tradershub/src/features/cfd/screens/Jurisdiction/JurisdictionCard/JurisdictionCardVerificationTag.tsx
+++ b/packages/tradershub/src/features/cfd/screens/Jurisdiction/JurisdictionCard/JurisdictionCardVerificationTag.tsx
@@ -5,7 +5,7 @@ import VerificationPendingIcon from '../../../../../public/images/ic-verificatio
 import VerificationSuccessIcon from '../../../../../public/images/ic-verification-success-status.svg';
 import { THooks } from '../../../../../types';
 
-type TProps = {
+type TJurisdictionCardVerificationTagProps = {
     category: 'poa' | 'poi' | null;
     icon: ReactNode;
 };
@@ -28,11 +28,11 @@ const verificationStatusIconMapper: Partial<
  * @returns
  */
 
-const JurisdictionCardVerificationTag = ({ category, icon }: TProps) => {
+const JurisdictionCardVerificationTag = ({ category, icon }: TJurisdictionCardVerificationTagProps) => {
     const { data } = useAuthentication();
 
     const renderStatusIcon = (
-        category: TProps['category'],
+        category: TJurisdictionCardVerificationTagProps['category'],
         status: NonNullable<THooks.Authentication['poa_status' | 'poi_status']>
     ) => {
         if (category && status && Object.keys(verificationStatusIconMapper).includes(status)) {

--- a/packages/tradershub/src/features/cfd/screens/Jurisdiction/JurisdictionTncSection/JurisdictionTncSection.tsx
+++ b/packages/tradershub/src/features/cfd/screens/Jurisdiction/JurisdictionTncSection/JurisdictionTncSection.tsx
@@ -6,7 +6,7 @@ import { THooks } from '../../../../../types';
 import { companyNamesAndUrls, Jurisdiction, MarketType } from '../../../constants';
 import { JurisdictionFootNoteTitle } from '../JurisdictionFootNoteTitle';
 
-type TProps = {
+type TJurisdictionTncSectionProps = {
     isCheckBoxChecked: boolean;
     selectedJurisdiction: THooks.AvailableMT5Accounts['shortcode'];
     setIsCheckBoxChecked: React.Dispatch<React.SetStateAction<boolean>>;
@@ -22,7 +22,11 @@ type TProps = {
  * @returns
  */
 
-const JurisdictionTncSection = ({ isCheckBoxChecked, selectedJurisdiction, setIsCheckBoxChecked }: TProps) => {
+const JurisdictionTncSection = ({
+    isCheckBoxChecked,
+    selectedJurisdiction,
+    setIsCheckBoxChecked,
+}: TJurisdictionTncSectionProps) => {
     const { isMobile } = useBreakpoint();
     const { getCFDState } = Provider.useCFDContext();
     const marketType = getCFDState('marketType') || MarketType.ALL;

--- a/packages/tradershub/src/features/cfd/screens/MT5AccountType/MT5AccountType.tsx
+++ b/packages/tradershub/src/features/cfd/screens/MT5AccountType/MT5AccountType.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React from 'react';
 import useRegulationFlags from '../../../../hooks/useRegulationFlags';
 import { MarketTypeDetails } from '../../constants';
 import { MT5AccountTypeCard } from '../MT5AccountTypeCard';
@@ -8,7 +8,7 @@ type TMT5AccountTypeProps = {
     selectedMarketType?: keyof typeof MarketTypeDetails;
 };
 
-const MT5AccountType: FC<TMT5AccountTypeProps> = ({ onMarketTypeSelect, selectedMarketType }) => {
+const MT5AccountType = ({ onMarketTypeSelect, selectedMarketType }: TMT5AccountTypeProps) => {
     const { isEU } = useRegulationFlags();
     const marketTypeDetails = MarketTypeDetails(isEU);
     const sortedMarketTypeEntries = Object.entries(marketTypeDetails).sort(([keyA], [keyB]) => {

--- a/packages/tradershub/src/features/cfd/screens/MT5AccountType/MT5AccountType.tsx
+++ b/packages/tradershub/src/features/cfd/screens/MT5AccountType/MT5AccountType.tsx
@@ -3,12 +3,12 @@ import useRegulationFlags from '../../../../hooks/useRegulationFlags';
 import { MarketTypeDetails } from '../../constants';
 import { MT5AccountTypeCard } from '../MT5AccountTypeCard';
 
-type TProps = {
+type TMT5AccountTypeProps = {
     onMarketTypeSelect: (marketType: keyof typeof MarketTypeDetails) => void;
     selectedMarketType?: keyof typeof MarketTypeDetails;
 };
 
-const MT5AccountType: FC<TProps> = ({ onMarketTypeSelect, selectedMarketType }) => {
+const MT5AccountType: FC<TMT5AccountTypeProps> = ({ onMarketTypeSelect, selectedMarketType }) => {
     const { isEU } = useRegulationFlags();
     const marketTypeDetails = MarketTypeDetails(isEU);
     const sortedMarketTypeEntries = Object.entries(marketTypeDetails).sort(([keyA], [keyB]) => {

--- a/packages/tradershub/src/features/cfd/screens/MT5AccountTypeCard/MT5AccountTypeCard.tsx
+++ b/packages/tradershub/src/features/cfd/screens/MT5AccountTypeCard/MT5AccountTypeCard.tsx
@@ -1,7 +1,7 @@
 import React, { FC, ReactNode } from 'react';
 import { qtMerge, Text } from '@deriv/quill-design';
 
-type TProps = {
+type TMT5AccountTypeCardProps = {
     description: string;
     icon: ReactNode;
     isSelected: boolean;
@@ -9,7 +9,7 @@ type TProps = {
     title: string;
 };
 
-const MT5AccountTypeCard: FC<TProps> = ({ description, icon, isSelected, onClick, title }) => {
+const MT5AccountTypeCard: FC<TMT5AccountTypeCardProps> = ({ description, icon, isSelected, onClick, title }) => {
     return (
         <div
             className={qtMerge(

--- a/packages/tradershub/src/features/cfd/screens/MT5AccountTypeCard/MT5AccountTypeCard.tsx
+++ b/packages/tradershub/src/features/cfd/screens/MT5AccountTypeCard/MT5AccountTypeCard.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 import { qtMerge, Text } from '@deriv/quill-design';
 
 type TMT5AccountTypeCardProps = {
@@ -9,7 +9,7 @@ type TMT5AccountTypeCardProps = {
     title: string;
 };
 
-const MT5AccountTypeCard: FC<TMT5AccountTypeCardProps> = ({ description, icon, isSelected, onClick, title }) => {
+const MT5AccountTypeCard = ({ description, icon, isSelected, onClick, title }: TMT5AccountTypeCardProps) => {
     return (
         <div
             className={qtMerge(

--- a/packages/tradershub/src/modals/RegulationModal/Row.tsx
+++ b/packages/tradershub/src/modals/RegulationModal/Row.tsx
@@ -3,11 +3,11 @@ import { qtMerge } from '@deriv/quill-design';
 import { Text } from '@deriv-com/ui/dist/components/Text';
 import { TRegulatorsContentProps, TRowItem } from '../../constants/regulators-modal-content';
 
-type TProps = TRegulatorsContentProps & {
+type TRowProps = TRegulatorsContentProps & {
     idx?: number;
 };
 
-const Row = ({ attribute, content, id, idx }: TProps) => (
+const Row = ({ attribute, content, id, idx }: TRowProps) => (
     <tr className={qtMerge('min-h-2000', idx === 0 && 'bg-brand-pink-light')} key={id}>
         <td
             className={`sticky z-10 align-middle border-solid start-50 py-500 px-400 border-system-light-active-background border-x-75 border-b-75 ${


### PR DESCRIPTION
## Changes:

- based on a slack discussion [here](https://deriv-group.slack.com/archives/C054SHJDZJP/p1706593314460919) we have decided to follow one convention to name our types 
- `TComponentName` format is easier to identify if there's any type error because the name is unique to that file/component
- no more `TProps` or `FC` in TH package

### Screenshots:

<img width="50%" alt="image" src="https://github.com/binary-com/deriv-app/assets/108507236/1fe95ca2-52c5-422d-b1b2-5491fc87a9cb">  <img width="42%" alt="image" src="https://github.com/binary-com/deriv-app/assets/108507236/b3d7f531-05f8-411b-a337-cb70f707c7f2">

<img height="500px" src="https://github.com/binary-com/deriv-app/assets/108507236/f5abc4b9-4baf-47f6-898f-1160ece4e9cc" />
 <img width="60%" alt="image" src="https://github.com/binary-com/deriv-app/assets/108507236/029d0cee-1743-4cfd-a8af-832990fb6241">


