### PR TITLE
[WALL] Lubega / WALL-3922 / Wallet carousel interactivity fix

### DIFF
--- a/packages/wallets/src/components/WalletsCarouselContent/WalletsCarouselContent.tsx
+++ b/packages/wallets/src/components/WalletsCarouselContent/WalletsCarouselContent.tsx
@@ -3,6 +3,7 @@ import useEmblaCarousel, { EmblaCarouselType, EmblaEventType } from 'embla-carou
 import { useHistory } from 'react-router-dom';
 import { useActiveWalletAccount, useCurrencyConfig, useMobileCarouselWalletsList } from '@deriv/api-v2';
 import useWalletAccountSwitcher from '../../hooks/useWalletAccountSwitcher';
+import { THooks } from '../../types';
 import { ProgressBar } from '../Base';
 import { WalletsCarouselLoader } from '../SkeletonLoader';
 import { WalletCard } from '../WalletCard';
@@ -109,6 +110,18 @@ const WalletsCarouselContent: React.FC<TProps> = ({ onWalletSettled }) => {
         containScroll: false,
         skipSnaps: true,
     });
+
+    const handleCardClick = useCallback(
+        (account: THooks.ActiveWalletAccount, index: number) => {
+            walletsCarouselEmblaApi?.scrollTo(index);
+            walletAccountsList && setSelectedLoginId(walletAccountsList[index].loginid);
+            account.is_active &&
+                (account.is_virtual
+                    ? history.push('/wallets/cashier/reset-balance')
+                    : history.push('/wallets/cashier/deposit'));
+        },
+        [walletsCarouselEmblaApi, walletAccountsList, history]
+    );
 
     useEffect(() => {
         walletsAccountsListRef.current = walletAccountsList;
@@ -220,7 +233,7 @@ const WalletsCarouselContent: React.FC<TProps> = ({ onWalletSettled }) => {
     return (
         <div className='wallets-carousel-content' ref={walletsCarouselEmblaRef}>
             <div className='wallets-carousel-content__container'>
-                {walletAccountsList?.map(account => (
+                {walletAccountsList?.map((account, index) => (
                     <WalletCard
                         balance={account.display_balance}
                         currency={account.currency || 'USD'}
@@ -229,11 +242,7 @@ const WalletsCarouselContent: React.FC<TProps> = ({ onWalletSettled }) => {
                         isDemo={account.is_virtual}
                         key={`wallet-card-${account.loginid}`}
                         landingCompanyName={account.landing_company_name}
-                        onClick={() =>
-                            account.is_virtual
-                                ? history.push('/wallets/cashier/reset-balance')
-                                : history.push('/wallets/cashier/deposit')
-                        }
+                        onClick={() => handleCardClick(account, index)}
                     />
                 ))}
             </div>


### PR DESCRIPTION
## Changes:

- [x] Fixed issue where wallets carousel card is redirecting to wrong account. Clicking on a neighbouring card now pulls that card into focus and only clicking on an active card will redirect to the cashier pages

### Bug:

https://github.com/binary-com/deriv-app/assets/142860499/ec71baf9-60dc-4561-a404-82280d3c63bd


### Fix:

https://github.com/binary-com/deriv-app/assets/142860499/021c8677-04d8-4c2b-b3c5-c3d42a6c3dfc


