### PR TITLE
[WALL] Aizad/WALL-3802/Error Message doesn't appear when Failed Reset MT5 Password Modal

### DIFF
--- a/packages/wallets/src/components/WalletsResetMT5Password/WalletsResetMT5Password.tsx
+++ b/packages/wallets/src/components/WalletsResetMT5Password/WalletsResetMT5Password.tsx
@@ -7,6 +7,7 @@ import { TPlatforms } from '../../types';
 import { validPassword, validPasswordMT5 } from '../../utils/password-validation';
 import { ModalWrapper, WalletButton, WalletPasswordFieldLazy, WalletText } from '../Base';
 import { useModal } from '../ModalProvider';
+import { WalletError } from '../WalletError';
 import WalletSuccessResetMT5Password from './WalletSuccessResetMT5Password';
 import './WalletsResetMT5Password.scss';
 
@@ -73,8 +74,14 @@ const WalletsResetMT5Password = ({
             localStorage.removeItem(`verification_code.${actionParams}`); // TODO:Remove verification code from local storage
             show(<WalletSuccessResetMT5Password title={title} />, { defaultRootId: 'wallets_modal_root' });
         } else if (isChangePasswordError) {
-            hide();
-        }
+            show(
+                <WalletError
+                    errorMessage={isChangePasswordError?.error?.message}
+                    onClick={hide}
+                    title={isChangePasswordError?.error?.code}
+                />
+            );
+        } else hide();
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [platform, title, actionParams, isChangePasswordSuccess, isChangePasswordError]);
 
@@ -85,8 +92,14 @@ const WalletsResetMT5Password = ({
                 defaultRootId: 'wallets_modal_root',
             });
         } else if (isChangeInvestorPasswordError) {
-            hide();
-        }
+            show(
+                <WalletError
+                    errorMessage={isChangeInvestorPasswordError?.error?.message}
+                    onClick={hide}
+                    title={isChangeInvestorPasswordError?.error?.code}
+                />
+            );
+        } else hide();
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [platform, title, actionParams, isChangeInvestorPasswordSuccess, isChangeInvestorPasswordError]);
 

--- a/packages/wallets/src/components/WalletsResetMT5Password/WalletsResetMT5Password.tsx
+++ b/packages/wallets/src/components/WalletsResetMT5Password/WalletsResetMT5Password.tsx
@@ -33,12 +33,14 @@ const WalletsResetMT5Password = ({
 }: WalletsResetMT5PasswordProps) => {
     const { title } = PlatformDetails[platform];
     const {
+        error: changePasswordError,
         isError: isChangePasswordError,
         isLoading: isChangePasswordLoading,
         isSuccess: isChangePasswordSuccess,
         mutate: changePassword,
     } = useTradingPlatformPasswordReset();
     const {
+        error: changeInvestorPasswordError,
         isError: isChangeInvestorPasswordError,
         isLoading: isChangeInvestorPasswordLoading,
         isSuccess: isChangeInvestorPasswordSuccess,
@@ -76,12 +78,12 @@ const WalletsResetMT5Password = ({
         } else if (isChangePasswordError) {
             show(
                 <WalletError
-                    errorMessage={isChangePasswordError?.error?.message}
+                    errorMessage={changePasswordError?.error?.message}
                     onClick={hide}
-                    title={isChangePasswordError?.error?.code}
+                    title={changePasswordError?.error?.code}
                 />
             );
-        } else hide();
+        }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [platform, title, actionParams, isChangePasswordSuccess, isChangePasswordError]);
 
@@ -94,12 +96,12 @@ const WalletsResetMT5Password = ({
         } else if (isChangeInvestorPasswordError) {
             show(
                 <WalletError
-                    errorMessage={isChangeInvestorPasswordError?.error?.message}
+                    errorMessage={changeInvestorPasswordError?.error?.message}
                     onClick={hide}
-                    title={isChangeInvestorPasswordError?.error?.code}
+                    title={changeInvestorPasswordError?.error?.code}
                 />
             );
-        } else hide();
+        }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [platform, title, actionParams, isChangeInvestorPasswordSuccess, isChangeInvestorPasswordError]);
 


### PR DESCRIPTION
## Changes:

- Added error handling for  ResetInvestorPasswordModal and for ResetMT5PasswordModal 

### Screenshots:

![image](https://github.com/binary-com/deriv-app/assets/103104395/e7f554db-7d70-4d72-974b-5fc701fed51f)

