### PR TITLE
Maryia/build: replace node_env for staging with production

### DIFF
--- a/.github/workflows/release_staging.yml
+++ b/.github/workflows/release_staging.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Build
       uses: "./.github/actions/build"
       with:
-        NODE_ENV: staging
+        NODE_ENV: production
         CROWDIN_WALLETS_API_KEY: ${{ secrets.CROWDIN_WALLETS_API_KEY }}
         IS_GROWTHBOOK_ENABLED: ${{ vars.IS_GROWTHBOOK_ENABLED }}
         DATADOG_APPLICATION_ID: ${{ vars.DATADOG_APPLICATION_ID }}


### PR DESCRIPTION
## Changes:

- to replace node_env for staging with production