### PR TITLE
[WALL] Lubega / WALL-3833 / Deposit locked welcome status description

### DIFF
--- a/packages/wallets/src/features/cashier/modules/DepositLocked/DepositLockedContent.tsx
+++ b/packages/wallets/src/features/cashier/modules/DepositLocked/DepositLockedContent.tsx
@@ -38,7 +38,7 @@ const getDepositLockedDesc = ({
         <WalletText align='center'>
             <Trans
                 components={components}
-                defaults={`You have reached the withdrawal limit. ${description}`}
+                defaults={unwelcomeStatus ? description : `You have reached the withdrawal limit. ${description}`}
                 values={{ values }}
             />
         </WalletText>


### PR DESCRIPTION
## Changes:

- [x] Update description for unwelcome_status for deposit locked

### Before:
![image](https://github.com/binary-com/deriv-app/assets/142860499/8f894e60-2c1b-4bce-94fc-906533e58f16)

### After:

<img width="1266" alt="image" src="https://github.com/binary-com/deriv-app/assets/142860499/e64565b0-6252-4182-8ca5-261d7b47f3c4">
