### PR TITLE
[FEQ] Jim/WEBREL-2573/clear the datadog instance in the window object

### DIFF
--- a/packages/bot-web-ui/src/types/global.d.ts
+++ b/packages/bot-web-ui/src/types/global.d.ts
@@ -2,6 +2,7 @@ declare global {
     interface Window {
         sendRequestsStatistic: (is_running: boolean) => void;
         is_datadog_logging_enabled: boolean;
+        DD_RUM: object | undefined;
     }
 }
 

--- a/packages/bot-web-ui/src/utils/datadog-logs.ts
+++ b/packages/bot-web-ui/src/utils/datadog-logs.ts
@@ -9,7 +9,13 @@ import { formatDate, formatTime } from '@deriv/shared';
  * @returns {void}
  * **/
 const initDatadogLogs = (is_datadog_enabled: boolean) => {
-    const DATADOG_CLIENT_TOKEN_LOGS = is_datadog_enabled ? process.env.DATADOG_CLIENT_TOKEN_LOGS ?? '' : '';
+    if(!is_datadog_enabled){
+        if(window.DD_RUM){
+            window.DD_RUM = undefined;
+        }
+        return;
+    }
+    const DATADOG_CLIENT_TOKEN_LOGS = process.env.DATADOG_CLIENT_TOKEN_LOGS ?? '';
     const isProduction = process.env.NODE_ENV === 'production';
     const isStaging = process.env.NODE_ENV === 'staging';
     let dataDogSessionSampleRate = 0;

--- a/packages/core/src/Utils/Datadog/index.ts
+++ b/packages/core/src/Utils/Datadog/index.ts
@@ -45,8 +45,14 @@ const getConfigValues = (environment: string) => {
  * @returns {void}
  * **/
 const initDatadog = (is_datadog_enabled: boolean) => {
-    const DATADOG_APP_ID = is_datadog_enabled ? process.env.DATADOG_APPLICATION_ID ?? '' : '';
-    const DATADOG_CLIENT_TOKEN = is_datadog_enabled ? process.env.DATADOG_CLIENT_TOKEN ?? '' : '';
+    if(!is_datadog_enabled){
+        if(window.DD_RUM){
+            window.DD_RUM = undefined;
+        }
+        return;
+    }
+    const DATADOG_APP_ID = process.env.DATADOG_APPLICATION_ID ?? '';
+    const DATADOG_CLIENT_TOKEN = process.env.DATADOG_CLIENT_TOKEN ?? '';
     const isProduction = process.env.NODE_ENV === 'production';
     const isStaging = process.env.NODE_ENV === 'staging';
 

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -16,6 +16,7 @@ declare global {
         Onfido: {
             init: (args: any) => any;
         };
+        DD_RUM: object | undefined;
     }
 }
 


### PR DESCRIPTION
## Changes:

- Cleared the `window.DD_RUM` object

![dd-dbot](https://github.com/binary-com/deriv-app/assets/104334373/8ef52d8b-4f21-42de-bf43-440926481b0c)
![dd](https://github.com/binary-com/deriv-app/assets/104334373/51eee482-7f57-4bd3-b66b-65f9d4799fd7)

