### PR TITLE
Hirad/CFDs-3152: fixed the hover effect of forgot password part

### DIFF
--- a/packages/appstore/src/components/cfds-listing/cfds-listing.scss
+++ b/packages/appstore/src/components/cfds-listing/cfds-listing.scss
@@ -447,6 +447,10 @@
             display: flex;
             align-items: center;
             gap: 0.8rem;
+
+            .dc-btn:hover {
+                text-decoration: underline;
+            }
         }
         &-action {
             text-decoration: underline;


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.

When hover on the "Forgot password?" hyperlink in MT5 Trade Modal, the underline goes away. It should stay and only the cursor should change to a hand symbol.

### Screenshots:

Please provide some screenshots of the change.

<img width="576" alt="image" src="https://github.com/binary-com/deriv-app/assets/91878582/123e6fc0-f03a-45e5-8721-2d44d6db6689">

