### PR TITLE
[DTRA]/update deriv-charts version to 2.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "@deriv-com/ui": "1.1.11",
                 "@deriv/api-types": "^1.0.118",
                 "@deriv/deriv-api": "^1.0.13",
-                "@deriv/deriv-charts": "^2.0.3",
+                "@deriv/deriv-charts": "^2.0.4",
                 "@deriv/js-interpreter": "^3.0.0",
                 "@deriv/quill-design": "^1.3.2",
                 "@deriv/quill-icons": "^1.17.4",
@@ -2964,9 +2964,9 @@
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@deriv/deriv-charts": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.0.3.tgz",
-            "integrity": "sha512-TB/97GSVvfki7mkild6JCvwJXjDIqjgoSTAeOSjy02Mi0my1yZ6JkDRXCg/IGeIAcHwaOVlvoIbuJgkxzWpksQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.0.4.tgz",
+            "integrity": "sha512-CjBu2gkgTeKEby7MniS+KM/dMWgLeHukJ6UovnRsQ+373X4RbDn2eDNK5e9zFTUYWCgTTZ4PVsWdFbg7hk+23A==",
             "dependencies": {
                 "@types/lodash.set": "^4.3.7",
                 "@welldone-software/why-did-you-render": "^3.3.8",

--- a/packages/bot-web-ui/package.json
+++ b/packages/bot-web-ui/package.json
@@ -70,7 +70,7 @@
         "@datadog/browser-logs": "^4.36.0",
         "@deriv/bot-skeleton": "^1.0.0",
         "@deriv/components": "^1.0.0",
-        "@deriv/deriv-charts": "^2.0.3",
+        "@deriv/deriv-charts": "^2.0.4",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",
         "@deriv/translations": "^1.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -106,7 +106,7 @@
         "@deriv/cfd": "^1.0.0",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.13",
-        "@deriv/deriv-charts": "^2.0.3",
+        "@deriv/deriv-charts": "^2.0.4",
         "@deriv/hooks": "^1.0.0",
         "@deriv/p2p": "^0.7.3",
         "@deriv/account-v2": "^1.0.0",

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -90,7 +90,7 @@
         "@deriv/deriv-api": "^1.0.13",
         "@deriv/api-types": "^1.0.118",
         "@deriv/hooks": "^1.0.0",
-        "@deriv/deriv-charts": "^2.0.3",
+        "@deriv/deriv-charts": "^2.0.4",
         "@deriv/reports": "^1.0.0",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",


### PR DESCRIPTION
## Changes:

update deriv-charts version to 2.0.4
------------------------------------------------------------------------------------------------

### Screenshots:

Please provide some screenshots of the change.
