### PR TITLE
refactor(deriv_go): updated Deriv Go's app links paths for dev and staging

### DIFF
--- a/packages/core/src/public/.well-known/apple-app-site-association
+++ b/packages/core/src/public/.well-known/apple-app-site-association
@@ -13,13 +13,13 @@
             {
                 "appID": "36S5Q8S4V5.com.deriv.app.dev",
                 "paths": [
-                    "/redirect"
+                    "/redirect/derivgo"
                 ]
             },
             {
                 "appID": "36S5Q8S4V5.com.deriv.app.staging",
                 "paths": [
-                    "/redirect"
+                    "/redirect/derivgo"
                 ]
             },
             {
@@ -61,7 +61,6 @@
             "36S5Q8S4V5.com.deriv.app",
             "36S5Q8S4V5.com.deriv.app.dev",
             "36S5Q8S4V5.com.deriv.app.staging",
-            "36S5Q8S4V5.com.deriv.dp2p",
             "36S5Q8S4V5.com.deriv.blanc",
             "36S5Q8S4V5.com.deriv.blanc.dev",
             "36S5Q8S4V5.com.deriv.blanc.stg",

--- a/packages/core/src/public/.well-known/apple-app-site-association
+++ b/packages/core/src/public/.well-known/apple-app-site-association
@@ -61,6 +61,7 @@
             "36S5Q8S4V5.com.deriv.app",
             "36S5Q8S4V5.com.deriv.app.dev",
             "36S5Q8S4V5.com.deriv.app.staging",
+            "36S5Q8S4V5.com.deriv.dp2p",
             "36S5Q8S4V5.com.deriv.blanc",
             "36S5Q8S4V5.com.deriv.blanc.dev",
             "36S5Q8S4V5.com.deriv.blanc.stg",

--- a/packages/core/src/public/.well-known/apple-app-site-association
+++ b/packages/core/src/public/.well-known/apple-app-site-association
@@ -7,7 +7,7 @@
             {
                 "appID": "36S5Q8S4V5.com.deriv.app",
                 "paths": [
-                    "/redirect"
+                    "/redirect/derivgo"
                 ]
             },
             {


### PR DESCRIPTION


## Changes:

Updated Deriv Go's app links paths for dev and staging in the file apple-app-site-association.
