### PR TITLE
[WALL] Fix notifications misalign in cashier wallets

### DIFF
--- a/packages/core/src/App/Containers/NotificationsDialog/notification-list-wrapper.tsx
+++ b/packages/core/src/App/Containers/NotificationsDialog/notification-list-wrapper.tsx
@@ -17,7 +17,7 @@ const NotificationListWrapperForwardRef = React.forwardRef(
         const { is_mobile } = ui;
 
         const traders_hub = window.location.pathname === routes.traders_hub;
-        const wallets_path = window.location.pathname === routes.wallets;
+        const wallets_path = window.location.pathname.startsWith(routes.wallets);
 
         return (
             <div


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- Fixed an issue where the notifications are misaligned when in Wallets cashier
### Before
![image](https://github.com/binary-com/deriv-app/assets/103016120/7505cf25-3d59-4a72-b4b2-e7262c88e976)

### After
<img width="1728" alt="Screenshot 2024-05-03 at 3 20 33 PM" src="https://github.com/binary-com/deriv-app/assets/103016120/2e1dffd7-444d-4a6a-a20c-d20184488cfb">


### Screenshots:

Please provide some screenshots of the change.
