### PR TITLE
[WALL] Lubega / WALL-2879 / Crypto transfer wrong exchange rate conversion 

### DIFF
--- a/packages/cashier/src/components/crypto-fiat-converter/crypto-fiat-converter.tsx
+++ b/packages/cashier/src/components/crypto-fiat-converter/crypto-fiat-converter.tsx
@@ -88,7 +88,7 @@ const CryptoFiatConverter = observer(
                                 setArrowIconDirection('right');
                             }}
                             onChange={(e: TReactChangeEvent) => {
-                                const rate = exchange_rates?.[from_currency]?.[to_currency] ?? 1;
+                                const rate = exchange_rates?.[from_currency]?.[to_currency] ?? 0;
                                 const converted_amount = Number(e.target.value) * rate;
                                 onChangeConverterFromAmount(e, from_currency, to_currency, converted_amount);
                                 handleChange(e);
@@ -128,7 +128,7 @@ const CryptoFiatConverter = observer(
                                     setArrowIconDirection('left');
                                 }}
                                 onChange={(e: TReactChangeEvent) => {
-                                    const rate = exchange_rates?.[to_currency]?.[from_currency] ?? 1;
+                                    const rate = exchange_rates?.[to_currency]?.[from_currency] ?? 0;
                                     const converted_amount = Number(e.target.value) * rate;
                                     onChangeConverterToAmount(e, from_currency, to_currency, converted_amount);
                                     handleChange(e);

--- a/packages/cashier/src/components/crypto-fiat-converter/crypto-fiat-converter.tsx
+++ b/packages/cashier/src/components/crypto-fiat-converter/crypto-fiat-converter.tsx
@@ -130,7 +130,7 @@ const CryptoFiatConverter = observer(
                                 onChange={(e: TReactChangeEvent) => {
                                     const rate = exchange_rates?.[to_currency]?.[from_currency] ?? 1;
                                     const converted_amount = Number(e.target.value) * rate;
-                                    onChangeConverterToAmount(e, to_currency, from_currency, converted_amount);
+                                    onChangeConverterToAmount(e, from_currency, to_currency, converted_amount);
                                     handleChange(e);
                                 }}
                                 type='text'


### PR DESCRIPTION
# Description
Addressing the issue raised in this thread https://deriv-group.slack.com/archives/CEP7GPTP0/p1707966455543589


![image](https://github.com/binary-com/deriv-app/assets/142860499/57aef91e-3d8f-4f27-bbee-8818b0a55749)

# Changes
- [x] changed fallback value to 0 to ensure that opposite field is empty until exchange rate occurs
- [x] Switched incorrect order of to_currency and from_currency in onChangeConverterToAmount  
