### PR TITLE
chore: :fire: fix the active_symbols refetching issue on bot

### DIFF
--- a/packages/bot-web-ui/src/app/app-content.jsx
+++ b/packages/bot-web-ui/src/app/app-content.jsx
@@ -99,10 +99,12 @@ const AppContent = observer(() => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    // use is_landing_company_loaded to know got details of accounts to identify should show an error or not
-    if (client.is_landing_company_loaded) {
-        changeActiveSymbolLoadingState();
-    }
+    React.useEffect(() => {
+        if (client.is_logged_in && client.is_landing_company_loaded) {
+            changeActiveSymbolLoadingState();
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [client.is_landing_company_loaded]);
 
     React.useEffect(() => {
         const onDisconnectFromNetwork = () => {

--- a/packages/bot-web-ui/src/stores/app-store.ts
+++ b/packages/bot-web-ui/src/stores/app-store.ts
@@ -23,6 +23,15 @@ export default class AppStore {
         makeObservable(this, {
             onMount: action,
             onUnmount: action,
+            onBeforeUnload: action,
+            registerReloadOnLanguageChange: action,
+            registerCurrencyReaction: action,
+            registerOnAccountSwitch: action,
+            registerLandingCompanyChangeReaction: action,
+            registerResidenceChangeReaction: action,
+            setDBotEngineStores: action,
+            onClickOutsideBlockly: action,
+            showDigitalOptionsMaltainvestError: action,
         });
 
         this.root_store = root_store;


### PR DESCRIPTION
## Changes:

- Fixed DBot keep on requesting for `active_symbols` API call

### Screenshots:

<img width="498" alt="Screenshot 2024-05-14 at 4 15 01 PM" src="https://github.com/binary-com/deriv-app/assets/90243468/26d76438-28bb-4654-bfda-fcb844a9dcc7">
