### PR TITLE
[DTRA-1018] / Kate / Fix last digit prediction

### DIFF
--- a/packages/trader/src/Modules/Contract/Components/Digits/digits.tsx
+++ b/packages/trader/src/Modules/Contract/Components/Digits/digits.tsx
@@ -46,6 +46,7 @@ type TTickData =
           bid: TTickStream['tick'];
           current_tick: number;
           epoch: TTickStream['epoch'];
+          quote: TTickStream['tick'];
           pip_size?: number;
       };
 
@@ -83,6 +84,7 @@ const DigitsWrapper = ({
                 bid: t.tick,
                 epoch: t.epoch,
                 pip_size: t.tick_display_value?.split('.')[1].length,
+                quote: t.tick,
                 current_tick: tick_stream.length,
             };
         }

--- a/packages/trader/src/Modules/Contract/Components/LastDigitPrediction/__tests__/last-digit-prediction.spec.tsx
+++ b/packages/trader/src/Modules/Contract/Components/LastDigitPrediction/__tests__/last-digit-prediction.spec.tsx
@@ -24,7 +24,7 @@ const mocked_props = {
     selected_digit: 1,
     tick: {
         pip_size: 2,
-        ask: 102.23,
+        quote: 102.23,
     },
 };
 describe('<LastDigitPrediction />', () => {

--- a/packages/trader/src/Modules/Contract/Components/LastDigitPrediction/last-digit-prediction.tsx
+++ b/packages/trader/src/Modules/Contract/Components/LastDigitPrediction/last-digit-prediction.tsx
@@ -110,11 +110,12 @@ const LastDigitPrediction = ({
     // latest last digit refers to digit and spot values from latest price
     // latest contract digit refers to digit and spot values from last digit contract in contracts array
     const latest_tick_pip_size = tick ? +tick.pip_size : null;
-    const latest_tick_ask_price = tick?.ask && latest_tick_pip_size ? tick.ask.toFixed(latest_tick_pip_size) : null;
-    const latest_tick_digit = latest_tick_ask_price ? +(latest_tick_ask_price.split('').pop() || '') : null;
+    const latest_tick_quote_price =
+        tick?.quote && latest_tick_pip_size ? tick.quote.toFixed(latest_tick_pip_size) : null;
+    const latest_tick_digit = latest_tick_quote_price ? +(latest_tick_quote_price.split('').pop() || '') : null;
     const position = tick ? getOffset()[latest_tick_digit ?? -1] : getOffset()[last_contract_digit.digit];
     const latest_digit = !(is_won || is_lost)
-        ? { digit: latest_tick_digit, spot: latest_tick_ask_price }
+        ? { digit: latest_tick_digit, spot: latest_tick_quote_price }
         : last_contract_digit;
     return (
         <div


### PR DESCRIPTION
## Changes:

Changed last digit prediction for all contracts. Now it's based on `quote`, previously - on `ask_price` (both are coming inside of `tick` response). `quote` has already been used in SmartTrader and SmartCharts.

### Screenshots:

![Screenshot 2024-04-09 at 11 20 23 AM](https://github.com/binary-com/deriv-app/assets/121025168/9ebddca3-680c-4390-bb47-825f9f6bc482)
![Screenshot 2024-04-09 at 11 19 24 AM](https://github.com/binary-com/deriv-app/assets/121025168/767f146d-7acb-4b3c-9002-72351f8c323b)
![Screenshot 2024-04-09 at 11 19 36 AM](https://github.com/binary-com/deriv-app/assets/121025168/8bbc0340-ddb6-4219-98cf-8af7264ab2d6)

