### PR TITLE
[TRAH] Mitra/TRAH-3025/Broken style of eu disclaimer in footer

### DIFF
--- a/packages/tradershub/src/components/EUDisclaimerMessage/EUDisclaimerMessage.tsx
+++ b/packages/tradershub/src/components/EUDisclaimerMessage/EUDisclaimerMessage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Text } from '@deriv-com/ui';
 
 const EUDisclaimerMessage = () => (
-    <div className='fixed bottom-[36px] w-full bg-system-light-secondary-background'>
+    <div className='fixed bottom-36 w-full bg-system-light-secondary-background'>
         <div className='max-w-[1440px] mx-auto py-8 px-16 lg:px-24'>
             <Text className='w-full text-xs lg:text-default leading-[1.5] '>
                 <span className='font-bold'>EU statutory disclaimer</span>: CFDs are complex instruments and come with a

--- a/packages/tradershub/src/components/EUDisclaimerMessage/EUDisclaimerMessage.tsx
+++ b/packages/tradershub/src/components/EUDisclaimerMessage/EUDisclaimerMessage.tsx
@@ -3,8 +3,8 @@ import { Text } from '@deriv-com/ui';
 
 const EUDisclaimerMessage = () => (
     <div className='fixed bottom-[36px] w-full bg-system-light-secondary-background'>
-        <div className='max-w-[1390px] mx-auto py-8 sm:px-16'>
-            <Text className='w-full text-default sm:text-xs leading-[1.5]'>
+        <div className='max-w-[1440px] mx-auto py-8 px-16 lg:px-24'>
+            <Text className='w-full text-xs lg:text-default leading-[1.5] '>
                 <span className='font-bold'>EU statutory disclaimer</span>: CFDs are complex instruments and come with a
                 high risk of losing money rapidly due to leverage.
                 <span className='font-bold'>

--- a/packages/tradershub/src/components/EUDisclaimerMessage/EUDisclaimerMessage.tsx
+++ b/packages/tradershub/src/components/EUDisclaimerMessage/EUDisclaimerMessage.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { Text } from '@deriv-com/ui';
 
 const EUDisclaimerMessage = () => (
-    <div className='absolute bottom-0 w-full bg-system-light-secondary-background'>
-        <div className='max-w-[1232px] mx-auto px-10 lg:px-0'>
-            <Text className='w-full text-2xs sm:text-default leading-[1.5] py-10'>
+    <div className='fixed bottom-[36px] w-full bg-system-light-secondary-background'>
+        <div className='max-w-[1390px] mx-auto py-8 sm:px-16'>
+            <Text className='w-full text-default sm:text-xs leading-[1.5]'>
                 <span className='font-bold'>EU statutory disclaimer</span>: CFDs are complex instruments and come with a
                 high risk of losing money rapidly due to leverage.
                 <span className='font-bold'>


### PR DESCRIPTION
## Changes:

EU disclaimer is not positioned properly in the Trader's Hub page and has styles issue

### Screenshots:

Before the fix:

![image](https://github.com/binary-com/deriv-app/assets/64970259/898549c3-d324-4196-9862-a8c633c5c8cf)

After the fix: 

Desktop: 
<img width="1728" alt="Screenshot 2024-03-12 at 12 46 39 PM" src="https://github.com/binary-com/deriv-app/assets/64970259/2e2e05d3-75b3-4871-a81e-597566961455">




Responsive: 

<img width="467" alt="Screenshot 2024-03-12 at 12 46 53 PM" src="https://github.com/binary-com/deriv-app/assets/64970259/d1f8b1c0-714e-4da5-85ac-1a6a7e0663be">

