### PR TITLE
Aizad/WALL-2067/Remove Landing Company Logo from Wallet Carousel Card

### DIFF
--- a/packages/wallets/src/components/WalletsAddMoreCard/WalletsAddMoreCard.tsx
+++ b/packages/wallets/src/components/WalletsAddMoreCard/WalletsAddMoreCard.tsx
@@ -1,26 +1,14 @@
 import React from 'react';
-import { THooks } from '../../types';
+import { TWalletCarouselItem } from '../../types';
 import { WalletGradientBackground } from '../WalletGradientBackground';
 import WalletsAddMoreCardBanner from '../WalletsAddMoreCardBanner';
 import WalletsAddMoreCardContent from '../WalletsAddMoreCardContent';
 
-type TProps = THooks.AllWalletAccounts;
-
-const WalletsAddMoreCard: React.FC<TProps> = ({
-    currency,
-    is_added: isAdded,
-    is_crypto: isCrypto,
-    landing_company_name: landingCompanyName,
-}) => {
+const WalletsAddMoreCard: React.FC<TWalletCarouselItem> = ({ currency, is_added: isAdded, is_crypto: isCrypto }) => {
     return (
         <div className='wallets-add-more__card'>
             <WalletGradientBackground currency={currency || 'USD'} device='mobile' hasShine type='card'>
-                <WalletsAddMoreCardBanner
-                    currency={currency || 'USD'}
-                    is_added={isAdded}
-                    is_crypto={isCrypto}
-                    landing_company_name={landingCompanyName ?? ''}
-                />
+                <WalletsAddMoreCardBanner currency={currency || 'USD'} is_added={isAdded} is_crypto={isCrypto} />
             </WalletGradientBackground>
             <WalletsAddMoreCardContent currency={currency ?? ''} />
         </div>

--- a/packages/wallets/src/components/WalletsAddMoreCardBanner/WalletsAddMoreCardBanner.scss
+++ b/packages/wallets/src/components/WalletsAddMoreCardBanner/WalletsAddMoreCardBanner.scss
@@ -16,8 +16,7 @@
             flex-shrink: 0;
         }
         &-header {
-            display: flex;
-            justify-content: space-between;
+            margin-right: auto;
         }
         &-button {
             background-color: #ffffff;

--- a/packages/wallets/src/components/WalletsAddMoreCardBanner/WalletsAddMoreCardBanner.tsx
+++ b/packages/wallets/src/components/WalletsAddMoreCardBanner/WalletsAddMoreCardBanner.tsx
@@ -6,22 +6,18 @@ import useSyncLocalStorageClientAccounts from '../../hooks/useSyncLocalStorageCl
 import useWalletAccountSwitcher from '../../hooks/useWalletAccountSwitcher';
 import CheckIcon from '../../public/images/check.svg';
 import PlusIcon from '../../public/images/plus.svg';
-import { THooks } from '../../types';
+import { TWalletCarouselItem } from '../../types';
 import { WalletButton } from '../Base';
 import { useModal } from '../ModalProvider';
 import { WalletAddedSuccess } from '../WalletAddedSuccess';
 import WalletAddMoreCurrencyIcon from '../WalletAddMoreCurrencyIcon';
 import { WalletError } from '../WalletError';
-import WalletListCardBadge from '../WalletListCardBadge/WalletListCardBadge';
 
-type TProps = THooks.AllWalletAccounts;
-
-const WalletsAddMoreCardBanner: React.FC<TProps> = ({
+const WalletsAddMoreCardBanner: React.FC<TWalletCarouselItem> = ({
     currency,
     is_added: isAdded,
     is_crypto: isCrypto,
-    landing_company_name: landingCompanyName,
-}: TProps) => {
+}) => {
     const switchWalletAccount = useWalletAccountSwitcher();
 
     const { data, error, isSuccess: isMutateSuccess, mutate, status } = useCreateWallet();
@@ -88,7 +84,6 @@ const WalletsAddMoreCardBanner: React.FC<TProps> = ({
                 <span className='wallets-add-more__banner-logo'>
                     <WalletAddMoreCurrencyIcon currency={currency ? currency.toLowerCase() : ''} />
                 </span>
-                <WalletListCardBadge label={landingCompanyName} />
             </div>
             <WalletButton
                 color='white'

--- a/packages/wallets/src/components/WalletsAddMoreCarousel/WalletsAddMoreCarousel.tsx
+++ b/packages/wallets/src/components/WalletsAddMoreCarousel/WalletsAddMoreCarousel.tsx
@@ -65,7 +65,6 @@ const WalletsAddMoreCarousel: React.FC = () => {
                                 is_added={wallet.is_added}
                                 is_crypto={wallet.is_crypto}
                                 key={`wallets_add_more_${wallet.currency}-${wallet.landing_company_name}-${wallet.is_added}`}
-                                landing_company_name={wallet.landing_company_name}
                             />
                         ))}
                 </div>

--- a/packages/wallets/src/types.ts
+++ b/packages/wallets/src/types.ts
@@ -98,3 +98,5 @@ export type TWalletLandingCompanyName =
     | Extract<THooks.MT5AccountsList['landing_company_short'], 'malta' | 'svg'>
     | 'virtual';
 export type TMT5LandingCompanyName = THooks.MT5AccountsList['landing_company_short'];
+
+export type TWalletCarouselItem = Omit<THooks.AllWalletAccounts, 'landing_company_name'>;


### PR DESCRIPTION
## Changes:

- Remove landing company logo from Wallet Card in Carousel.
- Fix types errors.
- Remove stylings.

### Screenshots:
![image](https://github.com/binary-com/deriv-app/assets/103104395/35c7a571-7b37-4aca-9431-cbf6bfc5ef93)

