### PR TITLE
Hirad/CFDs-3925/ Fixed the issue of wrong balance shown in trade modal

### DIFF
--- a/packages/cfd/src/Containers/ctrader-derivx-trade-modal.tsx
+++ b/packages/cfd/src/Containers/ctrader-derivx-trade-modal.tsx
@@ -216,7 +216,11 @@ const CTraderDerivXTradeModal = ({
                             weight='bold'
                         >
                             <Money
-                                amount={is_real ? ctrader_total_balance : ctrader_derivx_trade_account.display_balance}
+                                amount={
+                                    is_real && platform === CFD_PLATFORMS.CTRADER
+                                        ? ctrader_total_balance
+                                        : ctrader_derivx_trade_account.display_balance
+                                }
                                 currency={ctrader_derivx_trade_account.currency}
                                 has_sign={
                                     !!ctrader_derivx_trade_account.balance && ctrader_derivx_trade_account.balance < 0


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.

cTrader account balance is showing in DerivX trade modal. Account balance is correctly reflecting in TH .

### Screenshots:

Please provide some screenshots of the change.

<img width="629" alt="image" src="https://github.com/binary-com/deriv-app/assets/91878582/713decc4-d2dd-48c5-885a-ace0d2c08295">

