### PR TITLE
ci: pass the default github token from workflow

### DIFF
--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Download Remote Config Backup File
       uses: ./.github/actions/download_remote_config_backup
       with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ github.token }}
         REMOTE_CONFIG_URL: ${{ env.REMOTE_CONFIG_URL }}
         GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
         GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}


### PR DESCRIPTION
## Changes:

This is to pass the default github token from workflow to the action.

### Screenshots:

Please provide some screenshots of the change.
