### PR TITLE
[WALL] Lubega / WALL-3944 / Compare accounts header z-index

### DIFF
--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/CompareAccountsHeader.scss
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/CompareAccountsHeader.scss
@@ -7,7 +7,7 @@
     position: sticky;
     top: 0;
     background-color: #ffffff;
-    z-index: 999;
+    z-index: 1;
 
     &__title {
         display: flex;


### PR DESCRIPTION
## Changes:

- [x] Fixed issue where compare accounts headeris displaying above other component headers

### Issue:

https://github.com/binary-com/deriv-app/assets/142860499/74b2ee84-2bec-4718-8542-e60a2ceb06f0

### Fix:

https://github.com/binary-com/deriv-app/assets/142860499/d6d40028-9aed-4f4f-8819-97e7d0f301e9

