### PR TITLE
[WALL] Aizad/WALL-3769/Deposit Button text to be Bold 

### DIFF
--- a/packages/wallets/src/components/WalletListCardActions/WalletListCardActions.tsx
+++ b/packages/wallets/src/components/WalletListCardActions/WalletListCardActions.tsx
@@ -75,7 +75,9 @@ const WalletListCardActions = () => {
                                 }}
                                 size='lg'
                             />
-                            <WalletText size='sm'>{button.text}</WalletText>
+                            <WalletText size='sm' weight={button.text === 'Deposit' ? 'bold' : 'normal'}>
+                                {button.text}
+                            </WalletText>
                         </div>
                     ))}
                 </div>


### PR DESCRIPTION
## Changes:

- Added `bold` font weight to "Deposit" button only in Mobile.

### Screenshots:

![image](https://github.com/binary-com/deriv-app/assets/103104395/e36e9cb0-0c39-49f3-bcee-14ad24d320ce)

