### PR TITLE
chore: small fix for navbar icons

### DIFF
--- a/packages/core/src/sass/app/_common/layout/header.scss
+++ b/packages/core/src/sass/app/_common/layout/header.scss
@@ -153,11 +153,14 @@
 
     &__menu-left {
         justify-content: flex-start;
-        align-items: center;
         order: -1;
         display: inline-flex;
         flex: 1;
         height: #{$HEADER_HEIGHT - 1px};
+
+        @include desktop {
+            align-items: center;
+        }
 
         &-extensions {
             display: flex;


### PR DESCRIPTION
## Changes:

- Added only in desktop rule for `align-items: center`

### Screenshots:

<img width="327" alt="image" src="https://github.com/binary-com/deriv-app/assets/103104395/12c8fb48-7a8f-44a9-b669-402caab02442">
<img width="330" alt="image" src="https://github.com/binary-com/deriv-app/assets/103104395/57c61ea3-a692-4c5e-9d96-6aee1a61bcc9">
<img width="751" alt="image" src="https://github.com/binary-com/deriv-app/assets/103104395/2f5f62ed-918f-4a8a-81f6-714108aba4d4">