### PR TITLE
[WALL] Lubega / WALL-3595 / Wallet carousel responsive UI update and button reorder

### DIFF
--- a/packages/wallets/src/components/WalletCard/WalletCard.scss
+++ b/packages/wallets/src/components/WalletCard/WalletCard.scss
@@ -3,13 +3,17 @@
 .wallets-card {
     &__carousel-content {
         background-color: transparent;
-        margin: 0 -0.8rem;
+        margin: 0 -0.4rem;
 
         &:first-child {
             margin-left: 0;
         }
 
         &-details {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-between;
+            align-items: flex-start;
             padding: 1.6rem;
             width: 28.8rem;
             height: 17.6rem;

--- a/packages/wallets/src/components/WalletCard/WalletCard.tsx
+++ b/packages/wallets/src/components/WalletCard/WalletCard.tsx
@@ -37,8 +37,9 @@ const WalletCard: React.FC<TProps> = ({
                     type='card'
                 >
                     <div
-                        className={classNames('wallets-card__details', {
+                        className={classNames({
                             'wallets-card__carousel-content-details': isCarouselContent,
+                            'wallets-card__details': !isCarouselContent,
                         })}
                         data-testid='dt_wallet_card_details'
                     >

--- a/packages/wallets/src/components/WalletCard/__tests__/WalletCard.spec.tsx
+++ b/packages/wallets/src/components/WalletCard/__tests__/WalletCard.spec.tsx
@@ -82,7 +82,7 @@ describe('WalletCard', () => {
         const gradient = screen.getByTestId('dt_wallet_gradient_background');
         expect(gradient).toHaveClass('wallets-gradient--BTC-mobile-card-light');
         const details = screen.getByTestId('dt_wallet_card_details');
-        expect(details).toHaveClass('wallets-card__details wallets-card__carousel-content-details');
+        expect(details).toHaveClass('wallets-card__carousel-content-details');
     });
 
     it('should render the correct wallet card and gradient background for demo wallet', () => {

--- a/packages/wallets/src/components/WalletListCardActions/WalletListCardActions.tsx
+++ b/packages/wallets/src/components/WalletListCardActions/WalletListCardActions.tsx
@@ -36,7 +36,7 @@ const getWalletHeaderButtons = (isDemo?: boolean) => {
     // Filter out the "Withdraw" button when is_demo is true
     const filteredButtons = isDemo ? buttons.filter(button => button.name !== 'withdraw') : buttons;
 
-    const orderForDemo = ['transfer', 'transactions', 'reset-balance'];
+    const orderForDemo = ['reset-balance', 'transfer', 'transactions'];
 
     const sortedButtons = isDemo
         ? [...filteredButtons].sort((a, b) => orderForDemo.indexOf(a.name) - orderForDemo.indexOf(b.name))

--- a/packages/wallets/src/components/WalletsCarousel/WalletsCarousel.tsx
+++ b/packages/wallets/src/components/WalletsCarousel/WalletsCarousel.tsx
@@ -26,6 +26,7 @@ const WalletsCarousel: React.FC = () => {
 
     //this handle scroll function listens to the scroll as well as touchmove events to handle drag scrolling on mobile
     useEventListener('touchmove', handleScroll, containerRef);
+    useEventListener('touchend', handleScroll, containerRef);
     useEventListener('scroll', handleScroll, containerRef);
 
     useEffect(() => {

--- a/packages/wallets/src/components/WalletsCarouselContent/WalletsCarouselContent.tsx
+++ b/packages/wallets/src/components/WalletsCarouselContent/WalletsCarouselContent.tsx
@@ -14,8 +14,8 @@ type TProps = {
 
 const numberWithinRange = (number: number, min: number, max: number): number => Math.min(Math.max(number, min), max);
 
-// scale based on the width difference between active wallet (288px) and inactive wallets (240px)
-const TRANSITION_FACTOR_SCALE = 1 - 24 / 28.8;
+// scale based on the width difference between active wallet (288px) and inactive wallets + padding (240px + 16px)
+const TRANSITION_FACTOR_SCALE = 1 - 25.6 / 28.8;
 
 /**
  * carousel component

--- a/packages/wallets/src/components/WalletsCarouselHeader/WalletsCarouselHeader.scss
+++ b/packages/wallets/src/components/WalletsCarouselHeader/WalletsCarouselHeader.scss
@@ -12,9 +12,10 @@
     width: 100%;
     z-index: 1;
     opacity: 1;
-    transition: opacity 0.3s ease-in;
+    transition: all 0.3s ease-in;
 
     &--hidden {
+        z-index: -1;
         opacity: 0;
     }
 

--- a/packages/wallets/src/components/WalletsCarouselHeader/WalletsCarouselHeader.tsx
+++ b/packages/wallets/src/components/WalletsCarouselHeader/WalletsCarouselHeader.tsx
@@ -41,7 +41,6 @@ const WalletsCarouselHeader: React.FC<TProps> = ({ balance, currency, hidden, is
             <IconButton
                 color='transparent'
                 data-testid='dt_wallets_carousel_header_button'
-                disabled={hidden}
                 icon={<IcCashierTransfer />}
                 iconSize='lg'
                 onClick={() => {


### PR DESCRIPTION
## Changes:

- [x] Updated order of demo action buttons
- [x] Updated UI and event listener of wallets carousel 

### Screenshots:

<img width="424" alt="image" src="https://github.com/binary-com/deriv-app/assets/142860499/5991c464-80fd-4c19-9ae9-a7a2b8024475">

https://github.com/binary-com/deriv-app/assets/142860499/90d870ca-0fdb-4a35-90c4-c8a68b52ae25

