### PR TITLE
Aizad/WALL-3701/ Update missing MT5 Password Validation 

### DIFF
--- a/packages/wallets/src/utils/password-validation.ts
+++ b/packages/wallets/src/utils/password-validation.ts
@@ -66,6 +66,7 @@ export const calculateScore = (password: string) => {
 export const mt5Schema = Yup.string()
     .required(passwordErrorMessage.invalidLengthMT5)
     .matches(passwordRegex.isMT5LengthValid, passwordErrorMessage.invalidLengthMT5)
+    .matches(passwordRegex.isPasswordValid, passwordErrorMessage.missingCharacter)
     .matches(passwordRegex.isMT5PasswordValid, passwordErrorMessage.missingCharacterMT5);
 
 export const cfdSchema = Yup.string()


### PR DESCRIPTION
## Changes:

- Update missing MT5 password validation: `Password should have lower and uppercase English letters with numbers.`

### Screenshots:

<img width="867" alt="image" src="https://github.com/binary-com/deriv-app/assets/103104395/f9167fb1-a97d-4cd7-ae17-c5f44cbd9ca2">

