### PR TITLE
[DRAFT] feat: updated website_status and all balances hooks

### DIFF
--- a/packages/api-v2/src/AuthProvider.tsx
+++ b/packages/api-v2/src/AuthProvider.tsx
@@ -9,6 +9,7 @@ import { TSocketResponseData } from '../types';
 type AuthContextType = {
     loginIDKey?: string;
     data: TSocketResponseData<'authorize'> | null | undefined;
+    loginid: string | null;
     switchAccount: (loginid: string, forceRefresh?: boolean) => Promise<void>;
     isLoading: boolean;
     isSuccess: boolean;
@@ -208,8 +209,9 @@ const AuthProvider = ({ loginIDKey, children, cookieTimeout, selectDefaultAccoun
             isFetching,
             isSuccess: isSuccess && !isLoading,
             error: isError,
+            loginid,
         };
-    }, [data, switchAccount, refetch, isLoading, isError, isFetching, isSuccess]);
+    }, [data, switchAccount, refetch, isLoading, isError, isFetching, isSuccess, loginid]);
 
     return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };

--- a/packages/api-v2/src/hooks/useAuthorize.ts
+++ b/packages/api-v2/src/hooks/useAuthorize.ts
@@ -6,7 +6,7 @@ import { useAuthContext } from '../AuthProvider';
  */
 const useAuthorize = () => {
     const ctx = useAuthContext();
-    const { data, switchAccount, isLoading, isSuccess, isFetching, isError, refetch, error } = ctx;
+    const { data, switchAccount, isLoading, isSuccess, isFetching, isError, refetch, error, loginid } = ctx;
 
     const modifiedData = useMemo(() => {
         return { ...data?.authorize };
@@ -24,8 +24,9 @@ const useAuthorize = () => {
             isError,
             refetch,
             error,
+            loginid,
         };
-    }, [modifiedData, switchAccount, isLoading, isSuccess, isFetching, isError, refetch, error]);
+    }, [modifiedData, switchAccount, isLoading, isSuccess, isFetching, isError, refetch, error, loginid]);
 
     return value;
 };

--- a/packages/api-v2/src/hooks/useBalance.ts
+++ b/packages/api-v2/src/hooks/useBalance.ts
@@ -1,16 +1,21 @@
 import { useMemo } from 'react';
