### PR TITLE
[cashier-v2] george / bump version of deriv/quill-iconsi from 1.17.25 to 1.18.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "@deriv/deriv-charts": "^2.0.4",
                 "@deriv/js-interpreter": "^3.0.0",
                 "@deriv/quill-design": "^1.3.2",
-                "@deriv/quill-icons": "^1.17.27",
+                "@deriv/quill-icons": "^1.18.3",
                 "@deriv/react-joyride": "^2.6.2",
                 "@deriv/ui": "^0.6.0",
                 "@livechat/customer-sdk": "^2.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "@deriv/deriv-charts": "^2.0.4",
                 "@deriv/js-interpreter": "^3.0.0",
                 "@deriv/quill-design": "^1.3.2",
-                "@deriv/quill-icons": "^1.17.25",
+                "@deriv/quill-icons": "^1.17.27",
                 "@deriv/react-joyride": "^2.6.2",
                 "@deriv/ui": "^0.6.0",
                 "@livechat/customer-sdk": "^2.0.4",
@@ -3033,9 +3033,9 @@
             }
         },
         "node_modules/@deriv/quill-icons": {
-            "version": "1.17.25",
-            "resolved": "https://registry.npmjs.org/@deriv/quill-icons/-/quill-icons-1.17.25.tgz",
-            "integrity": "sha512-Een2BVmkWghGV7sMilTvcvWzfZDIY5Lf7tbDblIGynonLkoJnQ79yXeEvkI8wZateisHY9bjwLL6V7RKygJKLA==",
+            "version": "1.18.3",
+            "resolved": "https://registry.npmjs.org/@deriv/quill-icons/-/quill-icons-1.18.3.tgz",
+            "integrity": "sha512-Yfyww6o7L1LS7Tvq23xez4DHnukErB2+gkzqZ8Jn8canZCxvvl+OrHLq28Px3Rn3NqrQg/d5Z9Nf8saxleraZg==",
             "peerDependencies": {
                 "react": ">= 16",
                 "react-dom": ">= 16"
@@ -52382,9 +52382,9 @@
             "requires": {}
         },
         "@deriv/quill-icons": {
-            "version": "1.17.25",
-            "resolved": "https://registry.npmjs.org/@deriv/quill-icons/-/quill-icons-1.17.25.tgz",
-            "integrity": "sha512-Een2BVmkWghGV7sMilTvcvWzfZDIY5Lf7tbDblIGynonLkoJnQ79yXeEvkI8wZateisHY9bjwLL6V7RKygJKLA==",
+            "version": "1.18.3",
+            "resolved": "https://registry.npmjs.org/@deriv/quill-icons/-/quill-icons-1.18.3.tgz",
+            "integrity": "sha512-Yfyww6o7L1LS7Tvq23xez4DHnukErB2+gkzqZ8Jn8canZCxvvl+OrHLq28Px3Rn3NqrQg/d5Z9Nf8saxleraZg==",
             "requires": {}
         },
         "@deriv/react-joyride": {

--- a/packages/account-v2/package.json
+++ b/packages/account-v2/package.json
@@ -15,7 +15,7 @@
         "@deriv/api": "^1.0.0",
         "@deriv/library": "^1.0.0",
         "@deriv/quill-design": "^1.3.2",
-        "@deriv/quill-icons": "^1.17.27",
+        "@deriv/quill-icons": "^1.18.3",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",
         "formik": "^2.1.4",

--- a/packages/account-v2/package.json
+++ b/packages/account-v2/package.json
@@ -15,7 +15,7 @@
         "@deriv/api": "^1.0.0",
         "@deriv/library": "^1.0.0",
         "@deriv/quill-design": "^1.3.2",
-        "@deriv/quill-icons": "^1.17.25",
+        "@deriv/quill-icons": "^1.17.27",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",
         "formik": "^2.1.4",

--- a/packages/cashier-v2/package.json
+++ b/packages/cashier-v2/package.json
@@ -16,7 +16,7 @@
         "@deriv/api": "^1.0.0",
         "@deriv/integration": "^1.0.0",
         "@deriv/library": "^1.0.0",
-        "@deriv/quill-icons": "^1.17.25",
+        "@deriv/quill-icons": "^1.17.27",
         "@deriv/utils": "^1.0.0",
         "clsx": "^2.0.0",
         "formik": "^2.1.4",

--- a/packages/cashier-v2/package.json
+++ b/packages/cashier-v2/package.json
@@ -16,7 +16,7 @@
         "@deriv/api": "^1.0.0",
         "@deriv/integration": "^1.0.0",
         "@deriv/library": "^1.0.0",
-        "@deriv/quill-icons": "^1.17.27",
+        "@deriv/quill-icons": "^1.18.3",
         "@deriv/utils": "^1.0.0",
         "clsx": "^2.0.0",
         "formik": "^2.1.4",

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -5,7 +5,7 @@
     "main": "src/index.ts",
     "dependencies": {
         "@deriv/quill-design": "^1.3.2",
-        "@deriv/quill-icons": "^1.17.25",
+        "@deriv/quill-icons": "^1.17.27",
         "react": "^17.0.2",
         "usehooks-ts": "^2.7.0",
         "@deriv/api": "^1.0.0",

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -5,7 +5,7 @@
     "main": "src/index.ts",
     "dependencies": {
         "@deriv/quill-design": "^1.3.2",
-        "@deriv/quill-icons": "^1.17.27",
+        "@deriv/quill-icons": "^1.18.3",
         "react": "^17.0.2",
         "usehooks-ts": "^2.7.0",
         "@deriv/api": "^1.0.0",

--- a/packages/p2p-v2/package.json
+++ b/packages/p2p-v2/package.json
@@ -15,7 +15,7 @@
         "@deriv-com/ui": "1.5.3",
         "@deriv/api": "^1.0.0",
         "@deriv/integration": "^1.0.0",
-        "@deriv/quill-icons": "^1.17.25",
+        "@deriv/quill-icons": "^1.17.27",
         "@deriv/react-joyride": "^2.6.2",
         "@sendbird/chat": "^4.9.7",
         "@tanstack/react-table": "^8.10.3",

--- a/packages/p2p-v2/package.json
+++ b/packages/p2p-v2/package.json
@@ -15,7 +15,7 @@
         "@deriv-com/ui": "1.5.3",
         "@deriv/api": "^1.0.0",
         "@deriv/integration": "^1.0.0",
-        "@deriv/quill-icons": "^1.17.27",
+        "@deriv/quill-icons": "^1.18.3",
         "@deriv/react-joyride": "^2.6.2",
         "@sendbird/chat": "^4.9.7",
         "@tanstack/react-table": "^8.10.3",

--- a/packages/tradershub/package.json
+++ b/packages/tradershub/package.json
@@ -17,7 +17,7 @@
         "@deriv/integration": "^1.0.0",
         "@deriv/library": "^1.0.0",
         "@deriv/quill-design": "^1.3.2",
-        "@deriv/quill-icons": "^1.17.25",
+        "@deriv/quill-icons": "^1.17.27",
         "@deriv-com/ui": "1.5.3",
         "@deriv/react-joyride": "^2.6.2",
         "@deriv/utils": "^1.0.0",

--- a/packages/tradershub/package.json
+++ b/packages/tradershub/package.json
@@ -17,7 +17,7 @@
         "@deriv/integration": "^1.0.0",
         "@deriv/library": "^1.0.0",
         "@deriv/quill-design": "^1.3.2",
-        "@deriv/quill-icons": "^1.17.27",
+        "@deriv/quill-icons": "^1.18.3",
         "@deriv-com/ui": "1.5.3",
         "@deriv/react-joyride": "^2.6.2",
         "@deriv/utils": "^1.0.0",


### PR DESCRIPTION
## Changes:

Update the `deriv/quill-icons` package version from 1.17.25 to 1.17.27 in all the V2 packages.

### Screenshots:

Please provide some screenshots of the change.
