### PR TITLE
[WALL]Jim/WALL-4041/hide close icon and set ctrader account as default when transfer button is clicked

### DIFF
--- a/packages/wallets/src/features/cfd/flows/CTrader/AvailableCTraderAccountsList/AvailableCTraderAccountsList.tsx
+++ b/packages/wallets/src/features/cfd/flows/CTrader/AvailableCTraderAccountsList/AvailableCTraderAccountsList.tsx
@@ -11,7 +11,7 @@ import './AvailableCTraderAccountsList.scss';
 
 const AvailableCTraderAccountsList: React.FC = () => {
     const { hide, show } = useModal();
-    const { error, mutate, status } = useCreateOtherCFDAccount();
+    const { data: createdAccount, error, mutate, status } = useCreateOtherCFDAccount();
     const { data: activeWallet } = useActiveWalletAccount();
     const { t } = useTranslation();
 
@@ -31,6 +31,7 @@ const AvailableCTraderAccountsList: React.FC = () => {
         if (status === 'success') {
             show(
                 <CTraderSuccessModal
+                    createdAccount={createdAccount}
                     displayBalance={activeWallet?.display_balance || ''}
                     isDemo={accountType === 'demo'}
                     walletCurrencyType={activeWallet?.wallet_currency_type || 'USD'}

--- a/packages/wallets/src/features/cfd/modals/CTraderSuccessModal/CTraderSuccessModal.tsx
+++ b/packages/wallets/src/features/cfd/modals/CTraderSuccessModal/CTraderSuccessModal.tsx
@@ -9,12 +9,13 @@ import { CFDSuccess } from '../../screens';
 import { CTraderSuccessModalButtons } from './components';
 
 type TCTraderSuccessModal = {
+    createdAccount?: THooks.CreateOtherCFDAccount;
     displayBalance?: string;
     isDemo: boolean;
     walletCurrencyType: THooks.WalletAccountsList['wallet_currency_type'];
 };
 
-const CTraderSuccessModal = ({ displayBalance, isDemo, walletCurrencyType }: TCTraderSuccessModal) => {
+const CTraderSuccessModal = ({ createdAccount, displayBalance, isDemo, walletCurrencyType }: TCTraderSuccessModal) => {
     const { data: cTraderAccounts } = useCtraderAccountsList();
     const { isMobile } = useDevice();
     const { hide } = useModal();
@@ -26,7 +27,9 @@ const CTraderSuccessModal = ({ displayBalance, isDemo, walletCurrencyType }: TCT
     if (isMobile) {
         return (
             <ModalStepWrapper
-                renderFooter={() => <CTraderSuccessModalButtons hide={hide} isDemo={isDemo} />}
+                renderFooter={() => (
+                    <CTraderSuccessModalButtons createdAccount={createdAccount} hide={hide} isDemo={isDemo} />
+                )}
                 title={' '}
             >
                 <CFDSuccess
@@ -34,7 +37,9 @@ const CTraderSuccessModal = ({ displayBalance, isDemo, walletCurrencyType }: TCT
                     displayBalance={cTraderAccounts?.find(account => account.login)?.formatted_balance}
                     marketType='all'
                     platform='ctrader'
-                    renderButton={() => <CTraderSuccessModalButtons hide={hide} isDemo={isDemo} />}
+                    renderButton={() => (
+                        <CTraderSuccessModalButtons createdAccount={createdAccount} hide={hide} isDemo={isDemo} />
+                    )}
                     title={`Your ${PlatformDetails.ctrader.title} ${isDemo ? 'demo' : ''} account is ready`}
                 />
                 ;
@@ -42,13 +47,15 @@ const CTraderSuccessModal = ({ displayBalance, isDemo, walletCurrencyType }: TCT
         );
     }
     return (
-        <ModalWrapper>
+        <ModalWrapper hideCloseButton>
             <CFDSuccess
                 description={description}
                 displayBalance={cTraderAccounts?.find(account => account.login)?.formatted_balance}
                 marketType='all'
                 platform={PlatformDetails.ctrader.platform}
-                renderButton={() => <CTraderSuccessModalButtons hide={hide} isDemo={isDemo} />}
+                renderButton={() => (
+                    <CTraderSuccessModalButtons createdAccount={createdAccount} hide={hide} isDemo={isDemo} />
+                )}
                 title={`Your ${PlatformDetails.ctrader.title} ${isDemo ? 'demo' : ''} account is ready`}
             />
         </ModalWrapper>

--- a/packages/wallets/src/features/cfd/modals/CTraderSuccessModal/components/CTraderSuccessModalButtons.tsx
+++ b/packages/wallets/src/features/cfd/modals/CTraderSuccessModal/components/CTraderSuccessModalButtons.tsx
@@ -2,13 +2,15 @@ import React from 'react';
 import { useHistory } from 'react-router-dom';
 import { WalletButton, WalletButtonGroup } from '../../../../../components';
 import useDevice from '../../../../../hooks/useDevice';
+import { THooks } from '../../../../../types';
 
 type TCTraderSuccessModalButtons = {
+    createdAccount?: THooks.CreateOtherCFDAccount;
     hide: () => void;
     isDemo: boolean;
 };
 
-const CTraderSuccessModalButtons = ({ hide, isDemo }: TCTraderSuccessModalButtons) => {
+const CTraderSuccessModalButtons = ({ createdAccount, hide, isDemo }: TCTraderSuccessModalButtons) => {
     const history = useHistory();
     const { isMobile } = useDevice();
 
@@ -30,7 +32,7 @@ const CTraderSuccessModalButtons = ({ hide, isDemo }: TCTraderSuccessModalButton
             <WalletButton
                 onClick={() => {
                     hide();
-                    history.push('/wallets/cashier/transfer');
+                    history.push('/wallets/cashier/transfer', { toAccountLoginId: createdAccount?.account_id });
                 }}
                 size={isMobile ? 'lg' : 'md'}
             >


### PR DESCRIPTION
## Changes:
- Added prop to hide close button on desktop
- Added code to set `ctrader` account as the default `to account` when the transfer button is clicked after successful account creation.

### Screenshots:
#### Before
![CTrader Before](https://github.com/binary-com/deriv-app/assets/104334373/22771436-8f3e-447a-abd2-f8b4750841e4)
![CTrader Default Before](https://github.com/binary-com/deriv-app/assets/104334373/f52adaa9-ad37-4ed2-8f81-750d7f96a7b5)


#### After
![CTrader After Mobile](https://github.com/binary-com/deriv-app/assets/104334373/34b6050f-9565-4c02-addd-a2fce4933c4c)
![CTrader After](https://github.com/binary-com/deriv-app/assets/104334373/b932024d-0c98-4097-8897-ebcf658bd834)

https://github.com/binary-com/deriv-app/assets/104334373/5e59a566-1610-47bc-9315-07a9e3b0521b

![CTrader Default](https://github.com/binary-com/deriv-app/assets/104334373/ca6695a2-c4bd-4e74-9c24-c4a7cd38f698)
