### PR TITLE
[WALL] Lubega / WALL-3261 / Transactions GMT time display

### DIFF
--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsPendingRow/TransactionsPendingRow.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsPendingRow/TransactionsPendingRow.tsx
@@ -141,6 +141,7 @@ const TransactionsCryptoRow: React.FC<TProps> = ({ transaction }) => {
                     name='Time'
                     value={moment
                         .unix(transaction.submit_date)
+                        .utc()
                         .format(isMobile ? 'HH:mm:ss [GMT]' : 'DD MMM YYYY HH:mm:ss [GMT]')}
                     valueTextProps={{
                         color: 'general',


### PR DESCRIPTION
## Changes:

- [x] Fix GMT display time in pending transactions

### Screenshots:

<img width="1643" alt="Screenshot 2024-02-02 at 5 44 14 PM" src="https://github.com/binary-com/deriv-app/assets/142860499/798cda1d-03bc-4c2d-8d98-907e23fa5f88">
