### PR TITLE
[HOTFIX]/Mitra/WEBREL-2710/MT5 migration banner css issue

### DIFF
--- a/packages/cfd/src/Containers/migration-banner/index.ts
+++ b/packages/cfd/src/Containers/migration-banner/index.ts
@@ -1,4 +1,3 @@
 import MigrationBanner from './migration-banner';
-import './migration-banner.scss';
 
 export default MigrationBanner;

--- a/packages/cfd/src/Containers/migration-banner/migration-banner.tsx
+++ b/packages/cfd/src/Containers/migration-banner/migration-banner.tsx
@@ -13,6 +13,7 @@ import {
 } from '@deriv/shared';
 import { useCfdStore } from '../../Stores/Modules/CFD/Helpers/useCfdStores';
 import MigrationBannerImage from './migration-banner-image';
+import './migration-banner.scss';
 
 type TMigrationBannerProps = {
     is_trade_modal?: boolean;


### PR DESCRIPTION
## Changes:

To import CSS changes in the component itselve

### Screenshots:

Before fix:

![image](https://github.com/binary-com/deriv-app/assets/64970259/2ed77e46-d40b-40fe-9873-a028d7355ff5)

After Fix: 

<img width="1457" alt="Screenshot 2024-04-29 at 2 11 58 PM" src="https://github.com/binary-com/deriv-app/assets/64970259/98378339-f714-43bc-a08c-0272914cc784">

