### PR TITLE
Maryia/build: use NODE_ENV production for test and staging env

### DIFF
--- a/.github/workflows/release_staging.yml
+++ b/.github/workflows/release_staging.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Build
       uses: "./.github/actions/build"
       with:
-        NODE_ENV: staging
+        NODE_ENV: production
         CROWDIN_WALLETS_API_KEY: ${{ secrets.CROWDIN_WALLETS_API_KEY }}
         IS_GROWTHBOOK_ENABLED: ${{ vars.IS_GROWTHBOOK_ENABLED }}
         DATADOG_APPLICATION_ID: ${{ vars.DATADOG_APPLICATION_ID }}

--- a/.github/workflows/release_staging.yml
+++ b/.github/workflows/release_staging.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Build
       uses: "./.github/actions/build"
       with:
-        NODE_ENV: production
+        NODE_ENV: staging
         CROWDIN_WALLETS_API_KEY: ${{ secrets.CROWDIN_WALLETS_API_KEY }}
         IS_GROWTHBOOK_ENABLED: ${{ vars.IS_GROWTHBOOK_ENABLED }}
         DATADOG_APPLICATION_ID: ${{ vars.DATADOG_APPLICATION_ID }}

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -19,6 +19,7 @@ jobs:
     - name: Build
       uses: "./.github/actions/build"
       with:
+        NODE_ENV: production
         CROWDIN_WALLETS_API_KEY: ${{ secrets.CROWDIN_WALLETS_API_KEY }}
         DATADOG_APPLICATION_ID: ${{ vars.DATADOG_APPLICATION_ID }}
         IS_GROWTHBOOK_ENABLED: ${{ vars.IS_GROWTHBOOK_ENABLED }}


### PR DESCRIPTION
## Changes:

- to use `NODE_ENV: production` for test and staging env
