### PR TITLE
[BOT] Farabi/bot-1643/tablet view and switching between desktop and responsive

### DIFF
--- a/packages/bot-web-ui/src/components/bot-notification/bot-notification.scss
+++ b/packages/bot-web-ui/src/components/bot-notification/bot-notification.scss
@@ -12,7 +12,7 @@
         font-size: 1.4rem;
         font-family: inherit;
 
-        @include mobile {
+        @include mobile-tablet-mix {
             height: 4.4rem;
             min-height: 4.4rem;
             font-size: 1.2rem;
@@ -27,7 +27,7 @@
             inset-inline-start: 3.5rem;
             bottom: 6rem;
 
-            @include mobile {
+            @include mobile-tablet-mix {
                 inset-inline-start: 0;
                 bottom: 9rem;
                 padding: 0.8rem;
@@ -44,7 +44,7 @@
         margin-inline-start: 1.2rem;
         opacity: 0.8;
 
-        @include mobile {
+        @include mobile-tablet-mix {
             margin-inline-start: 1.2rem;
         }
 
@@ -53,7 +53,7 @@
             height: 2.2rem;
             width: 16px;
 
-            @include mobile {
+            @include mobile-tablet-mix {
                 height: 1.6rem;
             }
         }
@@ -77,7 +77,7 @@
         cursor: pointer;
         word-break: keep-all;
 
-        @include mobile {
+        @include mobile-tablet-mix {
             font-size: 1.2rem;
             margin-inline-start: 1.2rem;
         }

--- a/packages/bot-web-ui/src/components/run-panel/run-panel.scss
+++ b/packages/bot-web-ui/src/components/run-panel/run-panel.scss
@@ -47,7 +47,7 @@
         width: 35rem;
         background-color: var(--general-section-2);
 
-        @include mobile {
+        @include mobile-tablet-mix {
             margin: 0;
             position: fixed;
         }
@@ -132,7 +132,7 @@
         }
     }
     &__clear-button {
-        @include mobile {
+        @include mobile-tablet-mix {
             position: absolute !important;
             top: 0.5rem;
             right: 1.6rem;
@@ -223,7 +223,7 @@
         bottom: 0px;
         padding: 1.4rem;
         border-top: 2px solid var(--general-section-2);
-        @include mobile {
+        @include mobile-tablet-mix {
             position: absolute;
             width: 100%;
             bottom: 40px;
@@ -263,7 +263,7 @@
 }
 
 .limits__wrapper {
-    @include mobile {
+    @include mobile-tablet-mix {
         position: fixed;
         z-index: 5;
         width: 100%;
@@ -331,7 +331,7 @@
 }
 
 .dc-modal__container_statistics__modal {
-    @include mobile {
+    @include mobile-tablet-mix {
         width: 31.2rem !important;
     }
 
@@ -342,7 +342,7 @@
 
 .dc-dialog {
     &__button {
-        @include mobile {
+        @include mobile-tablet-mix {
             flex-basis: 100%;
             margin-left: unset;
         }

--- a/packages/bot-web-ui/src/components/summary/summary.scss
+++ b/packages/bot-web-ui/src/components/summary/summary.scss
@@ -3,6 +3,7 @@
     align-items: center;
     flex-direction: column;
     background-color: var(--general-section-2);
+    width: 100%;
     @include desktop {
         height: inherit;
     }

--- a/packages/bot-web-ui/src/components/trade-animation/trade-animation.scss
+++ b/packages/bot-web-ui/src/components/trade-animation/trade-animation.scss
@@ -208,7 +208,7 @@
 }
 
 .dc-modal__container_animation__modal {
-    @include mobile {
+    @include mobile-tablet-mix {
         width: 31.2rem !important;
     }
 }

--- a/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/form-wrappers/strategy-accordion.scss
+++ b/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/form-wrappers/strategy-accordion.scss
@@ -12,7 +12,7 @@
 
         padding-left: 0;
 
-        @include mobile {
+        @include mobile-tablet-mix {
             padding: 0.6rem 1rem;
         }
 
@@ -23,7 +23,7 @@
             border-bottom: none;
             padding: 0.6rem 0;
 
-            @include mobile {
+            @include mobile-tablet-mix {
                 padding: 0.6rem 0 0.6rem 1rem;
             }
         }
@@ -34,7 +34,7 @@
         text-align: start;
         padding-left: 1rem;
 
-        @include mobile {
+        @include mobile-tablet-mix {
             width: 100%;
             padding-left: 0;
         }
@@ -61,7 +61,7 @@
             opacity: 1;
             max-height: fit-content;
 
-            @include mobile {
+            @include mobile-tablet-mix {
                 padding-left: 1rem;
             }
         }

--- a/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/parts/loss-threshold-warning-dialog.scss
+++ b/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/parts/loss-threshold-warning-dialog.scss
@@ -14,19 +14,19 @@
             }
         }
         &__footer {
-            @include mobile {
+            @include mobile-tablet-mix {
                 display: flex;
                 width: 100%;
                 flex-wrap: unset;
             }
         }
         &__button:not(:last-child) {
-            @include mobile {
+            @include mobile-tablet-mix {
                 margin-right: 6px;
             }
         }
         &__button {
-            @include mobile {
+            @include mobile-tablet-mix {
                 margin-left: 6px;
             }
         }

--- a/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/quick-strategy.scss
+++ b/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/quick-strategy.scss
@@ -356,7 +356,7 @@
                 display: flex;
                 flex-direction: row-reverse;
 
-                @include mobile() {
+                @include mobile-tablet-mix {
                     top: -2.8rem;
                     right: 4rem;
                 }

--- a/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/quick-strategy.scss
+++ b/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/quick-strategy.scss
@@ -12,7 +12,7 @@
     --input-action-width: 4.6rem;
     --group-outer-padding: 1.6rem;
 
-    @include mobile() {
+    @include mobile-tablet-mix {
         --select-height: 4rem;
         --input-height: 3.4rem;
         --footer-height: 4.2rem;
@@ -56,7 +56,7 @@
             height: 72rem;
         }
 
-        @include mobile() {
+        @include mobile-tablet-mix {
             display: block;
         }
 
@@ -102,7 +102,7 @@
             position: relative;
             padding: 0.8rem;
 
-            @include mobile() {
+            @include mobile-tablet-mix {
                 width: 100%;
                 padding: 0;
             }
@@ -111,7 +111,7 @@
                 @include flex-center;
                 padding-bottom: 1rem;
 
-                @include mobile() {
+                @include mobile-tablet-mix {
                     padding: 0 1.6rem 1.6rem;
                     margin-top: 1.6rem;
                 }
@@ -123,7 +123,7 @@
                     border-radius: 0.6rem;
                     height: 4rem;
 
-                    @include mobile() {
+                    @include mobile-tablet-mix {
                         width: 100%;
                     }
 
@@ -135,7 +135,7 @@
                         border-radius: 0.4rem;
                         user-select: none;
 
-                        @include mobile() {
+                        @include mobile-tablet-mix {
                             min-width: auto;
                             width: 50%;
                         }
@@ -160,7 +160,7 @@
             &__description {
                 padding: 1rem 2.4rem;
 
-                @include mobile {
+                @include mobile-tablet-mix {
                     padding: 1rem;
                 }
             }
@@ -176,7 +176,7 @@
             &__form {
                 padding: 0 2.4rem;
 
-                @include mobile() {
+                @include mobile-tablet-mix {
                     padding: 0 1.6rem;
                 }
 
@@ -225,7 +225,7 @@
             margin-bottom: 1rem;
             overflow-y: auto;
 
-            @include mobile() {
+            @include mobile-tablet-mix {
                 margin-bottom: 0;
                 max-height: calc(100% - 12.2rem) !important;
             }
@@ -233,7 +233,7 @@
             &--no-footer {
                 max-height: 100% !important;
 
-                @include mobile() {
+                @include mobile-tablet-mix {
                     max-height: calc(100% - 8rem) !important;
                 }
             }
@@ -385,7 +385,7 @@
                 height: 2.4rem;
                 width: 2.4rem;
 
-                @include mobile() {
+                @include mobile-tablet-mix {
                     top: 50%;
                     left: 0;
                     transform: translateY(-50%);
@@ -431,7 +431,7 @@
                 font-weight: bold;
                 color: var(--text-general);
 
-                @include mobile {
+                @include mobile-tablet-mix {
                     text-align: center;
                 }
             }
@@ -521,7 +521,7 @@
                 left: 0.3rem;
                 color: var(--text-general);
 
-                @include mobile() {
+                @include mobile-tablet-mix {
                     left: 0.2rem;
                 }
 
@@ -540,7 +540,7 @@
                 right: 0.3rem;
                 color: var(--text-general);
 
-                @include mobile() {
+                @include mobile-tablet-mix {
                     right: 0.2rem;
                 }
 
@@ -619,7 +619,7 @@
                 span {
                     font-size: 1.2rem;
 
-                    @include mobile {
+                    @include mobile-tablet-mix {
                         font-size: 1.2rem;
                     }
                 }
@@ -642,7 +642,7 @@
             width: 100%;
             margin-bottom: 2rem;
 
-            @include mobile {
+            @include mobile-tablet-mix {
                 height: 36rem;
             }
 

--- a/packages/bot-web-ui/src/pages/bot-builder/toolbar/toolbar.scss
+++ b/packages/bot-web-ui/src/pages/bot-builder/toolbar/toolbar.scss
@@ -9,7 +9,7 @@
     inset-inline-start: 23.2rem;
     background-color: var(--general-main-1);
 
-    @include mobile {
+    @include mobile-tablet-mix {
         height: 64px;
         position: absolute;
         overflow-y: auto;
@@ -52,7 +52,7 @@
     &__section {
         display: flex;
 
-        @include mobile {
+        @include mobile-tablet-mix {
             flex-direction: row-reverse;
             height: 100%;
             column-gap: 1.6rem !important;
@@ -76,7 +76,7 @@
         width: 1.6rem;
         fill: var(--text-prominent);
 
-        @include mobile {
+        @include mobile-tablet-mix {
             margin: 1.2rem;
         }
     }
@@ -88,7 +88,7 @@
         &-btn {
             padding: 0 1.2rem;
             height: 4rem;
-            @include mobile {
+            @include mobile-tablet-mix {
                 padding: 0;
                 height: fit-content;
                 flex-direction: column;
@@ -113,7 +113,7 @@
         }
     }
     &__wrapper {
-        @include mobile {
+        @include mobile-tablet-mix {
             background-color: var(--general-main-1);
             position: absolute;
             top: 0;
@@ -140,7 +140,7 @@
     margin: 0.8rem;
     background-color: var(--border-normal);
 
-    @include mobile {
+    @include mobile-tablet-mix {
         transform: rotate(90deg);
         margin: 0;
     }

--- a/packages/bot-web-ui/src/pages/bot-builder/workspace.scss
+++ b/packages/bot-web-ui/src/pages/bot-builder/workspace.scss
@@ -4,7 +4,7 @@
     height: var(--bot-content-height);
     top: 0;
 
-    @include mobile {
+    @include mobile-tablet-mix {
         width: 100%;
     }
 }

--- a/packages/bot-web-ui/src/pages/chart/chart.scss
+++ b/packages/bot-web-ui/src/pages/chart/chart.scss
@@ -23,7 +23,7 @@
                 &.ciq-disabled {
                     display: none;
                 }
-                @include mobile {
+                @include mobile-tablet-mix {
                     min-width: 17rem;
                     max-width: 26rem;
                     width: auto;
@@ -61,7 +61,7 @@
         .sc-toolbar-widget {
             transition: transform 0.25s ease;
 
-            @include mobile {
+            @include mobile-tablet-mix {
                 background: transparent;
                 border-width: 0;
                 bottom: 20.8vh;

--- a/packages/bot-web-ui/src/pages/dashboard/dashboard.scss
+++ b/packages/bot-web-ui/src/pages/dashboard/dashboard.scss
@@ -5,14 +5,14 @@
     height: calc(100vh - 8.4rem);
     overflow: hidden;
 
-    @include mobile {
+    @include mobile-tablet-mix {
         height: calc(100vh - 3.4rem);
     }
 
     .toolbar__section {
         justify-content: end;
 
-        @include mobile {
+        @include mobile-tablet-mix {
             column-gap: 1rem;
         }
     }
@@ -50,7 +50,7 @@
             transform: translateX(calc(0px)) !important;
         }
 
-        @include mobile {
+        @include mobile-tablet-mix {
             transform: translateY(calc(-100% + 3.6rem));
         }
 
@@ -119,7 +119,7 @@
         &--tour-active {
             width: calc(100% - 36rem);
 
-            @include mobile {
+            @include mobile-tablet-mix {
                 width: 100%;
             }
         }
@@ -129,14 +129,14 @@
             &--listed {
                 margin-top: 0.6rem;
             }
-            @include mobile {
+            @include mobile-tablet-mix {
                 height: auto;
                 margin-top: 0;
             }
             .title {
                 text-align: center;
                 height: 7.2;
-                @include mobile {
+                @include mobile-tablet-mix {
                     height: auto;
                 }
             }
@@ -146,7 +146,7 @@
                 &__has-list {
                     margin-top: 0;
                     text-align: start;
-                    @include mobile {
+                    @include mobile-tablet-mix {
                         width: 85%;
                     }
                 }
@@ -156,6 +156,10 @@
         &__content {
             display: flex;
             align-items: flex-start;
+
+            @include mobile-tablet-mix {
+                display: unset;
+            }
 
             height: var(--tab-content-height);
             flex-grow: 1;
@@ -167,7 +171,7 @@
                 padding: 1.6rem 0 0;
             }
 
-            @include mobile {
+            @include mobile-tablet-mix {
                 height: calc(100vh - 19rem);
                 align-items: flex-start;
             }
@@ -179,7 +183,7 @@
                 flex: 1 1 56%;
                 &--active {
                     display: block;
-                    @include mobile {
+                    @include mobile-tablet-mix {
                         display: none;
                     }
                 }
@@ -205,7 +209,7 @@
                 width: 100%;
             }
 
-            @include mobile {
+            @include mobile-tablet-mix {
                 width: 100%;
                 padding: 0 1rem;
             }
@@ -228,7 +232,7 @@
         &__preview {
             height: calc(100% + 2rem);
 
-            @include mobile {
+            @include mobile-tablet-mix {
                 display: none;
             }
 
@@ -247,7 +251,7 @@
                     @include flex-center;
                     cursor: pointer;
 
-                    @include mobile {
+                    @include mobile-tablet-mix {
                         width: 3.2rem;
                         height: 3.2rem;
                         padding: 0.8rem;
@@ -333,7 +337,7 @@
                 font-size: 1.3rem;
                 text-align: center;
 
-                @include mobile {
+                @include mobile-tablet-mix {
                     flex-wrap: wrap;
                 }
 
@@ -359,7 +363,7 @@
                 flex-direction: column;
                 padding-inline-end: 2.4rem;
 
-                @include mobile {
+                @include mobile-tablet-mix {
                     padding: 1rem;
                 }
 
@@ -372,7 +376,7 @@
                     word-wrap: break-word;
                     text-align: center;
                     height: 4.2rem;
-                    @include mobile {
+                    @include mobile-tablet-mix {
                         height: auto;
                     }
                 }
@@ -397,7 +401,7 @@
                 padding: 1.6rem;
 
                 &--minimized {
-                    @include mobile {
+                    @include mobile-tablet-mix {
                         width: 6.4rem;
                         height: 6.4rem;
                         padding: 0.8rem;
@@ -421,7 +425,7 @@
         border-radius: 2.4rem;
         background-color: var(--general-section-1);
 
-        @include mobile {
+        @include mobile-tablet-mix {
             height: 3.2rem;
             width: 3.2rem;
             line-height: 3.6rem;
@@ -435,7 +439,7 @@
     &__icon {
         height: 24px;
         width: 24px;
-        @include mobile {
+        @include mobile-tablet-mix {
             height: 16px;
             width: 16px;
         }

--- a/packages/bot-web-ui/src/pages/dashboard/load-bot-preview/delete-dialog.scss
+++ b/packages/bot-web-ui/src/pages/dashboard/load-bot-preview/delete-dialog.scss
@@ -3,7 +3,7 @@
 .dc-dialog__delete-strategy--delete {
     .dc-dialog {
         &__footer {
-            @include mobile {
+            @include mobile-tablet-mix {
                 flex-wrap: unset;
                 @include flex-center(flex-end, flex-start);
                 width: 100%;

--- a/packages/bot-web-ui/src/pages/dashboard/load-bot-preview/index.scss
+++ b/packages/bot-web-ui/src/pages/dashboard/load-bot-preview/index.scss
@@ -11,7 +11,7 @@
         width: 100%;
 
         .dc-mobile-full-page-modal {
-            @include mobile {
+            @include mobile-tablet-mix {
                 width: 100%;
             }
 
@@ -24,7 +24,7 @@
         }
 
         & .dc-tabs {
-            @include mobile {
+            @include mobile-tablet-mix {
                 height: 100%;
                 display: unset;
                 flex: 1;
@@ -63,7 +63,7 @@
             }
         }
 
-        @include mobile {
+        @include mobile-tablet-mix {
             height: 100%;
             overflow: hidden;
             padding-inline-start: 0.5rem;
@@ -149,7 +149,7 @@
                 padding-top: 1.6rem;
             }
 
-            @include mobile {
+            @include mobile-tablet-mix {
                 height: 100%;
                 padding: 1.6rem;
             }
@@ -183,7 +183,7 @@
             flex-direction: column;
             position: relative;
 
-            @include mobile {
+            @include mobile-tablet-mix {
                 padding: 1.6rem;
                 height: calc(100% - 7.4rem); // - footer height
                 &--active {
@@ -192,7 +192,7 @@
             }
 
             &--listed {
-                @include mobile {
+                @include mobile-tablet-mix {
                     padding: 0;
                 }
             }
@@ -221,7 +221,7 @@
         @include flex-center;
         flex-direction: column;
 
-        @include mobile {
+        @include mobile-tablet-mix {
             border: dashed 0.2rem var(--border-normal);
             border-radius: $BORDER_RADIUS;
             margin: 1.6rem;
@@ -269,7 +269,7 @@
         padding: 1%;
     }
 
-    @include mobile {
+    @include mobile-tablet-mix {
         height: 100%;
         width: 100%;
         top: 0;
@@ -283,7 +283,7 @@
 }
 
 .dc-dialog {
-    @include mobile {
+    @include mobile-tablet-mix {
         &__wrapper--preview {
             top: 6.5rem;
 
@@ -374,14 +374,14 @@
         padding: 0 0.8rem;
         border-bottom: 1px solid var(--border-divider);
 
-        @include mobile {
+        @include mobile-tablet-mix {
             padding: 0;
         }
 
         &__label {
             padding: 0.8rem;
             width: 35%;
-            @include mobile {
+            @include mobile-tablet-mix {
                 width: 40%;
                 padding-inline-start: 0;
             }
@@ -389,7 +389,7 @@
         &__time-stamp {
             width: 20%;
             padding: 0.8rem;
-            @include mobile {
+            @include mobile-tablet-mix {
                 width: 25%;
                 padding-inline-end: 0;
             }
@@ -422,7 +422,7 @@
                 word-break: break-all;
             }
 
-            @include mobile {
+            @include mobile-tablet-mix {
                 width: 40%;
                 padding-inline-start: 0;
             }
@@ -431,7 +431,7 @@
         &__time-stamp {
             width: 20%;
             padding: 0.8rem;
-            @include mobile {
+            @include mobile-tablet-mix {
                 width: 25%;
             }
         }
@@ -458,7 +458,7 @@
                 }
             }
 
-            @include mobile {
+            @include mobile-tablet-mix {
                 width: 10%;
             }
 

--- a/packages/bot-web-ui/src/pages/dashboard/load-bot-preview/save-modal.scss
+++ b/packages/bot-web-ui/src/pages/dashboard/load-bot-preview/save-modal.scss
@@ -119,7 +119,7 @@ div.radio-group {
     top: 40px;
     z-index: 10;
 
-    @include mobile {
+    @include mobile-tablet-mix {
         form {
             display: flex;
             flex-direction: column;

--- a/packages/bot-web-ui/src/pages/main/main.scss
+++ b/packages/bot-web-ui/src/pages/main/main.scss
@@ -13,7 +13,7 @@
     width: 100%;
     height: calc(100vh - 9rem);
     padding: 1.6rem;
-    @include mobile {
+    @include mobile-tablet-mix {
         height: calc(100vh - 6rem);
         padding: 0;
     }
@@ -53,7 +53,7 @@
                 background: var(--general-section-1);
                 justify-content: start;
 
-                @include mobile {
+                @include mobile-tablet-mix {
                     overflow-x: auto;
                     overflow-y: hidden;
 
@@ -68,7 +68,7 @@
                 &--header {
                     &--main {
                         &__tabs {
-                            @include mobile {
+                            @include mobile-tablet-mix {
                                 width: 100%;
                                 overflow-x: auto;
                                 padding: 0.8rem 1.6rem 0;
@@ -78,14 +78,14 @@
                 }
 
                 &--border-bottom {
-                    @include mobile {
+                    @include mobile-tablet-mix {
                         border-bottom: 0;
                     }
                 }
             }
 
             &__content {
-                @include mobile {
+                @include mobile-tablet-mix {
                     width: 100%;
                     overflow-x: auto;
 
@@ -114,7 +114,7 @@
                         display: flex;
                         justify-content: space-between;
 
-                        @include mobile {
+                        @include mobile-tablet-mix {
                             flex-direction: column;
                             background-color: var(--general-section-1);
                         }
@@ -136,12 +136,18 @@
                     padding-inline-end: 0;
                     margin-inline-end: 0.8rem;
 
-                    @include mobile {
+                    @include mobile-tablet-mix {
                         margin-inline-end: 0.2rem;
                         // gave this -ve margin becaues we cannot
                         // overwrite the default core padding which
                         // will make the icon bigger
                         margin-top: -0.5rem;
+                    }
+                }
+
+                &__icon {
+                    @include mobile-tablet-mix {
+                        padding-top: 0.5rem;
                     }
                 }
             }
@@ -181,7 +187,7 @@
 }
 
 .bot-stopped-dialog {
-    @include mobile {
+    @include mobile-tablet-mix {
         padding: 2rem;
     }
 
@@ -204,7 +210,7 @@
             }
         }
 
-        @include mobile {
+        @include mobile-tablet-mix {
             &__footer {
                 flex-wrap: unset;
 
@@ -230,7 +236,7 @@
         width: 100%;
         transition: all 0.4s;
 
-        @include mobile {
+        @include mobile-tablet-mix {
             height: var(--tab-content-height-mobile);
             background: var(--general-main-1);
 
@@ -349,7 +355,7 @@
         .blocklyTrash {
             transition: all 0.4s;
 
-            @include mobile {
+            @include mobile-tablet-mix {
                 display: none;
             }
         }
@@ -369,7 +375,7 @@
         display: none;
     }
 
-    @include mobile {
+    @include mobile-tablet-mix {
         top: 5.6rem;
         inset-inline-start: 0;
         width: 100vw;
@@ -497,7 +503,7 @@
         &__left {
             margin: 0.3rem 0 0 1.2rem;
 
-            @include mobile {
+            @include mobile-tablet-mix {
                 margin: 0;
 
                 svg {

--- a/packages/bot-web-ui/src/pages/tutorials/quick-strategy-content/index.scss
+++ b/packages/bot-web-ui/src/pages/tutorials/quick-strategy-content/index.scss
@@ -7,7 +7,7 @@
         display: grid;
         grid-template-columns: repeat(2, 1fr);
 
-        @include mobile {
+        @include mobile-tablet-mix {
             width: 100%;
             grid-template-columns: 1fr;
         }
@@ -72,7 +72,7 @@
             padding: 1rem 0;
             width: 85%;
 
-            @include mobile {
+            @include mobile-tablet-mix {
                 height: calc(100vh - 16rem);
                 width: 100%;
             }
@@ -82,7 +82,7 @@
             width: 55%;
             margin-bottom: 4rem;
 
-            @include mobile {
+            @include mobile-tablet-mix {
                 height: 36rem;
                 width: 100%;
                 margin-bottom: 2rem;
@@ -104,7 +104,7 @@
             span {
                 font-size: 1.4rem;
 
-                @include mobile {
+                @include mobile-tablet-mix {
                     font-size: 1.2rem;
                 }
             }

--- a/packages/bot-web-ui/src/pages/tutorials/tutorials.scss
+++ b/packages/bot-web-ui/src/pages/tutorials/tutorials.scss
@@ -228,7 +228,7 @@
     }
 
     .dc-dialog__footer {
-        @include mobile {
+        @include mobile-tablet-mix {
             display: flex;
             flex-direction: column;
             height: unset;

--- a/packages/bot-web-ui/src/pages/tutorials/tutorials.scss
+++ b/packages/bot-web-ui/src/pages/tutorials/tutorials.scss
@@ -17,7 +17,7 @@
             border-radius: 0;
             position: relative;
             z-index: 1;
-            @include mobile {
+            @include mobile-tablet-mix {
                 width: 94%;
                 height: auto;
                 max-height: 80%;
@@ -54,12 +54,12 @@
         &__guides {
             display: flex;
             margin-top: 2.4rem;
-            @include mobile {
+            @include mobile-tablet-mix {
                 display: unset;
             }
         }
         &__title {
-            @include mobile {
+            @include mobile-tablet-mix {
                 margin-bottom: 1.4rem;
             }
         }
@@ -71,7 +71,7 @@
             text-align: center;
             flex-direction: column;
             margin-inline-end: 2.4rem;
-            @include mobile {
+            @include mobile-tablet-mix {
                 flex-direction: row;
                 width: auto;
                 span {
@@ -80,7 +80,7 @@
                 }
             }
         }
-        @include mobile {
+        @include mobile-tablet-mix {
             flex-direction: column;
             margin-bottom: 2.2rem;
         }
@@ -99,12 +99,12 @@
         background-size: 100% 100%;
         &__description {
             width: 28rem;
-            @include mobile {
+            @include mobile-tablet-mix {
                 text-align: start;
                 width: calc(100% - 14.8rem);
             }
         }
-        @include mobile {
+        @include mobile-tablet-mix {
             height: 8.7rem;
             width: 14.8rem;
             margin: 0;
@@ -117,7 +117,7 @@
             margin-inline-end: 0.8rem;
             width: 21.5rem;
             cursor: pointer;
-            @include mobile {
+            @include mobile-tablet-mix {
                 height: 8.7rem;
                 width: 14.8rem;
             }
@@ -133,7 +133,7 @@
             &--play {
                 filter: invert(1);
             }
-            @include mobile {
+            @include mobile-tablet-mix {
                 height: 6rem;
                 width: 8rem;
             }
@@ -155,7 +155,7 @@
         &__content {
             width: 85%;
 
-            @include mobile {
+            @include mobile-tablet-mix {
                 width: 100%;
             }
         }
@@ -172,14 +172,14 @@
                 &-content {
                     .loss-control {
                         width: 80%;
-                        @include mobile {
+                        @include mobile-tablet-mix {
                             width: 100%;
                         }
                     }
                     img {
                         width: 45%;
                     }
-                    @include mobile {
+                    @include mobile-tablet-mix {
                         width: 100%;
 
                         img {
@@ -202,7 +202,7 @@
         opacity: unset;
         transition: unset;
 
-        @include mobile {
+        @include mobile-tablet-mix {
             width: 90vw;
             padding: 1.6rem;
         }
@@ -290,7 +290,7 @@
                         border-color: var(--text-general);
                     }
 
-                    @include mobile {
+                    @include mobile-tablet-mix {
                         width: 100%;
                         margin-inline-start: 17px;
                         height: 4rem;
@@ -334,7 +334,7 @@
 
                 &--top {
                     display: flex;
-                    @include mobile {
+                    @include mobile-tablet-mix {
                         height: calc(100vh - 22rem);
                     }
                 }
@@ -405,7 +405,7 @@
         height: 4rem;
         margin-bottom: 1.5rem;
         @include flex-center;
-        @include mobile {
+        @include mobile-tablet-mix {
             .dc-select-native {
                 position: relative;
                 margin-inline-end: 17px;
@@ -457,7 +457,7 @@
     &__faq,
     &__qs-guide,
     &__search {
-        @include mobile {
+        @include mobile-tablet-mix {
             height: calc(var(--vh) - 280px);
             overflow: auto;
             .tutorials-wrap {
@@ -467,7 +467,7 @@
     }
 
     &__search {
-        @include mobile {
+        @include mobile-tablet-mix {
             .tutorials-wrap,
             .faq__wrapper {
                 overflow: unset;

--- a/packages/components/src/components/drawer/drawer.scss
+++ b/packages/components/src/components/drawer/drawer.scss
@@ -19,7 +19,7 @@
         left: calc(100vw - 16px);
     }
 
-    @include mobile {
+    @include mobile-tablet-mix {
         width: 100vw !important;
         height: calc(100% - 10.1rem) !important;
         top: calc(100% - 9.8rem) !important;
@@ -37,7 +37,7 @@
             padding-left: $toggler-width;
         }
 
-        @include mobile {
+        @include mobile-tablet-mix {
             height: calc(100% - 3.6rem);
         }
     }
@@ -70,7 +70,7 @@
         background-color: var(--general-section-5);
         cursor: pointer;
 
-        @include mobile {
+        @include mobile-tablet-mix {
             position: unset;
             width: 100%;
             height: 3.6rem;
@@ -87,7 +87,7 @@
                 transform: rotate(180deg);
             }
 
-            @include mobile {
+            @include mobile-tablet-mix {
                 width: 2.5rem;
                 height: 0.8rem;
                 transform: rotate(0);
@@ -101,13 +101,13 @@
                 transform: rotate(0);
             }
 
-            @include mobile {
+            @include mobile-tablet-mix {
                 transform: rotate(180deg);
             }
         }
     }
     &--open {
-        @include mobile {
+        @include mobile-tablet-mix {
             transform: translateY(calc(-100% + 3.6rem));
         }
     }

--- a/packages/components/src/components/drawer/drawer.tsx
+++ b/packages/components/src/components/drawer/drawer.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import React from 'react';
 import Icon from '../icon';
-import { isTabletDrawer } from '@deriv/shared';
+import { useStore } from '@deriv/stores';
 
 type TDrawer = {
     anchor?: string;
@@ -38,6 +38,8 @@ const Drawer = ({
     ...props
 }: React.PropsWithChildren<TDrawer>) => {
     const [is_open, setIsOpen] = React.useState(props.is_open);
+    const { ui } = useStore();
+    const { is_mobile } = ui;
 
     React.useEffect(() => {
         setIsOpen(props.is_open);
@@ -49,10 +51,6 @@ const Drawer = ({
             props.toggleDrawer(!is_open);
         }
     };
-
-    // Note: Cannot use isMobile from @deriv/shared due to dimension change error
-    // TODO: Maybe we can fix isMobile in @deriv/shared
-    const is_mobile = isTabletDrawer();
 
     return (
         <div

--- a/packages/core/src/Constants/ui.js
+++ b/packages/core/src/Constants/ui.js
@@ -1,2 +1,6 @@
-export const MAX_MOBILE_WIDTH = 767;
+import { isBot } from '@deriv/shared';
+
+const is_bot = isBot();
+
+export const MAX_MOBILE_WIDTH = is_bot ? 1023 : 767;
 export const MAX_TABLET_WIDTH = 1024;

--- a/packages/core/src/index.html
+++ b/packages/core/src/index.html
@@ -250,37 +250,6 @@
         <div id="modal_root_absolute" class="modal-root modal-root--absolute"></div>
         <!-- modal_root has background color. So, it cannot be used for toast messages. For those cases popup_root is used -->
         <div id="popup_root" class="popup-root"></div>
-        <!-- Temporary Mobile Landscape UI Blocker -->
-        <div id="landscape_blocker" class="landscape-blocker">
-            <div class="landscape-blocker__icon">
-                <svg xmlns="http://www.w3.org/2000/svg" width="80" height="62" fill="none">
-                    <path
-                        fill="#85ACB0"
-                        d="M52.308 62H9.23a9.204 9.204 0 0 1-6.524-2.727A9.345 9.345 0 0 1 0 52.7V9.3a9.344 9.344 0 0 1 2.707-6.573A9.205 9.205 0 0 1 9.23 0h61.538a9.204 9.204 0 0 1 6.524 2.727A9.345 9.345 0 0 1 80 9.3v24.8a3.104 3.104 0 0 1-1.538 2.685 3.058 3.058 0 0 1-3.077 0 3.104 3.104 0 0 1-1.539-2.685V9.3a3.117 3.117 0 0 0-.902-2.19 3.07 3.07 0 0 0-2.175-.91H9.231a3.07 3.07 0 0 0-2.175.91 3.116 3.116 0 0 0-.902 2.19v43.4c.001.822.325 1.61.902 2.19a3.07 3.07 0 0 0 2.175.91h43.077c1.1 0 2.115.59 2.664 1.55.55.959.55 2.14 0 3.1A3.073 3.073 0 0 1 52.308 62Z"
-                    />
-                    <path
-                        fill="#FF444F"
-                        d="M76.923 62H64.615c-1.1 0-2.115-.592-2.664-1.55a3.121 3.121 0 0 1 0-3.1 3.073 3.073 0 0 1 2.664-1.55h9.231v-9.3c0-1.109.587-2.132 1.539-2.686a3.058 3.058 0 0 1 3.076 0A3.104 3.104 0 0 1 80 46.5v12.4c0 .822-.324 1.611-.901 2.192a3.066 3.066 0 0 1-2.176.908ZM52.352 31.045h12.307c1.1 0 2.116.59 2.665 1.55.55.96.55 2.14 0 3.1a3.072 3.072 0 0 1-2.665 1.55h-9.23v9.3a3.104 3.104 0 0 1-1.539 2.685 3.058 3.058 0 0 1-3.077 0 3.104 3.104 0 0 1-1.538-2.685v-12.4c0-.822.324-1.61.9-2.192a3.066 3.066 0 0 1 2.177-.908Z"
-                    />
-                    <path
-                        fill="#85ACB0"
-                        d="M33.846 18.6H3.077c-1.1 0-2.115-.591-2.665-1.55-.55-.96-.55-2.141 0-3.1a3.073 3.073 0 0 1 2.665-1.55h30.77a3.07 3.07 0 0 0 2.174-.91 3.117 3.117 0 0 0 .902-2.19V3.1c0-1.108.587-2.131 1.539-2.685a3.058 3.058 0 0 1 3.076 0A3.104 3.104 0 0 1 43.078 3.1v6.2a9.344 9.344 0 0 1-2.707 6.573 9.205 9.205 0 0 1-6.524 2.727Z"
-                    />
-                    <path
-                        fill="#FF444F"
-                        d="M76.923 62a3.055 3.055 0 0 1-2.175-.909L54.66 40.852c-.755-.787-1.042-1.917-.755-2.973a3.092 3.092 0 0 1 2.154-2.17c1.048-.29 2.17 0 2.951.76l20.088 20.24a3.114 3.114 0 0 1 0 4.384 3.064 3.064 0 0 1-2.175.907Z"
-                    />
-                </svg>
-            </div>
-            <!-- Since its temporary blocker and landscape will be designed with multilingual support, we can ignore localization for text below -->
-            <div class="landscape-blocker__message--landscape">Please adjust your screen size for optimal viewing.</div>
-            <div class="landscape-blocker__message--portrait">
-                Please adjust your <br />
-                screen size for <br />
-                optimal viewing.
-            </div>
-        </div>
-        <!-- End Temporary Mobile Landscape UI Blocker -->
         <!-- LiveChat script -->
         <script type="text/javascript">
             window.__lc = window.__lc || {};

--- a/packages/core/src/sass/app/_common/components/platform-dropdown.scss
+++ b/packages/core/src/sass/app/_common/components/platform-dropdown.scss
@@ -9,7 +9,7 @@
     opacity: 0;
     transition: opacity 0.25s ease;
 
-    @include mobile {
+    @include mobile-tablet-mix {
         position: absolute;
 
         .platform-dropdown__list {
@@ -52,7 +52,7 @@
             color: var(--text-loss-danger);
         }
 
-        @include mobile {
+        @include mobile-tablet-mix {
             position: relative;
             padding: 1rem 0 0 1.3rem;
             text-align: center;
@@ -110,7 +110,7 @@
             &:not(.active):hover {
                 background: var(--state-hover);
             }
-            @include mobile {
+            @include mobile-tablet-mix {
                 width: 302px;
             }
         }

--- a/packages/core/src/sass/app/_common/layout/header.scss
+++ b/packages/core/src/sass/app/_common/layout/header.scss
@@ -184,7 +184,7 @@
         &--hidden {
             display: none;
         }
-        @include mobile {
+        @include mobile-tablet-mix {
             .acc-info__separator {
                 display: none;
             }
@@ -373,7 +373,7 @@
         margin-right: 0.8rem;
         vertical-align: middle;
     }
-    @include mobile {
+    @include mobile-tablet-mix {
         height: $MOBILE_HEADER_HEIGHT;
 
         .header__menu-left,

--- a/packages/shared/src/utils/screen/responsive.ts
+++ b/packages/shared/src/utils/screen/responsive.ts
@@ -1,3 +1,5 @@
+import { isBot } from '../platform';
+
 declare global {
     interface Navigator {
         msMaxTouchPoints: number;
@@ -8,7 +10,9 @@ declare global {
     }
 }
 
-export const MAX_MOBILE_WIDTH = 926; // iPhone 12 Pro Max has the world largest viewport size of 428 x 926
+const is_bot = isBot();
+
+export const MAX_MOBILE_WIDTH = is_bot ? 1023 : 926; // iPhone 12 Pro Max has the world largest viewport size of 428 x 926
 export const MAX_TABLET_WIDTH = 1081;
 
 export const isTouchDevice = () =>

--- a/packages/shared/src/utils/screen/responsive.ts
+++ b/packages/shared/src/utils/screen/responsive.ts
@@ -21,4 +21,3 @@ export const isTouchDevice = () =>
 export const isMobile = () => window.innerWidth <= MAX_MOBILE_WIDTH;
 export const isDesktop = () => isTablet() || window.innerWidth > MAX_TABLET_WIDTH; // TODO: remove tablet once there is a design for the specific size.
 export const isTablet = () => MAX_MOBILE_WIDTH < window.innerWidth && window.innerWidth <= MAX_TABLET_WIDTH;
-export const isTabletDrawer = () => window.innerWidth < 768;


### PR DESCRIPTION
## Changes:

- Removed mobile landscape UI blocker to enable tablet view
- Updated the breakpoint for `max_mobile_width` on ui constants only for deriv bot
- Used `mobile-tablet-mix` mixin instead of mobile to fix responsive issues.
 
### Screenshots:

<img width="1005" alt="Screenshot 2024-04-30 at 3 10 42 PM" src="https://github.com/binary-com/deriv-app/assets/102643568/8ea9802a-9f87-4c74-8058-b19e10d70d90">
