### PR TITLE
Update deriv-charts to 2.1.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "@deriv-com/utils": "^0.0.14",
                 "@deriv/api-types": "^1.0.172",
                 "@deriv/deriv-api": "^1.0.15",
-                "@deriv/deriv-charts": "^2.1.12",
+                "@deriv/deriv-charts": "^2.1.13",
                 "@deriv/js-interpreter": "^3.0.0",
                 "@deriv/quill-design": "^1.3.2",
                 "@deriv/quill-icons": "^1.21.1",
@@ -2993,9 +2993,9 @@
             }
         },
         "node_modules/@deriv/deriv-charts": {
-            "version": "2.1.12",
-            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.1.12.tgz",
-            "integrity": "sha512-BVio2dS/dh+uGkB7bO89i52DapoEYqicvRb+LSEbNfGwDMcr/QUQ2uvSQBSXQvkEn2iQXb3M728AZKK2JcvcLg==",
+            "version": "2.1.13",
+            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.1.13.tgz",
+            "integrity": "sha512-TFTl7WxW+6Drms3W00mBQU81X/6nNeNns9+bdOgqD8dGNuGUHvF6v56Lp/F/JeJ8ppm0yT/kMdLbPrxg5BVeKQ==",
             "dependencies": {
                 "@types/lodash.set": "^4.3.7",
                 "@welldone-software/why-did-you-render": "^3.3.8",

--- a/packages/bot-web-ui/package.json
+++ b/packages/bot-web-ui/package.json
@@ -74,7 +74,7 @@
         "@deriv/api-types": "^1.0.172",
         "@deriv/bot-skeleton": "^1.0.0",
         "@deriv/components": "^1.0.0",
-        "@deriv/deriv-charts": "^2.1.12",
+        "@deriv/deriv-charts": "^2.1.13",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",
         "@deriv/translations": "^1.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -105,7 +105,7 @@
         "@deriv/cfd": "^1.0.0",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv/deriv-charts": "^2.1.12",
+        "@deriv/deriv-charts": "^2.1.13",
         "@deriv/hooks": "^1.0.0",
         "@deriv/p2p": "^0.7.3",
         "@deriv/p2p-v2": "^1.0.0",

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -91,7 +91,7 @@
         "@deriv/api-types": "^1.0.172",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv/deriv-charts": "^2.1.12",
+        "@deriv/deriv-charts": "^2.1.13",
         "@deriv/hooks": "^1.0.0",
         "@deriv/reports": "^1.0.0",
         "@deriv/shared": "^1.0.0",


### PR DESCRIPTION
This PR updates @deriv/deriv-charts to 2.1.13