### PR TITLE
Revert back secure version of checkout

### DIFF
--- a/.github/workflows/smoketests.yml
+++ b/.github/workflows/smoketests.yml
@@ -28,7 +28,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           
     - name: Checkout external repository with Cypress tests
-      uses: actions/checkout@v4
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       with:
         repository: deriv-com/e2e-deriv-app
 


### PR DESCRIPTION

## Changes:

It was perceived that this was causing the issue for the run of the action. But as it wasn't it's best to revert it back.

### Screenshots:

jim-deriv's initial change: 
<img width="728" alt="image" src="https://github.com/binary-com/deriv-app/assets/144238191/d1a57351-fdc3-495a-a3cf-fa63053200ce">

