### PR TITLE
DTRA / Kate / FEQ-2213 + FEQ-2205 / Made popover optional

### DIFF
--- a/packages/core/src/App/Components/Layout/Header/account-actions.jsx
+++ b/packages/core/src/App/Components/Layout/Header/account-actions.jsx
@@ -57,6 +57,7 @@ const AccountActions = React.memo(
                             toggleDialog={toggleNotifications}
                             tooltip_message={<Localize i18n_default_text='View notifications' />}
                             should_disable_pointer_events
+                            showPopover={!isTabletOs}
                         />
                         {isTabletOs ? (
                             accountSettings

--- a/packages/core/src/App/Components/Layout/Header/account-actions.jsx
+++ b/packages/core/src/App/Components/Layout/Header/account-actions.jsx
@@ -1,7 +1,7 @@
 import * as PropTypes from 'prop-types';
 import React from 'react';
 import { Button, Icon, Popover } from '@deriv/components';
-import { routes, formatMoney, PlatformContext, moduleLoader } from '@deriv/shared';
+import { routes, formatMoney, PlatformContext, moduleLoader, isTabletOs } from '@deriv/shared';
 import { localize, Localize } from '@deriv/translations';
 import { LoginButton } from './login-button.jsx';
 import { SignupButton } from './signup-button.jsx';
@@ -41,6 +41,11 @@ const AccountActions = React.memo(
     }) => {
         const { is_appstore } = React.useContext(PlatformContext);
         const { isDesktop } = useDevice();
+        const accountSettings = (
+            <BinaryLink className='account-settings-toggle' to={routes.personal_details}>
+                <Icon icon='IcUserOutline' />
+            </BinaryLink>
+        );
 
         if (is_logged_in) {
             if (isDesktop) {
@@ -53,17 +58,19 @@ const AccountActions = React.memo(
                             tooltip_message={<Localize i18n_default_text='View notifications' />}
                             should_disable_pointer_events
                         />
-                        <Popover
-                            classNameBubble='account-settings-toggle__tooltip'
-                            alignment='bottom'
-                            message={<Localize i18n_default_text='Manage account settings' />}
-                            should_disable_pointer_events
-                            zIndex={9999}
-                        >
-                            <BinaryLink className='account-settings-toggle' to={routes.personal_details}>
-                                <Icon icon='IcUserOutline' />
-                            </BinaryLink>
-                        </Popover>
+                        {isTabletOs ? (
+                            accountSettings
+                        ) : (
+                            <Popover
+                                classNameBubble='account-settings-toggle__tooltip'
+                                alignment='bottom'
+                                message={<Localize i18n_default_text='Manage account settings' />}
+                                should_disable_pointer_events
+                                zIndex={9999}
+                            >
+                                {accountSettings}
+                            </Popover>
+                        )}
                         <React.Suspense fallback={<div />}>
                             <AccountInfo
                                 acc_switcher_disabled_message={acc_switcher_disabled_message}

--- a/packages/core/src/App/Components/Layout/Header/toggle-notifications.jsx
+++ b/packages/core/src/App/Components/Layout/Header/toggle-notifications.jsx
@@ -4,6 +4,7 @@ import { Counter, Icon, Popover } from '@deriv/components';
 import NotificationsDialog from 'App/Containers/NotificationsDialog';
 import 'Sass/app/modules/notifications-dialog.scss';
 import { useDevice } from '@deriv-com/ui';
+import { isTabletOs } from '@deriv/shared';
 
 const ToggleNotificationsDrawer = ({
     count,
@@ -44,15 +45,19 @@ const ToggleNotificationsDrawer = ({
                 'notifications-toggle--active': is_visible,
             })}
         >
-            <Popover
-                classNameBubble='notifications-toggle__tooltip'
-                alignment='bottom'
-                message={tooltip_message}
-                should_disable_pointer_events={should_disable_pointer_events}
-                zIndex='9999'
-            >
-                {notifications_toggler_el}
-            </Popover>
+            {isTabletOs ? (
+                notifications_toggler_el
+            ) : (
+                <Popover
+                    classNameBubble='notifications-toggle__tooltip'
+                    alignment='bottom'
+                    message={tooltip_message}
+                    should_disable_pointer_events={should_disable_pointer_events}
+                    zIndex='9999'
+                >
+                    {notifications_toggler_el}
+                </Popover>
+            )}
             <NotificationsDialog is_visible={is_visible} toggleDialog={toggleDialog} />
         </div>
     );

--- a/packages/core/src/App/Components/Layout/Header/toggle-notifications.jsx
+++ b/packages/core/src/App/Components/Layout/Header/toggle-notifications.jsx
@@ -4,7 +4,6 @@ import { Counter, Icon, Popover } from '@deriv/components';
 import NotificationsDialog from 'App/Containers/NotificationsDialog';
 import 'Sass/app/modules/notifications-dialog.scss';
 import { useDevice } from '@deriv-com/ui';
-import { isTabletOs } from '@deriv/shared';
 
 const ToggleNotificationsDrawer = ({
     count,
@@ -12,6 +11,7 @@ const ToggleNotificationsDrawer = ({
     toggleDialog,
     tooltip_message,
     should_disable_pointer_events = false,
+    showPopover = true,
 }) => {
     const { isMobile } = useDevice();
     const notifications_toggler_el = (
@@ -45,9 +45,7 @@ const ToggleNotificationsDrawer = ({
                 'notifications-toggle--active': is_visible,
             })}
         >
-            {isTabletOs ? (
-                notifications_toggler_el
-            ) : (
+            {showPopover ? (
                 <Popover
                     classNameBubble='notifications-toggle__tooltip'
                     alignment='bottom'
@@ -57,6 +55,8 @@ const ToggleNotificationsDrawer = ({
                 >
                     {notifications_toggler_el}
                 </Popover>
+            ) : (
+                notifications_toggler_el
             )}
             <NotificationsDialog is_visible={is_visible} toggleDialog={toggleDialog} />
         </div>

--- a/packages/core/src/App/Components/Layout/Header/wallets/account-actions-wallets.tsx
+++ b/packages/core/src/App/Components/Layout/Header/wallets/account-actions-wallets.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useHistory } from 'react-router';
-import { routes } from '@deriv/shared';
+import { routes, isTabletOs } from '@deriv/shared';
 import { Button, Icon, Popover } from '@deriv/components';
 import { localize, Localize } from '@deriv/translations';
 import { observer, useStore } from '@deriv/stores';
@@ -28,6 +28,12 @@ const AccountActionsWallets = observer(() => {
     const handleManageFundsRedirect = () => {
         history.push(routes.wallets_transfer, { toAccountLoginId: loginid });
     };
+
+    const accountSettings = (
+        <BinaryLink className='account-settings-toggle' to={routes.personal_details}>
+            <Icon icon='IcUserOutline' />
+        </BinaryLink>
+    );
 
     if (!is_logged_in) {
         return (
@@ -62,18 +68,21 @@ const AccountActionsWallets = observer(() => {
                 toggleDialog={toggleNotificationsModal}
                 tooltip_message={<Localize i18n_default_text='View notifications' />}
                 should_disable_pointer_events
+                showPopover={!isTabletOs}
             />
-            <Popover
-                classNameBubble='account-settings-toggle__tooltip'
-                alignment='bottom'
-                message={<Localize i18n_default_text='Manage account settings' />}
-                should_disable_pointer_events
-                zIndex='9999'
-            >
-                <BinaryLink className='account-settings-toggle' to={routes.personal_details}>
-                    <Icon icon='IcUserOutline' />
-                </BinaryLink>
-            </Popover>
+            {isTabletOs ? (
+                accountSettings
+            ) : (
+                <Popover
+                    classNameBubble='account-settings-toggle__tooltip'
+                    alignment='bottom'
+                    message={<Localize i18n_default_text='Manage account settings' />}
+                    should_disable_pointer_events
+                    zIndex='9999'
+                >
+                    {accountSettings}
+                </Popover>
+            )}
             <AccountInfoWallets is_dialog_on={is_accounts_switcher_on} toggleDialog={toggleAccountsDialog} />
             {!is_virtual && !currency && (
                 <div className='set-currency'>

--- a/packages/shared/src/utils/os/os_detect.ts
+++ b/packages/shared/src/utils/os/os_detect.ts
@@ -46,7 +46,8 @@ export const isMobileOs = () =>
 
 export const isTabletOs =
     /ipad|android 3.0|xoom|sch-i800|playbook|tablet|kindle/i.test(navigator.userAgent.toLowerCase()) ||
-    (/android/i.test(navigator.userAgent.toLowerCase()) && !/mobile/i.test(navigator.userAgent.toLowerCase()));
+    (/android/i.test(navigator.userAgent.toLowerCase()) && !/mobile/i.test(navigator.userAgent.toLowerCase())) ||
+    (/MacIntel|Linux/.test(navigator.platform) && navigator.maxTouchPoints > 0);
 
 export const OSDetect = () => {
     // For testing purposes or more compatibility, if we set 'config.os'

--- a/packages/trader/src/Modules/Trading/Components/Elements/purchase-fieldset.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Elements/purchase-fieldset.tsx
@@ -7,6 +7,7 @@ import PurchaseButton from 'Modules/Trading/Components/Elements/purchase-button'
 import CancelDealInfo from '../Form/Purchase/cancel-deal-info';
 import { TProposalTypeInfo, TTradeStore } from 'Types';
 import { useDevice } from '@deriv-com/ui';
+import { isTabletOs } from '@deriv/shared';
 
 type TPurchaseFieldset = {
     basis: string;
@@ -158,7 +159,7 @@ const PurchaseFieldset = ({
                             </Popover>
                         ) : (
                             <React.Fragment>
-                                {is_multiplier ? (
+                                {is_multiplier && !isTabletOs ? (
                                     <Popover
                                         alignment='left'
                                         is_bubble_hover_enabled


### PR DESCRIPTION
## Changes:

- Made popover optional for purchase button for Multipliers and links in the header (notifications and account settings).
Note: function for detection TabletOS was taken from [here](https://github.com/binary-com/deriv-app/pull/15123/files#diff-d05e01aebb22cbc5a1ee9d4830bedce5ace5a036dc9d4a8422c5083d0c259147). Failing test cases were also fixed there.

### Screenshots:

https://github.com/binary-com/deriv-app/assets/121025168/31ab74aa-4e6d-4383-a799-a6d69715bdf4



