### PR TITLE
Update deriv-charts to 2.1.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
                 "@types/lodash.pickby": "^4.6.7",
                 "@types/lodash.throttle": "^4.1.7",
                 "@types/md5": "^2.3.5",
-                "@types/object.fromentries": "^2.0.4",
+                "@types/object.fromentries": "^2.0.0",
                 "@types/qrcode.react": "^1.0.2",
                 "@types/react-loadable": "^5.5.6",
                 "@types/react-modal": "^3.16.3",


### PR DESCRIPTION
This PR updates @deriv/deriv-charts to 2.1.10