### PR TITLE
Ako/ remove the livechat placeholder when its disabled

### DIFF
--- a/packages/core/src/App/Components/Layout/Header/toggle-menu-drawer.jsx
+++ b/packages/core/src/App/Components/Layout/Header/toggle-menu-drawer.jsx
@@ -392,9 +392,11 @@ const ToggleMenuDrawer = observer(({ platform_config }) => {
                                         </a>
                                     </MobileDrawer.Item>
                                 )}
-                                <MobileDrawer.Item className='header__menu-mobile-livechat'>
-                                    {cs_chat_livechat && <LiveChat />}
-                                </MobileDrawer.Item>
+                                {cs_chat_livechat && (
+                                    <MobileDrawer.Item className='header__menu-mobile-livechat'>
+                                        <LiveChat />
+                                    </MobileDrawer.Item>
+                                )}
                                 {is_logged_in && (
                                     <MobileDrawer.Item
                                         onClick={() => {


### PR DESCRIPTION
## Changes:

This is to remove the placeholder for the whatsapp and live chat in mobile sidebar in case that they are disabled in the firebase.
### Screenshots:

Please provide some screenshots of the change.
