### PR TITLE
Update deriv-charts to 2.1.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "@deriv-com/utils": "^0.0.20",
                 "@deriv/api-types": "^1.0.172",
                 "@deriv/deriv-api": "^1.0.15",
-                "@deriv/deriv-charts": "^2.1.15",
+                "@deriv/deriv-charts": "^2.1.16",
                 "@deriv/js-interpreter": "^3.0.0",
                 "@deriv/quill-design": "^1.3.2",
                 "@deriv/quill-icons": "^1.22.4",
@@ -2993,9 +2993,9 @@
             }
         },
         "node_modules/@deriv/deriv-charts": {
-            "version": "2.1.15",
-            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.1.15.tgz",
-            "integrity": "sha512-UPbJsMH516s9d2Re+1K9adbhxbg7z+WDtfOTRHzkZvja+PKKvdQfgqOsO6Mg/9HwvE8faXKQfgKlCzXuQ4k0fQ==",
+            "version": "2.1.16",
+            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.1.16.tgz",
+            "integrity": "sha512-xuIdLZdAT6Ajt1fIC86/Qv+kXJUImmp9YavUzPKam9hpxK4a1rEZ9RsFyj1p0T8A9KCugWWagi9UuPwmE5eb3g==",
             "dependencies": {
                 "@types/lodash.set": "^4.3.7",
                 "@welldone-software/why-did-you-render": "^3.3.8",

--- a/packages/bot-web-ui/package.json
+++ b/packages/bot-web-ui/package.json
@@ -76,7 +76,7 @@
         "@deriv/api-types": "^1.0.172",
         "@deriv/bot-skeleton": "^1.0.0",
         "@deriv/components": "^1.0.0",
-        "@deriv/deriv-charts": "^2.1.15",
+        "@deriv/deriv-charts": "^2.1.16",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",
         "@deriv/translations": "^1.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -107,7 +107,7 @@
         "@deriv/cfd": "^1.0.0",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv/deriv-charts": "^2.1.15",
+        "@deriv/deriv-charts": "^2.1.16",
         "@deriv/hooks": "^1.0.0",
         "@deriv/p2p": "^0.7.3",
         "@deriv/p2p-v2": "^1.0.0",

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -93,7 +93,7 @@
         "@deriv/api-types": "^1.0.172",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv/deriv-charts": "^2.1.15",
+        "@deriv/deriv-charts": "^2.1.16",
         "@deriv/hooks": "^1.0.0",
         "@deriv/reports": "^1.0.0",
         "@deriv/shared": "^1.0.0",


### PR DESCRIPTION
This PR updates @deriv/deriv-charts to 2.1.16