### PR TITLE
Update deriv-charts to 2.1.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "@deriv-com/utils": "^0.0.14",
                 "@deriv/api-types": "^1.0.172",
                 "@deriv/deriv-api": "^1.0.15",
-                "@deriv/deriv-charts": "^2.1.11",
+                "@deriv/deriv-charts": "^2.1.12",
                 "@deriv/js-interpreter": "^3.0.0",
                 "@deriv/quill-design": "^1.3.2",
                 "@deriv/quill-icons": "^1.21.1",
@@ -46,6 +46,7 @@
                 "@types/classnames": "^2.2.11",
                 "@types/copy-webpack-plugin": "^10.1.0",
                 "@types/css-modules": "^1.0.2",
+                "@types/dompurify": "^3.0.5",
                 "@types/js-cookie": "^3.0.1",
                 "@types/jsdom": "^20.0.0",
                 "@types/loadjs": "^4.0.1",
@@ -97,6 +98,7 @@
                 "css-minimizer-webpack-plugin": "^3.0.1",
                 "dayjs": "^1.11.10",
                 "deep-diff": "^1.0.2",
+                "dompurify": "^3.1.0",
                 "dotenv": "^8.2.0",
                 "downshift": "^8.2.2",
                 "embla-carousel-react": "8.0.0-rc12",
@@ -2991,9 +2993,9 @@
             }
         },
         "node_modules/@deriv/deriv-charts": {
-            "version": "2.1.11",
-            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.1.11.tgz",
-            "integrity": "sha512-h9Is5ARTXO7HxtBwGvjWXrlIT9TzzG40aIeAGvIVo63b1ExVR7pnyu9kmsp47h5ZJJVciN881AVK/rkz6jMrsQ==",
+            "version": "2.1.12",
+            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.1.12.tgz",
+            "integrity": "sha512-BVio2dS/dh+uGkB7bO89i52DapoEYqicvRb+LSEbNfGwDMcr/QUQ2uvSQBSXQvkEn2iQXb3M728AZKK2JcvcLg==",
             "dependencies": {
                 "@types/lodash.set": "^4.3.7",
                 "@welldone-software/why-did-you-render": "^3.3.8",
@@ -18358,6 +18360,14 @@
                 "@types/ms": "*"
             }
         },
+        "node_modules/@types/dompurify": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+            "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+            "dependencies": {
+                "@types/trusted-types": "*"
+            }
+        },
         "node_modules/@types/eslint": {
             "version": "7.29.0",
             "license": "MIT",
@@ -26353,6 +26363,11 @@
             "dependencies": {
                 "domelementtype": "1"
             }
+        },
+        "node_modules/dompurify": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.0.tgz",
+            "integrity": "sha512-yoU4rhgPKCo+p5UrWWWNKiIq+ToGqmVVhk0PmMYBK4kRsR3/qhemNFL8f6CFmBd4gMwm3F4T7HBoydP5uY07fA=="
         },
         "node_modules/domready": {
             "version": "1.0.8",

--- a/packages/bot-web-ui/package.json
+++ b/packages/bot-web-ui/package.json
@@ -74,7 +74,7 @@
         "@deriv/api-types": "^1.0.172",
         "@deriv/bot-skeleton": "^1.0.0",
         "@deriv/components": "^1.0.0",
-        "@deriv/deriv-charts": "^2.1.11",
+        "@deriv/deriv-charts": "^2.1.12",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",
         "@deriv/translations": "^1.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -105,7 +105,7 @@
         "@deriv/cfd": "^1.0.0",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv/deriv-charts": "^2.1.11",
+        "@deriv/deriv-charts": "^2.1.12",
         "@deriv/hooks": "^1.0.0",
         "@deriv/p2p": "^0.7.3",
         "@deriv/p2p-v2": "^1.0.0",

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -91,7 +91,7 @@
         "@deriv/api-types": "^1.0.172",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv/deriv-charts": "^2.1.11",
+        "@deriv/deriv-charts": "^2.1.12",
         "@deriv/hooks": "^1.0.0",
         "@deriv/reports": "^1.0.0",
         "@deriv/shared": "^1.0.0",


### PR DESCRIPTION
This PR updates @deriv/deriv-charts to 2.1.12