### PR TITLE
[WALL] aum / WALL-3959 / fix-transfer-success-receipt-arrow-direction

### DIFF
--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferReceipt/TransferReceipt.scss
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferReceipt/TransferReceipt.scss
@@ -26,10 +26,8 @@
     }
 
     &__arrow-icon {
-        rotate: 180deg;
-
         @include mobile {
-            rotate: -90deg;
+            rotate: 90deg;
         }
     }
 


### PR DESCRIPTION
## Changes:

Fix the arrow direction shown between wallets in TransferReceipt after successful transfer.

### Screenshots:

https://github.com/binary-com/deriv-app/assets/125039206/694a584f-7411-48e5-9975-5694b449311e

https://github.com/binary-com/deriv-app/assets/125039206/d007d54d-ea4b-45fa-a21a-1fb71a6ae8e3