### PR TITLE
ci: use vars instead of env

### DIFF
--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -20,7 +20,7 @@ jobs:
       uses: ./.github/actions/download_remote_config_backup
       with:
         GITHUB_TOKEN: ${{ github.token }}
-        REMOTE_CONFIG_URL: ${{ env.REMOTE_CONFIG_URL }}
+        REMOTE_CONFIG_URL: ${{ vars.REMOTE_CONFIG_URL }}
         GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
         GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
     - name: Build


### PR DESCRIPTION
## Changes:

This is to fix the wrongly provided env to vars.

### Screenshots:

Please provide some screenshots of the change.
