### PR TITLE
[BOT][Spike /Experemental]Maryia/fix: block overlap on "reset" strategy, on "sort blocks" option

### DIFF
--- a/packages/bot-skeleton/src/constants/config.js
+++ b/packages/bot-skeleton/src/constants/config.js
@@ -274,6 +274,7 @@ export const config = {
         flyoutWorkspacesStartScale: 0.7,
         mainWorkspaceStartScale: 0.9,
         previewWorkspaceStartScale: 0.6,
+        indentWorkspace: { x: 0, y: 60 },
     },
     strategies: {
         martingale: {

--- a/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/trade_definition_multiplier.js
+++ b/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/trade_definition_multiplier.js
@@ -206,6 +206,12 @@ Blockly.Blocks.trade_definition_multiplier = {
         if (this.isDescendantOf('trade_definition')) {
             runIrreversibleEvents(() => {
                 runGroupedEvents(false, () => {
+                    const {
+                        workspaces: {
+                            indentWorkspace: { x, y },
+                        },
+                    } = config;
+
                     const duration_block = this.workspace.newBlock('trade_definition_tradeoptions');
                     duration_block.initSvg();
                     duration_block.render();
@@ -233,7 +239,7 @@ Blockly.Blocks.trade_definition_multiplier = {
                     stake_shadow_block.render(true);
 
                     this.dispose();
-                    Blockly.derivWorkspace.cleanUp();
+                    Blockly.derivWorkspace.cleanUp(x, y);
                 });
             });
         }

--- a/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/trade_definition_tradeoptions.js
+++ b/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/trade_definition_tradeoptions.js
@@ -251,6 +251,12 @@ Blockly.Blocks.trade_definition_tradeoptions = {
     },
     updateDurationInput(should_use_default_unit, should_update_value) {
         const { contracts_for } = ApiHelpers.instance;
+        const {
+            workspaces: {
+                indentWorkspace: { x, y },
+            },
+        } = config;
+        Blockly.derivWorkspace.cleanUp(x, y);
 
         if (this.selected_trade_type === 'multiplier' && this.isDescendantOf('trade_definition')) {
             runIrreversibleEvents(() => {
@@ -306,7 +312,6 @@ Blockly.Blocks.trade_definition_tradeoptions = {
                     stop_loss_block.render();
 
                     this.dispose();
-                    Blockly.derivWorkspace.cleanUp();
                 });
             });
         } else {

--- a/packages/bot-web-ui/src/stores/toolbar-store.ts
+++ b/packages/bot-web-ui/src/stores/toolbar-store.ts
@@ -90,13 +90,16 @@ export default class ToolbarStore implements IToolbarStore {
             from: null,
             showIncompatibleStrategyDialog: null,
         });
-        const { is_mobile = false } = this.root_store?.app?.core?.ui || {};
-        await Blockly.derivWorkspace.cleanUp(0, is_mobile ? 60 : 56);
         workspace.strategy_to_load = workspace.cached_xml.main;
     };
 
     onSortClick = () => {
-        Blockly.derivWorkspace.cleanUp();
+        const {
+            workspaces: {
+                indentWorkspace: { x, y },
+            },
+        } = config;
+        Blockly.derivWorkspace.cleanUp(x, y);
     };
 
     onUndoClick = (is_redo: boolean): void => {


### PR DESCRIPTION
## Changes:

fix issue 1): block overlap by pressing "reset" strategy button, on refreshing the default strategy page(as an example)
fix issue 2): by pressing  "sort blocks" option button blocks are made pinned on the top of the Blockly workspace

### Screenshots:

<img width="1312" alt="Screenshot 2024-02-21 at 11 38 13" src="https://github.com/binary-com/deriv-app/assets/103181650/5cf72863-10cb-4f50-a090-d40584864a0f">
<img width="1312" alt="Screenshot 2024-02-21 at 11 38 37" src="https://github.com/binary-com/deriv-app/assets/103181650/01478643-f2d1-4972-95a3-cbe7e4534be9">

