### PR TITLE
[WALL] aum / WALL-4034 / fix-wallet-crypto-withdrawal-arrow-direction

### DIFF
--- a/packages/wallets/src/features/cashier/modules/WithdrawalCrypto/components/WithdrawalCryptoForm/components/WithdrawalCryptoAmountConverter/WithdrawalCryptoAmountConverter.scss
+++ b/packages/wallets/src/features/cashier/modules/WithdrawalCrypto/components/WithdrawalCryptoForm/components/WithdrawalCryptoAmountConverter/WithdrawalCryptoAmountConverter.scss
@@ -20,20 +20,19 @@
 
         & > svg {
             transition: rotate 0.2s ease;
-            rotate: 180deg;
 
             @include mobile {
-                rotate: -90deg;
+                rotate: 90deg;
                 margin-bottom: 2.2rem;
             }
         }
 
         &--rtl {
             & > svg {
-                rotate: 0deg;
+                rotate: 180deg;
 
                 @include mobile {
-                    rotate: 90deg;
+                    rotate: -90deg;
                 }
             }
         }


### PR DESCRIPTION
## Changes:

Fix the arrow direction in WithdrawalCryptoAmountConverter after it was replaced from quill-icons.

### Screenshots:

<img height="299" alt="Screenshot 2024-05-08 at 2 33 59 PM" src="https://github.com/binary-com/deriv-app/assets/125039206/4ae6a37b-0d88-49a3-8fce-77f5ac476097">
<img height="299" alt="Screenshot 2024-05-08 at 2 34 17 PM" src="https://github.com/binary-com/deriv-app/assets/125039206/47b82e89-1966-4c5c-a8fa-1e035f7d54b1">