### PR TITLE
Update deriv-charts to 2.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "@deriv-com/utils": "latest",
                 "@deriv/api-types": "^1.0.118",
                 "@deriv/deriv-api": "^1.0.15",
-                "@deriv/deriv-charts": "^2.1.5",
+                "@deriv/deriv-charts": "^2.1.6",
                 "@deriv/js-interpreter": "^3.0.0",
                 "@deriv/quill-design": "^1.3.2",
                 "@deriv/quill-icons": "^1.19.0",
@@ -2978,9 +2978,9 @@
             }
         },
         "node_modules/@deriv/deriv-charts": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.1.5.tgz",
-            "integrity": "sha512-i38/yPpzOOiIGpQUrhInKE8JZjRAfuXRoOWGpcwYldAdG5qHfO19Zc+X39+xZJuNfntVtJfVg1DpXZGUbLVAng==",
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.1.6.tgz",
+            "integrity": "sha512-RfPTBxLLSfA0RS8qfzxDAt+GvfPNeSFZBRh5jrV/2zAxcckMUEIQQvkP53lCofYAIMjTPZutcCdd0OfrhFbJng==",
             "dependencies": {
                 "@types/lodash.set": "^4.3.7",
                 "@welldone-software/why-did-you-render": "^3.3.8",

--- a/packages/bot-web-ui/package.json
+++ b/packages/bot-web-ui/package.json
@@ -70,7 +70,7 @@
         "@datadog/browser-logs": "^4.36.0",
         "@deriv/bot-skeleton": "^1.0.0",
         "@deriv/components": "^1.0.0",
-        "@deriv/deriv-charts": "^2.1.5",
+        "@deriv/deriv-charts": "^2.1.6",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",
         "@deriv/api": "^1.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -105,7 +105,7 @@
         "@deriv/cfd": "^1.0.0",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv/deriv-charts": "^2.1.5",
+        "@deriv/deriv-charts": "^2.1.6",
         "@deriv/hooks": "^1.0.0",
         "@deriv/p2p": "^0.7.3",
         "@deriv/p2p-v2": "^1.0.0",

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -91,7 +91,7 @@
         "@deriv/api-types": "^1.0.118",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv/deriv-charts": "^2.1.5",
+        "@deriv/deriv-charts": "^2.1.6",
         "@deriv/hooks": "^1.0.0",
         "@deriv/reports": "^1.0.0",
         "@deriv/shared": "^1.0.0",


### PR DESCRIPTION
## Changes:

Update deriv-charts to 2.1.6

### Screenshots:

Please provide some screenshots of the change.
