### PR TITLE
[COJ]/Amina/COJ_643/Fixing MX account getting logged out on refreshing

### DIFF
--- a/packages/core/src/Services/socket-general.js
+++ b/packages/core/src/Services/socket-general.js
@@ -47,11 +47,6 @@ const BinarySocketGeneral = (() => {
         }, 30000);
 
         if (is_ready) {
-            if (!client_store.is_valid_login) {
-                client_store.logout();
-                return;
-            }
-
             if (client_store.is_logged_in || client_store.is_logging_in) {
                 WS.get()
                     .expectResponse('authorize')

--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -274,7 +274,6 @@ export default class ClientStore extends BaseStore {
             is_age_verified: computed,
             landing_company_shortcode: computed,
             landing_company: computed,
-            is_valid_login: computed,
             is_logged_in: computed,
             has_restricted_mt5_account: computed,
             has_mt5_account_with_rejected_poa: computed,
@@ -777,12 +776,6 @@ export default class ClientStore extends BaseStore {
 
     get landing_company() {
         return this.landing_companies;
-    }
-
-    get is_valid_login() {
-        if (!this.is_logged_in) return true;
-        const valid_login_ids_regex = new RegExp('^(MF|MFW|VRTC|VRW|MLT|CR|CRW)[0-9]+$', 'i');
-        return this.all_loginids.every(id => valid_login_ids_regex.test(id));
     }
 
     get is_logged_in() {


### PR DESCRIPTION
## Changes:
MX accounts were getting logged out on refreshing . The issue was due to FE logic to check valid LoginId. If the loginId is doesn't match regex, we used to call logout immediately. 
This PR removes this check from FE side since we do not need this logic in FE. By right, all authorized login from BE should be valid

### Screenshots:

Please provide some screenshots of the change.
