### PR TITLE
[KYC-1852]/Mahdiyeh/change validation for number of characters of first/last name

### DIFF
--- a/packages/account/src/Components/personal-details/__tests__/personal-details.spec.js
+++ b/packages/account/src/Components/personal-details/__tests__/personal-details.spec.js
@@ -339,7 +339,7 @@ describe('<PersonalDetails/>', () => {
             errors: {
                 ...mock_errors.errors,
                 first_name: 'letters, spaces, periods, hyphens, apostrophes only',
-                last_name: 'last name should be between 2 and 50 characters.',
+                last_name: 'last name should be between 1 and 50 characters.',
                 date_of_birth: 'You must be 18 years old and above.',
                 tax_identification_number: "Tax Identification Number can't be longer than 25 characters.",
             },
@@ -350,7 +350,7 @@ describe('<PersonalDetails/>', () => {
         fireEvent.change(tax_identification_number, { target: { value: '123456789012345678901234567890' } });
 
         expect(await screen.findByText(/letters, spaces, periods, hyphens, apostrophes only/i)).toBeInTheDocument();
-        expect(await screen.findByText(/last name should be between 2 and 50 characters/i)).toBeInTheDocument();
+        expect(await screen.findByText(/last name should be between 1 and 50 characters/i)).toBeInTheDocument();
         expect(await screen.findByText(/you must be 18 years old and above\./i)).toBeInTheDocument();
         expect(
             await screen.findByText(/tax Identification Number can't be longer than 25 characters\./i)

--- a/packages/account/src/Components/personal-details/__tests__/personal-details.spec.js
+++ b/packages/account/src/Components/personal-details/__tests__/personal-details.spec.js
@@ -338,8 +338,10 @@ describe('<PersonalDetails/>', () => {
             ...mock_warnings,
             errors: {
                 ...mock_errors.errors,
+                // TODO: This content needs to be adjusted based on the actual validation error message
                 first_name: 'letters, spaces, periods, hyphens, apostrophes only',
-                last_name: 'last name should be between 1 and 50 characters.',
+                // TODO: This content needs to be adjusted based on the actual validation error message
+                last_name: 'last name should be up to 50 characters.',
                 date_of_birth: 'You must be 18 years old and above.',
                 tax_identification_number: "Tax Identification Number can't be longer than 25 characters.",
             },
@@ -350,7 +352,8 @@ describe('<PersonalDetails/>', () => {
         fireEvent.change(tax_identification_number, { target: { value: '123456789012345678901234567890' } });
 
         expect(await screen.findByText(/letters, spaces, periods, hyphens, apostrophes only/i)).toBeInTheDocument();
-        expect(await screen.findByText(/last name should be between 1 and 50 characters/i)).toBeInTheDocument();
+        // TODO: This assertion needs to be adjusted based on the actual validation error message
+        expect(await screen.findByText(/last name should be up to 50 characters./i)).toBeInTheDocument();
         expect(await screen.findByText(/you must be 18 years old and above\./i)).toBeInTheDocument();
         expect(
             await screen.findByText(/tax Identification Number can't be longer than 25 characters\./i)

--- a/packages/account/src/Configs/personal-details-config.ts
+++ b/packages/account/src/Configs/personal-details-config.ts
@@ -51,7 +51,7 @@ export const personal_details_config = ({
             default_value: account_settings.first_name ?? '',
             rules: [
                 ['req', localize('First name is required.')],
-                ['length', localize('First name should be between 2 and 50 characters.'), { min: 2, max: 50 }],
+                ['length', localize('First name should be between 1 and 50 characters.'), { min: 1, max: 50 }],
                 ['name', getErrorMessages().name()],
             ],
         },
@@ -60,7 +60,7 @@ export const personal_details_config = ({
             default_value: account_settings.last_name ?? '',
             rules: [
                 ['req', localize('Last name is required.')],
-                ['length', localize('Last name should be between 2 and 50 characters.'), { min: 2, max: 50 }],
+                ['length', localize('Last name should be between 1 and 50 characters.'), { min: 1, max: 50 }],
                 ['name', getErrorMessages().name()],
             ],
         },

--- a/packages/account/src/Configs/personal-details-config.ts
+++ b/packages/account/src/Configs/personal-details-config.ts
@@ -51,7 +51,8 @@ export const personal_details_config = ({
             default_value: account_settings.first_name ?? '',
             rules: [
                 ['req', localize('First name is required.')],
-                ['length', localize('First name should be between 1 and 50 characters.'), { min: 1, max: 50 }],
+                //TODO: This message should be adjusted to due the new validation message from content team
+                ['length', localize('First name should be up 50 characters.'), { max: 50 }],
                 ['name', getErrorMessages().name()],
             ],
         },
@@ -60,7 +61,8 @@ export const personal_details_config = ({
             default_value: account_settings.last_name ?? '',
             rules: [
                 ['req', localize('Last name is required.')],
-                ['length', localize('Last name should be between 1 and 50 characters.'), { min: 1, max: 50 }],
+                //TODO: This message should be adjusted to due the new validation message from content team
+                ['length', localize('Last name should be up to 50 characters.'), { max: 50 }],
                 ['name', getErrorMessages().name()],
             ],
         },

--- a/packages/account/src/Helpers/utils.tsx
+++ b/packages/account/src/Helpers/utils.tsx
@@ -135,8 +135,8 @@ export const makeSettingsRequest = (values: FormikValues, changeable_fields: str
 
 export const validateName = (name: string) => {
     if (name) {
-        if (!validLength(name.trim(), { min: 2, max: 50 })) {
-            return localize('You should enter 2-50 characters.');
+        if (!validLength(name.trim(), { min: 1, max: 50 })) {
+            return localize('You should enter 1-50 characters.');
         } else if (!validName(name)) {
             return localize('Letters, spaces, periods, hyphens, apostrophes only.');
         }

--- a/packages/account/src/Helpers/utils.tsx
+++ b/packages/account/src/Helpers/utils.tsx
@@ -135,9 +135,11 @@ export const makeSettingsRequest = (values: FormikValues, changeable_fields: str
 
 export const validateName = (name: string) => {
     if (name) {
-        if (!validLength(name.trim(), { min: 1, max: 50 })) {
-            return localize('You should enter 1-50 characters.');
+        if (!validLength(name.trim(), { max: 50 })) {
+            //TODO: This message should be adjusted to due the new validation message from content team
+            return localize('You should enter up to 50 characters.');
         } else if (!validName(name)) {
+            //TODO: This message should be adjusted to due the new validation message from content team
             return localize('Letters, spaces, periods, hyphens, apostrophes only.');
         }
     }

--- a/packages/account/src/Sections/Profile/PersonalDetails/__tests__/personal-details-form.spec.tsx
+++ b/packages/account/src/Sections/Profile/PersonalDetails/__tests__/personal-details-form.spec.tsx
@@ -98,12 +98,13 @@ describe('<PersonalDetailsForm />', () => {
         });
     });
 
-    it('should display error for 1-50 characters length validation, for First name when entered characters are less than 1', async () => {
+    it('should display error characters more than 50 length validation', async () => {
         renderComponent();
         await waitFor(() => {
             const last_name = screen.getByTestId('dt_last_name');
             userEvent.type(last_name, 'b');
-            expect(screen.getByText(/You should enter 1-50 characters./)).toBeInTheDocument();
+            //TODO: This message should be adjusted to due the new validation message from content team
+            expect(screen.getByText(/You should enter up to 50 characters./)).toBeInTheDocument();
         });
     });
 

--- a/packages/account/src/Sections/Profile/PersonalDetails/__tests__/personal-details-form.spec.tsx
+++ b/packages/account/src/Sections/Profile/PersonalDetails/__tests__/personal-details-form.spec.tsx
@@ -98,12 +98,12 @@ describe('<PersonalDetailsForm />', () => {
         });
     });
 
-    it('should display error for 2-50 characters length validation, for First name when entered characters are less than 2', async () => {
+    it('should display error for 1-50 characters length validation, for First name when entered characters are less than 1', async () => {
         renderComponent();
         await waitFor(() => {
             const last_name = screen.getByTestId('dt_last_name');
             userEvent.type(last_name, 'b');
-            expect(screen.getByText(/You should enter 2-50 characters./)).toBeInTheDocument();
+            expect(screen.getByText(/You should enter 1-50 characters./)).toBeInTheDocument();
         });
     });
 

--- a/packages/account/src/Sections/Profile/PersonalDetails/validation.ts
+++ b/packages/account/src/Sections/Profile/PersonalDetails/validation.ts
@@ -7,19 +7,25 @@ const getBaseSchema = () =>
     Yup.object().shape({
         first_name: Yup.string()
             .required(localize('First name is required.'))
-            .min(1, localize('You should enter 1-50 characters.'))
-            .max(50, localize('You should enter 1-50 characters.'))
+            //TODO: This message should be adjusted to due the new validation message from content team
+            .max(50, localize('You should enter at most 50 characters.'))
             .matches(
-                /^(?!.*\s{2,})[\p{L}\s'.-]{1,50}$/u,
-                localize('Letters, spaces, periods, hyphens, apostrophes only.')
+                /^(?!.*\s{2,})(?:[一-鿿㐀-䶿]{1,16}|[\p{L}\s'.-]{2,50})$/u,
+                //TODO: This message should be adjusted to due the new validation message from content team
+                localize(
+                    'Letters, spaces, periods, hyphens, apostrophes only. It should be 1-50 characters for Chinese Characters and 2-50 characters for other languages.'
+                )
             ),
         last_name: Yup.string()
             .required(localize('Last name is required.'))
-            .min(1, localize('You should enter 1-50 characters.'))
+            //TODO: This message should be adjusted to due the new validation message from content team
             .max(50, localize('You should enter 1-50 characters.'))
             .matches(
-                /^(?!.*\s{2,})[\p{L}\s'.-]{1,50}$/u,
-                localize('Letters, spaces, periods, hyphens, apostrophes only.')
+                /^(?!.*\s{2,})(?:[一-鿿㐀-䶿]{1,16}|[\p{L}\s'.-]{2,50})$/u,
+                //TODO: This message should be adjusted to due the new validation message from content team
+                localize(
+                    'Letters, spaces, periods, hyphens, apostrophes only. It should be 1-50 characters for Chinese Characters and 2-50 characters for other languages.'
+                )
             ),
         phone: Yup.string()
             .required(localize('Phone is required.'))

--- a/packages/account/src/Sections/Profile/PersonalDetails/validation.ts
+++ b/packages/account/src/Sections/Profile/PersonalDetails/validation.ts
@@ -7,18 +7,18 @@ const getBaseSchema = () =>
     Yup.object().shape({
         first_name: Yup.string()
             .required(localize('First name is required.'))
-            .min(2, localize('You should enter 2-50 characters.'))
-            .max(50, localize('You should enter 2-50 characters.'))
+            .min(1, localize('You should enter 1-50 characters.'))
+            .max(50, localize('You should enter 1-50 characters.'))
             .matches(
-                /^(?!.*\s{2,})[\p{L}\s'.-]{2,50}$/u,
+                /^(?!.*\s{2,})[\p{L}\s'.-]{1,50}$/u,
                 localize('Letters, spaces, periods, hyphens, apostrophes only.')
             ),
         last_name: Yup.string()
             .required(localize('Last name is required.'))
-            .min(2, localize('You should enter 2-50 characters.'))
-            .max(50, localize('You should enter 2-50 characters.'))
+            .min(1, localize('You should enter 1-50 characters.'))
+            .max(50, localize('You should enter 1-50 characters.'))
             .matches(
-                /^(?!.*\s{2,})[\p{L}\s'.-]{2,50}$/u,
+                /^(?!.*\s{2,})[\p{L}\s'.-]{1,50}$/u,
                 localize('Letters, spaces, periods, hyphens, apostrophes only.')
             ),
         phone: Yup.string()


### PR DESCRIPTION
## Changes:

- Change validation for first_name and last_name in set_account_setting to accept [1-50] characters instead of [2-50]

### Screenshots:

Please provide some screenshots of the change.
