### PR TITLE
Maryia/DTRA-952/build: update @deriv/deriv-charts version to 2.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,10 +19,10 @@
                 "@deriv-com/utils": "latest",
                 "@deriv/api-types": "^1.0.118",
                 "@deriv/deriv-api": "^1.0.15",
-                "@deriv/deriv-charts": "^2.0.5",
+                "@deriv/deriv-charts": "^2.1.4",
                 "@deriv/js-interpreter": "^3.0.0",
                 "@deriv/quill-design": "^1.3.2",
-                "@deriv/quill-icons": "^1.18.3",
+                "@deriv/quill-icons": "^1.19.0",
                 "@deriv/react-joyride": "^2.6.2",
                 "@deriv/ui": "^0.6.0",
                 "@livechat/customer-sdk": "^2.0.4",
@@ -2977,9 +2977,9 @@
             }
         },
         "node_modules/@deriv/deriv-charts": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.0.5.tgz",
-            "integrity": "sha512-qJEBqxt4Q+nrdATMHdY6SDZw71SucrDJwyEwEt916WeBKphC77qZNnUaPAvOL7iyId+jyhO1vobFUZUbGXw6aw==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.1.4.tgz",
+            "integrity": "sha512-6A6mhkzR4Q7VnwbM9d95vXjGwu2GKtgAcJuKJzbeGXCd+1XKmcDn+vGjWguDQHBYYC9VmizjJbNXe+xYihyDMA==",
             "dependencies": {
                 "@types/lodash.set": "^4.3.7",
                 "@welldone-software/why-did-you-render": "^3.3.8",
@@ -2991,7 +2991,6 @@
                 "mobx": "^6.5.0",
                 "mobx-react-lite": "^3.4.0",
                 "moment": "^2.24.0",
-                "prop-types": "^15.7.2",
                 "react": "^17.0.2",
                 "react-dom": "^17.0.2",
                 "react-tabs": "^4.3.0",

--- a/packages/bot-web-ui/package.json
+++ b/packages/bot-web-ui/package.json
@@ -70,7 +70,7 @@
         "@datadog/browser-logs": "^4.36.0",
         "@deriv/bot-skeleton": "^1.0.0",
         "@deriv/components": "^1.0.0",
-        "@deriv/deriv-charts": "^2.0.5",
+        "@deriv/deriv-charts": "^2.1.4",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",
         "@deriv/translations": "^1.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -105,7 +105,7 @@
         "@deriv/cfd": "^1.0.0",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv/deriv-charts": "^2.0.5",
+        "@deriv/deriv-charts": "^2.1.4",
         "@deriv/hooks": "^1.0.0",
         "@deriv/p2p": "^0.7.3",
         "@deriv/p2p-v2": "^1.0.0",

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -91,7 +91,7 @@
         "@deriv/api-types": "^1.0.118",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv/deriv-charts": "^2.0.5",
+        "@deriv/deriv-charts": "^2.1.4",
         "@deriv/hooks": "^1.0.0",
         "@deriv/reports": "^1.0.0",
         "@deriv/shared": "^1.0.0",


### PR DESCRIPTION
## Changes:

- update @deriv/deriv-charts version to 2.1.4
