### PR TITLE
[WALL] aum / WALL-3816 / fix-DatePicker-overlap-Dropzone-in-doc-upload

### DIFF
--- a/packages/wallets/src/components/DatePicker/DatePicker.scss
+++ b/packages/wallets/src/components/DatePicker/DatePicker.scss
@@ -26,6 +26,7 @@ abbr[title] {
         display: inline-block;
         width: 28rem;
         transform: translateY(4rem);
+        z-index: 1;
 
         @include mobile {
             align-self: center;


### PR DESCRIPTION
## Changes:

Fix the overlapping of document preview of Dropzone on DatePicker by adding z-index to DatePicker

### Screenshots:

<img height="400" alt="Screenshot 2024-05-01 at 11 08 22 AM" src="https://github.com/binary-com/deriv-app/assets/125039206/1706b5aa-c35d-4ead-bbc1-4af30c0b278a">

<img height="400" alt="Screenshot 2024-05-01 at 11 07 54 AM" src="https://github.com/binary-com/deriv-app/assets/125039206/4fe02234-5ee1-44c5-a729-5c5641aca00b">


