### PR TITLE
[P2PS] farrah/P2PS-2733/fix: p2p app redirection

### DIFF
--- a/packages/core/src/public/.well-known/apple-app-site-association
+++ b/packages/core/src/public/.well-known/apple-app-site-association
@@ -59,7 +59,6 @@
             "36S5Q8S4V5.com.deriv.app",
             "36S5Q8S4V5.com.deriv.app.dev",
             "36S5Q8S4V5.com.deriv.app.staging",
-            "36S5Q8S4V5.com.deriv.dp2p",
             "36S5Q8S4V5.com.deriv.blanc",
             "36S5Q8S4V5.com.deriv.blanc.dev",
             "36S5Q8S4V5.com.deriv.blanc.stg",

--- a/packages/core/src/public/.well-known/assetslinks.json
+++ b/packages/core/src/public/.well-known/assetslinks.json
@@ -46,8 +46,7 @@
   },
   {
     "relation": [
-      "delegate_permission/common.handle_all_urls",
-      "delegate_permission/common.get_login_creds"
+      "delegate_permission/common.handle_all_urls"
     ],
     "target": {
       "namespace": "android_app",


### PR DESCRIPTION
## Changes:

Updated the following files to remove the passkeys configuration related to P2P since it's not yet implemented in the mobile app:
core/src/public/.well-known/assetslinks.json
core/src/public/.well-known/apple-app-site-association

### Screenshots:

