### PR TITLE
[REFACTORING] shontzu/bump-api-types-version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "@deriv-com/analytics": "1.4.13",
                 "@deriv-com/ui": "^1.14.5",
                 "@deriv-com/utils": "^0.0.20",
-                "@deriv/api-types": "^1.0.172",
+                "@deriv/api-types": "^1.0.322",
                 "@deriv/deriv-api": "^1.0.15",
                 "@deriv/deriv-charts": "^2.1.13",
                 "@deriv/js-interpreter": "^3.0.0",

--- a/packages/account-v2/package.json
+++ b/packages/account-v2/package.json
@@ -14,7 +14,7 @@
     "dependencies": {
         "@deriv-com/ui": "^1.14.5",
         "@deriv-com/utils": "^0.0.20",
-        "@deriv/api-types": "^1.0.172",
+        "@deriv/api-types": "^1.0.322",
         "@deriv/api-v2": "^1.0.0",
         "@deriv/quill-icons": "^1.22.4",
         "class-variance-authority": "^0.7.0",

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -30,7 +30,7 @@
     "dependencies": {
         "@binary-com/binary-document-uploader": "^2.4.8",
         "@deriv-com/analytics": "1.4.13",
-        "@deriv/api-types": "^1.0.172",
+        "@deriv/api-types": "^1.0.322",
         "@deriv/api": "^1.0.0",
         "@deriv/components": "^1.0.0",
         "@deriv/hooks": "^1.0.0",

--- a/packages/api-v2/package.json
+++ b/packages/api-v2/package.json
@@ -14,7 +14,7 @@
         "uuid": "^9.0.1"
     },
     "devDependencies": {
-        "@deriv/api-types": "^1.0.172",
+        "@deriv/api-types": "^1.0.322",
         "@testing-library/react": "^12.0.0",
         "@testing-library/react-hooks": "^7.0.2",
         "@testing-library/user-event": "^13.5.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -14,7 +14,7 @@
         "uuid": "^9.0.1"
     },
     "devDependencies": {
-        "@deriv/api-types": "^1.0.172",
+        "@deriv/api-types": "^1.0.322",
         "@testing-library/react": "^12.0.0",
         "@testing-library/react-hooks": "^7.0.2",
         "@testing-library/user-event": "^13.5.0",

--- a/packages/appstore/package.json
+++ b/packages/appstore/package.json
@@ -27,7 +27,7 @@
     "dependencies": {
         "@deriv-com/analytics": "1.4.13",
         "@deriv/account": "^1.0.0",
-        "@deriv/api-types": "^1.0.172",
+        "@deriv/api-types": "^1.0.322",
         "@deriv/cashier": "^1.0.0",
         "@deriv/cfd": "^1.0.0",
         "@deriv/components": "^1.0.0",

--- a/packages/bot-skeleton/package-lock.json
+++ b/packages/bot-skeleton/package-lock.json
@@ -75,7 +75,7 @@
             "version": "1.0.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@deriv/api-types": "^1.0.118",
+                "@deriv/api-types": "^1.0.322",
                 "@deriv/translations": "^1.0.0",
                 "@types/js-cookie": "^3.0.1",
                 "@types/react-loadable": "^5.5.6",

--- a/packages/bot-web-ui/package.json
+++ b/packages/bot-web-ui/package.json
@@ -72,7 +72,7 @@
     "dependencies": {
         "@datadog/browser-logs": "^5.11.0",
         "@deriv/api": "^1.0.0",
-        "@deriv/api-types": "^1.0.172",
+        "@deriv/api-types": "^1.0.322",
         "@deriv/bot-skeleton": "^1.0.0",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-charts": "^2.1.13",

--- a/packages/cashier/package.json
+++ b/packages/cashier/package.json
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@deriv/api": "^1.0.0",
-        "@deriv/api-types": "^1.0.172",
+        "@deriv/api-types": "^1.0.322",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
         "@deriv/hooks": "^1.0.0",

--- a/packages/cfd/package.json
+++ b/packages/cfd/package.json
@@ -87,7 +87,7 @@
         "@deriv-com/utils": "^0.0.20",
         "@deriv/account": "^1.0.0",
         "@deriv/api": "^1.0.0",
-        "@deriv/api-types": "^1.0.172",
+        "@deriv/api-types": "^1.0.322",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
         "@deriv/hooks": "^1.0.0",

--- a/packages/p2p/package.json
+++ b/packages/p2p/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@deriv-com/utils": "^0.0.20",
         "@deriv/api": "^1.0.0",
-        "@deriv/api-types": "^1.0.172",
+        "@deriv/api-types": "^1.0.322",
         "@deriv/components": "^1.0.0",
         "@deriv/hooks": "^1.0.0",
         "@deriv/shared": "^1.0.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -46,7 +46,7 @@
     },
     "dependencies": {
         "@deriv-com/analytics": "1.4.13",
-        "@deriv/api-types": "^1.0.172",
+        "@deriv/api-types": "^1.0.322",
         "@deriv/translations": "^1.0.0",
         "@types/js-cookie": "^3.0.1",
         "@types/react-loadable": "^5.5.6",

--- a/packages/stores/package.json
+++ b/packages/stores/package.json
@@ -12,7 +12,7 @@
         "react": "^17.0.2"
     },
     "devDependencies": {
-        "@deriv/api-types": "^1.0.172",
+        "@deriv/api-types": "^1.0.322",
         "@testing-library/react": "^12.0.0",
         "typescript": "^4.6.3",
         "react-router": "^5.2.0",

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -89,7 +89,7 @@
         "@cloudflare/stream-react": "^1.9.1",
         "@deriv-com/analytics": "1.4.13",
         "@deriv-com/utils": "^0.0.20",
-        "@deriv/api-types": "^1.0.172",
+        "@deriv/api-types": "^1.0.322",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
         "@deriv/deriv-charts": "^2.1.13",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -9,7 +9,7 @@
         "moment": "^2.29.2"
     },
     "devDependencies": {
-        "@deriv/api-types": "^1.0.172",
+        "@deriv/api-types": "^1.0.322",
         "@types/lodash.groupby": "^4.6.7",
         "@types/lodash.pickby": "^4.6.7",
         "typescript": "^4.6.3"


### PR DESCRIPTION
## Changes:

[this PR](https://github.com/binary-com/deriv-app/pull/14608) is failing because it is using`white_label_link` which is in v1.0.177 
current latest: v1.0.322

### Screenshots:
<img width="50%" alt="image" src="https://github.com/binary-com/deriv-app/assets/108507236/1407f7f6-f1dc-4f36-bf3c-c7ff044bac3c"> <img src="https://github.com/binary-com/deriv-app/assets/108507236/d2aa0659-b607-408d-954b-47429205151b" />
