### PR TITLE
[WALL] Aizad/WALL-3762/ Update Reset MT5 Password Fix based on new MT5 Policy changes

### DIFF
--- a/packages/wallets/src/components/WalletsResetMT5Password/WalletSuccessResetMT5Password.tsx
+++ b/packages/wallets/src/components/WalletsResetMT5Password/WalletSuccessResetMT5Password.tsx
@@ -1,54 +1,40 @@
 import React, { FC, useCallback } from 'react';
 import { Trans } from 'react-i18next';
 import { DerivLightIcMt5PasswordUpdatedIcon, DerivLightMt5SuccessPasswordResetIcon } from '@deriv/quill-icons';
+import { PlatformDetails } from '../../features/cfd/constants';
 import useDevice from '../../hooks/useDevice';
-import { ModalStepWrapper, WalletButton } from '../Base';
+import { ModalWrapper, WalletButton, WalletText } from '../Base';
 import { useModal } from '../ModalProvider';
 import { WalletsActionScreen } from '../WalletsActionScreen';
 
 type WalletSuccessResetMT5PasswordProps = {
     isInvestorPassword?: boolean;
-    onClickSuccess?: () => void;
     title: string;
 };
 
 const WalletSuccessResetMT5Password: FC<WalletSuccessResetMT5PasswordProps> = ({
     isInvestorPassword = false,
-    onClickSuccess,
     title,
 }) => {
     const { hide } = useModal();
-    const { isDesktop, isMobile } = useDevice();
-
-    const handleSuccess = useCallback(() => {
-        onClickSuccess?.();
-        hide();
-    }, [onClickSuccess, hide]);
-
-    const renderFooter = useCallback(() => {
-        return isMobile ? (
-            <WalletButton isFullWidth onClick={handleSuccess} size='lg'>
-                <Trans defaults='Done' />
-            </WalletButton>
-        ) : null;
-    }, [isMobile, handleSuccess]);
+    const { isMobile } = useDevice();
 
     const renderButtons = useCallback(() => {
-        return isDesktop ? (
-            <WalletButton onClick={handleSuccess} size='lg'>
-                <Trans defaults='Done' />
+        return (
+            <WalletButton onClick={() => hide()} size='lg'>
+                {isInvestorPassword ? <Trans defaults='Ok' /> : <Trans defaults='Done' />}
             </WalletButton>
-        ) : null;
-    }, [isDesktop, handleSuccess]);
+        );
+    }, [hide, isInvestorPassword]);
 
     return (
-        <ModalStepWrapper
-            renderFooter={isMobile ? renderFooter : undefined}
-            shouldFixedFooter={isMobile}
-            shouldHideHeader={!isMobile}
-            title={`Manage ${title} password`}
-        >
+        <ModalWrapper hideCloseButton={isMobile || !isInvestorPassword}>
             <div className='wallets-reset-mt5-password'>
+                {isInvestorPassword && (
+                    <WalletText size='md' weight='bold'>
+                        Reset {PlatformDetails.mt5.title} investor password
+                    </WalletText>
+                )}
                 <WalletsActionScreen
                     description={
                         isInvestorPassword
@@ -67,7 +53,7 @@ const WalletSuccessResetMT5Password: FC<WalletSuccessResetMT5PasswordProps> = ({
                     title={isInvestorPassword ? 'Password saved' : 'Success'}
                 />
             </div>
-        </ModalStepWrapper>
+        </ModalWrapper>
     );
 };
 

--- a/packages/wallets/src/components/WalletsResetMT5Password/WalletSuccessResetMT5Password.tsx
+++ b/packages/wallets/src/components/WalletsResetMT5Password/WalletSuccessResetMT5Password.tsx
@@ -9,23 +9,30 @@ import { WalletsActionScreen } from '../WalletsActionScreen';
 
 type WalletSuccessResetMT5PasswordProps = {
     isInvestorPassword?: boolean;
+    onClickSuccess?: () => void;
     title: string;
 };
 
 const WalletSuccessResetMT5Password: FC<WalletSuccessResetMT5PasswordProps> = ({
     isInvestorPassword = false,
+    onClickSuccess,
     title,
 }) => {
     const { hide } = useModal();
     const { isMobile } = useDevice();
 
+    const handleSuccess = useCallback(() => {
+        onClickSuccess?.();
+        hide();
+    }, [onClickSuccess, hide]);
+
     const renderButtons = useCallback(() => {
         return (
-            <WalletButton onClick={() => hide()} size='lg'>
+            <WalletButton onClick={handleSuccess} size='lg'>
                 {isInvestorPassword ? <Trans defaults='Ok' /> : <Trans defaults='Done' />}
             </WalletButton>
         );
-    }, [hide, isInvestorPassword]);
+    }, [handleSuccess, isInvestorPassword]);
 
     return (
         <ModalWrapper hideCloseButton={isMobile || !isInvestorPassword}>

--- a/packages/wallets/src/components/WalletsResetMT5Password/WalletsResetMT5Password.tsx
+++ b/packages/wallets/src/components/WalletsResetMT5Password/WalletsResetMT5Password.tsx
@@ -71,7 +71,7 @@ const WalletsResetMT5Password = ({
     useEffect(() => {
         if (isChangePasswordSuccess) {
             localStorage.removeItem(`verification_code.${actionParams}`); // TODO:Remove verification code from local storage
-            show(<WalletSuccessResetMT5Password title={title} />);
+            show(<WalletSuccessResetMT5Password title={title} />, { defaultRootId: 'wallets_modal_root' });
         } else if (isChangePasswordError) {
             hide();
         }
@@ -81,7 +81,9 @@ const WalletsResetMT5Password = ({
     useEffect(() => {
         if (isChangeInvestorPasswordSuccess) {
             localStorage.removeItem(`verification_code.${actionParams}`); // TODO:Remove verification code from local storage
-            show(<WalletSuccessResetMT5Password isInvestorPassword title={title} />);
+            show(<WalletSuccessResetMT5Password isInvestorPassword title={title} />, {
+                defaultRootId: 'wallets_modal_root',
+            });
         } else if (isChangeInvestorPasswordError) {
             hide();
         }

--- a/packages/wallets/src/components/WalletsResetMT5Password/WalletsResetMT5Password.tsx
+++ b/packages/wallets/src/components/WalletsResetMT5Password/WalletsResetMT5Password.tsx
@@ -10,6 +10,13 @@ import { useModal } from '../ModalProvider';
 import WalletSuccessResetMT5Password from './WalletSuccessResetMT5Password';
 import './WalletsResetMT5Password.scss';
 
+const modalDescription = {
+    [CFD_PLATFORMS.DXTRADE]:
+        'Strong passwords contain at least 8 characters, combine uppercase and lowercase letters, numbers, and symbols.',
+    [CFD_PLATFORMS.MT5]:
+        'Your password must contain between 8-16 characters that include uppercase and lowercase letters, and at least one number and special character such as ( _ @ ? ! / # ).',
+} as const;
+
 type WalletsResetMT5PasswordProps = {
     actionParams: string;
     isInvestorPassword?: boolean;
@@ -41,13 +48,15 @@ const WalletsResetMT5Password = ({
     const [password, setPassword] = useState('');
     const { isMobile } = useDevice();
 
+    const isMT5 = platform === CFD_PLATFORMS.MT5;
+
     const handleSubmit = () => {
-        if (isInvestorPassword) {
+        if (isInvestorPassword && isMT5) {
             const accountId = localStorage.getItem('trading_platform_investor_password_reset_account_id') ?? '';
             changeInvestorPassword({
                 account_id: accountId,
                 new_password: password,
-                platform: 'mt5',
+                platform: CFD_PLATFORMS.MT5,
                 verification_code: verificationCode,
             });
         } else {
@@ -58,15 +67,6 @@ const WalletsResetMT5Password = ({
             });
         }
     };
-
-    const description = {
-        [CFD_PLATFORMS.DXTRADE]:
-            'Strong passwords contain at least 8 characters, combine uppercase and lowercase letters, numbers, and symbols.',
-        [CFD_PLATFORMS.MT5]:
-            'Your password must contain between 8-16 characters that include uppercase and lowercase letters, and at least one number and special character such as ( _ @ ? ! / # ).',
-    } as const;
-
-    const isMT5 = platform === CFD_PLATFORMS.MT5;
 
     useEffect(() => {
         if (isChangePasswordSuccess) {
@@ -92,7 +92,7 @@ const WalletsResetMT5Password = ({
         <ModalWrapper hideCloseButton={isMobile}>
             <div className='wallets-reset-mt5-password'>
                 <WalletText weight='bold'>
-                    Create a new {title} {isInvestorPassword && 'investor'} Password
+                    {isInvestorPassword ? `Reset ${title} investor password` : `Create a new ${title} password`}
                 </WalletText>
                 {isMT5 && !isInvestorPassword && (
                     <WalletText size='sm'>You can use this password for all your {title} accounts.</WalletText>
@@ -103,7 +103,7 @@ const WalletsResetMT5Password = ({
                     onChange={e => setPassword(e.target.value)}
                     password={password}
                 />
-                <WalletText size='sm'>{description[platform]}</WalletText>
+                <WalletText size='sm'>{modalDescription[platform]}</WalletText>
                 <div className='wallets-reset-mt5-password__button-group'>
                     <WalletButton onClick={() => hide()} variant='outlined'>
                         <Trans defaults='Cancel' />

--- a/packages/wallets/src/components/WalletsResetMT5Password/WalletsResetMT5Password.tsx
+++ b/packages/wallets/src/components/WalletsResetMT5Password/WalletsResetMT5Password.tsx
@@ -4,7 +4,7 @@ import { useTradingPlatformInvestorPasswordReset, useTradingPlatformPasswordRese
 import { CFD_PLATFORMS, PlatformDetails } from '../../features/cfd/constants';
 import useDevice from '../../hooks/useDevice';
 import { TPlatforms } from '../../types';
-import { validPassword } from '../../utils/password-validation';
+import { validPassword, validPasswordMT5 } from '../../utils/password-validation';
 import { ModalWrapper, WalletButton, WalletPasswordFieldLazy, WalletText } from '../Base';
 import { useModal } from '../ModalProvider';
 import WalletSuccessResetMT5Password from './WalletSuccessResetMT5Password';
@@ -99,6 +99,7 @@ const WalletsResetMT5Password = ({
                 )}
                 <WalletPasswordFieldLazy
                     label={isInvestorPassword ? 'New investor password' : `${title} password`}
+                    mt5Policy={isMT5}
                     onChange={e => setPassword(e.target.value)}
                     password={password}
                 />
@@ -108,7 +109,7 @@ const WalletsResetMT5Password = ({
                         <Trans defaults='Cancel' />
                     </WalletButton>
                     <WalletButton
-                        disabled={!validPassword(password)}
+                        disabled={isMT5 ? !validPasswordMT5(password) : !validPassword(password)}
                         isLoading={isChangeInvestorPasswordLoading || isChangePasswordLoading}
                         onClick={handleSubmit}
                         variant='contained'


### PR DESCRIPTION
## Checklist

- [x]  As per the figma, the header text should be Reset Deriv MT5 investor password
- [x] A validation message for a missing special character should appear
- [x] And user should be able to use this password to change the investor password again - if needed
- [x] System should show a validation message after entering more than 16 characters 
- [x] We should show a success popup representing that the investor password is created 

## Changes:

- Update password validation for MT5 Reset modal.
- Fix disable button for both MT5 and DerivX reset modal.
- Updated Modal Title for MT5 Investor password reset.
- Updated content for Success Modal both for investor and non-investor clients.

### Screenshots:

<img width="722" alt="image" src="https://github.com/binary-com/deriv-app/assets/103104395/82688b73-3261-475b-839d-ff39f3c9eb9f">
<img width="722" alt="image" src="https://github.com/binary-com/deriv-app/assets/103104395/64130a9e-7b6e-48c6-9d13-a438e199f01e">
<img width="722" alt="image" src="https://github.com/binary-com/deriv-app/assets/103104395/bdf01070-657b-4216-98a0-aac24e71a1c0">
<img width="945" alt="image" src="https://github.com/binary-com/deriv-app/assets/103104395/74ccb924-b048-45f8-a418-434a7f26e27a">


