### PR TITLE
[WALL-3538] wojtek/prevent api-v2 from being imported to legacy code

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -180,3 +180,9 @@
 # ==============================================================
 
 /packages/api-v2/**/*                                           @adrienne-deriv @thisyahlen-deriv @farhan-nurzi-deriv @wojciech-deriv
+
+# ==============================================================
+#  scripts/check-imports.js 
+# ==============================================================
+
+/scripts/check-imports.js                                       @wojciech-deriv @matin-deriv @yashim-deriv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,8 @@ jobs:
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
     - name: Setup Node
       uses: "./.github/actions/setup_node"
+    - name: Check imports
+      run: npm run check-imports
     - name: Install dependencies
       uses: "./.github/actions/npm_install_from_cache"
     # - name: Invalidate NPM Cache

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
         "build:prod": "export NODE_ENV=staging && npm run build:all && export NODE_ENV=",
         "build:storybook": "cd packages/components && build-storybook --output-dir .out",
         "build:gh-pages": "f () { nx run-many --target=build --projects=@deriv/components,@deriv/p2p && nx run-many --target=build --projects=@deriv/cashier,@deriv/account,@deriv/cfd,@deriv/reports && npm run build:local $1 ;}; f",
+        "check-imports": "node ./scripts/check-imports.js",
         "clean": "echo \"Remove $(git rev-parse --show-toplevel)/node_modules\" && lerna clean && rm -rf \"$(git rev-parse --show-toplevel)/node_modules\"",
         "deploy": "f () { export NODE_ENV=staging && npm run build:all && lerna exec --scope @deriv/core -- npm run deploy $@ && export NODE_ENV= ;}; f",
         "deploy:clean": "f () { npm run build:travis && npm run build:local && lerna exec --scope @deriv/core -- npm run deploy:clean $@ ;}; f",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -7,6 +7,7 @@
         "@binary-com/binary-document-uploader": "^2.4.8",
         "@deriv-com/analytics": "1.4.10",
         "@deriv/api": "^1.0.0",
+        "@deriv/api-v2": "^1.0.0",
         "@deriv/stores": "^1.0.0",
         "@deriv/utils": "^1.0.0",
         "@deriv/shared": "^1.0.0",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -7,7 +7,6 @@
         "@binary-com/binary-document-uploader": "^2.4.8",
         "@deriv-com/analytics": "1.4.10",
         "@deriv/api": "^1.0.0",
-        "@deriv/api-v2": "^1.0.0",
         "@deriv/stores": "^1.0.0",
         "@deriv/utils": "^1.0.0",
         "@deriv/shared": "^1.0.0",

--- a/scripts/check-imports.js
+++ b/scripts/check-imports.js
@@ -1,0 +1,57 @@
+/**
+ * This script checks if any of the packages contain prohibited imports.
+ * Thats to avoid classic monorepo import-spaghetti.
+ *
+ * Context: not all packages have eslint running, running it globally tends to be slow and problematic.
+ * So added this tiny script to just go over packages and check if they contain any prohibited imports.
+ * Feel free to change it to eslint or smth better.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const BLOCKED_IMPORTS = {
+    '/packages/account': ['@deriv/api-v2'],
+    '/packages/api': ['@deriv/api-v2'],
+    '/packages/appstore': ['@deriv/api-v2'],
+    '/packages/bot-skeleton': ['@deriv/api-v2'],
+    '/packages/bot-web-ui': ['@deriv/api-v2'],
+    '/packages/cashier': ['@deriv/api-v2'],
+    '/packages/cfd': ['@deriv/api-v2'],
+    '/packages/components': ['@deriv/api-v2'],
+    '/packages/core': ['@deriv/api-v2'],
+    '/packages/hooks': ['@deriv/api-v2'],
+    '/packages/indicators': ['@deriv/api-v2'],
+    '/packages/integration': ['@deriv/api-v2'],
+    '/packages/p2p': ['@deriv/api-v2'],
+    '/packages/publisher': ['@deriv/api-v2'],
+    '/packages/reports': ['@deriv/api-v2'],
+    '/packages/shared': ['@deriv/api-v2'],
+    '/packages/stores': ['@deriv/api-v2'],
+    '/packages/trader': ['@deriv/api-v2'],
+    '/packages/translations': ['@deriv/api-v2'],
+    '/packages/utils': ['@deriv/api-v2'],
+};
+
+// eslint-disable-next-line no-console
+console.log('Validating imports...');
+
+// go over each package and check if it contains any prohibited imports
+Object.entries(BLOCKED_IMPORTS).forEach(([packagePath, blockedPackages]) => {
+    const packageJsonPath = path.join(process.cwd(), packagePath, 'package.json');
+
+    // check if package.json exists
+    if (fs.existsSync(packageJsonPath)) {
+        const packageJsonContent = fs.readFileSync(packageJsonPath, 'utf8');
+
+        blockedPackages.forEach(packageName => {
+            if (packageJsonContent.includes(packageName)) {
+                // eslint-disable-next-line no-console
+                console.error(`Using / importing "${packageName}" in ${packagePath}/package.json is NOT ALLOWED!`);
+                process.exit(1);
+            }
+        });
+    } else {
+        // eslint-disable-next-line no-console
+        console.warn(`Warning: package.json not found at ${packagePath}. Skipping.`);
+    }
+});

--- a/scripts/check-imports.js
+++ b/scripts/check-imports.js
@@ -46,7 +46,7 @@ Object.entries(BLOCKED_IMPORTS).forEach(([packagePath, blockedPackages]) => {
         blockedPackages.forEach(packageName => {
             if (packageJsonContent.includes(packageName)) {
                 // eslint-disable-next-line no-console
-                console.error(`Using / importing "${packageName}" in ${packagePath}/package.json is NOT ALLOWED!`);
+                console.error(`Using of "${packageName}" in ${packagePath}/package.json is NOT ALLOWED!`);
                 process.exit(1);
             }
         });


### PR DESCRIPTION
This PR is to prevent API-v2 from being imported in legacy codebase.
Previously, /api was imported this was and it generated serious hassle (as it was not build for that and was not supposed to be used that way). 

Initially I've attempted to use eslint for this, but turned out that eslint use is very inconsistent across packages, while running clean global config was slow, so decided to implement tiny fast script to just check package.json against disallowed imports (so its fast and easy to change if needed).