-import useQuery from '../useQuery';
+import useAuthorizedQuery from '../useAuthorizedQuery';
 import useAuthorize from './useAuthorize';
 
 /** A custom hook that gets the balance for all the user accounts. */
 const useBalance = () => {
-    const { isSuccess } = useAuthorize();
-    const { data: balance_data, ...rest } = useQuery('balance', {
-        payload: { account: 'all' },
-        options: {
-            enabled: isSuccess,
+    const { data: balance_data, ...rest } = useAuthorizedQuery(
+        'balance',
+        {
+            account: 'all',
         },
-    });
+        {
+            // 30 seconds, just enough to avoid duplicated calls, but without freezing it for too long if someone actually wants to update it,
+            // though if user wants it to get updated, its likely that they will refresh page, so then its gonna be invalidated anyway
+            staleTime: 30 * 1000,
+        },
+        false
+    );
 
     // Add additional information to the balance data.
     const modified_balance = useMemo(() => ({ ...balance_data?.balance }), [balance_data?.balance]);

--- a/packages/api-v2/src/hooks/useClientCountry.ts
+++ b/packages/api-v2/src/hooks/useClientCountry.ts
@@ -1,9 +1,9 @@
 import { useMemo } from 'react';
-import useQuery from '../useQuery';
+import useWebsiteStatus from './useWebsiteStatus';
 
 /** A custom hook that gets the client country. */
 const useClientCountry = () => {
-    const { data, ...website_status_rest } = useQuery('website_status');
+    const { data, ...rest } = useWebsiteStatus();
 
     /** Modify the client country. */
     const modified_client_country = useMemo(() => {
@@ -13,7 +13,7 @@ const useClientCountry = () => {
     return {
         /** The client's country */
         data: modified_client_country,
-        ...website_status_rest,
+        ...rest,
     };
 };
 

--- a/packages/api-v2/src/hooks/useCurrencyConfig.ts
+++ b/packages/api-v2/src/hooks/useCurrencyConfig.ts
@@ -1,19 +1,12 @@
 import { useCallback, useMemo } from 'react';
 import useQuery from '../useQuery';
 import useAuthorize from './useAuthorize';
+import useWebsiteStatus from './useWebsiteStatus';
 
 /** A custom hook to get the currency config information from `website_status` endpoint and `crypto_config` endpoint. */
 const useCurrencyConfig = () => {
     const { isSuccess } = useAuthorize();
-    const {
-        data: website_status_data,
-        isLoading: isWebsiteStatusLoading,
-        ...rest
-    } = useQuery('website_status', {
-        options: {
-            enabled: isSuccess,
-        },
-    });
+    const { data: website_status_data, isLoading: isWebsiteStatusLoading, ...rest } = useWebsiteStatus();
     const { data: crypto_config_data, isLoading: isCryptConfigLoading } = useQuery('crypto_config', {
         options: {
             enabled: isSuccess,

--- a/packages/api-v2/src/hooks/useWebsiteStatus.ts
+++ b/packages/api-v2/src/hooks/useWebsiteStatus.ts
@@ -1,0 +1,15 @@
+import useAuthorizedQuery from '../useAuthorizedQuery';
+
+const useWebsiteStatus = () => {
+    // pretty much static data, only refresh it when account is added (just in case, probably even then its not needed)
+    return useAuthorizedQuery(
+        'website_status',
+        {},
+        {
+            staleTime: 10 * 60 * 1000,
+        },
+        false
+    );
+};
+
+export default useWebsiteStatus;

--- a/packages/api-v2/src/useAPI.ts
+++ b/packages/api-v2/src/useAPI.ts
@@ -15,7 +15,7 @@ const useAPI = () => {
     const send = useCallback(
         async <T extends TSocketEndpointNames | TSocketPaginateableEndpointNames = TSocketEndpointNames>(
             name: T,
-            payload?: TSocketRequestPayload<T>
+            payload?: TSocketRequestPayload<T>['payload']
         ): Promise<TSocketResponseData<T>> => {
             const response = await derivAPI?.send({ [name]: 1, ...(payload || {}) });
 

--- a/packages/api-v2/src/useAuthorizedQuery.ts
+++ b/packages/api-v2/src/useAuthorizedQuery.ts
@@ -1,0 +1,57 @@
+import { useQuery as _useQuery } from '@tanstack/react-query';
+import type {
+    TSocketEndpointNames,
+    TSocketError,
+    TSocketRequestPayload,
+    TSocketRequestQueryOptions,
+    TSocketResponseData,
+} from '../types';
+import useAPI from './useAPI';
+import { getQueryKeys } from './utils';
+import { useAuthorize } from './hooks';
+
+/**
+ * just like useQuery, but only runs when user is authorized
+ * plus, have couple extra option for more granular cache control
+ *
+ * default options are "safe", so its just gonna work correctly,
+ * but if specific hook wants more granular control, then its that hook responsibility to understand the implications
+ * e.g. useBalance with account=all does not need to be refetched when account is being switched,
+ * but useBalance with account=123 does need to be refetched when account is being switched,
+ *
+ * unfortunatelly, there is missing bit of context/state - loginid, as normally its "hidden" in the connection,
+ * its not a part of payload, thus, the standard "getKeys()" is just not enough, needs to add extra keys to handle user changing and switching
+ *
+ * @param name
+ * @param payload
+ * @param options
+ * @param refreshOnAccountSwitch
+ * @param refreshOnAccountAdded
+ * @returns
+ */
+const useAuthorizedQuery = <T extends TSocketEndpointNames>(
+    name: T,
+    payload?: TSocketRequestPayload<T>['payload'],
+    options?: TSocketRequestQueryOptions<T>,
+    refreshOnAccountSwitch = true,
+    refreshOnAccountAdded = true
+) => {
+    const { send } = useAPI();
+    const { isSuccess, isLoading, loginid, data } = useAuthorize();
+
+    const keys = getQueryKeys(name, payload);
+    if (refreshOnAccountSwitch && loginid) {
+        keys.unshift(loginid);
+    }
+
+    if (refreshOnAccountAdded && data?.account_list?.length) {
+        keys.unshift(`${data?.account_list?.length}`);
+    }
+
+    return _useQuery<TSocketResponseData<T>, TSocketError<T>>(keys, () => send(name, payload), {
+        ...options,
+        enabled: !!(isSuccess && !isLoading && loginid),
+    });
+};
+
+export default useAuthorizedQuery;

--- a/packages/api-v2/src/useQuery.ts
+++ b/packages/api-v2/src/useQuery.ts
@@ -12,7 +12,7 @@ import { getQueryKeys } from './utils';
 
 const useQuery = <T extends TSocketEndpointNames>(name: T, ...props: TSocketAcceptableProps<T, true>) => {
     const prop = props?.[0];
-    const payload = prop && 'payload' in prop ? (prop.payload as TSocketRequestPayload<T>) : undefined;
+    const payload = prop && 'payload' in prop ? (prop.payload as TSocketRequestPayload<T>['payload']) : undefined;
     const options = prop && 'options' in prop ? (prop.options as TSocketRequestQueryOptions<T>) : undefined;
     const { send } = useAPI();
 

--- a/packages/wallets/src/features/cashier/modules/DepositLocked/DepositLocked.tsx
+++ b/packages/wallets/src/features/cashier/modules/DepositLocked/DepositLocked.tsx
@@ -11,11 +11,12 @@ import {
 import { WalletsActionScreen } from '../../../../components';
 import getDepositLockedDesc from './DepositLockedContent';
 import './DepositLocked.scss';
+import useWebsiteStatus from '@deriv/api-v2/src/hooks/useWebsiteStatus';
 
 const DepositLocked: React.FC<React.PropsWithChildren> = ({ children }) => {
     const { data: activeWallet } = useActiveWalletAccount();
     const { data: settings } = useSettings();
-    const { data: websiteStatus } = useQuery('website_status');
+    const { data: websiteStatus } = useWebsiteStatus();
     const { data: authentication } = useAuthentication();
     const { data: cashierValidation } = useCashierValidation();
     const { data: status } = useAccountStatus();


### PR DESCRIPTION
## Changes:

Added generic authorized hooks with more granular cache control

Updated hooks:
- website_status: staleTime 10 min, no refresh on account switch, only refresh when new account added
- balance: staleTime 30s, no refresh on account switch, only refresh when newly account added, 
.. more in progress..

### Screenshots:

Please provide some screenshots of the change.
