### PR TITLE
[WALL] george / WALL-3615 / Transfer tab doesn't require to be loaded when cashier page is locked

### DIFF
--- a/packages/wallets/src/features/cashier/components/WalletCashierContent/WalletCashierContent.tsx
+++ b/packages/wallets/src/features/cashier/components/WalletCashierContent/WalletCashierContent.tsx
@@ -6,6 +6,7 @@ import { WalletResetBalance } from '../../flows/WalletResetBalance';
 import { WalletTransactions } from '../../flows/WalletTransactions';
 import { WalletTransfer } from '../../flows/WalletTransfer';
 import { WalletWithdrawal } from '../../flows/WalletWithdrawal';
+import { CashierLocked, DepositLocked, WithdrawalLocked } from '../../modules';
 
 const WalletCashierContent = () => {
     const history = useHistory();
@@ -24,18 +25,41 @@ const WalletCashierContent = () => {
         }
     }, [isTransfer, isDeposit, isTransactions, isWithdraw, isResetBalance, isFiatOnRamp, history]);
 
-    if (isDeposit) return <WalletDeposit />;
+    if (isDeposit)
+        return (
+            <CashierLocked module='deposit'>
+                <DepositLocked>
+                    <WalletDeposit />
+                </DepositLocked>
+            </CashierLocked>
+        );
 
-    if (isFiatOnRamp) return <WalletFiatOnRamp />;
+    if (isFiatOnRamp)
+        return (
+            <CashierLocked module='deposit'>
+                <WalletFiatOnRamp />
+            </CashierLocked>
+        );
 
     if (isResetBalance) return <WalletResetBalance />;
 
-    if (isTransfer) return <WalletTransfer />;
+    if (isTransfer)
+        return (
+            <CashierLocked>
+                <WalletTransfer />
+            </CashierLocked>
+        );
 
     if (isTransactions) return <WalletTransactions />;
 
     if (isWithdraw) {
-        return <WalletWithdrawal />;
+        return (
+            <CashierLocked module='withdrawal'>
+                <WithdrawalLocked>
+                    <WalletWithdrawal />
+                </WithdrawalLocked>
+            </CashierLocked>
+        );
     }
 
     return <></>;

--- a/packages/wallets/src/features/cashier/flows/WalletDeposit/WalletDeposit.tsx
+++ b/packages/wallets/src/features/cashier/flows/WalletDeposit/WalletDeposit.tsx
@@ -1,16 +1,12 @@
 import React from 'react';
 import { useActiveWalletAccount } from '@deriv/api-v2';
-import { CashierLocked, DepositCryptoModule, DepositFiatModule, DepositLocked } from '../../modules';
+import { DepositCryptoModule, DepositFiatModule } from '../../modules';
 
 const WalletDeposit = () => {
     const { data } = useActiveWalletAccount();
     const isCrypto = data?.currency_config?.is_crypto;
 
-    return (
-        <CashierLocked module='deposit'>
-            <DepositLocked>{isCrypto ? <DepositCryptoModule /> : <DepositFiatModule />}</DepositLocked>
-        </CashierLocked>
-    );
+    return isCrypto ? <DepositCryptoModule /> : <DepositFiatModule />;
 };
 
 export default WalletDeposit;

--- a/packages/wallets/src/features/cashier/flows/WalletFiatOnRamp/WalletFiatOnRamp.tsx
+++ b/packages/wallets/src/features/cashier/flows/WalletFiatOnRamp/WalletFiatOnRamp.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useActiveWalletAccount } from '@deriv/api-v2';
-import { CashierLocked, FiatOnRampModule } from '../../modules';
+import { FiatOnRampModule } from '../../modules';
 
 const WalletFiatOnRamp = () => {
     const { data } = useActiveWalletAccount();
@@ -16,11 +16,7 @@ const WalletFiatOnRamp = () => {
         }
     }, [history, isCrypto]);
 
