### PR TITLE
[CFDS]/Hasan/CFDS-3891/tooltip overflow issue

### DIFF
--- a/packages/tradershub/src/components/Tooltip/Tooltip.classnames.ts
+++ b/packages/tradershub/src/components/Tooltip/Tooltip.classnames.ts
@@ -1,9 +1,9 @@
 import { cva, VariantProps } from 'class-variance-authority';
 
-export const TooltipClass = cva('z-1 absolute invisible flex flex-col group-hover:visible', {
+export const TooltipClass = cva('z-10 absolute invisible flex flex-col peer-hover:visible', {
     variants: {
         alignment: {
-            bottom: 'top-full transform -translate-x-1/2',
+            bottom: 'top-full right-0',
             left: 'right-full top-1/2 transform -translate-y-1/2',
             right: 'left-full top-1/2 transform -translate-y-1/2',
             top: 'bottom-full transform -translate-x-1/2',

--- a/packages/tradershub/src/components/Tooltip/Tooltip.tsx
+++ b/packages/tradershub/src/components/Tooltip/Tooltip.tsx
@@ -33,8 +33,8 @@ type TTooltipProps = {
  */
 const Tooltip = ({ alignment = 'bottom', children, className, message }: TTooltipProps) => {
     return (
-        <div className='relative w-max h-max group z-1'>
-            <div className='border rounded-md border-neutral-12'>{children}</div>
+        <div className='relative w-max h-max z-1'>
+            <div className='border rounded-md border-neutral-12 peer'>{children}</div>
 
             <div className={twMerge(TooltipClass({ alignment }), className)}>
                 <div className={twMerge(TooltipPointerClass({ alignment }), className)} />


### PR DESCRIPTION
## Changes:

* Fixed: tooltip overflow and alignment issue

### Screenshots:

**Before:**
<img width="778" alt="Screenshot 2024-04-30 at 4 11 40 PM" src="https://github.com/binary-com/deriv-app/assets/126637868/2b82ead1-1ca1-4120-ba6a-8f9e0e959daf">

**After:**
<img width="724" alt="Screenshot 2024-04-30 at 4 13 17 PM" src="https://github.com/binary-com/deriv-app/assets/126637868/0a7944b7-d034-4bed-aa0a-ea977d852c82">

