### PR TITLE
Update deriv-charts to 2.1.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "@deriv-com/utils": "^0.0.11",
                 "@deriv/api-types": "^1.0.118",
                 "@deriv/deriv-api": "^1.0.15",
-                "@deriv/deriv-charts": "^2.1.8",
+                "@deriv/deriv-charts": "^2.1.9",
                 "@deriv/js-interpreter": "^3.0.0",
                 "@deriv/quill-design": "^1.3.2",
                 "@deriv/quill-icons": "^1.19.5",
@@ -2980,9 +2980,9 @@
             }
         },
         "node_modules/@deriv/deriv-charts": {
-            "version": "2.1.8",
-            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.1.8.tgz",
-            "integrity": "sha512-ed1OfSQO6XbS6BpzqpItjeMvMaMXlyE89shR7bVMtmxhUTUJ6f8QHDE8to/BrclGAX/kfbds3+fOuby6ukigLQ==",
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.1.9.tgz",
+            "integrity": "sha512-uuKtZA+WcP9mVMESMRizjvdwld31v+V+brp0eEGgdoSYrylxSBtYJJhMnskGL7V6rKJJuR0vT8dOs+BSpprtcg==",
             "dependencies": {
                 "@types/lodash.set": "^4.3.7",
                 "@welldone-software/why-did-you-render": "^3.3.8",

--- a/packages/bot-web-ui/package.json
+++ b/packages/bot-web-ui/package.json
@@ -72,7 +72,7 @@
         "@datadog/browser-logs": "^5.11.0",
         "@deriv/bot-skeleton": "^1.0.0",
         "@deriv/components": "^1.0.0",
-        "@deriv/deriv-charts": "^2.1.8",
+        "@deriv/deriv-charts": "^2.1.9",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",
         "@deriv/api": "^1.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -105,7 +105,7 @@
         "@deriv/cfd": "^1.0.0",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv/deriv-charts": "^2.1.8",
+        "@deriv/deriv-charts": "^2.1.9",
         "@deriv/hooks": "^1.0.0",
         "@deriv/p2p": "^0.7.3",
         "@deriv/p2p-v2": "^1.0.0",

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -91,7 +91,7 @@
         "@deriv/api-types": "^1.0.118",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv/deriv-charts": "^2.1.8",
+        "@deriv/deriv-charts": "^2.1.9",
         "@deriv/hooks": "^1.0.0",
         "@deriv/reports": "^1.0.0",
         "@deriv/shared": "^1.0.0",


### PR DESCRIPTION
This PR updates @deriv/deriv-charts to 2.1.9