### PR TITLE
fix: redirection issue in ios for cashier withdrawal

### DIFF
--- a/packages/core/src/public/.well-known/apple-app-site-association
+++ b/packages/core/src/public/.well-known/apple-app-site-association
@@ -24,7 +24,6 @@
                 "paths": [
                     "/cashier/p2p",
                     "/cashier/p2p/advertiser",
-                    "/redirect",
                     "/redirect/p2p"
                 ]
             },


### PR DESCRIPTION
## Changes:

Redirection to cashier withdrawal issue to p2p.

### Screenshots:

Please provide some screenshots of the change.
