### PR TITLE
[CFDS] [TRAH] shontzu/CFDS-3884/Add-the-functionality-of-Change-password-button-on-trademodal

### DIFF
--- a/packages/tradershub/src/components/Tooltip/Tooltip.classnames.ts
+++ b/packages/tradershub/src/components/Tooltip/Tooltip.classnames.ts
@@ -3,10 +3,10 @@ import { cva, VariantProps } from 'class-variance-authority';
 export const TooltipClass = cva('z-1 absolute invisible flex flex-col group-hover:visible', {
     variants: {
         alignment: {
-            bottom: 'top-1500 right-1',
-            left: 'top-1 right-2000',
-            right: 'top-1 left-2000',
-            top: 'bottom-1500 right-1',
+            bottom: 'top-full transform -translate-x-1/2',
+            left: 'right-full top-1/2 transform -translate-y-1/2',
+            right: 'left-full top-1/2 transform -translate-y-1/2',
+            top: 'bottom-full transform -translate-x-1/2',
         },
     },
 });
@@ -14,10 +14,10 @@ export const TooltipClass = cva('z-1 absolute invisible flex flex-col group-hove
 export const TooltipPointerClass = cva('absolute transform rotate-45 h-8 w-8 bg-system-light-active-background', {
     variants: {
         alignment: {
-            bottom: '-mb-1 bottom-28 right-1/2',
-            left: '-mb-1 top-12 -right-200',
-            right: '-mb-1 top-12 -left-200',
-            top: '-mb-1 top-28 right-1/2',
+            bottom: '-top-2 right-1/4 transform -translate-x-1/2',
+            left: 'top-1/2 -right-2 transform -translate-y-1/2',
+            right: 'top-1/2 -left-2 transform -translate-y-1/2',
+            top: '-bottom-2 right-1/4 transform -translate-x-1/2',
         },
     },
 });

--- a/packages/tradershub/src/features/cfd/screens/TradeScreen/TradeDetailsItem/TradeDetailsItem.tsx
+++ b/packages/tradershub/src/features/cfd/screens/TradeScreen/TradeDetailsItem/TradeDetailsItem.tsx
@@ -38,10 +38,16 @@ const TradeDetailsItem = ({ className, label, value, variant = 'clipboard' }: TT
                 )}
                 {variant === 'clipboard' && <Clipboard textCopy={value} />}
                 {variant === 'password' && (
-                    <Tooltip alignment='left' isVisible={isHovered && isDesktop} message='Change password'>
+                    <Tooltip alignment='bottom' isVisible={isHovered && isDesktop} message='Change password'>
                         <div ref={hoverRef}>
-                            <Button className='underline' color='white' size='sm' variant='ghost'>
-                                <EditIcon className='cursor-pointer' onClick={() => openModal('ChangePassword')} />
+                            <Button
+                                className='underline'
+                                color='white'
+                                onClick={() => openModal('ChangePassword')}
+                                size='sm'
+                                variant='ghost'
+                            >
+                                <EditIcon className='cursor-pointer' />
                             </Button>
                         </div>
                     </Tooltip>


### PR DESCRIPTION
## Changes:

this is for V2 (!standalone)
fixed the tooltip which is covering the button clickability and hiding the whole flow

### Screenshots:

<img src="https://github.com/binary-com/deriv-app/assets/108507236/4115597b-624e-492a-8fb0-5dcf8715e3c6" height="500" /><img src="https://github.com/binary-com/deriv-app/assets/108507236/bb4dee21-5170-425c-a4cd-eb7765a22587" height="500" /><img src="https://github.com/binary-com/deriv-app/assets/108507236/a89ab02e-9232-42f0-b94d-8a89ac43ab61" height="500" /><img src="https://github.com/binary-com/deriv-app/assets/108507236/cfa79d13-ed2f-454d-86ab-961e76df9b7a" height="500"/>

