### PR TITLE
Bala/Update deriv charts version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,10 @@
                 "@datadog/browser-logs": "^4.36.0",
                 "@datadog/browser-rum": "^4.37.0",
                 "@deriv-com/analytics": "1.4.10",
-                "@deriv-com/ui": "0.0.1-beta.8",
+                "@deriv-com/ui": "1.0.1",
                 "@deriv/api-types": "^1.0.118",
                 "@deriv/deriv-api": "^1.0.13",
-                "@deriv/deriv-charts": "^2.0.2",
+                "@deriv/deriv-charts": "^2.0.3",
                 "@deriv/js-interpreter": "^3.0.0",
                 "@deriv/quill-design": "^1.3.2",
                 "@deriv/quill-icons": "^1.17.0",
@@ -2925,9 +2925,12 @@
             }
         },
         "node_modules/@deriv-com/ui": {
-            "version": "0.0.1-beta.8",
-            "resolved": "https://registry.npmjs.org/@deriv-com/ui/-/ui-0.0.1-beta.8.tgz",
-            "integrity": "sha512-McmqGpGqEyu4KNJOOAZj9auHUx5UIw8egEoR2BGuhEqnjKhDVdY4276zurGVzbd6eASNPCwYtRXWjfMlgSKmgw=="
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@deriv-com/ui/-/ui-1.0.1.tgz",
+            "integrity": "sha512-jY6B2nQe5uhVZtC/iu7nxPpSUIBwvFfn0ww7+0I+LBD2H+mzdPU886m3PNcZ2a0muX4dvVPBspL13wn0mdo5tQ==",
+            "optionalDependencies": {
+                "@rollup/rollup-linux-x64-gnu": "^4.9.6"
+            }
         },
         "node_modules/@deriv/api-types": {
             "version": "1.0.158",
@@ -2961,9 +2964,9 @@
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@deriv/deriv-charts": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.0.2.tgz",
-            "integrity": "sha512-FmiWo+DVafGUqN5z1oun/YmOiCJoDVJ7gYaek52WcXlyerY0wvJDfWw9es3roOASV2kPXYb7zrBywA3xePJdPg==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.0.3.tgz",
+            "integrity": "sha512-TB/97GSVvfki7mkild6JCvwJXjDIqjgoSTAeOSjy02Mi0my1yZ6JkDRXCg/IGeIAcHwaOVlvoIbuJgkxzWpksQ==",
             "dependencies": {
                 "@types/lodash.set": "^4.3.7",
                 "@welldone-software/why-did-you-render": "^3.3.8",
@@ -8305,6 +8308,18 @@
             "version": "0.0.39",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
             "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+        },
+        "node_modules/@rollup/rollup-linux-x64-gnu": {
+            "version": "4.9.6",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.6.tgz",
+            "integrity": "sha512-HUNqM32dGzfBKuaDUBqFB7tP6VMN74eLZ33Q9Y1TBqRDn+qDonkAUyKWwF9BR9unV7QUzffLnz9GrnKvMqC/fw==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
         },
         "node_modules/@segment/localstorage-retry": {
             "version": "1.3.0",

--- a/packages/bot-web-ui/package.json
+++ b/packages/bot-web-ui/package.json
@@ -70,7 +70,7 @@
         "@datadog/browser-logs": "^4.36.0",
         "@deriv/bot-skeleton": "^1.0.0",
         "@deriv/components": "^1.0.0",
-        "@deriv/deriv-charts": "^2.0.2",
+        "@deriv/deriv-charts": "^2.0.3",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",
         "@deriv/translations": "^1.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -106,7 +106,7 @@
         "@deriv/cfd": "^1.0.0",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.13",
-        "@deriv/deriv-charts": "^2.0.2",
+        "@deriv/deriv-charts": "^2.0.3",
         "@deriv/hooks": "^1.0.0",
         "@deriv/p2p": "^0.7.3",
         "@deriv/account-v2": "^1.0.0",

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -90,7 +90,7 @@
         "@deriv/deriv-api": "^1.0.13",
         "@deriv/api-types": "^1.0.118",
         "@deriv/hooks": "^1.0.0",
-        "@deriv/deriv-charts": "^2.0.2",
+        "@deriv/deriv-charts": "^2.0.3",
         "@deriv/reports": "^1.0.0",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",


### PR DESCRIPTION
## Changes:

Update deriv charts version to 2.0.3

---------------------------------------------

### Screenshots:

Please provide some screenshots of the change.
