### PR TITLE
ci: update appid reference

### DIFF
--- a/.github/workflows/generate_app_id.yml
+++ b/.github/workflows/generate_app_id.yml
@@ -25,7 +25,7 @@ jobs:
                   preview_url_regexp: \[Visit Preview\]\((.*?.sx)\)
             - name: Generate Deriv App ID for deployment Preview URL
               id: generate_app_id
-              uses: binary-com/deriv-app-id-action@v1
+              uses: deriv-com/deriv-app-id-action@v1
               with:
                   DERIV_API_TOKEN: ${{ secrets.DERIV_API_TOKEN }}
                   DERIV_APP_ID: ${{ secrets.DERIV_APP_ID }}


### PR DESCRIPTION
## Changes:

- Updated `.github/workflows/generate_app_id.yml` action to point to the action `tag` at `https://github.com/deriv-com/deriv-app-id-action/tree/v1/` instead of `binary-com`

