### PR TITLE
[WALL] [Fix] Rostislav / WALL-3744 / cTrader acc number design mismatch

### DIFF
--- a/packages/wallets/src/features/cfd/flows/CTrader/AddedCTraderAccountsList/AddedCTraderAccountsList.tsx
+++ b/packages/wallets/src/features/cfd/flows/CTrader/AddedCTraderAccountsList/AddedCTraderAccountsList.tsx
@@ -30,9 +30,7 @@ const AddedCTraderAccountsList: React.FC = () => {
                         <WalletText size='sm' weight='bold'>
                             {account?.formatted_balance}
                         </WalletText>
-                        <WalletText color='primary' size='xs' weight='bold'>
-                            {account.login}
-                        </WalletText>
+                        <WalletText size='xs'>{account.login}</WalletText>
                     </div>
                 </TradingAccountCard>
             ))}


### PR DESCRIPTION
## Changes:

 - [x] fix appearance of cTrader acc number in wallets landing page to match Figma

### Screenshots:

<img width="1121" alt="Screenshot 2024-04-09 at 11 32 28" src="https://github.com/binary-com/deriv-app/assets/119863957/a70de05e-7e45-4b1c-b7a9-3b6e292a2ad7">

