### PR TITLE
chore: added locators in top four blocks for cypress test

### DIFF
--- a/packages/bot-skeleton/src/scratch/hooks/workspace_svg.js
+++ b/packages/bot-skeleton/src/scratch/hooks/workspace_svg.js
@@ -133,6 +133,7 @@ Blockly.WorkspaceSvg.prototype.cleanUp = function (x = 0, y = 0, blocks_to_clean
         let column_index = 0;
 
         root_blocks.forEach((block, index) => {
+            block?.svgGroup_?.setAttribute('data-testid', block?.category_);
             if (index === (column_index + 1) * blocks_per_column) {
                 original_cursor_y = y;
                 column_index++;


### PR DESCRIPTION
## Changes:

- Added locators on Blockly top four blocks for cypress testing
- Used the cleanup function for this purpose as it always runs when a new strategy is loaded to the workspace
