### PR TITLE
Niloofar/Updated @deriv/quill-icons to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "@deriv/deriv-charts": "^2.0.4",
                 "@deriv/js-interpreter": "^3.0.0",
                 "@deriv/quill-design": "^1.3.2",
-                "@deriv/quill-icons": "^1.17.4",
+                "@deriv/quill-icons": "^1.17.25",
                 "@deriv/react-joyride": "^2.6.2",
                 "@deriv/ui": "^0.6.0",
                 "@livechat/customer-sdk": "^2.0.4",
@@ -3049,9 +3049,9 @@
             }
         },
         "node_modules/@deriv/quill-icons": {
-            "version": "1.17.10",
-            "resolved": "https://registry.npmjs.org/@deriv/quill-icons/-/quill-icons-1.17.10.tgz",
-            "integrity": "sha512-n7Px956qO+NINtCioTS/UpbPbjDUbsYw82V/u1fGHl/jgs3BP7VzglBkA3ZNZuJ18vB7becOs4z92dyjbIbYUw==",
+            "version": "1.17.25",
+            "resolved": "https://registry.npmjs.org/@deriv/quill-icons/-/quill-icons-1.17.25.tgz",
+            "integrity": "sha512-Een2BVmkWghGV7sMilTvcvWzfZDIY5Lf7tbDblIGynonLkoJnQ79yXeEvkI8wZateisHY9bjwLL6V7RKygJKLA==",
             "peerDependencies": {
                 "react": ">= 16",
                 "react-dom": ">= 16"
@@ -52412,9 +52412,9 @@
             "requires": {}
         },
         "@deriv/quill-icons": {
-            "version": "1.17.10",
-            "resolved": "https://registry.npmjs.org/@deriv/quill-icons/-/quill-icons-1.17.10.tgz",
-            "integrity": "sha512-n7Px956qO+NINtCioTS/UpbPbjDUbsYw82V/u1fGHl/jgs3BP7VzglBkA3ZNZuJ18vB7becOs4z92dyjbIbYUw==",
+            "version": "1.17.25",
+            "resolved": "https://registry.npmjs.org/@deriv/quill-icons/-/quill-icons-1.17.25.tgz",
+            "integrity": "sha512-Een2BVmkWghGV7sMilTvcvWzfZDIY5Lf7tbDblIGynonLkoJnQ79yXeEvkI8wZateisHY9bjwLL6V7RKygJKLA==",
             "requires": {}
         },
         "@deriv/react-joyride": {

--- a/packages/account-v2/package.json
+++ b/packages/account-v2/package.json
@@ -15,7 +15,7 @@
         "@deriv/api": "^1.0.0",
         "@deriv/library": "^1.0.0",
         "@deriv/quill-design": "^1.3.2",
-        "@deriv/quill-icons": "^1.17.4",
+        "@deriv/quill-icons": "^1.17.25",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",
         "formik": "^2.1.4",

--- a/packages/cashier-v2/package.json
+++ b/packages/cashier-v2/package.json
@@ -16,7 +16,7 @@
         "@deriv/api": "^1.0.0",
         "@deriv/integration": "^1.0.0",
         "@deriv/library": "^1.0.0",
-        "@deriv/quill-icons": "^1.17.4",
+        "@deriv/quill-icons": "^1.17.25",
         "@deriv/utils": "^1.0.0",
         "clsx": "^2.0.0",
         "formik": "^2.1.4",

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -5,7 +5,7 @@
     "main": "src/index.ts",
     "dependencies": {
         "@deriv/quill-design": "^1.3.2",
-        "@deriv/quill-icons": "^1.17.4",
+        "@deriv/quill-icons": "^1.17.25",
         "react": "^17.0.2",
         "usehooks-ts": "^2.7.0",
         "@deriv/api": "^1.0.0",

--- a/packages/p2p-v2/package.json
+++ b/packages/p2p-v2/package.json
@@ -15,7 +15,7 @@
         "@deriv-com/ui": "1.3.1",
         "@deriv/api": "^1.0.0",
         "@deriv/integration": "^1.0.0",
-        "@deriv/quill-icons": "^1.17.4",
+        "@deriv/quill-icons": "^1.17.25",
         "@deriv/react-joyride": "^2.6.2",
         "@sendbird/chat": "^4.9.7",
         "@tanstack/react-table": "^8.10.3",

--- a/packages/tradershub/package.json
+++ b/packages/tradershub/package.json
@@ -17,7 +17,7 @@
         "@deriv/integration": "^1.0.0",
         "@deriv/library": "^1.0.0",
         "@deriv/quill-design": "^1.3.2",
-        "@deriv/quill-icons": "^1.17.4",
+        "@deriv/quill-icons": "^1.17.25",
         "@deriv-com/ui": "1.3.1",
         "@deriv/react-joyride": "^2.6.2",
         "@deriv/utils": "^1.0.0",


### PR DESCRIPTION
## Changes:

The sourcemap reported issue has been successfully resolved in the latest release of @deriv/quill-icons@v1.17.16.
In this PR I updated the version of it.
