### PR TITLE
[WALL] Lubega / WALL-3351/3353 / Transfer form account card icon styling

### DIFF
--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormAccountCard/TransferFormAccountCard.scss
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormAccountCard/TransferFormAccountCard.scss
@@ -51,4 +51,14 @@
     &__modal-badge {
         margin-left: 1rem;
     }
+
+    .wallets-app-linked-with-wallet-icon {
+        .wallets-gradient {
+            border-radius: 0.15rem;
+        }
+    }
+
+    .wallets-gradient {
+        border-radius: 0.4rem;
+    }
 }

--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormAccountSelection/TransferFormAccountSelection.scss
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormAccountSelection/TransferFormAccountSelection.scss
@@ -8,7 +8,6 @@
     /* Shadows/xxxl */
     box-shadow: 0rem 3.2rem 6.4rem 0rem rgba(14, 14, 14, 0.14);
     max-height: 52.8rem;
-    z-index: 2;
 
     @include mobile {
         position: absolute;

--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormAccountSelection/TransferFormAccountSelection.scss
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormAccountSelection/TransferFormAccountSelection.scss
@@ -8,6 +8,7 @@
     /* Shadows/xxxl */
     box-shadow: 0rem 3.2rem 6.4rem 0rem rgba(14, 14, 14, 0.14);
     max-height: 52.8rem;
+    z-index: 2;
 
     @include mobile {
         position: absolute;


### PR DESCRIPTION
## Changes:

- [x] Matched border radius of wallet icon in transfer form account selection to figma

### Screenshots:
Bug:
<img width="422" alt="image" src="https://github.com/binary-com/deriv-app/assets/142860499/45ab1d95-62e5-4e0a-b9ab-f530c5458e5b">

Fix:
<img width="422" alt="Screenshot 2024-02-02 at 3 53 37 PM" src="https://github.com/binary-com/deriv-app/assets/142860499/ccd8c6f9-f9c4-423a-8168-c8a4a56e2a43">

<img width="422" alt="Screenshot 2024-02-02 at 3 53 47 PM" src="https://github.com/binary-com/deriv-app/assets/142860499/cbc3d9cd-18f0-43d2-9ce4-d327b351abb1">
