### PR TITLE
Re-add Github token

### DIFF
--- a/.github/workflows/smoketests.yml
+++ b/.github/workflows/smoketests.yml
@@ -48,7 +48,7 @@ jobs:
         # in GitHub repo → Settings → Secrets → Actions
         CYPRESS_RECORD_KEY: ${{ secrets.E2E_CYPRESS_RECORD_KEY }}
         # Creating a token https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
-        # GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # Set Base Url from client_payload.
         CYPRESS_BASE_URL: ${{ steps.vercel_preview_url.outputs.vercel_preview_url }}
         # Send PR details to Cypress test run
@@ -69,7 +69,7 @@ jobs:
         if [[ "${{ job.status }}" == "success" ]]; then
           echo "msg=:rocket: Smoke test run (${{ matrix.containers }}) passed successfully!" >> $GITHUB_OUTPUT
         else
-          echo "msg=:x: Smoke test run (${{ matrix.containers }}) failed. See logs for details: [Visit Action](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}})" >> $GITHUB_OUTPUT
+          # echo "msg=:x: Smoke test run (${{ matrix.containers }}) failed. See logs for details: [Visit Action](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}})" >> $GITHUB_OUTPUT
         fi
         
     - name: Leave comment


### PR DESCRIPTION
## Changes:

The github.event info isn't being pushed through to Cypress Cloud, which may be because we haven't supplied the token.
NB. I've temporarily removed the write to comments on failure, to avoid confusion with devs, whilst we're testing this.

### Screenshots:

<img width="873" alt="image" src="https://github.com/binary-com/deriv-app/assets/144238191/9b30cb41-211b-41b0-9080-1268b192e486">
