### PR TITLE
[draft] [WALL] Aum / WALL-3681 / change-transfer-to-dropdown-placeholder-content

### DIFF
--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormDropdown/TransferFormDropdown.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormDropdown/TransferFormDropdown.tsx
@@ -127,7 +127,7 @@ const TransferFormDropdown: React.FC<TProps> = ({ fieldName, mobileAccountsListR
                 ) : (
                     <div className='wallets-transfer-form-dropdown__select-account-cta'>
                         <WalletText size='sm' weight='bold'>
-                            Select a trading account or a Wallet
+                            Select a trading account{activeWallet?.demo_account === 0 ? ` or a Wallet` : ''}
                         </WalletText>
                     </div>
                 )}


### PR DESCRIPTION
## Changes:

Fix: change content of the placeholder for toAccount selector when transferring from demo wallet as there is only one demo wallet.

Old content: `Select a trading account or a Wallet`
New Content: `Select a trading account`

### Screenshots:
Demo Wallet
<img width="1229" alt="Screenshot 2024-04-17 at 4 45 28 PM" src="https://github.com/binary-com/deriv-app/assets/125039206/3ef2ee1b-e331-4089-ace9-73f66b26cf28">
Real Wallet Transfer:
![image](https://github.com/binary-com/deriv-app/assets/125039206/e617506d-ebcb-492e-8314-7e0d29a06096)

