### PR TITLE
[DTRA-1266] shahzaib / style - accumulator tick count bar misaligned in contract card

### DIFF
--- a/packages/components/src/components/contract-card/contract-card-items/tick-counter-bar.tsx
+++ b/packages/components/src/components/contract-card/contract-card-items/tick-counter-bar.tsx
@@ -9,7 +9,7 @@ type TTickCounterBar = {
 const TickCounterBar = ({ current_tick, label, max_ticks_duration }: TTickCounterBar) => (
     <div className='dc-tick-counter-bar__container'>
         <div className='dc-tick-counter-bar__track'>
-            <Text size='xxs' weight='bold' className='dc-tick-counter-bar__text'>
+            <Text size='xxs' weight='bold' align='center' className='dc-tick-counter-bar__text'>
                 {`${current_tick}/${max_ticks_duration} ${label}`}
             </Text>
         </div>

--- a/packages/components/src/components/contract-card/contract-card-items/tick-counter-bar.tsx
+++ b/packages/components/src/components/contract-card/contract-card-items/tick-counter-bar.tsx
@@ -9,7 +9,7 @@ type TTickCounterBar = {
 const TickCounterBar = ({ current_tick, label, max_ticks_duration }: TTickCounterBar) => (
     <div className='dc-tick-counter-bar__container'>
         <div className='dc-tick-counter-bar__track'>
-            <Text size='xxs' weight='bold' align='center' className='dc-tick-counter-bar__text'>
+            <Text size='xxs' weight='bold' align='center' color='profit-success' className='dc-tick-counter-bar__text'>
                 {`${current_tick}/${max_ticks_duration} ${label}`}
             </Text>
         </div>

--- a/packages/components/src/components/contract-card/contract-card.scss
+++ b/packages/components/src/components/contract-card/contract-card.scss
@@ -700,12 +700,6 @@
             border-bottom: unset;
             margin: unset;
         }
-
-        .dc-tick-counter-bar__text {
-            position: absolute;
-            color: var(--status-success);
-            width: 100%;
-        }
     }
     &__track {
         height: 1.8rem;
@@ -722,5 +716,9 @@
             border-bottom: unset;
             margin: 0.2rem 0 0.4rem;
         }
+    }
+    &__text {
+        position: absolute;
+        width: 100%;
     }
 }

--- a/packages/components/src/components/contract-card/contract-card.scss
+++ b/packages/components/src/components/contract-card/contract-card.scss
@@ -700,6 +700,12 @@
             border-bottom: unset;
             margin: unset;
         }
+
+        .dc-tick-counter-bar__text {
+            position: absolute;
+            color: var(--status-success);
+            width: 100%;
+        }
     }
     &__track {
         height: 1.8rem;
@@ -716,10 +722,5 @@
             border-bottom: unset;
             margin: 0.2rem 0 0.4rem;
         }
-    }
-    &__text {
-        position: absolute;
-        color: var(--status-success) !important;
-        width: 100%;
     }
 }

--- a/packages/components/src/components/contract-card/contract-card.scss
+++ b/packages/components/src/components/contract-card/contract-card.scss
@@ -719,8 +719,7 @@
     }
     &__text {
         position: absolute;
-        color: var(--status-success);
+        color: var(--status-success) !important;
         width: 100%;
-        text-align: center;
     }
 }


### PR DESCRIPTION
## Changes:

Fix: style for tick counter bar alignment and color
- Removed text-align & color css styles in favor of `Text` component props


### Screenshots:
#### Before
![image (6)](https://github.com/binary-com/deriv-app/assets/129842155/642cb436-a029-4dca-bcc3-3193d9d650a2)
#### After 
<img width="1720" alt="Screenshot 2024-05-09 at 12 38 43 PM" src="https://github.com/binary-com/deriv-app/assets/129842155/9583d701-c5da-4999-b907-3674b789feba">
