### PR TITLE
version update for api-types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "@deriv-com/analytics": "1.4.13",
                 "@deriv-com/ui": "1.11.2",
                 "@deriv-com/utils": "^0.0.11",
-                "@deriv/api-types": "^1.0.118",
+                "@deriv/api-types": "^1.0.172",
                 "@deriv/deriv-api": "^1.0.15",
                 "@deriv/deriv-charts": "^2.1.10",
                 "@deriv/js-interpreter": "^3.0.0",
@@ -2965,9 +2965,9 @@
             "integrity": "sha512-O2ueP2Gu0FjPAe/4x94cj9b/cre8bIm0FdBL42TGy8dFa4zqA44fJdyl6uI1Ohg/uqQia7f/aR9iBBtnK3pg3A=="
         },
         "node_modules/@deriv/api-types": {
-            "version": "1.0.168",
-            "resolved": "https://registry.npmjs.org/@deriv/api-types/-/api-types-1.0.168.tgz",
-            "integrity": "sha512-eMZwQQeFlomkEOUKoJvs1S0ju7U6wRn0pDV14im3ic/jbdLlYSvaXudtOxfVjWGX9W5C/h6ce/Mopp/eWjjPAg=="
+            "version": "1.0.172",
+            "resolved": "https://registry.npmjs.org/@deriv/api-types/-/api-types-1.0.172.tgz",
+            "integrity": "sha512-3y5hTiqDRBcB6kEZagRpVnnBymM2Psvy0wQHBW6dL/jG4ww07DyOLJ/uH7uIVmcQZeYUKBpemcwRcnvieuVnRQ=="
         },
         "node_modules/@deriv/deriv-api": {
             "version": "1.0.15",

--- a/packages/account-v2/package.json
+++ b/packages/account-v2/package.json
@@ -15,7 +15,7 @@
         "@deriv/api-v2": "^1.0.0",
         "@deriv-com/utils": "^0.0.11",
         "@deriv/quill-icons": "^1.19.5",
-        "@deriv/api-types": "^1.0.118",
+        "@deriv/api-types": "^1.0.172",
         "class-variance-authority": "^0.7.0",
         "formik": "^2.1.4",
         "i18n-iso-countries": "^6.8.0",

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -28,7 +28,7 @@
     },
     "dependencies": {
         "@binary-com/binary-document-uploader": "^2.4.8",
-        "@deriv/api-types": "^1.0.118",
+        "@deriv/api-types": "^1.0.172",
         "@deriv/api": "^1.0.0",
         "@deriv/components": "^1.0.0",
         "@deriv/hooks": "^1.0.0",

--- a/packages/api-v2/package.json
+++ b/packages/api-v2/package.json
@@ -14,7 +14,7 @@
         "uuid": "^9.0.1"
     },
     "devDependencies": {
-        "@deriv/api-types": "^1.0.118",
+        "@deriv/api-types": "^1.0.172",
         "@testing-library/react": "^12.0.0",
         "@testing-library/react-hooks": "^7.0.2",
         "@testing-library/user-event": "^13.5.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -14,7 +14,7 @@
         "uuid": "^9.0.1"
     },
     "devDependencies": {
-        "@deriv/api-types": "^1.0.118",
+        "@deriv/api-types": "^1.0.172",
         "@testing-library/react": "^12.0.0",
         "@testing-library/react-hooks": "^7.0.2",
         "@testing-library/user-event": "^13.5.0",

--- a/packages/appstore/package.json
+++ b/packages/appstore/package.json
@@ -27,7 +27,7 @@
         "@deriv-com/analytics": "1.4.13",
         "@deriv/api": "^1.0.0",
         "@deriv/account": "^1.0.0",
-        "@deriv/api-types": "^1.0.118",
+        "@deriv/api-types": "^1.0.172",
         "@deriv/cashier": "^1.0.0",
         "@deriv/cfd": "^1.0.0",
         "@deriv/components": "^1.0.0",

--- a/packages/bot-web-ui/package.json
+++ b/packages/bot-web-ui/package.json
@@ -68,7 +68,7 @@
         "webpack-cli": "^4.7.2"
     },
     "dependencies": {
-        "@deriv/api-types": "^1.0.118",
+        "@deriv/api-types": "^1.0.172",
         "@datadog/browser-logs": "^5.11.0",
         "@deriv/bot-skeleton": "^1.0.0",
         "@deriv/components": "^1.0.0",

--- a/packages/cashier/package.json
+++ b/packages/cashier/package.json
@@ -36,7 +36,7 @@
     },
     "dependencies": {
         "@deriv/api": "^1.0.0",
-        "@deriv/api-types": "^1.0.118",
+        "@deriv/api-types": "^1.0.172",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
         "@deriv/hooks": "^1.0.0",

--- a/packages/cfd/package.json
+++ b/packages/cfd/package.json
@@ -86,7 +86,7 @@
         "@deriv-com/utils": "^0.0.11",
         "@deriv/account": "^1.0.0",
         "@deriv/api": "^1.0.0",
-        "@deriv/api-types": "^1.0.118",
+        "@deriv/api-types": "^1.0.172",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
         "@deriv/hooks": "^1.0.0",

--- a/packages/hooks/src/__tests__/useResidenceSelfDeclaration.spec.tsx
+++ b/packages/hooks/src/__tests__/useResidenceSelfDeclaration.spec.tsx
@@ -11,11 +11,11 @@ describe('useResidenceSelfDeclaration', () => {
                 residence_list: [
                     {
                         value: 'es',
-                        account_opening_self_declaration_required: true,
+                        account_opening_self_declaration_required: 1,
                     },
                     {
                         value: 'id',
-                        account_opening_self_declaration_required: false,
+                        account_opening_self_declaration_required: 0,
                     },
                 ],
             },

--- a/packages/p2p/package.json
+++ b/packages/p2p/package.json
@@ -32,7 +32,7 @@
     "dependencies": {
         "@deriv-com/utils": "^0.0.11",
         "@deriv/api": "^1.0.0",
-        "@deriv/api-types": "^1.0.118",
+        "@deriv/api-types": "^1.0.172",
         "@deriv/components": "^1.0.0",
         "@deriv/hooks": "^1.0.0",
         "@deriv/shared": "^1.0.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -44,7 +44,7 @@
         "typescript": "^4.6.3"
     },
     "dependencies": {
-        "@deriv/api-types": "^1.0.118",
+        "@deriv/api-types": "^1.0.172",
         "@deriv/translations": "^1.0.0",
         "@types/js-cookie": "^3.0.1",
         "@types/react-loadable": "^5.5.6",

--- a/packages/stores/package.json
+++ b/packages/stores/package.json
@@ -13,7 +13,7 @@
         "usehooks-ts": "^2.7.0"
     },
     "devDependencies": {
-        "@deriv/api-types": "^1.0.118",
+        "@deriv/api-types": "^1.0.172",
         "@testing-library/react": "^12.0.0",
         "typescript": "^4.6.3",
         "react-router": "^5.2.0",

--- a/packages/stores/types.ts
+++ b/packages/stores/types.ts
@@ -15,6 +15,7 @@ import type {
     LogOutResponse,
     Portfolio1,
     ProposalOpenContract,
+    ResidenceList,
     SetFinancialAssessmentRequest,
     SetFinancialAssessmentResponse,
     StatesList,
@@ -542,7 +543,7 @@ type TClientStore = {
         upload_file?: string;
         poi_state?: string;
     };
-    residence_list: TResidenceList; // TODO: replace this with ResidenceList from @deriv/api-types once account_opening_self_declaration_required is available
+    residence_list: ResidenceList;
     should_restrict_bvi_account_creation: boolean;
     should_restrict_vanuatu_account_creation: boolean;
     should_show_eu_content: boolean;
@@ -606,44 +607,6 @@ type TClientStore = {
     setRealAccountSignupFormData: (data: Array<Record<string, unknown>>) => void;
     setRealAccountSignupFormStep: (step: number) => void;
 };
-
-// TODO: This is a temporary type. It should be replaced with the actual type from deriv/api-types
-type TResidenceList = {
-    account_opening_self_declaration_required?: boolean;
-    disabled?: string;
-    identity?: {
-        services?: {
-            idv?: {
-                documents_supported?: {
-                    [k: string]: {
-                        additional?: {
-                            display_name?: string;
-                            format?: string;
-                        };
-                        display_name?: string;
-                        format?: string;
-                    };
-                };
-                has_visual_sample?: 0 | 1;
-                is_country_supported?: 0 | 1;
-            };
-            onfido?: {
-                documents_supported?: {
-                    [k: string]: {
-                        display_name?: string;
-                        format?: string;
-                    };
-                };
-                is_country_supported?: 0 | 1;
-            };
-        };
-    };
-    phone_idd?: null | string;
-    selected?: string;
-    text?: string;
-    tin_format?: string[];
-    value?: string;
-}[];
 
 type TCommonStoreError = {
     header?: string | JSX.Element;

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -88,7 +88,7 @@
         "@cloudflare/stream-react": "^1.9.1",
         "@deriv-com/analytics": "1.4.13",
         "@deriv-com/utils": "^0.0.11",
-        "@deriv/api-types": "^1.0.118",
+        "@deriv/api-types": "^1.0.172",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
         "@deriv/deriv-charts": "^2.1.10",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -9,7 +9,7 @@
         "moment": "^2.29.2"
     },
     "devDependencies": {
-        "@deriv/api-types": "^1.0.118",
+        "@deriv/api-types": "^1.0.172",
         "@types/lodash.groupby": "^4.6.7",
         "@types/lodash.pickby": "^4.6.7",
         "typescript": "^4.6.3"


### PR DESCRIPTION
## Changes:

Updated version for deriv/api-types from 1.0.118 to 1.0.172, to include p2p_country_list endpoint. also replaced the TResidenceList with ResidenceList from api-types.

### Screenshots:

Please provide some screenshots of the change.
