### PR TITLE
[P2PS] farrah/P2PS-2415/fix: reset password redirection

### DIFF
--- a/packages/core/src/public/.well-known/apple-app-site-association
+++ b/packages/core/src/public/.well-known/apple-app-site-association
@@ -24,6 +24,7 @@
                 "paths": [
                     "/cashier/p2p",
                     "/cashier/p2p/advertiser",
+                    "/redirect?action=reset_password",
                     "/redirect/p2p"
                 ]
             },


### PR DESCRIPTION
## Changes:

Added `/redirect?action=reset_password` path to redirect the iOS users to P2P app when they click the link to reset the password. 

### Screenshots:

Please provide some screenshots of the change.
