### PR TITLE
[WALL] Farhan/WALL-3399/Add MT5 account fails on the first attempt

### DIFF
--- a/packages/wallets/src/features/cfd/modals/MT5PasswordModal/MT5PasswordModal.tsx
+++ b/packages/wallets/src/features/cfd/modals/MT5PasswordModal/MT5PasswordModal.tsx
@@ -35,7 +35,7 @@ const MT5PasswordModal: React.FC<TProps> = ({ marketType, platform }) => {
         mutate,
         status,
     } = useCreateMT5Account();
-    const { isLoading: tradingPlatformPasswordChangeLoading, mutate: tradingPasswordChange } =
+    const { isLoading: tradingPlatformPasswordChangeLoading, mutateAsync: tradingPasswordChange } =
         useTradingPlatformPasswordChange();
     const { data: accountStatus } = useAccountStatus();
     const { data: activeWallet } = useActiveWalletAccount();


### PR DESCRIPTION
## Changes:

The problem was we send mt5 account creation before trading_platform_password_change give us back the response. Use mutateAsync and await for that fix this issue.

### Screenshots:

Please provide some screenshots of the change.
