### PR TITLE
[WALL] george / WALL-3652 / Hide dark theme and language switcher for client with wallet account

### DIFF
--- a/packages/account/src/Containers/Account/__tests__/account.spec.tsx
+++ b/packages/account/src/Containers/Account/__tests__/account.spec.tsx
@@ -8,6 +8,11 @@ import Account from '../account';
 
 jest.mock('../../Account/page-overlay-wrapper', () => jest.fn(() => <div>MockPageOverlayWrapper</div>));
 
+jest.mock('@deriv/hooks', () => ({
+    ...jest.requireActual('@deriv/hooks'),
+    useStoreWalletAccountsList: jest.fn(() => ({ has_wallet: false })),
+}));
+
 jest.mock('@deriv/components', () => ({
     ...jest.requireActual('@deriv/components'),
     Loading: () => <div>MockLoading</div>,

--- a/packages/account/src/Containers/Account/account.tsx
+++ b/packages/account/src/Containers/Account/account.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { FadeWrapper, Loading } from '@deriv/components';
+import { useStoreWalletAccountsList } from '@deriv/hooks';
 import { flatten, matchRoute, routes as shared_routes } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
 import PageOverlayWrapper from './page-overlay-wrapper';
@@ -32,6 +33,7 @@ const Account = observer(({ history, location, routes }: TAccountProps) => {
         is_passkey_supported,
     } = client;
     const { toggleAccountSettings, is_account_settings_visible, is_mobile, is_desktop } = ui;
+    const { has_wallet } = useStoreWalletAccountsList();
 
     // subroutes of a route is structured as an array of arrays
     const subroutes = flatten(routes.map(i => i.subroutes));
@@ -67,6 +69,10 @@ const Account = observer(({ history, location, routes }: TAccountProps) => {
 
                 if (route.path === shared_routes.passkeys) {
                     route.is_hidden = should_remove_passkeys_route;
+                }
+
+                if (route.path === shared_routes.languages) {
+                    route.is_hidden = has_wallet;
                 }
             });
         }

--- a/packages/account/src/Sections/Profile/LanguageSettings/language-settings.tsx
+++ b/packages/account/src/Sections/Profile/LanguageSettings/language-settings.tsx
@@ -1,16 +1,19 @@
 import React from 'react';
 import { Redirect } from 'react-router-dom';
 import { localize, getAllowedLanguages } from '@deriv/translations';
-import { isMobile, routes } from '@deriv/shared';
+import { useStoreWalletAccountsList } from '@deriv/hooks';
+import { routes } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
 import FormSubHeader from 'Components/form-sub-header';
 import LanguageRadioButton from 'Components/language-settings';
 
 const LanguageSettings = observer(() => {
-    const { common } = useStore();
+    const { common, ui } = useStore();
+    const { is_mobile } = ui;
     const { changeSelectedLanguage, current_language } = common;
+    const { has_wallet } = useStoreWalletAccountsList();
 
-    if (window.location.pathname === routes.languages && isMobile()) {
+    if (is_mobile || has_wallet) {
         return <Redirect to={routes.traders_hub} />;
     }
 

--- a/packages/core/src/App/AppContent.tsx
+++ b/packages/core/src/App/AppContent.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Cookies from 'js-cookie';
 import { useRemoteConfig } from '@deriv/api';
 import { DesktopWrapper } from '@deriv/components';
-import { useFeatureFlags } from '@deriv/hooks';
+import { useFeatureFlags, useStoreWalletAccountsList } from '@deriv/hooks';
 import { getAppId, LocalStore, useIsMounted } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
 import { getLanguage } from '@deriv/translations';
@@ -24,6 +24,7 @@ import initDatadog from '../Utils/Datadog';
 
 const AppContent: React.FC<{ passthrough: unknown }> = observer(({ passthrough }) => {
     const { is_next_wallet_enabled } = useFeatureFlags();
+    const { has_wallet } = useStoreWalletAccountsList();
     const store = useStore();
 
     const isMounted = useIsMounted();
@@ -69,6 +70,13 @@ const AppContent: React.FC<{ passthrough: unknown }> = observer(({ passthrough }
     React.useEffect(() => {
         initDatadog(tracking_datadog);
     }, [tracking_datadog]);
+
+    // intentionally switch the user with wallets to light mode
+    React.useLayoutEffect(() => {
+        if (has_wallet) {
+            store.ui.setDarkMode(false);
+        }
+    }, [has_wallet, store.ui]);
 
     return (
         <PlatformContainer>

--- a/packages/core/src/App/AppContent.tsx
+++ b/packages/core/src/App/AppContent.tsx
@@ -71,12 +71,17 @@ const AppContent: React.FC<{ passthrough: unknown }> = observer(({ passthrough }
         initDatadog(tracking_datadog);
     }, [tracking_datadog]);
 
-    // intentionally switch the user with wallets to light mode
+    // intentionally switch the user with wallets to light mode and EN language
     React.useLayoutEffect(() => {
         if (has_wallet) {
-            store.ui.setDarkMode(false);
+            if (store.ui.is_dark_mode_on) {
+                store.ui.setDarkMode(false);
+            }
+            if (store.common.current_language !== 'EN') {
+                store.common.changeSelectedLanguage('EN');
+            }
         }
-    }, [has_wallet, store.ui]);
+    }, [has_wallet, store.common, store.ui]);
 
     return (
         <PlatformContainer>

--- a/packages/core/src/App/Components/Layout/Header/Components/ToggleMenu/menu-title.tsx
+++ b/packages/core/src/App/Components/Layout/Header/Components/ToggleMenu/menu-title.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useStoreWalletAccountsList } from '@deriv/hooks';
 import { observer, useStore } from '@deriv/stores';
 import { Icon, Text } from '@deriv/components';
 import { localize, Localize } from '@deriv/translations';
@@ -7,31 +8,35 @@ const MenuTitle = observer(() => {
     const { common, ui } = useStore();
     const { current_language } = common;
     const { is_mobile_language_menu_open, setMobileLanguageMenuOpen } = ui;
+    const { has_wallet } = useStoreWalletAccountsList();
+
     return (
         <React.Fragment>
             <div>{localize('Menu')}</div>
-            <div
-                className='settings-language__language-button_wrapper'
-                onClick={() => {
-                    if (!is_mobile_language_menu_open) {
-                        setMobileLanguageMenuOpen(true);
-                    }
-                }}
-            >
-                {!is_mobile_language_menu_open && (
-                    <React.Fragment>
-                        <Icon
-                            icon={`IcFlag${current_language.replace('_', '-')}`}
-                            data_testid='dt_icon'
-                            className='ic-settings-language__icon'
-                            size={22}
-                        />
-                        <Text weight='bold' size='xxs'>
-                            <Localize i18n_default_text={current_language} />
-                        </Text>
-                    </React.Fragment>
-                )}
-            </div>
+            {!has_wallet && (
+                <div
+                    className='settings-language__language-button_wrapper'
+                    onClick={() => {
+                        if (!is_mobile_language_menu_open) {
+                            setMobileLanguageMenuOpen(true);
+                        }
+                    }}
+                >
+                    {!is_mobile_language_menu_open && (
+                        <React.Fragment>
+                            <Icon
+                                icon={`IcFlag${current_language.replace('_', '-')}`}
+                                data_testid='dt_icon'
+                                className='ic-settings-language__icon'
+                                size={22}
+                            />
+                            <Text weight='bold' size='xxs'>
+                                <Localize i18n_default_text={current_language} />
+                            </Text>
+                        </React.Fragment>
+                    )}
+                </div>
+            )}
         </React.Fragment>
     );
 });

--- a/packages/core/src/App/Components/Layout/Header/toggle-menu-drawer.jsx
+++ b/packages/core/src/App/Components/Layout/Header/toggle-menu-drawer.jsx
@@ -11,6 +11,7 @@ import {
     useOnrampVisible,
     usePaymentAgentTransferVisible,
     useP2PSettings,
+    useStoreWalletAccountsList,
 } from '@deriv/hooks';
 import { getStaticUrl, routes, useIsMounted, whatsapp_url } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
@@ -60,6 +61,8 @@ const ToggleMenuDrawer = observer(({ platform_config }) => {
     const is_onramp_visible = useOnrampVisible();
     const { data: is_payment_agent_transfer_visible } = usePaymentAgentTransferVisible();
     const { is_p2p_enabled } = useIsP2PEnabled();
+    const { is_next_wallet_enabled } = useFeatureFlags();
+    const { has_wallet } = useStoreWalletAccountsList();
 
     const { pathname: route } = useLocation();
 
@@ -78,7 +81,6 @@ const ToggleMenuDrawer = observer(({ platform_config }) => {
 
     const timeout = React.useRef();
     const history = useHistory();
-    const { is_next_wallet_enabled } = useFeatureFlags();
     const {
         subscribe,
         rest: { isSubscribed },
@@ -182,6 +184,8 @@ const ToggleMenuDrawer = observer(({ platform_config }) => {
         const hideRoute = route_path => {
             if (/passkeys/.test(route_path)) {
                 return should_hide_passkeys_route;
+            } else if (/languages/.test(route_path)) {
+                return has_wallet;
             }
             return false;
         };
@@ -336,23 +340,27 @@ const ToggleMenuDrawer = observer(({ platform_config }) => {
                                 {primary_routes_config.map((route_config, idx) =>
                                     getRoutesWithSubMenu(route_config, idx)
                                 )}
-                                <MobileDrawer.Item
-                                    className='header__menu-mobile-theme'
-                                    onClick={e => {
-                                        e.preventDefault();
-                                        toggleTheme(!is_dark_mode);
-                                    }}
-                                >
-                                    <div className={classNames('header__menu-mobile-link')}>
-                                        <Icon className='header__menu-mobile-link-icon' icon={'IcTheme'} />
-                                        <span className='header__menu-mobile-link-text'>{localize('Dark theme')}</span>
-                                        <ToggleSwitch
-                                            id='dt_mobile_drawer_theme_toggler'
-                                            handleToggle={() => toggleTheme(!is_dark_mode)}
-                                            is_enabled={is_dark_mode}
-                                        />
-                                    </div>
-                                </MobileDrawer.Item>
+                                {!has_wallet && (
+                                    <MobileDrawer.Item
+                                        className='header__menu-mobile-theme'
+                                        onClick={e => {
+                                            e.preventDefault();
+                                            toggleTheme(!is_dark_mode);
+                                        }}
+                                    >
+                                        <div className={classNames('header__menu-mobile-link')}>
+                                            <Icon className='header__menu-mobile-link-icon' icon={'IcTheme'} />
+                                            <span className='header__menu-mobile-link-text'>
+                                                {localize('Dark theme')}
+                                            </span>
+                                            <ToggleSwitch
+                                                id='dt_mobile_drawer_theme_toggler'
+                                                handleToggle={() => toggleTheme(!is_dark_mode)}
+                                                is_enabled={is_dark_mode}
+                                            />
+                                        </div>
+                                    </MobileDrawer.Item>
+                                )}
 
                                 {HelpCentreRoute()}
                                 {is_logged_in && (

--- a/packages/core/src/App/Containers/Layout/default-footer.jsx
+++ b/packages/core/src/App/Containers/Layout/default-footer.jsx
@@ -15,6 +15,7 @@ import NetworkStatus, {
 import LiveChat from 'App/Components/Elements/LiveChat';
 import WhatsApp from 'App/Components/Elements/WhatsApp/index.ts';
 import ServerTime from '../server-time.jsx';
+import { useStoreWalletAccountsList } from '@deriv/hooks';
 import { observer, useStore } from '@deriv/stores';
 import { useRemoteConfig } from '@deriv/api';
 import { useIsMounted } from '@deriv/shared';
@@ -52,6 +53,8 @@ const Footer = observer(() => {
     const { data } = useRemoteConfig(isMounted());
     const { cs_chat_livechat, cs_chat_whatsapp } = data;
     const { show_eu_related_content } = traders_hub;
+    const { has_wallet } = useStoreWalletAccountsList();
+
     let footer_extensions_left = [];
     let footer_extensions_right = [];
     if (footer_extensions.filter) {
@@ -97,11 +100,13 @@ const Footer = observer(() => {
                     enableApp={enableApp}
                     settings_extension={settings_extension}
                 />
-                <ToggleLanguageSettings
-                    is_settings_visible={is_language_settings_modal_on}
-                    toggleSettings={toggleLanguageSettingsModal}
-                    lang={current_language}
-                />
+                {!has_wallet && (
+                    <ToggleLanguageSettings
+                        is_settings_visible={is_language_settings_modal_on}
+                        toggleSettings={toggleLanguageSettingsModal}
+                        lang={current_language}
+                    />
+                )}
                 <ToggleFullScreen />
             </div>
         </footer>

--- a/packages/core/src/App/Containers/Layout/trading-hub-footer.jsx
+++ b/packages/core/src/App/Containers/Layout/trading-hub-footer.jsx
@@ -16,6 +16,7 @@ import NetworkStatus, {
 import LiveChat from 'App/Components/Elements/LiveChat';
 import WhatsApp from 'App/Components/Elements/WhatsApp/index.ts';
 import ServerTime from '../server-time.jsx';
+import { useStoreWalletAccountsList } from '@deriv/hooks';
 import { routes, useIsMounted } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
 import DarkModeToggleIcon from 'Assets/SvgComponents/footer/ic-footer-light-theme.svg';
@@ -56,6 +57,7 @@ const TradingHubFooter = observer(() => {
         is_dark_mode_on: is_dark_mode,
         setDarkMode,
     } = ui;
+    const { has_wallet } = useStoreWalletAccountsList();
 
     let footer_extensions_left = [];
     let footer_extensions_right = [];
@@ -103,15 +105,17 @@ const TradingHubFooter = observer(() => {
                         show_eu_related_content={show_eu_related_content}
                     />
                 )}
-                <div className='footer__links--dark-mode'>
-                    <Popover alignment='top' message={localize('Change theme')} zIndex={9999}>
-                        {is_dark_mode ? (
-                            <LightModeToggleIcon onClick={changeTheme} />
-                        ) : (
-                            <DarkModeToggleIcon onClick={changeTheme} />
-                        )}
-                    </Popover>
-                </div>
+                {!has_wallet && (
+                    <div className='footer__links--dark-mode'>
+                        <Popover alignment='top' message={localize('Change theme')} zIndex={9999}>
+                            {is_dark_mode ? (
+                                <LightModeToggleIcon onClick={changeTheme} />
+                            ) : (
+                                <DarkModeToggleIcon onClick={changeTheme} />
+                            )}
+                        </Popover>
+                    </div>
+                )}
                 <FooterIconSeparator />
                 <HelpCentre />
                 {location === routes.trade && (
@@ -123,11 +127,13 @@ const TradingHubFooter = observer(() => {
                         settings_extension={settings_extension}
                     />
                 )}
-                <ToggleLanguageSettings
-                    is_settings_visible={is_language_settings_modal_on}
-                    toggleSettings={toggleLanguageSettingsModal}
-                    lang={current_language}
-                />
+                {!has_wallet && (
+                    <ToggleLanguageSettings
+                        is_settings_visible={is_language_settings_modal_on}
+                        toggleSettings={toggleLanguageSettingsModal}
+                        lang={current_language}
+                    />
+                )}
                 <ToggleFullScreen />
             </div>
         </footer>


### PR DESCRIPTION
## Changes:

Hide dark theme and language switcher for client with wallet account:
- in footer
- in mobile menu drawer

Switch theme to light mode if the user is going to `wallets` route with already selected dark mode 

### Screenshots:


https://github.com/binary-com/deriv-app/assets/103181646/9f1bc285-5d8f-4ed6-8b5c-7f911256f9b3

![Screenshot 2024-04-17 at 18 56 16](https://github.com/binary-com/deriv-app/assets/103181646/c4e98e6c-b94b-4d50-8e30-a868be68b33f)
![Screenshot 2024-04-17 at 18 58 36](https://github.com/binary-com/deriv-app/assets/103181646/f1502c3f-d7f9-4382-937d-75cc1f0d66bb)
![Screenshot 2024-04-17 at 19 16 59](https://github.com/binary-com/deriv-app/assets/103181646/bab6ed4e-373f-445e-85cf-c4cc5b3c2805)



