### PR TITLE
[DTRA]/Ahmad/FEQ-1943/restrict unsupported indicators

### DIFF
--- a/packages/trader/src/Modules/Trading/Containers/trade-chart.tsx
+++ b/packages/trader/src/Modules/Trading/Containers/trade-chart.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 import { ActiveSymbols } from '@deriv/api-types';
 import { isDesktop } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
@@ -31,6 +31,7 @@ const TradeChart = observer((props: TTradeChartProps) => {
         updateChartType,
         updateGranularity,
     } = contract_trade;
+    const ref = useRef<{ hasPredictionIndicators(): void; triggerPopup(arg: () => void): void }>(null);
     const { all_positions } = portfolio;
     const { is_chart_countdown_visible, is_chart_layout_default, is_dark_mode_on, is_mobile, is_positions_drawer_on } =
         ui;
@@ -48,6 +49,8 @@ const TradeChart = observer((props: TTradeChartProps) => {
         setChartStatus,
         show_digits_stats,
         symbol,
+        onChange,
+        prev_contract_type,
         wsForget,
         wsForgetStream,
         wsSendRequest,
@@ -73,6 +76,13 @@ const TradeChart = observer((props: TTradeChartProps) => {
         [is_accumulator]
     );
 
+    useEffect(() => {
+        if ((is_accumulator || show_digits_stats) && ref.current?.hasPredictionIndicators()) {
+            const cancelCallback = () => onChange({ target: { name: 'contract_type', value: prev_contract_type } });
+            ref.current?.triggerPopup(cancelCallback);
+        }
+    }, [is_accumulator, show_digits_stats]);
+
     const getMarketsOrder = (active_symbols: ActiveSymbols): string[] => {
         const synthetic_index = 'synthetic_index';
         const has_synthetic_index = active_symbols.some(s => s.market === synthetic_index);
@@ -97,6 +107,7 @@ const TradeChart = observer((props: TTradeChartProps) => {
     if (!symbol || !active_symbols.length) return null;
     return (
         <SmartChart
+            ref={ref}
             barriers={barriers}
             contracts_array={markers_array}
             bottomWidgets={(is_accumulator || show_digits_stats) && isDesktop() ? bottomWidgets : props.bottomWidgets}

--- a/packages/trader/src/Stores/Modules/Trading/trade-store.ts
+++ b/packages/trader/src/Stores/Modules/Trading/trade-store.ts
@@ -200,6 +200,7 @@ export default class TradeStore extends BaseStore {
     contract_expiry_type = '';
     contract_start_type = '';
     contract_type = '';
+    prev_contract_type = '';
     contract_types_list: TContractTypesList = {};
     non_available_contract_types_list: TContractTypesList = {};
     trade_types: { [key: string]: string } = {};
@@ -285,7 +286,11 @@ export default class TradeStore extends BaseStore {
     cancellation_duration = '60m';
     cancellation_range_list: Array<TTextValueStrings> = [];
     cached_multiplier_cancellation_list: Array<TTextValueStrings> = [];
-
+    ref: React.RefObject<{
+        hasPredictionIndicators(): void;
+        triggerPopup(arg: () => void): void;
+    }> | null = null;
+    // { hasPredictionIndicators(): void; triggerPopup(arg: () => void): void } | null = null;
     // Turbos trade params
     long_barriers: TBarriersData = {};
     short_barriers: TBarriersData = {};
@@ -313,9 +318,7 @@ export default class TradeStore extends BaseStore {
     initial_barriers?: { barrier_1: string; barrier_2: string };
     is_initial_barrier_applied = false;
     is_digits_widget_active = false;
-
     should_skip_prepost_lifecycle = false;
-
     constructor({ root_store }: { root_store: TCoreStores }) {
         const local_storage_properties = [
             'amount',
@@ -346,6 +349,7 @@ export default class TradeStore extends BaseStore {
             'is_trade_params_expanded',
         ];
         const session_storage_properties = ['contract_type', 'symbol'];
+
         super({
             root_store,
             local_storage_properties,
@@ -416,6 +420,7 @@ export default class TradeStore extends BaseStore {
             multiplier: observable,
             non_available_contract_types_list: observable,
             previous_symbol: observable,
+            ref: observable,
             proposal_info: observable.ref,
             purchase_info: observable.ref,
             setHoveredBarrier: action.bound,
@@ -789,6 +794,13 @@ export default class TradeStore extends BaseStore {
 
     async onChange(e: { target: { name: string; value: unknown } }) {
         const { name, value } = e.target;
+        if (
+            name == 'contract_type' &&
+            ['accumulator', 'match_diff', 'even_odd', 'over_under'].includes(value as string)
+        ) {
+            this.prev_contract_type = this.contract_type;
+        }
+
         if (name === 'symbol' && value) {
             // set trade params skeleton and chart loader to true until processNewValuesAsync resolves
             this.setChartStatus(true);


### PR DESCRIPTION
The PR restrict the unsupported indicators to which with time interval of 1 tick when the time interval is changed via selecting trade types such as accumulators, digits. It shows the same popup as the one that is shown when selected unsopported indicator and change its time interval to tick