### PR TITLE
[COJ]/Likhith/COJ-464/fix: fixed the condition to handle appropriate currency selection during account creation

### DIFF
--- a/packages/account/src/Components/currency-selector/__tests__/currency-selector.spec.tsx
+++ b/packages/account/src/Components/currency-selector/__tests__/currency-selector.spec.tsx
@@ -262,7 +262,7 @@ describe('<CurrencySelector/>', () => {
         });
     });
 
-    it('should disable fiat if user already have a fiat ', () => {
+    fit('should not disable fiat if crypto is disabled ', () => {
         const new_store: TStores = {
             ...store,
             client: {
@@ -284,9 +284,136 @@ describe('<CurrencySelector/>', () => {
                         balance: 10000,
                         accepted_bch: 0,
                     },
+                    CR90000123: {
+                        account_category: 'trading',
+                        account_type: 'binary',
+                        broker: 'CR',
+                        created_at: 1707466247,
+                        currency: 'ETH',
+                        is_disabled: 1,
+                        is_virtual: 0,
+                        landing_company_shortcode: 'svg',
+                        linked_to: [],
+                        excluded_until: '',
+                        landing_company_name: 'svg',
+                    },
                 },
                 has_active_real_account: true,
                 has_fiat: true,
+                upgradeable_currencies: [
+                    {
+                        value: 'BTC',
+                        fractional_digits: 8,
+                        is_deposit_suspended: 0,
+                        is_suspended: 0,
+                        is_withdrawal_suspended: 0,
+                        name: 'Bitcoin',
+                        stake_default: 0.0002,
+                        type: 'crypto',
+                    },
+                    {
+                        value: 'AUD',
+                        fractional_digits: 2,
+                        is_deposit_suspended: 0,
+                        is_suspended: 0,
+                        is_withdrawal_suspended: 0,
+                        name: 'Australian Dollar',
+                        stake_default: 15,
+                        type: 'fiat',
+                    },
+                    {
+                        value: 'USD',
+                        fractional_digits: 2,
+                        is_deposit_suspended: 0,
+                        is_suspended: 0,
+                        is_withdrawal_suspended: 0,
+                        name: 'US Dollar',
+                        stake_default: 10,
+                        type: 'fiat',
+                    },
+                ],
+            },
+            ui: {
+                ...store.ui,
+                real_account_signup_target: 'svg',
+            },
+        };
+
+        renderComponent({ store_config: new_store });
+        expect(screen.getByRole('radio', { name: /us dollar \(usd\)/i })).toBeEnabled();
+        expect(screen.getByRole('radio', { name: /Bitcoin/i })).toBeDisabled();
+    });
+
+    fit('should disable fiat accout is one account is already created', () => {
+        const new_store: TStores = {
+            ...store,
+            client: {
+                ...store.client,
+                accounts: {
+                    VRTC90000010: {
+                        account_type: 'trading',
+                        currency: 'USD',
+                        is_disabled: 0,
+                        is_virtual: 1,
+                        landing_company_shortcode: 'svg',
+                        trading: {},
+                        token: '',
+                        email: '',
+                        session_start: 1651059038,
+                        excluded_until: '',
+                        landing_company_name: 'svg',
+                        residence: 'es',
+                        balance: 10000,
+                        accepted_bch: 0,
+                    },
+                    CR90000123: {
+                        account_category: 'trading',
+                        account_type: 'binary',
+                        broker: 'CR',
+                        created_at: 1707466247,
+                        currency: 'USD',
+                        is_disabled: 1,
+                        is_virtual: 0,
+                        landing_company_shortcode: 'svg',
+                        linked_to: [],
+                        excluded_until: '',
+                        landing_company_name: 'svg',
+                    },
+                },
+                has_active_real_account: true,
+                has_fiat: true,
+                upgradeable_currencies: [
+                    {
+                        value: 'BTC',
+                        fractional_digits: 8,
+                        is_deposit_suspended: 0,
+                        is_suspended: 0,
+                        is_withdrawal_suspended: 0,
+                        name: 'Bitcoin',
+                        stake_default: 0.0002,
+                        type: 'crypto',
+                    },
+                    {
+                        value: 'AUD',
+                        fractional_digits: 2,
+                        is_deposit_suspended: 0,
+                        is_suspended: 0,
+                        is_withdrawal_suspended: 0,
+                        name: 'Australian Dollar',
+                        stake_default: 15,
+                        type: 'fiat',
+                    },
+                    {
+                        value: 'USD',
+                        fractional_digits: 2,
+                        is_deposit_suspended: 0,
+                        is_suspended: 0,
+                        is_withdrawal_suspended: 0,
+                        name: 'US Dollar',
+                        stake_default: 10,
+                        type: 'fiat',
+                    },
+                ],
             },
             ui: {
                 ...store.ui,
@@ -296,7 +423,6 @@ describe('<CurrencySelector/>', () => {
 
         renderComponent({ store_config: new_store });
         expect(screen.getByRole('radio', { name: /us dollar \(usd\)/i })).toBeDisabled();
-        expect(screen.getByRole('radio', { name: /euro \(eur\)/i })).toBeDisabled();
     });
 
     it('should render Fiat currencies when is_dxtrade_allowed and is_mt5_allowed are true', () => {

--- a/packages/account/src/Components/currency-selector/__tests__/currency-selector.spec.tsx
+++ b/packages/account/src/Components/currency-selector/__tests__/currency-selector.spec.tsx
@@ -32,8 +32,6 @@ describe('<CurrencySelector/>', () => {
 
     const fiat_msg =
         'You are limited to one fiat account. You won’t be able to change your account currency if you have already made your first deposit.';
-    const mt5_cfd_msg =
-        'You are limited to one fiat account. You won’t be able to change your account currency if you have already made your first deposit or created a real CFDs account.';
     const dxtrade_non_eu_msg =
         'You are limited to one fiat account. You won’t be able to change your account currency if you have already made your first deposit or created a real Deriv MT5 or Deriv X account.';
     const mt5_eu =
@@ -262,7 +260,7 @@ describe('<CurrencySelector/>', () => {
         });
     });
 
-    fit('should not disable fiat if crypto is disabled ', () => {
+    it('should not disable fiat if crypto is disabled ', () => {
         const new_store: TStores = {
             ...store,
             client: {
@@ -344,7 +342,7 @@ describe('<CurrencySelector/>', () => {
         expect(screen.getByRole('radio', { name: /Bitcoin/i })).toBeDisabled();
     });
 
-    fit('should disable fiat accout is one account is already created', () => {
+    it('should disable fiat accout is one account is already created', () => {
         const new_store: TStores = {
             ...store,
             client: {

--- a/packages/account/src/Components/currency-selector/currency-selector.tsx
+++ b/packages/account/src/Components/currency-selector/currency-selector.tsx
@@ -89,8 +89,7 @@ const CurrencySelector = observer(
 
         const has_currency = Boolean(currency);
 
-        const { real_account_signup, real_account_signup_target, resetRealAccountSignupParams, is_desktop, is_mobile } =
-            ui;
+        const { real_account_signup, resetRealAccountSignupParams, is_desktop, is_mobile } = ui;
 
         // Wrapped with String() to avoid type mismatch
         const crypto = legal_allowed_currencies.filter(
@@ -103,9 +102,18 @@ const CurrencySelector = observer(
         );
         const [is_bypass_step, setIsBypassStep] = React.useState<boolean>(false);
 
-        const should_disable_fiat = !!Object.values(accounts).filter(
-            item => item.landing_company_shortcode === real_account_signup_target
-        ).length;
+        const should_disable_fiat = React.useMemo(() => {
+            const disabled_accounts = Object.values(accounts).filter(account => account.is_disabled);
+            const disabled_currencies = disabled_accounts.map(account => account.currency);
+            const existing_account = legal_allowed_currencies.find(allowed_currency_data =>
+                disabled_currencies.includes(allowed_currency_data.value)
+            );
+
+            if (existing_account?.type) {
+                return existing_account.type === CURRENCY_TYPE.FIAT;
+            }
+            return false;
+        }, [accounts, legal_allowed_currencies]);
 
         const handleCancel = (values: TCurrencySelectorFormProps) => {
             const current_step = getCurrentStep() - 1;


### PR DESCRIPTION
## Changes:

User is not able to create any FIAT account when  one of the crypto account is disabled. The issue is because we were not filtering accounts based on is_disabled flag and checking the type of account disabled (FIAT/Crypto)


