### PR TITLE
[WALL] Aizad/WALL-3900/Re-add Buttons inside of Compare Account Page

### DIFF
--- a/packages/wallets/src/components/Base/IconButton/IconButton.scss
+++ b/packages/wallets/src/components/Base/IconButton/IconButton.scss
@@ -75,8 +75,15 @@ $border-radius-map: (
     @each $color, $values in $color-map {
         &__color--#{$color} {
             background-color: map-get($values, backgroundcolor);
-            &:hover {
-                background-color: map-get($values, hover);
+            @include desktop {
+                &:hover {
+                    background-color: map-get($values, hover);
+                }
+            }
+            @include mobile {
+                &:active {
+                    background-color: map-get($values, hover);
+                }
             }
         }
     }

--- a/packages/wallets/src/features/cfd/components/CompareAccountsCarousel/CompareAccountsCarouselButton.scss
+++ b/packages/wallets/src/features/cfd/components/CompareAccountsCarousel/CompareAccountsCarouselButton.scss
@@ -26,8 +26,4 @@
         opacity: 0.3;
         display: none;
     }
-
-    @include mobile {
-        display: none;
-    }
 }

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/CompareAccountsScreen.tsx
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/CompareAccountsScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { useActiveWalletAccount, useCFDAccountsList, useCFDCompareAccounts } from '@deriv/api-v2';
 import { CompareAccountsCarousel } from '../../components';
-import CFDCompareAccountsCard from './CompareAccountsCard';
+import CompareAccountsCard from './CompareAccountsCard';
 import { isCTraderAccountAdded, isDxtradeAccountAdded } from './compareAccountsConfig';
 import CompareAccountsHeader from './CompareAccountsHeader';
 import './CompareAccountsScreen.scss';
@@ -33,7 +33,7 @@ const CompareAccountsScreen = () => {
             <div className='wallets-compare-accounts__card-list'>
                 <CompareAccountsCarousel>
                     {mt5Accounts?.map(item => (
-                        <CFDCompareAccountsCard
+                        <CompareAccountsCard
                             isAccountAdded={item?.is_added}
                             isDemo={isDemo}
                             isEuRegion={isEuRegion}
@@ -46,7 +46,7 @@ const CompareAccountsScreen = () => {
                     ))}
                     {/* Renders cTrader data */}
                     {mt5Accounts?.length && hasCTraderAccountAvailable && ctraderAccount && (
-                        <CFDCompareAccountsCard
+                        <CompareAccountsCard
                             isAccountAdded={isCtraderAdded}
                             isDemo={isDemo}
                             isEuRegion={isEuRegion}
@@ -58,7 +58,7 @@ const CompareAccountsScreen = () => {
                     )}
                     {/* Renders Deriv X data */}
                     {mt5Accounts?.length && hasDxtradeAccountAvailable && dxtradeAccount && (
-                        <CFDCompareAccountsCard
+                        <CompareAccountsCard
                             isAccountAdded={isDxtradeAdded}
                             isDemo={isDemo}
                             isEuRegion={isEuRegion}


### PR DESCRIPTION
## Changes:
- Re-add previous and next button inside of Compare Account Page inside of mobile
- Rename CFDCompareAccountsCard to CompareAccountsCard to match with component name and filename
- Disable hover background on mobile instead show on active
- Refactor code

### Screenshots:

<img width="384" alt="image" src="https://github.com/binary-com/deriv-app/assets/103104395/9e23b4a5-fbaf-4f4c-9caa-ca259ffd6db9">

