### PR TITLE
[WALL-4020] feat: fixed flickering of USD background

### DIFF
--- a/packages/wallets/src/components/WalletGradientBackground/WalletGradientBackground.tsx
+++ b/packages/wallets/src/components/WalletGradientBackground/WalletGradientBackground.tsx
@@ -6,7 +6,7 @@ import './WalletGradientBackground.scss';
 type TProps = {
     bodyClassName?: string;
     children: React.ReactNode;
-    currency: THooks.WalletAccountsList['wallet_currency_type'];
+    currency: THooks.WalletAccountsList['wallet_currency_type'] | undefined;
     device?: 'desktop' | 'mobile';
     hasShine?: boolean;
     isDemo?: THooks.WalletAccountsList['is_virtual'];
@@ -26,7 +26,7 @@ const WalletGradientBackground: React.FC<TProps> = ({
 }) => {
     // All of the currency classnames are uppercase'd in WalletGradientBackground.scss
     // This is uppercase'd to normalize some currency names like eUSDT and tUSDT to EUSDT and TUSDT
-    const gradientCurrencyClassName = currency.toUpperCase();
+    const gradientCurrencyClassName = currency?.toUpperCase();
 
     const getClassName = () => {
         if (isDemo) return `wallets-gradient--demo-${device}-${type}-${theme}`;

--- a/packages/wallets/src/components/WalletGradientBackground/WalletGradientBackground.tsx
+++ b/packages/wallets/src/components/WalletGradientBackground/WalletGradientBackground.tsx
@@ -6,7 +6,7 @@ import './WalletGradientBackground.scss';
 type TProps = {
     bodyClassName?: string;
     children: React.ReactNode;
-    currency: THooks.WalletAccountsList['wallet_currency_type'] | undefined;
+    currency?: THooks.WalletAccountsList['wallet_currency_type'];
     device?: 'desktop' | 'mobile';
     hasShine?: boolean;
     isDemo?: THooks.WalletAccountsList['is_virtual'];

--- a/packages/wallets/src/features/cashier/components/WalletCashierHeader/WalletCashierHeader.tsx
+++ b/packages/wallets/src/features/cashier/components/WalletCashierHeader/WalletCashierHeader.tsx
@@ -78,7 +78,7 @@ const WalletCashierHeader: React.FC<TProps> = ({ hideWalletDetails }) => {
 
     return (
         <WalletGradientBackground
-            currency={activeWallet?.currency_config?.display_code || 'USD'}
+            currency={activeWallet?.currency}
             device={isMobile ? 'mobile' : 'desktop'}
             isDemo={activeWallet?.is_virtual}
             theme='light'


### PR DESCRIPTION
All across the codebase we tend to default to USD currency. While its risky pattern, typically it does not cause any visible problems. Fixed the single case known to cause visible flickering of incorrect currency. 
Separately, as technical improvement, we should remove all the cases where we default to USD (imagine defaulting to incorrect currency exchange rate etc - really do not want to show incorrect data to users). 

Before:

https://github.com/binary-com/deriv-app/assets/141034155/66a21b0d-6dce-4d0c-910e-345a2f67d2dc

After:

https://github.com/binary-com/deriv-app/assets/141034155/95195e34-ad43-48e0-bf5b-a8cd20d58b37


