### PR TITLE
[UPM]Utkarsha/Notifications for 'Proof of identity required' & 'Account verification required' appear even after being clicked on

### DIFF
--- a/packages/core/src/App/Components/Elements/NotificationMessage/notification.jsx
+++ b/packages/core/src/App/Components/Elements/NotificationMessage/notification.jsx
@@ -125,6 +125,7 @@ const Notification = ({ data, removeNotificationMessage }) => {
                                                 'dc-btn--secondary',
                                                 'notification__cta-button'
                                             )}
+                                            onClick={onClick}
                                             to={data.action.route}
                                         >
                                             <Text size='xxs' weight='bold'>

--- a/packages/core/src/Stores/notification-store.js
+++ b/packages/core/src/Stores/notification-store.js
@@ -1444,6 +1444,7 @@ export default class NotificationStore extends BaseStore {
                     route: routes.proof_of_identity,
                     text: localize('Go to my account settings'),
                 },
+                closeOnClick: () => this.markNotificationMessage({ key: 'svg_needs_poi_poa' }),
             },
             svg_needs_poa: {
                 key: 'svg_needs_poa',
@@ -1468,6 +1469,7 @@ export default class NotificationStore extends BaseStore {
                     route: routes.proof_of_identity,
                     text: localize('Submit proof of identity'),
                 },
+                closeOnClick: () => this.markNotificationMessage({ key: 'svg_needs_poi_poa' }),
             },
             svg_poi_expired: {
                 key: 'svg_poi_expired',

--- a/packages/core/src/Stores/notification-store.js
+++ b/packages/core/src/Stores/notification-store.js
@@ -1444,7 +1444,7 @@ export default class NotificationStore extends BaseStore {
                     route: routes.proof_of_identity,
                     text: localize('Go to my account settings'),
                 },
-                closeOnClick: () => this.markNotificationMessage({ key: 'svg_needs_poi_poa' }),
+                closeOnClick: notification_obj => this.markNotificationMessage({ key: notification_obj.key }),
             },
             svg_needs_poa: {
                 key: 'svg_needs_poa',
@@ -1469,7 +1469,7 @@ export default class NotificationStore extends BaseStore {
                     route: routes.proof_of_identity,
                     text: localize('Submit proof of identity'),
                 },
-                closeOnClick: () => this.markNotificationMessage({ key: 'svg_needs_poi' }),
+                closeOnClick: notification_obj => this.markNotificationMessage({ key: notification_obj.key }),
             },
             svg_poi_expired: {
                 key: 'svg_poi_expired',

--- a/packages/core/src/Stores/notification-store.js
+++ b/packages/core/src/Stores/notification-store.js
@@ -1469,7 +1469,7 @@ export default class NotificationStore extends BaseStore {
                     route: routes.proof_of_identity,
                     text: localize('Submit proof of identity'),
                 },
-                closeOnClick: () => this.markNotificationMessage({ key: 'svg_needs_poi_poa' }),
+                closeOnClick: () => this.markNotificationMessage({ key: 'svg_needs_poi' }),
             },
             svg_poi_expired: {
                 key: 'svg_poi_expired',


### PR DESCRIPTION
## Changes:

This PR fixes the issue of permanently closing the `Proof of identity required` & `Account verification required` notifications after clicking the redirect button. This is done by adding a onClick function which internally marks the respective notifications. Marking the notifications helps us identify which notifications should not be displayed. 

### Screenshots:

![image](https://github.com/binary-com/deriv-app/assets/125863995/eb551e13-5f24-4164-aa99-d865f68f7152)

