### PR TITLE
[WALL] aum / WALL-4085 / fix-routing-for-manage-funds-button-in-account-settings

### DIFF
--- a/packages/shared/src/utils/routes/routes.ts
+++ b/packages/shared/src/utils/routes/routes.ts
@@ -82,7 +82,7 @@ export const routes = {
     wallets_cashier: '/wallets/cashier',
     wallets_deposit: '/wallets/cashier/deposit',
     wallets_withdrawal: '/wallets/cashier/withdraw',
-    wallets_transfer: 'wallets/cashier/transfer',
+    wallets_transfer: '/wallets/cashier/transfer',
     wallets_transactions: '/wallets/cashier/transactions',
     wallets_compare_accounts: '/wallets/compare-accounts',
 


### PR DESCRIPTION
## Changes:

Fixed the routing issue for the `Manage Funds` button in account settings page. On clicking the button, the user must be routed to wallets transfer page with the correct wallet authorized and correct destination account selection.

### Screenshots:

https://github.com/binary-com/deriv-app/assets/125039206/384753fb-ce85-4913-87e7-2e9193ffc649

https://github.com/binary-com/deriv-app/assets/125039206/b198030f-7c5f-4a9c-adb2-354fbbcdf487