### PR TITLE
Update deriv-charts to 2.1.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "@deriv-com/utils": "^0.0.11",
                 "@deriv/api-types": "^1.0.172",
                 "@deriv/deriv-api": "^1.0.15",
-                "@deriv/deriv-charts": "^2.1.10",
+                "@deriv/deriv-charts": "^2.1.11",
                 "@deriv/js-interpreter": "^3.0.0",
                 "@deriv/quill-design": "^1.3.2",
                 "@deriv/quill-icons": "^1.19.5",
@@ -54,7 +54,7 @@
                 "@types/lodash.pickby": "^4.6.7",
                 "@types/lodash.throttle": "^4.1.7",
                 "@types/md5": "^2.3.5",
-                "@types/object.fromentries": "^2.0.4",
+                "@types/object.fromentries": "^2.0.0",
                 "@types/qrcode.react": "^1.0.2",
                 "@types/react-loadable": "^5.5.6",
                 "@types/react-modal": "^3.16.3",
@@ -2985,9 +2985,9 @@
             }
         },
         "node_modules/@deriv/deriv-charts": {
-            "version": "2.1.10",
-            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.1.10.tgz",
-            "integrity": "sha512-qLCmUQWyel3dRgDr/oFmb/mBbMMcwSl596kJcnlMsugVKmZ02O8OPIjMkKLDQshqAPWbwPzBWAOo39qHZSvxag==",
+            "version": "2.1.11",
+            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.1.11.tgz",
+            "integrity": "sha512-h9Is5ARTXO7HxtBwGvjWXrlIT9TzzG40aIeAGvIVo63b1ExVR7pnyu9kmsp47h5ZJJVciN881AVK/rkz6jMrsQ==",
             "dependencies": {
                 "@types/lodash.set": "^4.3.7",
                 "@welldone-software/why-did-you-render": "^3.3.8",

--- a/packages/bot-web-ui/package.json
+++ b/packages/bot-web-ui/package.json
@@ -72,7 +72,7 @@
         "@datadog/browser-logs": "^5.11.0",
         "@deriv/bot-skeleton": "^1.0.0",
         "@deriv/components": "^1.0.0",
-        "@deriv/deriv-charts": "^2.1.10",
+        "@deriv/deriv-charts": "^2.1.11",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",
         "@deriv/api": "^1.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -105,7 +105,7 @@
         "@deriv/cfd": "^1.0.0",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv/deriv-charts": "^2.1.10",
+        "@deriv/deriv-charts": "^2.1.11",
         "@deriv/hooks": "^1.0.0",
         "@deriv/p2p": "^0.7.3",
         "@deriv/p2p-v2": "^1.0.0",

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -91,7 +91,7 @@
         "@deriv/api-types": "^1.0.172",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv/deriv-charts": "^2.1.10",
+        "@deriv/deriv-charts": "^2.1.11",
         "@deriv/hooks": "^1.0.0",
         "@deriv/reports": "^1.0.0",
         "@deriv/shared": "^1.0.0",


### PR DESCRIPTION
This PR updates @deriv/deriv-charts to 2.1.11