### PR TITLE
[WALL] [cashier-v2] Aum / WALL-3363 / content-change-withdrawal-email-verification

### DIFF
--- a/packages/cashier-v2/src/lib/WithdrawalVerification/WithdrawalVerificationRequest/WithdrawalVerificationRequest.tsx
+++ b/packages/cashier-v2/src/lib/WithdrawalVerification/WithdrawalVerificationRequest/WithdrawalVerificationRequest.tsx
@@ -18,11 +18,8 @@ const WithdrawalVerificationRequest: React.FC<TProps> = ({ sendEmail }) => {
                 }
                 description={
                     <div className={styles.description}>
-                        <Text align='center'>
-                            Click the button below and we&apos;ll send you an email with a link. Click that link to
-                            verify your withdrawal request.
-                        </Text>
-                        <Text align='center'>This is to protect your account from unauthorised withdrawals.</Text>
+                        <Text align='center'>Hit the button below, and we&apos;ll email you a verification link.</Text>
+                        <Text align='center'>This is to confirm that it&apos;s you making the withdrawal request.</Text>
                     </div>
                 }
                 icon={
@@ -30,7 +27,7 @@ const WithdrawalVerificationRequest: React.FC<TProps> = ({ sendEmail }) => {
                         <EmailVerification />
                     </div>
                 }
-                title='Please help us verify your withdrawal request.'
+                title='Confirm your identity to make a withdrawal.'
             />
         </div>
     );

