### PR TITLE
[WEBREL] shontzu/WEBREL-2544/Incorrect-Capitalisation-macOS

### DIFF
--- a/packages/cfd/src/Helpers/constants.ts
+++ b/packages/cfd/src/Helpers/constants.ts
@@ -144,7 +144,7 @@ const getDesktopDownloadOptions = ({ mt5_trade_account }: { mt5_trade_account: D
         },
         {
             icon: 'IcMacosLogo',
-            text: localize('MetaTrader 5 macOS app'),
+            text: localize('MetaTrader 5 MacOS app'),
             button_text: 'Download',
             href: getPlatformMt5DownloadLink('macos'),
         },


### PR DESCRIPTION
## Changes:
- corrected capitalisation macOS --> MacOS
- Due to the changes of this card  , the capitalisation in MT5 modal has changed

### Screenshots:

![image](https://github.com/binary-com/deriv-app/assets/108507236/5e6c7661-dd87-4441-8e7e-38bcfac211c1)
