### PR TITLE
[P2PS] / Ameerul / P2PS-2322 Loading icon in the p2p cashier is shifted to the right of the screen

### DIFF
--- a/packages/p2p/src/pages/app.jsx
+++ b/packages/p2p/src/pages/app.jsx
@@ -255,7 +255,7 @@ const App = () => {
     }, [action_param, code_param]);
 
     if (is_logging_in || general_store.is_loading) {
-        return <Loading is_fullscreen />;
+        return <Loading className='p2p__loading' is_fullscreen={false} />;
     }
 
     return (

--- a/packages/p2p/src/pages/app.scss
+++ b/packages/p2p/src/pages/app.scss
@@ -61,6 +61,10 @@
         }
     }
 
+    &__loading {
+        height: 80vh;
+    }
+
     @include mobile {
         .dc-autocomplete__field {
             border: none;


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- added className to Loading component and changed the styling of the height

### Screenshots:

Please provide some screenshots of the change.
<img width="548" alt="Screenshot 2024-01-31 at 5 15 21 PM" src="https://github.com/binary-com/deriv-app/assets/103412909/7af1ae48-9107-4528-808b-0315b67776c9">
<img width="1728" alt="Screenshot 2024-01-31 at 5 15 48 PM" src="https://github.com/binary-com/deriv-app/assets/103412909/9b3baec6-d7fa-4fcc-b2d4-1ef9cc32725c">
