### PR TITLE
fix: [WEBREL-2641]/evgeniy/account settings flickering, not showing the error in passkeys page

### DIFF
--- a/packages/account/src/Sections/Security/Passkeys/__tests__/passkeys.spec.tsx
+++ b/packages/account/src/Sections/Security/Passkeys/__tests__/passkeys.spec.tsx
@@ -48,7 +48,6 @@ describe('Passkeys', () => {
     let mock_store: ReturnType<typeof mockStore>, modal_root_el: HTMLElement;
     const create_passkey = 'Create passkey';
 
-    // let modal_root_el: HTMLElement;
     beforeAll(() => {
         modal_root_el = document.createElement('div');
         modal_root_el.setAttribute('id', 'modal_root');

--- a/packages/account/src/Sections/Security/Passkeys/__tests__/passkeys.spec.tsx
+++ b/packages/account/src/Sections/Security/Passkeys/__tests__/passkeys.spec.tsx
@@ -7,6 +7,7 @@ import { useGetPasskeysList, useRegisterPasskey } from '@deriv/hooks';
 import { mockStore, StoreProvider } from '@deriv/stores';
 import Passkeys from '../passkeys';
 import PasskeysList from '../components/passkeys-list';
+import { beforeEach } from '@jest/globals';
 
 const passkey_name_1 = 'Test Passkey 1';
 const passkey_name_2 = 'Test Passkey 2';
@@ -44,18 +45,22 @@ jest.mock('@deriv/components', () => ({
 }));
 
 describe('Passkeys', () => {
-    const mock_store = mockStore({
-        ui: { is_mobile: true },
-        client: { is_passkey_supported: true },
-        common: { network_status: { class: 'online' } },
-    });
+    let mock_store: ReturnType<typeof mockStore>, modal_root_el: HTMLElement;
     const create_passkey = 'Create passkey';
 
-    let modal_root_el: HTMLElement;
+    // let modal_root_el: HTMLElement;
     beforeAll(() => {
         modal_root_el = document.createElement('div');
         modal_root_el.setAttribute('id', 'modal_root');
         document.body.appendChild(modal_root_el);
+    });
+
+    beforeEach(() => {
+        mock_store = mockStore({
+            ui: { is_mobile: true },
+            client: { is_passkey_supported: true },
+            common: { network_status: { class: 'online' } },
+        });
     });
 
     afterAll(() => {
@@ -156,7 +161,20 @@ describe('Passkeys', () => {
             is_passkeys_list_loading: true,
         });
 
-        mock_store.client.is_passkey_supported = false;
+        render(
+            <RenderWrapper>
+                <Passkeys />
+            </RenderWrapper>
+        );
+
+        expect(screen.getByText('MockLoading')).toBeInTheDocument();
+    });
+    it('renders loader if network_status is offline', () => {
+        (useGetPasskeysList as jest.Mock).mockReturnValue({
+            is_passkeys_list_loading: false,
+        });
+
+        mock_store.common.network_status.class = 'offline';
 
         render(
             <RenderWrapper>
@@ -171,6 +189,7 @@ describe('Passkeys', () => {
             is_passkeys_list_loading: false,
         });
         mock_store.client.is_passkey_supported = true;
+        // mock_store.common.network_status.class = 'online';
 
         (useRegisterPasskey as jest.Mock).mockReturnValue({
             createPasskey: mockCreatePasskey,

--- a/packages/account/src/Sections/Security/Passkeys/passkeys-configs.tsx
+++ b/packages/account/src/Sections/Security/Passkeys/passkeys-configs.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { TSocketError } from '@deriv/api/types';
 import { Text } from '@deriv/components';
 import { Localize } from '@deriv/translations';
 import { mobileOSDetect } from '@deriv/shared';
@@ -109,7 +110,11 @@ export const getStatusContent = (status: Exclude<TPasskeysStatus, ''>) => {
     };
 };
 
-type TGetModalContent = { error: TServerError | null; is_passkey_registration_started: boolean };
+// TODO: fix types for TServerError and TSocketError
+type TGetModalContent = {
+    error: TServerError | null | TSocketError<'passkeys_list' | 'passkeys_register' | 'passkeys_register_options'>;
+    is_passkey_registration_started: boolean;
+};
 
 export const getModalContent = ({ error, is_passkey_registration_started }: TGetModalContent) => {
     if (is_passkey_registration_started) {
@@ -127,7 +132,7 @@ export const getModalContent = ({ error, is_passkey_registration_started }: TGet
     }
 
     return {
-        description: error?.message ?? '',
+        description: (error as TServerError)?.message ?? '',
         button_text: error ? <Localize i18n_default_text='Try again' /> : undefined,
     };
 };

--- a/packages/account/src/Sections/Security/Passkeys/passkeys.tsx
+++ b/packages/account/src/Sections/Security/Passkeys/passkeys.tsx
@@ -56,7 +56,7 @@ const Passkeys = observer(() => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [error, is_passkey_registration_started]);
 
-    if (is_passkeys_list_loading || common.network_status.class !== 'online') {
+    if (should_show_passkeys && (is_passkeys_list_loading || common.network_status.class !== 'online')) {
         return <Loading is_fullscreen={false} className='account__initial-loader' />;
     }
     if (!should_show_passkeys) {

--- a/packages/account/src/Types/common.type.ts
+++ b/packages/account/src/Types/common.type.ts
@@ -79,6 +79,7 @@ export type TRoute = {
     component?: ((props?: RouteProps['component']) => JSX.Element) | Partial<typeof Redirect> | TPage404;
     getTitle?: () => string;
     is_disabled?: boolean;
+    is_hidden?: boolean;
     subroutes?: TRoute[];
 };
 

--- a/packages/core/src/App/Components/Layout/Header/toggle-menu-drawer.jsx
+++ b/packages/core/src/App/Components/Layout/Header/toggle-menu-drawer.jsx
@@ -12,7 +12,7 @@ import {
     usePaymentAgentTransferVisible,
     useP2PSettings,
 } from '@deriv/hooks';
-import { deepCopy, getStaticUrl, removeExactRouteFromRoutes, routes, whatsapp_url } from '@deriv/shared';
+import { getStaticUrl, routes, whatsapp_url } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
 import { localize } from '@deriv/translations';
 import NetworkStatus from 'App/Components/Layout/Footer';
@@ -92,12 +92,7 @@ const ToggleMenuDrawer = observer(({ platform_config }) => {
 
     React.useEffect(() => {
         const processRoutes = () => {
-            let routes_config = getRoutesConfig({});
-
-            const should_remove_passkeys_route = !is_mobile || !is_passkey_supported;
-            if (should_remove_passkeys_route) {
-                routes_config = removeExactRouteFromRoutes(deepCopy(routes_config), 'passkeys');
-            }
+            const routes_config = getRoutesConfig({});
             let primary_routes = [];
 
             const location = window.location.pathname;
@@ -166,6 +161,7 @@ const ToggleMenuDrawer = observer(({ platform_config }) => {
         }
 
         const has_subroutes = route_config.routes.some(route => route.subroutes);
+        const should_hide_passkeys_route = !is_mobile || !is_passkey_supported;
 
         const disableRoute = route_path => {
             if (/financial-assessment/.test(route_path)) {
@@ -181,6 +177,14 @@ const ToggleMenuDrawer = observer(({ platform_config }) => {
             }
             return false;
         };
+
+        const hideRoute = route_path => {
+            if (/passkeys/.test(route_path)) {
+                return should_hide_passkeys_route;
+            }
+            return false;
+        };
+
         return (
             <MobileDrawer.SubMenu
                 key={idx}
@@ -229,6 +233,7 @@ const ToggleMenuDrawer = observer(({ platform_config }) => {
                                         link_to={subroute.path}
                                         text={subroute.getTitle()}
                                         onClickLink={toggleDrawer}
+                                        is_hidden={hideRoute(subroute.path)}
                                     />
                                 ))}
                             </MobileDrawer.SubMenuSection>

--- a/packages/hooks/src/useGetPasskeysList.ts
+++ b/packages/hooks/src/useGetPasskeysList.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@deriv/api';
 import { useStore } from '@deriv/stores';
 
 const useGetPasskeysList = () => {
-    const { client, ui } = useStore();
+    const { client } = useStore();
     const { is_passkey_supported, is_logged_in } = client;
 
     const { data, error, isLoading, refetch, ...rest } = useQuery('passkeys_list', {
@@ -13,7 +13,7 @@ const useGetPasskeysList = () => {
 
     return {
         passkeys_list: data?.passkeys_list,
-        passkeys_list_error: error?.error ?? null,
+        passkeys_list_error: error ?? null,
         reloadPasskeysList: refetch,
         is_passkeys_list_loading: isLoading,
         ...rest,

--- a/packages/shared/src/utils/object/__tests__/object.spec.ts
+++ b/packages/shared/src/utils/object/__tests__/object.spec.ts
@@ -215,46 +215,4 @@ describe('Utility', () => {
             });
         });
     });
-    describe('deepCopy', () => {
-        it('should create a deep copy of an array', () => {
-            const originalArray = [1, 2, [3, 4], { a: 5 }];
-            const copiedArray = Utility.deepCopy(originalArray);
-
-            // Check if the values are equal
-            expect(copiedArray).toEqual(originalArray);
-
-            // Check if the reference is different
-            expect(copiedArray).not.toBe(originalArray);
-
-            // Check if nested arrays/objects are also deep-copied
-            expect(copiedArray[2]).not.toBe(originalArray[2]);
-            expect(copiedArray[3]).not.toBe(originalArray[3]);
-        });
-
-        it('should create a deep copy of an object', () => {
-            const originalObject = { a: 1, b: { c: 2 }, d: [3, 4] };
-            const copiedObject = Utility.deepCopy(originalObject);
-
-            // Check if the values are equal
-            expect(copiedObject).toEqual(originalObject);
-
-            // Check if the reference is different
-            expect(copiedObject).not.toBe(originalObject);
-
-            // Check if nested arrays/objects are also deep-copied
-            expect(copiedObject.b).not.toBe(originalObject.b);
-            expect(copiedObject.d).not.toBe(originalObject.d);
-        });
-
-        it('should return primitive values unchanged', () => {
-            const primitiveValue = 42;
-            const copiedValue = Utility.deepCopy(primitiveValue);
-
-            // Check if the values are equal
-            expect(copiedValue).toEqual(primitiveValue);
-
-            // Check if the reference is the same for primitive values
-            expect(copiedValue).toBe(primitiveValue);
-        });
-    });
 });

--- a/packages/shared/src/utils/object/object.ts
+++ b/packages/shared/src/utils/object/object.ts
@@ -119,27 +119,3 @@ export const deepFreeze = (obj: any) => {
     });
     return Object.freeze(obj);
 };
-
-export const deepCopy = (value: any) => {
-    if (value === null) {
-        return null;
-    } else if (Array.isArray(value)) {
-        const count = value.length;
-        const arr = new Array(count);
-        for (let i = 0; i < count; i++) {
-            arr[i] = deepCopy(value[i]);
-        }
-
-        return arr;
-    } else if (typeof value === 'object') {
-        const obj: { [key: string]: any } = {};
-        for (let prop in value) {
-            obj[prop] = deepCopy(value[prop]);
-        }
-
-        return obj;
-    } else {
-        // Primitive value
-        return value;
-    }
-};

--- a/packages/shared/src/utils/route/route.tsx
+++ b/packages/shared/src/utils/route/route.tsx
@@ -3,7 +3,6 @@
 // TODO: Add test cases for this
 import React from 'react';
 import { Redirect } from 'react-router-dom';
-import { routes } from '../routes';
 
 export type TRoute = Partial<{
     component: React.ElementType | null | ((routes?: TRoute[]) => JSX.Element) | typeof Redirect;
@@ -40,18 +39,3 @@ export const getSelectedRoute = ({ routes, pathname }: TGetSelectedRoute) => {
 
 export const isRouteVisible = (route: TRoute, is_logged_in: boolean) =>
     !(route && route.is_authenticated && !is_logged_in);
-
-export const removeExactRouteFromRoutes = (routes_array: TRoute[], route_to_remove: keyof typeof routes) => {
-    return routes_array.filter((route: TRoute) => {
-        if (route.path === routes[route_to_remove]) {
-            return false;
-        }
-        if (route.routes) {
-            route.routes = removeExactRouteFromRoutes(route.routes, route_to_remove);
-        }
-        if (route.subroutes) {
-            route.subroutes = removeExactRouteFromRoutes(route.subroutes, route_to_remove);
-        }
-        return true;
-    });
-};


### PR DESCRIPTION

## Changes:

1) Removed filtering the routes, which caused double rerendering. Add just hiding the menu if passkeys are not supported
2) Fixed error fetching for passkeys_list (not showing the PasskeysOff error)
