### PR TITLE
[WALL] aum / WALL-3530 / wallets-header-design-changes

### DIFF
--- a/packages/wallets/src/components/Base/WalletDropdown/WalletDropdown.tsx
+++ b/packages/wallets/src/components/Base/WalletDropdown/WalletDropdown.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import classNames from 'classnames';
 import { useCombobox } from 'downshift';
-import { LabelPairedChevronDownLgBoldIcon } from '@deriv/quill-icons';
+import { LabelPairedChevronDownLgFillIcon } from '@deriv/quill-icons';
 import { TGenericSizes } from '../../../types';
 import reactNodeToString from '../../../utils/react-node-to-string';
 import { WalletText } from '../WalletText';
@@ -133,7 +133,7 @@ const WalletDropdown: React.FC<TProps> = ({
                                 'wallets-dropdown__button--active': isOpen,
                             })}
                         >
-                            <LabelPairedChevronDownLgBoldIcon />
+                            <LabelPairedChevronDownLgFillIcon />
                         </button>
                     )}
                     showMessageContainer={showMessageContainer}

--- a/packages/wallets/src/components/WalletCurrencyCard/WalletCurrencyCard.scss
+++ b/packages/wallets/src/components/WalletCurrencyCard/WalletCurrencyCard.scss
@@ -6,8 +6,8 @@
     border-radius: 0.4rem;
 
     &--lg {
-        min-width: 12.2rem;
-        min-height: 7.5rem;
+        width: 12.8rem;
+        height: 8rem;
         padding: 1rem 1.6rem;
     }
 

--- a/packages/wallets/src/components/WalletListCard/WalletListCard.scss
+++ b/packages/wallets/src/components/WalletListCard/WalletListCard.scss
@@ -25,9 +25,5 @@
         gap: 2.4rem;
         align-self: stretch;
         border-radius: 1.6rem;
-
-        &-icon {
-            padding-top: 0.8rem;
-        }
     }
 }

--- a/packages/wallets/src/components/WalletListCard/WalletListCard.tsx
+++ b/packages/wallets/src/components/WalletListCard/WalletListCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useActiveWalletAccount } from '@deriv/api-v2';
-import { WalletCurrencyIcon } from '../WalletCurrencyIcon';
-import WalletListCardDetails from '../WalletListCardDetails/WalletListCardDetails';
+import { WalletCurrencyCard } from '../WalletCurrencyCard';
+import { WalletListCardDetails } from '../WalletListCardDetails';
 import './WalletListCard.scss';
 
 const WalletListCard = () => {
@@ -14,9 +14,7 @@ const WalletListCard = () => {
         <div className='wallets-list-header__card_container'>
             <div className='wallets-list-header__content'>
                 <div className='wallets-list-header__details-container'>
-                    <div className='wallets-list-header__details-container-icon'>
-                        <WalletCurrencyIcon currency={isDemo ? 'DEMO' : currency} rounded size='xl' />
-                    </div>
+                    <WalletCurrencyCard currency={isDemo ? 'Demo' : currency} isDemo={isDemo} size='lg' />
                     <WalletListCardDetails />
                 </div>
             </div>

--- a/packages/wallets/src/components/WalletListCard/__tests__/WalletListCard.spec.tsx
+++ b/packages/wallets/src/components/WalletListCard/__tests__/WalletListCard.spec.tsx
@@ -20,8 +20,8 @@ jest.mock('../../WalletListCardDetails/WalletListCardDetails', () => ({
     default: jest.fn(() => <div>Mocked WalletListCardDetails</div>),
 }));
 
-jest.mock('../../WalletCurrencyIcon', () => ({
-    WalletCurrencyIcon: jest.fn(() => <div>Mocked WalletCurrencyIcon</div>),
+jest.mock('../../WalletCurrencyCard', () => ({
+    WalletCurrencyCard: jest.fn(() => <div>Mocked WalletCurrencyCard</div>),
 }));
 
 describe('WalletListCard', () => {
@@ -36,7 +36,7 @@ describe('WalletListCard', () => {
     it('should render with components correctly', () => {
         render(<WalletListCard />);
 
-        expect(screen.getByText('Mocked WalletCurrencyIcon')).toBeInTheDocument();
+        expect(screen.getByText('Mocked WalletCurrencyCard')).toBeInTheDocument();
         expect(screen.getByText('Mocked WalletListCardDetails')).toBeInTheDocument();
     });
 
@@ -48,7 +48,7 @@ describe('WalletListCard', () => {
         });
         render(<WalletListCard />);
 
-        expect(screen.getByText('Mocked WalletCurrencyIcon')).toBeInTheDocument();
+        expect(screen.getByText('Mocked WalletCurrencyCard')).toBeInTheDocument();
         expect(screen.getByText('Mocked WalletListCardDetails')).toBeInTheDocument();
     });
 });

--- a/packages/wallets/src/components/WalletListCardDetails/WalletListCardDetails.scss
+++ b/packages/wallets/src/components/WalletListCardDetails/WalletListCardDetails.scss
@@ -5,11 +5,12 @@
         justify-content: center;
         align-items: flex-start;
         flex: 1 0 0;
+        gap: 0.8rem;
     }
 
     &__content {
         display: flex;
-        gap: 1.6rem;
+        gap: 0.8rem;
         flex-direction: column;
         align-items: flex-start;
     }


### PR DESCRIPTION
## Changes:

- Replaced WalletCurrencyIcon with WalletCurrencyCard for the header.
- Replaced bold chevron with filled chevron.
- Add gap between active wallet name (dropdown) and balance.

### Screenshots:

https://github.com/binary-com/deriv-app/assets/125039206/480afeba-0951-445c-9e49-06d3c6b50330