### PR TITLE
[DTRA] Maryia/fix: avoid showing UrlUnavailableModal when logging into account where selected asset is unavailable

### DIFF
--- a/packages/trader/src/Stores/Modules/Trading/trade-store.ts
+++ b/packages/trader/src/Stores/Modules/Trading/trade-store.ts
@@ -631,7 +631,9 @@ export default class TradeStore extends BaseStore {
         await this.setActiveSymbols();
         await this.root_store.active_symbols.setActiveSymbols();
         const { symbol, showModal } = getTradeURLParams({ active_symbols: this.active_symbols });
-        if (showModal && should_show_loading) this.root_store.ui.toggleUrlUnavailableModal(true);
+        if (showModal && should_show_loading && !this.root_store.client.is_logging_in) {
+            this.root_store.ui.toggleUrlUnavailableModal(true);
+        }
         const hasSymbolChanged = symbol && symbol !== this.symbol;
         if (hasSymbolChanged) this.symbol = symbol;
         if (should_set_default_symbol && !symbol) await this.setDefaultSymbol();


### PR DESCRIPTION
## Changes:

This is an additional fix for https://github.com/binary-com/deriv-app/pull/13179 to avoid showing UrlUnavailableModal when a user logs in while the asset, which was selected before login, stops being available.
