### PR TITLE
Aizad/WALL-3966/Back Arrow Incorrect Placement fix

### DIFF
--- a/packages/wallets/src/features/cfd/screens/DynamicLeverage/DynamicLeverageTitle.tsx
+++ b/packages/wallets/src/features/cfd/screens/DynamicLeverage/DynamicLeverageTitle.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { LegacyArrowRight2pxIcon } from '@deriv/quill-icons';
+import { LegacyArrowLeft2pxIcon } from '@deriv/quill-icons';
 import { WalletText } from '../../../../components';
 import useDevice from '../../../../hooks/useDevice';
 import { useDynamicLeverageModalState } from '../../components/DynamicLeverageContext';
@@ -12,7 +12,7 @@ export const DynamicLeverageTitle: FC = () => {
 
     return (
         <div className='wallets-dynamic-leverage-screen__title'>
-            <LegacyArrowRight2pxIcon
+            <LegacyArrowLeft2pxIcon
                 className='wallets-dynamic-leverage-screen__title-back'
                 data-testid='back_icon'
                 iconSize='xs'

--- a/packages/wallets/src/features/cfd/screens/Jurisdiction/JurisdictionCard/JurisdictionCardBack.tsx
+++ b/packages/wallets/src/features/cfd/screens/Jurisdiction/JurisdictionCard/JurisdictionCardBack.tsx
@@ -1,5 +1,5 @@
 import React, { Dispatch, FC, SetStateAction } from 'react';
-import { LegacyArrowRight2pxIcon } from '@deriv/quill-icons';
+import { LegacyArrowLeft2pxIcon } from '@deriv/quill-icons';
 import { WalletText } from '../../../../../components/Base/WalletText';
 import IdCardIcon from '../../../../../public/images/ic-id-card.svg';
 import DocumentIcon from '../../../../../public/images/ic-id-number.svg';
@@ -40,7 +40,7 @@ const JurisdictionCardBack: FC<TJurisdictionCardBackProps> = ({ setIsFlipped, ve
     if (verificationDocs)
         return (
             <div className='wallets-jurisdiction-card-back'>
-                <LegacyArrowRight2pxIcon
+                <LegacyArrowLeft2pxIcon
                     className='wallets-jurisdiction-card-back__icon'
                     iconSize='xs'
                     onClick={e => {


### PR DESCRIPTION
## Changes:

- Replace icon inside of `JurisdictionCardBack`
- Replace icon inside of `DynamicLeverageTitle`

### Screenshots:
![image](https://github.com/binary-com/deriv-app/assets/103104395/0953ae6c-58a4-4fa6-b432-7d320822de99)

![image](https://github.com/binary-com/deriv-app/assets/103104395/47907761-a7ba-40d9-8f3e-d245823668bf)

