### PR TITLE
[BOT] fix: Trading view chart drag issue

### DIFF
--- a/packages/bot-web-ui/src/components/trading-view-chart/trading-view-modal.tsx
+++ b/packages/bot-web-ui/src/components/trading-view-chart/trading-view-modal.tsx
@@ -36,7 +36,7 @@ const TradingViewModal = observer(() => {
 
     return (
         <Draggable
-            bounds='.bot-dashboard'
+            bounds='.main'
             xaxis={xaxis}
             yaxis={yaxis}
             is_visible={is_trading_view_modal_visible}

--- a/packages/bot-web-ui/src/components/trading-view-chart/trading-view-modal.tsx
+++ b/packages/bot-web-ui/src/components/trading-view-chart/trading-view-modal.tsx
@@ -36,7 +36,7 @@ const TradingViewModal = observer(() => {
 
     return (
         <Draggable
-            bounds='.dashboard__main'
+            bounds='.bot-dashboard'
             xaxis={xaxis}
             yaxis={yaxis}
             is_visible={is_trading_view_modal_visible}


### PR DESCRIPTION
## Changes:

Trading view chart modal is getting stuck at the top left corner upon dragging.

- The previously added boundary class was removed
- Newly named boundary class is added for the draggable boundary
