### PR TITLE
[WALL] Lubega / WALL-3511 / Verification failed modal design fixes

### DIFF
--- a/packages/wallets/src/components/Base/ModalWrapper/ModalWrapper.scss
+++ b/packages/wallets/src/components/Base/ModalWrapper/ModalWrapper.scss
@@ -1,6 +1,8 @@
 .wallets-modal-wrapper {
     position: relative;
     animation: popup 0.4s;
+    display: flex;
+    justify-content: center;
 
     @include mobile {
         animation: popup 0.2s;

--- a/packages/wallets/src/features/cfd/modals/VerificationFailedModal/VerificationFailedModal.tsx
+++ b/packages/wallets/src/features/cfd/modals/VerificationFailedModal/VerificationFailedModal.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
-import { THooks } from '../../../../types';
 import { ModalWrapper } from '../../../../components/Base';
+import { THooks } from '../../../../types';
 import { VerificationFailed } from '../../screens';
 
 type TVerificationFailedModalProps = {

--- a/packages/wallets/src/features/cfd/screens/VerificationFailed/VerificationFailed.scss
+++ b/packages/wallets/src/features/cfd/screens/VerificationFailed/VerificationFailed.scss
@@ -6,19 +6,37 @@
     border-radius: 0.8rem;
     background-color: var(--system-light-8-primary-background, #fff);
     width: 44rem;
-    height: 34.4rem;
 
     @include mobile {
         width: 32rem;
-        height: 30rem;
         padding: 1.6rem;
         gap: 1.6rem;
+    }
+
+    & ul {
+        display: flex;
+        flex-direction: column;
+        gap: 0.6rem;
+
+        @include mobile {
+            gap: 0.4rem;
+        }
     }
 
     & li {
         left: 1rem;
         position: relative;
         list-style-type: disc;
+    }
+
+    &__content {
+        display: flex;
+        flex-direction: column;
+        gap: 2rem;
+
+        @include mobile {
+            gap: 1rem;
+        }
     }
 
     &__footer {

--- a/packages/wallets/src/features/cfd/screens/VerificationFailed/VerificationFailed.tsx
+++ b/packages/wallets/src/features/cfd/screens/VerificationFailed/VerificationFailed.tsx
@@ -1,15 +1,16 @@
 import React, { FC } from 'react';
-import { THooks } from '../../../../types';
 import { usePOA, usePOI } from '@deriv/api-v2';
 import { WalletButton, WalletText } from '../../../../components/Base';
 import { useModal } from '../../../../components/ModalProvider';
+import useDevice from '../../../../hooks/useDevice';
+import { THooks } from '../../../../types';
 import { Verification } from '../../flows/Verification';
 import './VerificationFailed.scss';
 
 const getDocumentTitle = (isPOIFailed?: boolean, isPOAFailed?: boolean) => {
-    if (isPOIFailed && isPOAFailed) return 'proof of identity and proof of address';
-    if (isPOIFailed) return 'proof of identity';
-    return 'proof of address';
+    if (isPOIFailed && isPOAFailed) return 'proof of identity and proof of address documents';
+    if (isPOIFailed) return 'proof of identity document';
+    return 'proof of address document';
 };
 
 type TVerificationFailedProps = {
@@ -20,40 +21,43 @@ const VerificationFailed: FC<TVerificationFailedProps> = ({ selectedJurisdiction
     const { hide, show } = useModal();
     const { data: poiStatus } = usePOI();
     const { data: poaStatus } = usePOA();
+    const { isMobile } = useDevice();
 
     const isPOIFailed = poiStatus?.is_rejected || poiStatus?.is_expired || poiStatus?.is_suspected;
     const isPOAFailed = poaStatus?.is_rejected || poaStatus?.is_expired || poaStatus?.is_suspected;
 
     return (
         <div className='wallets-verification-failed'>
-            <WalletText size='sm' weight='bold'>
+            <WalletText size='md' weight='bold'>
                 Why did my verification fail?
             </WalletText>
-            <WalletText size='sm'>
-                Your {getDocumentTitle(isPOIFailed, isPOAFailed)} did not pass our verification checks. This could be
-                due to reasons such as:
-            </WalletText>
-            <ul>
-                <li>
-                    <WalletText size='sm'>Document details do not match profile details</WalletText>
-                </li>
-                <li>
-                    <WalletText size='sm'>Expired documents</WalletText>
-                </li>
-                <li>
-                    <WalletText size='sm'>Poor image quality</WalletText>
-                </li>
-            </ul>
-            <WalletText size='sm'>
-                Click <strong>Resubmit documents</strong> to find out more and submit your documents again.
-            </WalletText>
+            <div className='wallets-verification-failed__content'>
+                <WalletText size='sm'>
+                    Your {getDocumentTitle(isPOIFailed, isPOAFailed)} did not pass our verification checks. This could
+                    be due to reasons such as:
+                </WalletText>
+                <ul>
+                    <li>
+                        <WalletText size='sm'>Document details do not match profile details</WalletText>
+                    </li>
+                    <li>
+                        <WalletText size='sm'>Expired documents</WalletText>
+                    </li>
+                    <li>
+                        <WalletText size='sm'>Poor image quality</WalletText>
+                    </li>
+                </ul>
+                <WalletText size='sm'>
+                    Click <strong>Resubmit documents</strong> to find out more and try again.
+                </WalletText>
+            </div>
             <div className='wallets-verification-failed__footer'>
-                <WalletButton onClick={() => hide()} size='lg' variant='outlined'>
+                <WalletButton onClick={() => hide()} size={isMobile ? 'md' : 'lg'} variant='outlined'>
                     Maybe later
                 </WalletButton>
                 <WalletButton
                     onClick={() => show(<Verification selectedJurisdiction={selectedJurisdiction} />)}
-                    size='lg'
+                    size={isMobile ? 'md' : 'lg'}
                 >
                     Resubmit documents
                 </WalletButton>


### PR DESCRIPTION
## Changes:

- [x] Matched gap and font size for desktop and responsive to figma design
- [x] Fixed text content to match figma design
- [x] Center content of modal in responsive
- [x] Sorted imports

### Screenshots:
<img width="1033" alt="Screenshot 2024-03-04 at 5 08 58 PM" src="https://github.com/binary-com/deriv-app/assets/142860499/b8b46d48-b8bd-47a3-a48b-a587c21db766">

<img width="1022" alt="Screenshot 2024-03-04 at 5 10 19 PM" src="https://github.com/binary-com/deriv-app/assets/142860499/e6bc717b-dca4-4604-abef-ee27a188c3dd">
