### PR TITLE
[WALL-3531] wojtek/lock old api

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -171,7 +171,7 @@
 
 # ==============================================================
 #  deriv-app/api
-#  Deprecated - do not use. For -v2 projects use api-v2. For old projects - do not use api nor api-v2, use old pattenrs / old hooks. 
+#  Deprecated - do not use. For -v2 projects use api-v2. For old projects - do not use api nor api-v2, use old patterns / old hooks. 
 # ==============================================================
 
 /packages/api/**/*                                              @wojciech-deriv @matin-deriv @yashim-deriv

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -171,9 +171,10 @@
 
 # ==============================================================
 #  deriv-app/api
+#  Deprecated - do not use. For -v2 projects use api-v2. For old projects - do not use api nor api-v2, use old pattenrs / old hooks. 
 # ==============================================================
 
-/packages/api/**/*                                              @adrienne-deriv @thisyahlen-deriv @farhan-nurzi-deriv @wojciech-deriv
+/packages/api/**/*                                              @wojciech-deriv @matin-deriv @yashim-deriv
 
 # ==============================================================
 #  deriv-app/api-v2


### PR DESCRIPTION
Lock old API to prevent them from being updated / used.

Next step in next PR: add linting to prevent cross-package imports spaghetti (basically to avoid e.g. use of api-v2 within legacy code and other imports which shouldn't happen but used to cause problems before)