### PR TITLE
[BOT] Maryia/BOT-1618/ fix: Transaction infos are not being shown under the run panel stats …

### DIFF
--- a/packages/bot-web-ui/src/components/transaction-details/transaction-details-desktop.tsx
+++ b/packages/bot-web-ui/src/components/transaction-details/transaction-details-desktop.tsx
@@ -33,13 +33,13 @@ const result_columns: TColumn[] = [
 const TransactionDetailsDesktop = observer(() => {
     const { client } = useStore();
     const { loginid, balance } = client;
-    const { transactions, run_panel } = useDBotStore();
+    const { transactions } = useDBotStore();
     const {
         toggleTransactionDetailsModal,
         is_transaction_details_modal_open,
         transactions: transaction_list,
     }: Partial<TTransactionStore> = transactions;
-    const { statistics }: Partial<TRunPanelStore> = run_panel;
+    const { statistics }: Partial<TRunPanelStore> = transactions;
 
     return (
         <React.Fragment>

--- a/packages/bot-web-ui/src/components/transaction-details/transaction-details-mobile.tsx
+++ b/packages/bot-web-ui/src/components/transaction-details/transaction-details-mobile.tsx
@@ -20,8 +20,9 @@ const TransactionDetailsMobile = observer(() => {
         toggleTransactionDetailsModal,
         is_transaction_details_modal_open,
         transactions: transaction_list,
+        statistics,
     }: Partial<TTransactionStore> = transactions;
-    const { statistics, toggleStatisticsInfoModal }: Partial<TRunPanelStore> = run_panel;
+    const { toggleStatisticsInfoModal }: Partial<TRunPanelStore> = run_panel;
 
     return (
         <MobileFullPageModal
@@ -49,15 +50,15 @@ const TransactionDetailsMobile = observer(() => {
             </div>
             <div className='transaction-details-modal-mobile__card__footer'>
                 <StatisticsSummary
+                    is_mobile
                     currency={client?.currency}
-                    is_mobile={true}
                     lost_contracts={statistics?.lost_contracts ?? 0}
                     number_of_runs={statistics?.number_of_runs ?? 0}
-                    toggleStatisticsInfoModal={toggleStatisticsInfoModal}
                     total_payout={statistics?.total_payout ?? 0}
                     total_profit={statistics?.total_profit ?? 0}
                     total_stake={statistics?.total_stake ?? 0}
                     won_contracts={statistics?.won_contracts ?? 0}
+                    toggleStatisticsInfoModal={toggleStatisticsInfoModal}
                 />
             </div>
         </MobileFullPageModal>

--- a/packages/bot-web-ui/src/components/transaction-details/transaction-details.types.ts
+++ b/packages/bot-web-ui/src/components/transaction-details/transaction-details.types.ts
@@ -50,6 +50,7 @@ export type TTransactionStore = {
     transactions: TTransactions[];
     is_transaction_details_modal_open: boolean;
     toggleTransactionDetailsModal: (is_open: boolean) => void;
+    statistics: TStatistics;
 };
 
 export type TRunPanelStore = {


### PR DESCRIPTION
…on responsive

## Changes:

1) fix: Transaction infos are not being shown under the run panel stats on responsive
2) On Dekstop the transaction is not being shown total results on the row of the table


### Screenshots:

<img width="384" alt="Screenshot 2024-04-10 at 12 39 05" src="https://github.com/binary-com/deriv-app/assets/103181650/f39a27f6-af47-4e15-95ee-620e96121d0e">
<img width="909" alt="Screenshot 2024-04-18 at 10 17 23" src="https://github.com/binary-com/deriv-app/assets/103181650/9b5fa7e9-d14e-4319-beed-4f5e9300fa72">

