### PR TITLE
[WEBREL] / Ameerul / WEBREL-2701 Update ad button needs to be clicked twice to dismiss duplicate ad pop up

### DIFF
--- a/packages/p2p/src/pages/my-ads/create-ad-form.jsx
+++ b/packages/p2p/src/pages/my-ads/create-ad-form.jsx
@@ -5,7 +5,6 @@ import { Button, Div100vhContainer, Input, RadioGroup, Text, ThemedScrollbars } 
 import { formatMoney, isDesktop, isMobile } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
 import { useP2PExchangeRate, useP2PSettings } from '@deriv/hooks';
-import { reaction } from 'mobx';
 import FloatingRate from 'Components/floating-rate';
 import { Localize, localize } from 'Components/i18next';
 import { buy_sell } from 'Constants/buy-sell';
@@ -72,15 +71,7 @@ const CreateAdForm = () => {
         my_profile_store.getPaymentMethodsList();
         my_profile_store.getAdvertiserPaymentMethods();
 
-        const disposeApiErrorReaction = reaction(
-            () => my_ads_store.api_error_message,
-            () => {
-                if (my_ads_store.api_error_message) general_store.showModal({ key: 'AdCreateEditErrorModal' });
-            }
-        );
-
         return () => {
-            disposeApiErrorReaction();
             onCleanup();
         };
 


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- removed reaction to display modal in create-ad-form because it was already being handled in the store when user clicks the create ad button. The reaction caused it to create two modals instead of one

### Screenshots:

Please provide some screenshots of the change.
