### PR TITLE
[DTRA] Maryia/WEBREL-2553/hotfix: restore redirection to Trader's hub upon logging in

### DIFF
--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -2140,7 +2140,9 @@ export default class ClientStore extends BaseStore {
             const target_url = is_next_wallet_enabled ? routes.wallets : routes.traders_hub;
 
             if (
-                (redirect_url?.endsWith('/') || redirect_url?.endsWith(routes.bot)) &&
+                (redirect_url?.endsWith('/') ||
+                    redirect_url?.endsWith(routes.bot) ||
+                    /chart_type|interval|symbol|trade_type/.test(redirect_url)) &&
                 (isTestLink() || isProduction() || isLocal() || isStaging() || isTestDerivApp())
             ) {
                 window.history.replaceState({}, document.title, target_url);


### PR DESCRIPTION
## Changes:

- Ignore new trade query params from redirect_url in order to keep redirection to Trader's hub upon logging in.
