### PR TITLE
[WALL-3905] wojtek/eature/fix transation status

### DIFF
--- a/packages/wallets/src/features/cashier/modules/TransactionStatus/TransactionStatus.tsx
+++ b/packages/wallets/src/features/cashier/modules/TransactionStatus/TransactionStatus.tsx
@@ -6,6 +6,7 @@ import { Divider, WalletText } from '../../../../components/Base';
 import { THooks } from '../../../../types';
 import { TransactionStatusError } from './components/TransactionStatusError';
 import { TransactionStatusSuccess } from './components/TransactionStatusSuccess';
+
 import './TransactionStatus.scss';
 
 type TTransactionStatus = {

--- a/packages/wallets/src/features/cashier/modules/TransactionStatus/TransactionStatus.tsx
+++ b/packages/wallets/src/features/cashier/modules/TransactionStatus/TransactionStatus.tsx
@@ -29,14 +29,17 @@ const TransactionStatus: React.FC<TTransactionStatus> = ({ transactionType }) =>
         refetch,
     } = useActiveWalletAccount();
 
-    useEffect(() => {
-        subscribe({ payload: { transaction_type: transactionType } });
-        return () => unsubscribe();
-    }, [subscribe, transactionType, unsubscribe]);
-
     const isLoading = isTransactionsLoading || isActiveWalletAccountLoading;
     const isError = !!activeWalletAccountError || !!recentTransactionsError;
     const isTransactionStatusSuccessVisible = !isLoading && !isError && wallet;
+
+    useEffect(() => {
+        if (isLoading) {
+            return;
+        }
+        subscribe({ payload: { transaction_type: transactionType } });
+        return () => unsubscribe();
+    }, [subscribe, transactionType, unsubscribe, isLoading]);
 
     const refresh = useCallback(() => {
         unsubscribe();


### PR DESCRIPTION
Fixed scenario in which TransactionStatus resubscribes before reopened connection is authorized and thus errors out. 

Separately, there is upcoming PR to fix the problem with reconnection itself - sometimes it does not reconnect properly when tab is asleep in background. 