### PR TITLE
Maryia/build: restore envs except for node_env

### DIFF
--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Build
       uses: "./.github/actions/build"
       with:
-        NODE_ENV: staging
+        CROWDIN_WALLETS_API_KEY: ${{ secrets.CROWDIN_WALLETS_API_KEY }}
         DATADOG_APPLICATION_ID: ${{ vars.DATADOG_APPLICATION_ID }}
         IS_GROWTHBOOK_ENABLED: ${{ vars.IS_GROWTHBOOK_ENABLED }}
         DATADOG_CLIENT_TOKEN: ${{ vars.DATADOG_CLIENT_TOKEN }}


### PR DESCRIPTION
## Changes:

- to restore envs except for `NODE_ENV: staging`
