### PR TITLE
[WEBREL] Farabi/webrel-2310/trading view section should have light theme

### DIFF
--- a/packages/bot-web-ui/src/components/trading-view-chart/trading-view.tsx
+++ b/packages/bot-web-ui/src/components/trading-view-chart/trading-view.tsx
@@ -4,7 +4,7 @@ const TradingViewComponent = () => {
     return (
         <iframe
             id='trading-view-iframe'
-            style={{ width: '100%', height: '100%' }}
+            style={{ width: '100%', height: '100%', backgroundColor: 'white' }}
             src={'https://tradingview.deriv.com/deriv?hide_banner=1&hide-signup=true'}
         />
     );

--- a/packages/bot-web-ui/src/pages/bot-builder/toolbar/workspace-group.tsx
+++ b/packages/bot-web-ui/src/pages/bot-builder/toolbar/workspace-group.tsx
@@ -63,8 +63,8 @@ const WorkspaceGroup = observer(
                     data_testid='dt_toolbar_sort_button'
                     action={onSortClick}
                 />
-                <div className='vertical-divider' />
                 <DesktopWrapper>
+                    <div className='vertical-divider' />
                     <ToolbarIcon
                         popover_message={localize('Charts')}
                         icon='IcChartsTabDbot'


### PR DESCRIPTION
## Changes:

Trading view chart section should remain white even on dark theme

### Screenshots:

<img width="731" alt="Screenshot 2024-01-31 at 5 58 42 PM" src="https://github.com/binary-com/deriv-app/assets/102643568/3da698c7-a2fe-4a16-a735-f999894e11b6">
