### PR TITLE
[BOT] Shafin/bot 1586/fix RTL workspace issue

### DIFF
--- a/packages/bot-skeleton/src/scratch/utils/index.js
+++ b/packages/bot-skeleton/src/scratch/utils/index.js
@@ -423,10 +423,9 @@ export const isAllRequiredBlocksEnabled = workspace => {
 
 export const scrollWorkspace = (workspace, scroll_amount, is_horizontal, is_chronological) => {
     const ws_metrics = workspace.getMetrics();
-
     let scroll_x = ws_metrics.viewLeft - ws_metrics.contentLeft;
-    let scroll_y = ws_metrics.viewTop - ws_metrics.contentTop;
-
+    const delta_y = ws_metrics.viewTop - ws_metrics.contentTop;
+    let scroll_y = delta_y;
     if (is_horizontal) {
         scroll_x += is_chronological ? scroll_amount : -scroll_amount;
         scroll_y += -20;
@@ -434,7 +433,17 @@ export const scrollWorkspace = (workspace, scroll_amount, is_horizontal, is_chro
         scroll_x += -20;
         scroll_y += is_chronological ? scroll_amount : -scroll_amount;
     }
-
+    const is_RTL = Blockly.derivWorkspace.RTL;
+    if (is_RTL) {
+        // For RTL scroll we need to adjust the scroll amount
+        scroll_x = scroll_amount;
+        // Adjust scroll_y to prevent scrolling vertically on every render
+        const toolbox_top = document.getElementById('gtm-toolbox')?.getBoundingClientRect()?.top;
+        const block_canvas_rect_top = workspace.svgBlockCanvas_?.getBoundingClientRect()?.top;
+        if (block_canvas_rect_top > toolbox_top) {
+            scroll_y = delta_y;
+        }
+    }
     workspace.scrollbar.set(scroll_x, scroll_y);
 };
 

--- a/packages/bot-web-ui/src/stores/toolbox-store.js
+++ b/packages/bot-web-ui/src/stores/toolbox-store.js
@@ -102,7 +102,7 @@ export default class ToolboxStore {
                     : toolbox_width - block_canvas_rect.left + 36;
                 scrollWorkspace(workspace, scroll_distance, true, false);
             }
-        }, 100);
+        }, 300);
     }
 
     toggleDrawer() {

--- a/packages/bot-web-ui/src/stores/toolbox-store.js
+++ b/packages/bot-web-ui/src/stores/toolbox-store.js
@@ -89,19 +89,20 @@ export default class ToolboxStore {
         workspace.options.hasCategories = hasCategories;
         workspace.options.languageTree = languageTree;
     }
-
     // eslint-disable-next-line class-methods-use-this
     adjustWorkspace() {
-        const workspace = Blockly.derivWorkspace;
-        const toolbox_width = document.getElementById('gtm-toolbox')?.getBoundingClientRect().width || 0;
-        const block_canvas_rect = workspace.svgBlockCanvas_?.getBoundingClientRect(); // eslint-disable-line
+        setTimeout(() => {
+            const workspace = Blockly.derivWorkspace;
+            const toolbox_width = document.getElementById('gtm-toolbox')?.getBoundingClientRect().width || 0;
+            const block_canvas_rect = workspace.svgBlockCanvas_?.getBoundingClientRect(); // eslint-disable-line
 
-        if (Math.round(block_canvas_rect?.left) <= toolbox_width) {
-            const scroll_distance = this.core.ui.is_mobile
-                ? toolbox_width - block_canvas_rect.left + 20
-                : toolbox_width - block_canvas_rect.left + 36;
-            scrollWorkspace(workspace, scroll_distance, true, false);
-        }
+            if (Math.round(block_canvas_rect?.left) <= toolbox_width) {
+                const scroll_distance = this.core.ui.is_mobile
+                    ? toolbox_width - block_canvas_rect.left + 20
+                    : toolbox_width - block_canvas_rect.left + 36;
+                scrollWorkspace(workspace, scroll_distance, true, false);
+            }
+        }, 100);
     }
 
     toggleDrawer() {


### PR DESCRIPTION
## Changes:

On RTL the Blockly Workspace scroll was not working properly and the blocks were getting hidden under the flyout on the right side.

- Updated the calculation for horizontal scroll on RTL mode
- Updated the calculation for vertical scroll on RTL mode so that it doesn't keep decreasing the Y value on each render
