### PR TITLE
[Draft] [WALL] aum / WALL-3367 / fix-wallet-linked-app-icon-overlap-issue

### DIFF
--- a/packages/wallets/src/components/WalletsAppLinkedWithWalletIcon/WalletsAppLinkedWithWalletIcon.scss
+++ b/packages/wallets/src/components/WalletsAppLinkedWithWalletIcon/WalletsAppLinkedWithWalletIcon.scss
@@ -44,7 +44,6 @@
         position: absolute;
         top: 0;
         left: 0;
-        z-index: 1;
     }
 
     &__wallet-icon {


### PR DESCRIPTION
## Changes:

Fixed the overlapping of the app-icon rendered in `<WalletsAppLinkedWithWalletIcon />` by removing its z-index property from styles.

### Screenshots:

https://github.com/binary-com/deriv-app/assets/125039206/eef660c0-e7dd-40f0-a0ba-6b01539f49ea

