### PR TITLE
[WALL] Lubega / WALL-3539 / Withdrawal locked part 2

### DIFF
--- a/packages/wallets/src/features/cashier/modules/WithdrawalLocked/WithdrawalLockedContent.tsx
+++ b/packages/wallets/src/features/cashier/modules/WithdrawalLocked/WithdrawalLockedContent.tsx
@@ -33,30 +33,14 @@ export const getWithdrawalLimitReachedDesc = ({
 }: TWithdrawalLimitReachedDescProps) => {
     let description = null;
 
-    if (poiNeedsVerification) {
-        if (poiStatus === 'none') {
-            description = generateDescription(
-                'Please upload your <0>proof of identity</0> to lift the limit to continue your withdrawal.',
-                [<WalletLink href='/account/proof-of-identity' key={0} variant='bold' />]
-            );
-        } else if (poiStatus !== 'verified' && poiStatus !== 'none') {
-            description = generateDescription(
-                'Please check your <0>proof of identity</0> document verification status to lift the limit to continue your withdrawal.',
-                [<WalletLink href='/account/proof-of-identity' key={0} variant='bold' />]
-            );
-        }
-    } else if (poaNeedsVerification) {
-        if (poaStatus === 'none') {
-            description = generateDescription(
-                'Please upload your <0>proof of address</0> to lift the limit to continue your withdrawal.',
-                [<WalletLink href='/account/proof-of-address' key={0} variant='bold' />]
-            );
-        } else if (poaStatus !== 'verified' && poaStatus !== 'none') {
-            description = generateDescription(
-                'Please check your <0>proof of address</0> document verification status to lift the limit to continue your withdrawal.',
-                [<WalletLink href='/account/proof-of-address' key={0} variant='bold' />]
-            );
-        }
+    if (poiNeedsVerification || poaNeedsVerification || poaStatus !== 'verified' || poiStatus !== 'verified') {
+        description = generateDescription(
+            'Please check your <0>proof of identity</0> and <1>address</1> document verification status to lift the limit to continue your withdrawal.',
+            [
+                <WalletLink href='/account/proof-of-identity' key={0} variant='bold' />,
+                <WalletLink href='/account/proof-of-address' key={1} variant='bold' />,
+            ]
+        );
     } else if (askFinancialRiskApproval) {
         description = generateDescription(
             'Please complete the <0>financial assessment form</0> to lift the limit to continue your withdrawal.',

--- a/packages/wallets/src/features/cashier/modules/WithdrawalLocked/__tests__/WithdrawalLockedContent.spec.tsx
+++ b/packages/wallets/src/features/cashier/modules/WithdrawalLocked/__tests__/WithdrawalLockedContent.spec.tsx
@@ -11,9 +11,9 @@ describe('WithdrawalLockedContent', () => {
         const result = getWithdrawalLimitReachedDesc({
             askFinancialRiskApproval: false,
             poaNeedsVerification: false,
-            poaStatus: 'none',
+            poaStatus: 'verified',
             poiNeedsVerification: false,
-            poiStatus: 'none',
+            poiStatus: 'verified',
         });
 
         expect(result).toBeFalsy();
@@ -31,6 +31,21 @@ describe('WithdrawalLockedContent', () => {
         expect(result).toBeFalsy();
     });
 
+    it('should render correct message when withdrawal limit is reached and both POI/POA has not been uploaded', () => {
+        const result = getWithdrawalLimitReachedDesc({
+            askFinancialRiskApproval: false,
+            poaNeedsVerification: true,
+            poaStatus: 'none',
+            poiNeedsVerification: true,
+            poiStatus: 'none',
+        });
+
+        if (result) render(result);
+        expect(screen.getByText(/You have reached the withdrawal limit. Please check your/)).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'proof of identity' })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'address' })).toBeInTheDocument();
+    });
+
     it('should render correct message when withdrawal limit is reached and POI has not been uploaded', () => {
         const result = getWithdrawalLimitReachedDesc({
             askFinancialRiskApproval: false,
@@ -41,8 +56,9 @@ describe('WithdrawalLockedContent', () => {
         });
 
         if (result) render(result);
-        expect(screen.getByText(/You have reached the withdrawal limit. Please upload/)).toBeInTheDocument();
+        expect(screen.getByText(/You have reached the withdrawal limit. Please check your/)).toBeInTheDocument();
         expect(screen.getByRole('link', { name: 'proof of identity' })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'address' })).toBeInTheDocument();
     });
 
     it('should render correct message when withdrawal limit is reached and POI has been uploaded but not yet verified', () => {
@@ -55,8 +71,9 @@ describe('WithdrawalLockedContent', () => {
         });
 
         if (result) render(result);
-        expect(screen.getByText(/You have reached the withdrawal limit. Please check/)).toBeInTheDocument();
+        expect(screen.getByText(/You have reached the withdrawal limit. Please check your/)).toBeInTheDocument();
         expect(screen.getByRole('link', { name: 'proof of identity' })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'address' })).toBeInTheDocument();
     });
 
     it('should render correct message when withdrawal limit is reached and POA has not been uploaded', () => {
@@ -69,8 +86,9 @@ describe('WithdrawalLockedContent', () => {
         });
 
         if (result) render(result);
-        expect(screen.getByText(/You have reached the withdrawal limit. Please upload/)).toBeInTheDocument();
-        expect(screen.getByRole('link', { name: 'proof of address' })).toBeInTheDocument();
+        expect(screen.getByText(/You have reached the withdrawal limit. Please check your/)).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'proof of identity' })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'address' })).toBeInTheDocument();
     });
 
     it('should render correct message when withdrawal limit is reached and POA has been uploaded but not yet verified', () => {
@@ -83,17 +101,18 @@ describe('WithdrawalLockedContent', () => {
         });
 
         if (result) render(result);
-        expect(screen.getByText(/You have reached the withdrawal limit. Please check/)).toBeInTheDocument();
-        expect(screen.getByRole('link', { name: 'proof of address' })).toBeInTheDocument();
+        expect(screen.getByText(/You have reached the withdrawal limit. Please check your/)).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'proof of identity' })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'address' })).toBeInTheDocument();
     });
 
     it('should render correct message when withdrawal limit is reached and askFinancialRiskApproval status received', () => {
         const result = getWithdrawalLimitReachedDesc({
             askFinancialRiskApproval: true,
             poaNeedsVerification: false,
-            poaStatus: 'none',
+            poaStatus: 'verified',
             poiNeedsVerification: false,
-            poiStatus: 'none',
+            poiStatus: 'verified',
         });
 
         if (result) render(result);


### PR DESCRIPTION
## Changes:

- [x] Updated withdrawal locked content locked scenarios. Message for POI/POA locks are generalized so that withdrawal will be locked if
1. Withdrawal limit reached
2. POI not uploaded and verified
3. POA not uploaded and verified