### PR TITLE
[WALL] Lubega / WALL-3745 / CFD chevron design fixes

### DIFF
--- a/packages/wallets/src/components/Base/WalletText/WalletText.tsx
+++ b/packages/wallets/src/components/Base/WalletText/WalletText.tsx
@@ -25,7 +25,7 @@ const WalletText: React.FC<WalletTextProps> = ({
     weight = 'normal',
 }) => {
     const textClassNames = classNames(
-        'wallet-text',
+        'wallets-text',
         `wallets-text__size--${size}`,
         `wallets-text__weight--${weight}`,
         `wallets-text__align--${align}`,

--- a/packages/wallets/src/components/TradingAccountCard/TradingAccountCard.scss
+++ b/packages/wallets/src/components/TradingAccountCard/TradingAccountCard.scss
@@ -7,7 +7,7 @@
     background: none;
 
     @include desktop {
-        padding: 0 2.3rem 0 1.6rem;
+        padding: 0 1.6rem;
         $columns: 3;
         $grid-last-row-children: '&:nth-last-child(-n+#{$columns})';
         #{$grid-last-row-children} > &__content,

--- a/packages/wallets/src/features/cfd/components/CFDPlatformsListAccounts/CFDPlatformsListAccounts.scss
+++ b/packages/wallets/src/features/cfd/components/CFDPlatformsListAccounts/CFDPlatformsListAccounts.scss
@@ -5,7 +5,7 @@
         padding-bottom: 2.4rem;
 
         @include desktop {
-            gap: 1.6rem 4.8rem;
+            gap: 1.6rem;
         }
 
         @include mobile {

--- a/packages/wallets/src/features/cfd/components/CFDPlatformsListAccounts/CFDPlatformsListAccounts.tsx
+++ b/packages/wallets/src/features/cfd/components/CFDPlatformsListAccounts/CFDPlatformsListAccounts.tsx
@@ -22,7 +22,11 @@ type TProps = {
 };
 
 const CFDPlatformsListAccounts: React.FC<TProps> = ({ onMT5PlatformListLoaded }) => {
-    const { areAllAccountsCreated, data: mt5AccountsList, isLoading: isMT5Loading } = useSortedMT5Accounts();
+    const {
+        areAllAccountsCreated,
+        data: mt5AccountsList,
+        isFetchedAfterMount: isMT5FetchedAfterMount,
+    } = useSortedMT5Accounts();
     const { data: ctraderAccountsList } = useCtraderAccountsList();
     const { data: dxtradeAccountsList } = useDxtradeAccountsList();
     const { data: activeWallet } = useActiveWalletAccount();
@@ -34,15 +38,15 @@ const CFDPlatformsListAccounts: React.FC<TProps> = ({ onMT5PlatformListLoaded })
     const hasDxtradeAccount = !!dxtradeAccountsList?.length;
 
     useEffect(() => {
-        onMT5PlatformListLoaded?.(!isMT5Loading);
+        onMT5PlatformListLoaded?.(isMT5FetchedAfterMount);
         return () => onMT5PlatformListLoaded?.(false);
-    }, [isMT5Loading, onMT5PlatformListLoaded]);
+    }, [isMT5FetchedAfterMount, onMT5PlatformListLoaded]);
 
     return (
         <div className='wallets-cfd-list-accounts__content'>
             {/* TODO: Update loader with updated skeleton loader design */}
-            {isMT5Loading && <TradingAppCardLoader />}
-            {!isMT5Loading &&
+            {!isMT5FetchedAfterMount && <TradingAppCardLoader />}
+            {isMT5FetchedAfterMount &&
                 mt5AccountsList?.map((account, index) => {
                     if (account.is_added)
                         return (

--- a/packages/wallets/src/features/cfd/flows/MT5/AddedMT5AccountsList/AddedMT5AccountsList.scss
+++ b/packages/wallets/src/features/cfd/flows/MT5/AddedMT5AccountsList/AddedMT5AccountsList.scss
@@ -30,6 +30,10 @@
                 gap: 0.4rem;
                 border-radius: 0.4rem;
                 background: var(--system-light-7-secondary-background, #f2f3f4);
+
+                & > .wallets-text {
+                    opacity: 0.7;
+                }
             }
         }
 

--- a/packages/wallets/src/features/cfd/flows/MT5/AddedMT5AccountsList/AddedMT5AccountsList.tsx
+++ b/packages/wallets/src/features/cfd/flows/MT5/AddedMT5AccountsList/AddedMT5AccountsList.tsx
@@ -5,6 +5,7 @@ import { LabelPairedChevronRightCaptionRegularIcon } from '@deriv/quill-icons';
 import { InlineMessage, WalletText } from '../../../../../components/Base';
 import { useModal } from '../../../../../components/ModalProvider';
 import { TradingAccountCard } from '../../../../../components/TradingAccountCard';
+import useDevice from '../../../../../hooks/useDevice';
 import { THooks } from '../../../../../types';
 import { MarketTypeDetails, PlatformDetails } from '../../../constants';
 import { MT5TradeModal, VerificationFailedModal } from '../../../modals';
@@ -22,6 +23,7 @@ const AddedMT5AccountsList: React.FC<TProps> = ({ account }) => {
         [account.landing_company_short, account.status, getVerificationStatus]
     );
     const { title } = MarketTypeDetails[account.market_type ?? 'all'];
+    const { isMobile } = useDevice();
     const { show } = useModal();
     const { t } = useTranslation();
 
@@ -55,7 +57,7 @@ const AddedMT5AccountsList: React.FC<TProps> = ({ account }) => {
                     <WalletText size='sm'>{title}</WalletText>
                     {!activeWallet?.is_virtual && (
                         <div className='wallets-added-mt5__details-title-landing-company'>
-                            <WalletText size='2xs' weight='bold'>
+                            <WalletText color='black' size={isMobile ? 'sm' : 'xs'}>
                                 {account.landing_company_short?.toUpperCase()}
                             </WalletText>
                         </div>

--- a/packages/wallets/src/features/cfd/flows/OtherCFDs/Dxtrade/AddedDxtradeAccountsList/AddedDxtradeAccountsList.scss
+++ b/packages/wallets/src/features/cfd/flows/OtherCFDs/Dxtrade/AddedDxtradeAccountsList/AddedDxtradeAccountsList.scss
@@ -1,4 +1,4 @@
-.wallets-available-dxtrade {
+.wallets-added-dxtrade {
     &__icon {
         width: fit-content;
     }

--- a/packages/wallets/src/features/cfd/flows/OtherCFDs/Dxtrade/AddedDxtradeAccountsList/AddedDxtradeAccountsList.tsx
+++ b/packages/wallets/src/features/cfd/flows/OtherCFDs/Dxtrade/AddedDxtradeAccountsList/AddedDxtradeAccountsList.tsx
@@ -17,15 +17,15 @@ const AddedDxtradeAccountsList: React.FC = () => {
             {data?.map(account => (
                 <TradingAccountCard
                     key={account?.account_id}
-                    leading={<div className='wallets-available-dxtrade__icon'>{PlatformDetails.dxtrade.icon}</div>}
+                    leading={<div className='wallets-added-dxtrade__icon'>{PlatformDetails.dxtrade.icon}</div>}
                     onClick={() => show(<MT5TradeModal platform={PlatformDetails.dxtrade.platform} />)}
                     trailing={
-                        <div className='wallets-available-dxtrade__icon'>
+                        <div className='wallets-added-dxtrade__icon'>
                             <LabelPairedChevronRightCaptionRegularIcon width={16} />
                         </div>
                     }
                 >
-                    <div className='wallets-available-dxtrade__details'>
+                    <div className='wallets-added-dxtrade__details'>
                         <WalletText size='sm'>{PlatformDetails.dxtrade.title}</WalletText>
                         <WalletText size='sm' weight='bold'>
                             {account?.display_balance}


### PR DESCRIPTION
## Changes:

- [x] Update cfd chevron design as per discussion and figma reference
- [x] Fix design for account badge
- [x] Revert usage of isLoading to isFetchedAfterMount for useSortedMT5Accounts  

### Screenshots:

https://github.com/binary-com/deriv-app/assets/142860499/45f22c9a-1798-4e63-9c9e-7f9b246a9e5d

https://github.com/binary-com/deriv-app/assets/142860499/5b4c0d7b-deed-45f1-87c8-d9f7a39e4367

