### PR TITLE
[TRAH]/Mitra/TRAH-3381/Set performance value for login time once cfd section is loaded

### DIFF
--- a/packages/appstore/src/components/cfds-listing/index.tsx
+++ b/packages/appstore/src/components/cfds-listing/index.tsx
@@ -9,6 +9,7 @@ import {
     MT5_ACCOUNT_STATUS,
     makeLazyLoader,
     moduleLoader,
+    setPerformanceValue,
 } from '@deriv/shared';
 import { localize, Localize } from '@deriv/translations';
 import { Analytics } from '@deriv-com/analytics';
@@ -67,7 +68,6 @@ const CFDsListing = observer(() => {
     const { setAccountType, toggleCTraderTransferModal } = cfd;
     const {
         account_status,
-        ctrader_accounts_list,
         is_landing_company_loaded,
         is_populating_mt5_account_list,
         real_account_creation_unlock_date,
@@ -171,6 +171,16 @@ const CFDsListing = observer(() => {
         }
         return null;
     };
+
+    React.useEffect(() => {
+        if (is_landing_company_loaded && !is_populating_mt5_account_list) {
+            setPerformanceValue('login_time');
+            setPerformanceValue('redirect_from_deriv_com_time');
+            setPerformanceValue('switch_currency_accounts_time');
+            setPerformanceValue('switch_from_demo_to_real_time');
+            setPerformanceValue('switch_from_real_to_demo_time');
+        }
+    }, [is_landing_company_loaded]);
 
     return (
         <ListingContainer

--- a/packages/appstore/src/components/cfds-listing/index.tsx
+++ b/packages/appstore/src/components/cfds-listing/index.tsx
@@ -173,14 +173,14 @@ const CFDsListing = observer(() => {
     };
 
     useEffect(() => {
-        if (is_landing_company_loaded && !is_populating_mt5_account_list) {
+        if (is_landing_company_loaded && is_populating_mt5_account_list) {
             setPerformanceValue('login_time');
             setPerformanceValue('redirect_from_deriv_com_time');
             setPerformanceValue('switch_currency_accounts_time');
             setPerformanceValue('switch_from_demo_to_real_time');
             setPerformanceValue('switch_from_real_to_demo_time');
         }
-    }, [is_landing_company_loaded]);
+    }, [is_populating_mt5_account_list]);
 
     return (
         <ListingContainer

--- a/packages/appstore/src/components/cfds-listing/index.tsx
+++ b/packages/appstore/src/components/cfds-listing/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { observer, useStore } from '@deriv/stores';
 import { Loading, Text, StaticUrl } from '@deriv/components';
 import {
@@ -172,7 +172,7 @@ const CFDsListing = observer(() => {
         return null;
     };
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (is_landing_company_loaded && !is_populating_mt5_account_list) {
             setPerformanceValue('login_time');
             setPerformanceValue('redirect_from_deriv_com_time');

--- a/packages/appstore/src/components/main-title-bar/asset-summary.tsx
+++ b/packages/appstore/src/components/main-title-bar/asset-summary.tsx
@@ -63,7 +63,7 @@ const AssetSummary = observer(() => {
     }
 
     // measure performance metrics
-    setPerformanceValue('login_time');
+    is_landing_company_loaded && setPerformanceValue('login_time');
     setPerformanceValue('redirect_from_deriv_com_time');
     setPerformanceValue('switch_currency_accounts_time');
     setPerformanceValue('switch_from_demo_to_real_time');

--- a/packages/appstore/src/components/main-title-bar/asset-summary.tsx
+++ b/packages/appstore/src/components/main-title-bar/asset-summary.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Text, Popover } from '@deriv/components';
 import { localize } from '@deriv/translations';
-import { isMobile, setPerformanceValue } from '@deriv/shared';
+import { isMobile } from '@deriv/shared';
 import BalanceText from 'Components/elements/text/balance-text';
 import { observer, useStore } from '@deriv/stores';
 import './asset-summary.scss';
@@ -61,13 +61,6 @@ const AssetSummary = observer(() => {
             </React.Fragment>
         );
     }
-
-    // measure performance metrics
-    is_landing_company_loaded && setPerformanceValue('login_time');
-    setPerformanceValue('redirect_from_deriv_com_time');
-    setPerformanceValue('switch_currency_accounts_time');
-    setPerformanceValue('switch_from_demo_to_real_time');
-    setPerformanceValue('switch_from_real_to_demo_time');
 
     return (
         <div className='asset-summary'>

--- a/packages/appstore/src/components/options-multipliers-listing/index.tsx
+++ b/packages/appstore/src/components/options-multipliers-listing/index.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { observer } from 'mobx-react-lite';
 import { Text, StaticUrl } from '@deriv/components';
-import { ContentFlag } from '@deriv/shared';
+import { ContentFlag, setPerformanceValue } from '@deriv/shared';
 import { useStore } from '@deriv/stores';
 import { Localize, localize } from '@deriv/translations';
 import ListingContainer from 'Components/containers/listing-container';
@@ -52,6 +52,12 @@ const OptionsAndMultipliersListing = observer(() => {
         }
         return null;
     };
+
+    useEffect(() => {
+        if (is_landing_company_loaded) {
+            setPerformanceValue('option_multiplier_section_loading_time');
+        }
+    }, [is_landing_company_loaded]);
 
     return (
         <ListingContainer

--- a/packages/appstore/src/modules/traders-hub/index.tsx
+++ b/packages/appstore/src/modules/traders-hub/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { DesktopWrapper, MobileWrapper, ButtonToggle, Div100vhContainer, Text } from '@deriv/components';
-import { isDesktop, routes, ContentFlag, checkServerMaintenance } from '@deriv/shared';
+import { isDesktop, routes, ContentFlag, checkServerMaintenance, startPerformanceEventTimer } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
 import { Localize, localize } from '@deriv/translations';
 import CFDsListing from 'Components/cfds-listing';
@@ -79,6 +79,10 @@ const TradersHub = observer(() => {
         }, 100);
         return () => clearTimeout(timer);
     }, [handleScroll, is_eu_user, is_tour_open, setTogglePlatformType]);
+
+    React.useLayoutEffect(() => {
+        startPerformanceEventTimer('option_multiplier_section_loading_time');
+    }, []);
 
     const eu_title = content_flag === ContentFlag.EU_DEMO || content_flag === ContentFlag.EU_REAL || is_eu_user;
 

--- a/packages/shared/src/services/performance-metrics-methods.ts
+++ b/packages/shared/src/services/performance-metrics-methods.ts
@@ -16,6 +16,7 @@ declare global {
             switch_currency_accounts_time: number;
             switch_from_demo_to_real_time: number;
             switch_from_real_to_demo_time: number;
+            options_multipliers_section_loading_time: number;
         };
     }
 }
@@ -36,6 +37,7 @@ export const startPerformanceEventTimer = (action: keyof typeof global.Window.pr
             switch_currency_accounts_time: 0,
             switch_from_demo_to_real_time: 0,
             switch_from_real_to_demo_time: 0,
+            options_multipliers_section_loading_time: 0,
         };
     }
 


### PR DESCRIPTION
## Changes:

End login_time rudderstack metrics calculation once CFD section is loaded. Right now it's ending while total deposit is getting loaded. This is skewing the data, as users are changing pages before this event


Start a new metric when client is on tradershub and end it once option and multiplier section is loaded we need to measure how much time it takes till option and multiplier section loads

