### PR TITLE
[WALL] feat: fix icon component failing on new currencies

### DIFF
--- a/packages/wallets/src/components/WalletCurrencyIcon/WalletCurrencyIcon.tsx
+++ b/packages/wallets/src/components/WalletCurrencyIcon/WalletCurrencyIcon.tsx
@@ -92,6 +92,8 @@ const WalletCurrencyIcon: React.FC<TWalletCurrencyIconsProps> = ({
     const IconSize = rounded || isFiat ? roundedIconWidth[size] : defaultIconWidth[size];
     const Icon = rounded || isFiat ? roundedIcons[currency] : defaultIcons[currency];
 
+    if (!Icon) return null;
+
     return (
         <Icon
             className={className}


### PR DESCRIPTION
Fixed WalletCurrencyIcon so it does not fail on new currencies. 

Will raise separate PR with tests for that component. 
We also might want to implement default icon for such case - but thats out of scope for this PR. 