### PR TITLE
Revert "Matin/ Update Vercel Preview URL"

### DIFF
--- a/.github/workflows/generate_app_id.yml
+++ b/.github/workflows/generate_app_id.yml
@@ -19,7 +19,7 @@ jobs:
         steps:
             - name: Capture Vercel preview URL
               id: vercel_preview_url
-              uses: binary-com/vercel-preview-url-action@v1.0.6
+              uses: binary-com/vercel-preview-url-action@v1.0.5
               with:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   preview_url_regexp: \[Visit Preview\]\((.*?.sx)\)

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Capture Vercel preview URL
         id: vercel_preview_url
-        uses: binary-com/vercel-preview-url-action@v1.0.6
+        uses: binary-com/vercel-preview-url-action@v1.0.5
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           preview_url_regexp: \[Visit Preview\]\((.*?.sx)\)

--- a/.github/workflows/smoketests.yml
+++ b/.github/workflows/smoketests.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - name: Capture Vercel preview URL
       id: vercel_preview_url
-      uses: binary-com/vercel-preview-url-action@v1.0.6
+      uses: binary-com/vercel-preview-url-action@v1.0.5
       with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           


### PR DESCRIPTION
Reverts binary-com/deriv-app#14233

This is to revert bumping vercel preview url version as it is not working on production.