--- a/packages/cashier-v2/src/lib/WithdrawalVerification/WithdrawalVerificationRequest/__tests__/WithdrawalVerificationRequest.spec.tsx
+++ b/packages/cashier-v2/src/lib/WithdrawalVerification/WithdrawalVerificationRequest/__tests__/WithdrawalVerificationRequest.spec.tsx
@@ -6,13 +6,12 @@ describe('WithdrawalVerificationRequest', () => {
     test('should render component correctly', () => {
         render(<WithdrawalVerificationRequest sendEmail={jest.fn()} />);
 
-        expect(screen.getByText('Please help us verify your withdrawal request.')).toBeInTheDocument();
+        expect(screen.getByText("Hit the button below, and we'll email you a verification link.")).toBeInTheDocument();
 
         const sendEmailButton = screen.getByRole('button', { name: 'Send email' });
         expect(sendEmailButton).toBeInTheDocument();
 
-        expect(screen.getByText(/Click that link to verify your withdrawal request./)).toBeInTheDocument();
-        expect(screen.getByText('This is to protect your account from unauthorised withdrawals.')).toBeInTheDocument();
+        expect(screen.getByText("This is to confirm that it's you making the withdrawal request.")).toBeInTheDocument();
 
         const emailVerificationIcon = screen.getByTestId('dt_withdrawal_verification_request_icon');
         expect(emailVerificationIcon).toBeInTheDocument();

--- a/packages/cashier-v2/src/lib/WithdrawalVerification/__tests_/WithdrawalVerification.spec.tsx
+++ b/packages/cashier-v2/src/lib/WithdrawalVerification/__tests_/WithdrawalVerification.spec.tsx
@@ -13,7 +13,7 @@ jest.mock('@deriv/api-v2', () => ({
 describe('WithdrawalVerification', () => {
     it('should render WithdrawalVerificationRequest initially', () => {
         render(<WithdrawalVerification withdrawalType='payment_withdraw' />);
-        expect(screen.getByText('Please help us verify your withdrawal request.')).toBeInTheDocument();
+        expect(screen.getByText("Hit the button below, and we'll email you a verification link.")).toBeInTheDocument();
     });
 
     it('should send withdrawal verification email and render WithdrawalVerificationSent after clicking send email', async () => {

--- a/packages/wallets/src/features/cashier/modules/WithdrawalVerification/WithdrawalVerificationRequest/WithdrawalVerificationRequest.tsx
+++ b/packages/wallets/src/features/cashier/modules/WithdrawalVerification/WithdrawalVerificationRequest/WithdrawalVerificationRequest.tsx
@@ -14,11 +14,10 @@ const WithdrawalVerificationRequest: React.FC<TProps> = ({ sendEmail }) => {
                 description={
                     <div className='wallets-withdrawal-verification-request__description'>
                         <WalletText align='center'>
-                            Click the button below and we&apos;ll send you an email with a link. Click that link to
-                            verify your withdrawal request.
+                            Hit the button below, and we&apos;ll email you a verification link.
                         </WalletText>
                         <WalletText align='center'>
-                            This is to protect your account from unauthorised withdrawals.
+                            This is to confirm that it&apos;s you making the withdrawal request.
                         </WalletText>
                     </div>
                 }
@@ -35,7 +34,7 @@ const WithdrawalVerificationRequest: React.FC<TProps> = ({ sendEmail }) => {
                         Send email
                     </WalletButton>
                 )}
-                title='Please help us verify your withdrawal request.'
+                title='Confirm your identity to make a withdrawal.'
             />
         </div>
     );

--- a/packages/wallets/src/features/cashier/modules/WithdrawalVerification/WithdrawalVerificationRequest/__tests__/WithdrawalVerificationRequest.spec.tsx
+++ b/packages/wallets/src/features/cashier/modules/WithdrawalVerification/WithdrawalVerificationRequest/__tests__/WithdrawalVerificationRequest.spec.tsx
@@ -6,13 +6,12 @@ describe('WithdrawalVerificationRequest', () => {
     test('should render component correctly', () => {
         render(<WithdrawalVerificationRequest sendEmail={jest.fn()} />);
 
-        expect(screen.getByText('Please help us verify your withdrawal request.')).toBeInTheDocument();
+        expect(screen.getByText("Hit the button below, and we'll email you a verification link.")).toBeInTheDocument();
 
         const sendEmailButton = screen.getByRole('button', { name: 'Send email' });
         expect(sendEmailButton).toBeInTheDocument();
 
-        expect(screen.getByText(/Click that link to verify your withdrawal request./)).toBeInTheDocument();
-        expect(screen.getByText('This is to protect your account from unauthorised withdrawals.')).toBeInTheDocument();
+        expect(screen.getByText("This is to confirm that it's you making the withdrawal request.")).toBeInTheDocument();
 
         const emailVerificationIcon = screen.getByTestId('dt_withdrawal_verification_request_icon');
         expect(emailVerificationIcon).toBeInTheDocument();

--- a/packages/wallets/src/features/cashier/modules/WithdrawalVerification/__tests_/WithdrawalVerification.spec.tsx
+++ b/packages/wallets/src/features/cashier/modules/WithdrawalVerification/__tests_/WithdrawalVerification.spec.tsx
@@ -12,7 +12,7 @@ jest.mock('@deriv/api-v2', () => ({
 describe('WithdrawalVerification', () => {
     it('should render WithdrawalVerificationRequest initially', () => {
         render(<WithdrawalVerification />);
-        expect(screen.getByText('Please help us verify your withdrawal request.')).toBeInTheDocument();
+        expect(screen.getByText("Hit the button below, and we'll email you a verification link.")).toBeInTheDocument();
     });
 
     it('should send withdrawal verification email and render WithdrawalVerificationSent after clicking send email', async () => {


### PR DESCRIPTION
## Changes:

Update the content for WithdrawalEmailVerification request page for both `Wallets` and `Cashier-v2`.

Old Content
<img height='90' src='https://github.com/binary-com/deriv-app/assets/125039206/2d257829-0bc2-498a-8d1e-e2adf4917c03' />
New Content
<img height='90' src='https://github.com/binary-com/deriv-app/assets/125039206/1d50c7c6-09be-4249-9a4c-8087d5a5ef61' />


### Screenshots:

<img width="881" alt="Screenshot 2024-04-16 at 1 14 09 PM" src="https://github.com/binary-com/deriv-app/assets/125039206/8523e2ad-bc49-4e14-8e47-8b776aaf26ee">
<img width="896" alt="Screenshot 2024-04-16 at 1 14 51 PM" src="https://github.com/binary-com/deriv-app/assets/125039206/33e620bb-fdba-4942-9b70-9362a67a852c">