-    return (
-        <CashierLocked module='deposit'>
-            <FiatOnRampModule />
-        </CashierLocked>
-    );
+    return <FiatOnRampModule />;
 };
 
 export default WalletFiatOnRamp;

--- a/packages/wallets/src/features/cashier/flows/WalletTransfer/WalletTransfer.tsx
+++ b/packages/wallets/src/features/cashier/flows/WalletTransfer/WalletTransfer.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect } from 'react';
 import { useTransferBetweenAccounts } from '@deriv/api-v2';
 import { Loader } from '../../../../components';
-import { CashierLocked, TransferModule } from '../../modules';
+import { TransferModule } from '../../modules';
 import { TransferNotAvailable } from '../../screens/TransferNotAvailable';
 
 const WalletTransfer = () => {
@@ -16,11 +16,9 @@ const WalletTransfer = () => {
     if (isTransferAccountsLoading || !data?.accounts) return <Loader />;
 
     return (
-        <CashierLocked>
-            <TransferNotAvailable accounts={data.accounts}>
-                <TransferModule accounts={data.accounts} />
-            </TransferNotAvailable>
-        </CashierLocked>
+        <TransferNotAvailable accounts={data.accounts}>
+            <TransferModule accounts={data.accounts} />
+        </TransferNotAvailable>
     );
 };
 

--- a/packages/wallets/src/features/cashier/flows/WalletWithdrawal/WalletWithdrawal.tsx
+++ b/packages/wallets/src/features/cashier/flows/WalletWithdrawal/WalletWithdrawal.tsx
@@ -1,13 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useActiveWalletAccount, useAuthorize, useCurrencyConfig } from '@deriv/api-v2';
 import { Loader } from '../../../../components';
-import {
-    CashierLocked,
-    WithdrawalCryptoModule,
-    WithdrawalFiatModule,
-    WithdrawalLocked,
-    WithdrawalVerificationModule,
-} from '../../modules';
+import { WithdrawalCryptoModule, WithdrawalFiatModule, WithdrawalVerificationModule } from '../../modules';
 
 const WalletWithdrawal = () => {
     const { isSuccess: isCurrencyConfigSuccess } = useCurrencyConfig();
@@ -41,33 +35,21 @@ const WalletWithdrawal = () => {
 
     if (verificationCode) {
         if (isCurrencyConfigSuccess && activeWallet?.currency) {
-            return (
-                <CashierLocked module='withdrawal'>
-                    <WithdrawalLocked>
-                        {isCrypto ? (
-                            <WithdrawalCryptoModule
-                                onClose={() => {
-                                    setVerificationCode('');
-                                }}
-                                verificationCode={verificationCode}
-                            />
-                        ) : (
-                            <WithdrawalFiatModule verificationCode={verificationCode} />
-                        )}
-                    </WithdrawalLocked>
-                </CashierLocked>
+            return isCrypto ? (
+                <WithdrawalCryptoModule
+                    onClose={() => {
+                        setVerificationCode('');
+                    }}
+                    verificationCode={verificationCode}
+                />
+            ) : (
+                <WithdrawalFiatModule verificationCode={verificationCode} />
             );
         }
         return <Loader />;
     }
 
-    return (
-        <CashierLocked module='withdrawal'>
-            <WithdrawalLocked>
-                <WithdrawalVerificationModule />
-            </WithdrawalLocked>
-        </CashierLocked>
-    );
+    return <WithdrawalVerificationModule />;
 };
 
 export default WalletWithdrawal;


### PR DESCRIPTION
## Changes:

-  lift up cashier locked wrapper to prevent API calls that caused extra loading states

### Screenshots:

**Before** the fix Transfer tab sent the request for accounts even if cashier is locked:

https://github.com/binary-com/deriv-app/assets/103181646/a5f172be-398d-4372-9853-422e28b1f8b5
**After**


https://github.com/binary-com/deriv-app/assets/103181646/5798a51b-424e-4a5f-a6a2-78d57f394b0c

