### PR TITLE
[TRAH]/Mitra/ TRAH-3032/ Using currency type from account list for removing GBP for eu client

### DIFF
--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -543,26 +543,12 @@ export default class ClientStore extends BaseStore {
     }
 
     get has_fiat() {
-        const values = Object.values(this.accounts).reduce((acc, item) => {
-            if (!item.is_virtual && item.landing_company_shortcode === this.landing_company_shortcode) {
-                acc.push(item.currency);
-            }
-            return acc;
-        }, []);
-        return !!this.upgradeable_currencies.filter(acc => values.includes(acc.value) && acc.type === 'fiat').length;
+        return Object.values(this.accounts).some(item => item.currency_type === 'fiat' && !item.is_virtual);
     }
 
     get current_fiat_currency() {
-        const values = Object.values(this.accounts).reduce((acc, item) => {
-            if (!item.is_virtual) {
-                acc.push(item.currency);
-            }
-            return acc;
-        }, []);
-
-        return this.has_fiat
-            ? this.upgradeable_currencies.filter(acc => values.includes(acc.value) && acc.type === 'fiat')[0].value
-            : undefined;
+        const account = Object.values(this.accounts).find(item => item.currency_type === 'fiat' && !item.is_virtual);
+        return account?.currency;
     }
 
     // return the landing company object that belongs to the current client by matching shortcode

--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -552,7 +552,12 @@ export default class ClientStore extends BaseStore {
     }
 
     get current_fiat_currency() {
-        const account = Object.values(this.accounts).find(item => item.currency_type === 'fiat' && !item.is_virtual);
+        const account = Object.values(this.accounts).find(
+            item =>
+                item.currency_type === 'fiat' &&
+                !item.is_virtual &&
+                item.landing_company_shortcode === this.landing_company_shortcode
+        );
         return account?.currency;
     }
 

--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -543,7 +543,12 @@ export default class ClientStore extends BaseStore {
     }
 
     get has_fiat() {
-        return Object.values(this.accounts).some(item => item.currency_type === 'fiat' && !item.is_virtual);
+        return Object.values(this.accounts).some(
+            item =>
+                item.currency_type === 'fiat' &&
+                !item.is_virtual &&
+                item.landing_company_shortcode === this.landing_company_shortcode
+        );
     }
 
     get current_fiat_currency() {


### PR DESCRIPTION
## Changes:

To show the add or manage modal, we have a check to see if the currency is fiat or crypto which we rely on `legal_allowed_currency` and `website_status => currencies_config` ( the type of the currency is shown here but all other currencies are here also ), as GBP is removed from `legal_allowed_currency` our condition is failing for existing client, this means the changes are not backward compatible, 
We needed the BE here to help us with this, they added the type of currency in the `account_list` itself so we don't check it in currencies_config in website_status which is another endpoint. 

before the changes

![image](https://github.com/binary-com/deriv-app/assets/64970259/62b00b88-7730-4da6-a6e4-ebea035fbb79)


After changes

<img width="978" alt="Screenshot 2024-03-22 at 2 39 33 PM" src="https://github.com/binary-com/deriv-app/assets/64970259/77d53040-831f-4078-9475-c8ca69c0e79e">

