### PR TITLE
Maryia/build: restore envs besides CROWDIN_WALLETS_API_KEY

### DIFF
--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -18,6 +18,23 @@ jobs:
       uses: "./.github/actions/npm_install_from_cache"
     - name: Build
       uses: "./.github/actions/build"
+      with:
+        NODE_ENV: staging
+        DATADOG_APPLICATION_ID: ${{ vars.DATADOG_APPLICATION_ID }}
+        IS_GROWTHBOOK_ENABLED: ${{ vars.IS_GROWTHBOOK_ENABLED }}
+        DATADOG_CLIENT_TOKEN: ${{ vars.DATADOG_CLIENT_TOKEN }}
+        DATADOG_CLIENT_TOKEN_LOGS: ${{ vars.DATADOG_CLIENT_TOKEN_LOGS }}
+        DATADOG_SESSION_REPLAY_SAMPLE_RATE: ${{ vars.DATADOG_SESSION_REPLAY_SAMPLE_RATE }}
+        DATADOG_SESSION_SAMPLE_RATE: ${{ vars.DATADOG_SESSION_SAMPLE_RATE }}
+        DATADOG_SESSION_SAMPLE_RATE_LOGS: ${{ vars.DATADOG_SESSION_SAMPLE_RATE_LOGS }}
+        GD_API_KEY: ${{ secrets.GD_API_KEY }}
+        GD_APP_ID: ${{ secrets.GD_APP_ID }}
+        GD_CLIENT_ID: ${{ secrets.GD_CLIENT_ID }}
+        RUDDERSTACK_KEY: ${{ vars.RUDDERSTACK_KEY }}
+        GROWTHBOOK_CLIENT_KEY: ${{ vars.GROWTHBOOK_CLIENT_KEY }}
+        GROWTHBOOK_DECRYPTION_KEY: ${{ vars.GROWTHBOOK_DECRYPTION_KEY }}
+        REF_NAME: ${{ github.ref_name }}
+        REMOTE_CONFIG_URL: ${{ vars.REMOTE_CONFIG_URL }}
     - name: Run tests
       run: npm test
     - name: Publish to Cloudflare Pages Test


### PR DESCRIPTION
## Changes:

- to restore all envs besides `CROWDIN_WALLETS_API_KEY: ${{ secrets.CROWDIN_WALLETS_API_KEY }}`