### PR TITLE
[WALL] aum / WALL-4052 / fix-arrow-direction-wallet-withdrawal-crypto-receipt

### DIFF
--- a/packages/wallets/src/features/cashier/modules/FiatOnRamp/FiatOnRamp.tsx
+++ b/packages/wallets/src/features/cashier/modules/FiatOnRamp/FiatOnRamp.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { LegacyArrowRight2pxIcon } from '@deriv/quill-icons';
+import { LegacyArrowLeft2pxIcon } from '@deriv/quill-icons';
 import { WalletButton, WalletText } from '../../../../components';
 import { FiatOnRampDisclaimer, FiatOnRampProviderCard } from './components';
 import { fiatOnRampProvider } from './constants';
@@ -21,7 +21,7 @@ const FiatOnRamp = () => {
                     <div className='wallets-fiat-onramp__actions'>
                         <WalletButton
                             color='white'
-                            icon={<LegacyArrowRight2pxIcon iconSize='xs' />}
+                            icon={<LegacyArrowLeft2pxIcon iconSize='xs' />}
                             onClick={() => history.push('/wallets/cashier/deposit')}
                         >
                             Back

--- a/packages/wallets/src/features/cashier/modules/WithdrawalCrypto/components/WithdrawalCryptoReceipt/WithdrawalCryptoReceipt.scss
+++ b/packages/wallets/src/features/cashier/modules/WithdrawalCrypto/components/WithdrawalCryptoReceipt/WithdrawalCryptoReceipt.scss
@@ -25,10 +25,6 @@
                 padding: 0.8rem;
             }
         }
-
-        & > svg {
-            transform: rotate(-90deg);
-        }
     }
 
     &__withdrawal-info {

--- a/packages/wallets/src/features/cashier/modules/WithdrawalCrypto/components/WithdrawalCryptoReceipt/WithdrawalCryptoReceipt.tsx
+++ b/packages/wallets/src/features/cashier/modules/WithdrawalCrypto/components/WithdrawalCryptoReceipt/WithdrawalCryptoReceipt.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useHistory } from 'react-router-dom';
-import { LegacyArrowRight2pxIcon } from '@deriv/quill-icons';
+import { LegacyArrowDown2pxIcon } from '@deriv/quill-icons';
 import { WalletButton, WalletCard, WalletText } from '../../../../../../components';
 import { LandingCompanyDetails } from '../../../../constants';
 import { TWithdrawalReceipt } from '../../types';
@@ -25,7 +25,7 @@ const WithdrawalCryptoReceipt: React.FC<TProps> = ({ onClose, withdrawalReceipt 
                     iconSize='md'
                     landingCompanyName={LandingCompanyDetails.svg.shortcode}
                 />
-                <LegacyArrowRight2pxIcon iconSize='xs' />
+                <LegacyArrowDown2pxIcon iconSize='xs' />
                 <WithdrawalCryptoDestinationAddress address={address} />
             </div>
             <div className='wallets-withdrawal-crypto-receipt__withdrawal-info'>


### PR DESCRIPTION
## Changes:

- Fix the arrow direction in WithdrawalCryptoReceipt by replacing it with the correct quill-icon counterpart.
- (Extra) Fixed arrow for back button in FiatOnRamp

### Screenshots:
<img height="400" alt="Screenshot 2024-05-09 at 4 45 13 PM" src="https://github.com/binary-com/deriv-app/assets/125039206/34b37d42-bf47-4dbc-9cec-30659a07e539" />
<img height="400" alt="Screenshot 2024-05-09 at 4 45 18 PM" src="https://github.com/binary-com/deriv-app/assets/125039206/066e9e25-5407-41b1-8983-14840ca017d6" />
<img height="400" alt="Screenshot 2024-05-10 at 12 55 26 PM" src="https://github.com/binary-com/deriv-app/assets/125039206/81fc899c-155d-47d7-9f08-99a9ca5fc725" />
