### PR TITLE
[WALL] Lubega / WALL-4047 / Demo switcher input different browsers support

### DIFF
--- a/packages/wallets/src/components/WalletListHeader/WalletListHeader.scss
+++ b/packages/wallets/src/components/WalletListHeader/WalletListHeader.scss
@@ -33,6 +33,7 @@
         &-input {
             width: 0;
             height: 0;
+            opacity: 0;
         }
 
         &:hover {


### PR DESCRIPTION
## Changes:

- [x] Fix issue where small input checkbox is appearing for the demo switcher on other browsers

### Before:
Safari:
<img width="761" alt="Screenshot 2024-05-09 at 6 02 50 PM" src="https://github.com/binary-com/deriv-app/assets/142860499/e8adf02f-481a-4f4e-828a-9d1a8b9c4b58">
Firefox:
![image](https://github.com/binary-com/deriv-app/assets/142860499/b49404b3-91ad-4e27-be65-d02beb2731b8)


### After:
Safari:
<img width="761" alt="Screenshot 2024-05-09 at 6 01 31 PM" src="https://github.com/binary-com/deriv-app/assets/142860499/5990320d-3774-46bc-9d40-a0d7d7474be1">
Firefox:
![image](https://github.com/binary-com/deriv-app/assets/142860499/05c81a8e-3649-4223-bdee-de3697e36a54)



