### PR TITLE
DTRA/ Kate / WEBREL-5 / Add tests for loader component

### DIFF
--- a/packages/reports/src/_common/components/__tests__/loading.spec.tsx
+++ b/packages/reports/src/_common/components/__tests__/loading.spec.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Loading from '../loading';
+
+const dataTestID = 'dt_loading';
+const className = 'mockedClassName';
+const defaultClassName = 'barspinner barspinner--dark';
+const mockedDefaultProps: React.ComponentProps<typeof Loading> = {
+    id: 'mockedId',
+    data_testid: dataTestID,
+};
+
+describe('<Loading />', () => {
+    it('should render component with default props', () => {
+        render(<Loading {...mockedDefaultProps} />);
+
+        const loader = screen.getByTestId(dataTestID);
+        expect(loader).toBeInTheDocument();
+        expect(loader).toHaveClass(defaultClassName);
+    });
+
+    it('should apply passed className to the component', () => {
+        render(<Loading {...mockedDefaultProps} className={className} />);
+
+        expect(screen.getByTestId(dataTestID)).toHaveClass(`${defaultClassName} ${className}`);
+    });
+    it('should apply invisible className if is_invisible is true', () => {
+        render(<Loading {...mockedDefaultProps} is_invisible />);
+
+        expect(screen.getByTestId(dataTestID)).toHaveClass(`${defaultClassName} invisible`);
+    });
+    it('should apply theme className if theme was passed', () => {
+        render(<Loading {...mockedDefaultProps} theme='light' />);
+
+        expect(screen.getByTestId(dataTestID)).toHaveClass(`barspinner barspinner--light`);
+    });
+});


### PR DESCRIPTION
## Changes:

Add tests for packages/reports/src/_common/components/loading.tsx

### Screenshots:
<img width="1725" alt="Screenshot 2024-05-10 at 3 58 34 PM" src="https://github.com/binary-com/deriv-app/assets/121025168/c3c9ad7a-d2c6-4c6e-b706-6afbd55a5157">


