### PR TITLE
[P2PS] / Ameerul / P2PS-2819 Unable to click on save button upon getting duplicate error

### DIFF
--- a/packages/p2p/src/components/modal-manager/modals/add-payment-method-error-modal/add-payment-method-error-modal.tsx
+++ b/packages/p2p/src/components/modal-manager/modals/add-payment-method-error-modal/add-payment-method-error-modal.tsx
@@ -24,7 +24,6 @@ const AddPaymentMethodErrorModal = () => {
                     text={localize('Ok')}
                     onClick={() => {
                         setAddPaymentMethodErrorMessage('');
-                        setSelectedPaymentMethod('');
                         setSavedFormState(null);
                         setFormikRef(null);
                         hideModal({

--- a/packages/p2p/src/pages/my-profile/payment-methods/edit-payment-method-form/edit-payment-method-form.tsx
+++ b/packages/p2p/src/pages/my-profile/payment-methods/edit-payment-method-form/edit-payment-method-form.tsx
@@ -28,7 +28,6 @@ const EditPaymentMethodForm = () => {
         setShouldShowEditPaymentMethodForm,
         validatePaymentMethodFields,
     } = my_profile_store;
-    const setSubmittingRef = React.useRef(null);
 
     const updatePaymentMethod = values => {
         update(payment_method_to_edit.id, values);
@@ -60,12 +59,10 @@ const EditPaymentMethodForm = () => {
         } else if (mutation_status === 'error') {
             my_profile_store.setAddPaymentMethodErrorMessage(mutation_error.message);
             showModal({ key: 'AddPaymentMethodErrorModal', props: {} });
-            if (setSubmittingRef.current) {
-                setSubmittingRef.current(false);
-            }
+            general_store.formik_ref.setSubmitting(false);
             reset();
         }
-    }, [mutation_error, mutation_status, reset, setSubmittingRef]);
+    }, [mutation_error, mutation_status, reset, general_store.formik_ref]);
 
     if (isEmptyObject(payment_method_to_edit)) {
         return <Loading is_fullscreen={false} />;
@@ -78,8 +75,7 @@ const EditPaymentMethodForm = () => {
             onSubmit={updatePaymentMethod}
             validate={validatePaymentMethodFields}
         >
-            {({ dirty, handleChange, isSubmitting, errors, setSubmitting }: FormikValues) => {
-                setSubmittingRef.current = setSubmitting;
+            {({ dirty, handleChange, isSubmitting, errors }: FormikValues) => {
                 return (
                     <React.Fragment>
                         <DesktopWrapper>

--- a/packages/p2p/src/pages/my-profile/payment-methods/edit-payment-method-form/edit-payment-method-form.tsx
+++ b/packages/p2p/src/pages/my-profile/payment-methods/edit-payment-method-form/edit-payment-method-form.tsx
@@ -19,7 +19,7 @@ const EditPaymentMethodForm = () => {
     } = useStore();
     const { showModal } = useModalManagerContext();
     const { mutation, update } = useP2PAdvertiserPaymentMethods();
-    const { error: mutation_error, status: mutation_status } = mutation;
+    const { error: mutation_error, reset, status: mutation_status } = mutation;
     const {
         payment_method_to_edit,
         setPaymentMethodToEdit,
@@ -28,6 +28,7 @@ const EditPaymentMethodForm = () => {
         setShouldShowEditPaymentMethodForm,
         validatePaymentMethodFields,
     } = my_profile_store;
+    const setSubmittingRef = React.useRef(null);
 
     const updatePaymentMethod = values => {
         update(payment_method_to_edit.id, values);
@@ -59,8 +60,12 @@ const EditPaymentMethodForm = () => {
         } else if (mutation_status === 'error') {
             my_profile_store.setAddPaymentMethodErrorMessage(mutation_error.message);
             showModal({ key: 'AddPaymentMethodErrorModal', props: {} });
+            if (setSubmittingRef.current) {
+                setSubmittingRef.current(false);
+            }
+            reset();
         }
-    }, [mutation_error, mutation_status]);
+    }, [mutation_error, mutation_status, reset, setSubmittingRef]);
 
     if (isEmptyObject(payment_method_to_edit)) {
         return <Loading is_fullscreen={false} />;
@@ -73,7 +78,8 @@ const EditPaymentMethodForm = () => {
             onSubmit={updatePaymentMethod}
             validate={validatePaymentMethodFields}
         >
-            {({ dirty, handleChange, isSubmitting, errors }: FormikValues) => {
+            {({ dirty, handleChange, isSubmitting, errors, setSubmitting }: FormikValues) => {
+                setSubmittingRef.current = setSubmitting;
                 return (
                     <React.Fragment>
                         <DesktopWrapper>


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- Fixed issues with user not able to click on save changes button after receiving error
- Fixed issues with user not being able to stay on create payment method page after an error is received

### Screenshots:

Please provide some screenshots of the change.

https://github.com/binary-com/deriv-app/assets/103412909/f9a7f475-33dc-4636-a563-83eef2847ac1



