### PR TITLE
Ako/ prevent remote config url error on local development

### DIFF
--- a/packages/api/src/hooks/useRemoteConfig.ts
+++ b/packages/api/src/hooks/useRemoteConfig.ts
@@ -2,10 +2,12 @@ import { useQuery } from '@tanstack/react-query';
 import initData from '../remote_config.json';
 
 const remoteConfigQuery = async function () {
-    if (!process.env.REMOTE_CONFIG_URL) {
+    const isProductionOrStaging = process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'staging';
+    const REMOTE_CONFIG_URL = process.env.REMOTE_CONFIG_URL || '';
+    if (isProductionOrStaging && REMOTE_CONFIG_URL === '') {
         throw new Error('Remote Config URL is not set!');
     }
-    const response = await fetch(process.env.REMOTE_CONFIG_URL);
+    const response = await fetch(REMOTE_CONFIG_URL);
     if (!response.ok) {
         throw new Error('Remote Config Server is out of reach!');
     }


### PR DESCRIPTION
## Changes:

In case the app is running on local we dont need to have access to remote config url and therefore the error is not needed. so i just removed that error from the local development server.

### Screenshots:

Please provide some screenshots of the change.
