### PR TITLE
[DTRA] Maryia/WEBREL-2551/hotfix: restore logic of redirecting back to other pages by using history.replaceState for DTrader URL

### DIFF
--- a/packages/shared/src/utils/contract/__tests__/trade-url-params-config.spec.ts
+++ b/packages/shared/src/utils/contract/__tests__/trade-url-params-config.spec.ts
@@ -123,36 +123,36 @@ describe('setTradeURLParams', () => {
     });
 
     it('should set interval query param into URL based on the received granularity value', async () => {
-        const spyHistoryPushState = jest.spyOn(window.history, 'pushState');
+        const spyHistoryReplaceState = jest.spyOn(window.history, 'replaceState');
         setTradeURLParams({
             granularity: 0,
         });
-        expect(spyHistoryPushState).toBeCalledWith(null, '', `/?interval=${oneTickInterval}`);
+        expect(spyHistoryReplaceState).toBeCalledWith({}, document.title, `/?interval=${oneTickInterval}`);
     });
     it('should set chart_type query param into URL based on the received chart_type value', async () => {
-        const spyHistoryPushState = jest.spyOn(window.history, 'pushState');
+        const spyHistoryReplaceState = jest.spyOn(window.history, 'replaceState');
         setTradeURLParams({
             chartType: areaChartType.value,
         });
-        expect(spyHistoryPushState).toBeCalledWith(null, '', `/?chart_type=${areaChartType.text}`);
+        expect(spyHistoryReplaceState).toBeCalledWith({}, document.title, `/?chart_type=${areaChartType.text}`);
     });
     it('should set symbol query param into URL based on the received symbol value', async () => {
-        const spyHistoryPushState = jest.spyOn(window.history, 'pushState');
+        const spyHistoryReplaceState = jest.spyOn(window.history, 'replaceState');
         setTradeURLParams({
             symbol,
         });
-        expect(spyHistoryPushState).toBeCalledWith(null, '', `/?symbol=${symbol}`);
+        expect(spyHistoryReplaceState).toBeCalledWith({}, document.title, `/?symbol=${symbol}`);
     });
     it('should set trade_type query param into URL based on the received contract_type value', async () => {
-        const spyHistoryPushState = jest.spyOn(window.history, 'pushState');
+        const spyHistoryReplaceState = jest.spyOn(window.history, 'replaceState');
         setTradeURLParams({
             contractType: TRADE_TYPES.ACCUMULATOR,
         });
-        expect(spyHistoryPushState).toBeCalledWith(null, '', `/?trade_type=${TRADE_TYPES.ACCUMULATOR}`);
+        expect(spyHistoryReplaceState).toBeCalledWith({}, document.title, `/?trade_type=${TRADE_TYPES.ACCUMULATOR}`);
     });
     it('should not set any query params into URL when called with empty object', async () => {
-        const spyHistoryPushState = jest.spyOn(window.history, 'pushState');
+        const spyHistoryReplaceState = jest.spyOn(window.history, 'replaceState');
         setTradeURLParams({});
-        expect(spyHistoryPushState).not.toBeCalled();
+        expect(spyHistoryReplaceState).not.toBeCalled();
     });
 });

--- a/packages/shared/src/utils/contract/trade-url-params-config.ts
+++ b/packages/shared/src/utils/contract/trade-url-params-config.ts
@@ -94,6 +94,6 @@ export const setTradeURLParams = ({ contractType, symbol, chartType, granularity
     contractType && searchParams.set(TRADE_URL_PARAMS.TRADE_TYPE, contractType);
     if (searchParams.toString()) {
         const newQuery = `${window.location.pathname}?${searchParams.toString()}`;
-        window.history.pushState(null, '', newQuery);
+        window.history.replaceState({}, document.title, newQuery);
     }
 };


### PR DESCRIPTION
## Changes:

- to hotfix redirecting user back from DTrader to other pages by using history.replaceState to not affect routing history.
