### PR TITLE
[WALL] aum / WALL-3679 / wallets-traders-hub-white-bg

### DIFF
--- a/packages/wallets/src/components/DesktopWalletsList/DesktopWalletsList.scss
+++ b/packages/wallets/src/components/DesktopWalletsList/DesktopWalletsList.scss
@@ -5,4 +5,6 @@
     display: flex;
     flex-direction: column;
     gap: 2.4rem;
+    border: 1px solid #ebecef;
+    border-radius: 1.6rem;
 }

--- a/packages/wallets/src/components/WalletsAddMoreCarousel/WalletsAddMoreCarousel.scss
+++ b/packages/wallets/src/components/WalletsAddMoreCarousel/WalletsAddMoreCarousel.scss
@@ -21,7 +21,7 @@
     &__carousel {
         overflow: hidden;
         background-color: #fff;
-        padding: 3.2rem 2.4rem;
+        padding: 3.2rem 0;
         border-radius: 0.8rem;
         position: relative;
         height: 100%;

--- a/packages/wallets/src/components/WalletsAddMoreCarousel/WalletsAddMoreCarousel.tsx
+++ b/packages/wallets/src/components/WalletsAddMoreCarousel/WalletsAddMoreCarousel.tsx
@@ -47,7 +47,7 @@ const WalletsAddMoreCarousel: React.FC = () => {
     return (
         <div className='wallets-add-more' ref={hoverRef}>
             <div className='wallets-add-more__header'>
-                <WalletText size='2xl' weight='bold'>
+                <WalletText size='xl' weight='bold'>
                     Add more Wallets
                 </WalletText>
             </div>

--- a/packages/wallets/src/routes/WalletsListingRoute/WalletsListingRoute.scss
+++ b/packages/wallets/src/routes/WalletsListingRoute/WalletsListingRoute.scss
@@ -6,10 +6,7 @@
     align-items: center;
     justify-content: center;
     gap: 2.4rem;
-
-    @include mobile {
-        background-color: var(--general-main-1, #ffffff);
-    }
+    background-color: var(--general-main-1, #ffffff);
 
     @include desktop {
         padding: 4rem;


### PR DESCRIPTION
## Changes:

- Change the Trader's Hub with Wallets background in desktop to white.
- Add border radius and color for DesktopWalletsList.

### Screenshots:

https://github.com/binary-com/deriv-app/assets/125039206/19a63c86-37d7-4a8f-8ae1-2cfe2a6f5f49