### PR TITLE
[WALL-4083] george / WALL-4083 / demo wallet balance is displayed instead CFDs balance on CFDs success popup

### DIFF
--- a/packages/wallets/src/features/cfd/flows/CTrader/AvailableCTraderAccountsList/AvailableCTraderAccountsList.tsx
+++ b/packages/wallets/src/features/cfd/flows/CTrader/AvailableCTraderAccountsList/AvailableCTraderAccountsList.tsx
@@ -32,7 +32,6 @@ const AvailableCTraderAccountsList: React.FC = () => {
             show(
                 <CTraderSuccessModal
                     createdAccount={createdAccount}
-                    displayBalance={activeWallet?.display_balance || ''}
                     isDemo={accountType === 'demo'}
                     walletCurrencyType={activeWallet?.wallet_currency_type || 'USD'}
                 />

--- a/packages/wallets/src/features/cfd/modals/CTraderSuccessModal/CTraderSuccessModal.tsx
+++ b/packages/wallets/src/features/cfd/modals/CTraderSuccessModal/CTraderSuccessModal.tsx
@@ -10,18 +10,18 @@ import { CTraderSuccessModalButtons } from './components';
 
 type TCTraderSuccessModal = {
     createdAccount?: THooks.CreateOtherCFDAccount;
-    displayBalance?: string;
     isDemo: boolean;
     walletCurrencyType: THooks.WalletAccountsList['wallet_currency_type'];
 };
 
-const CTraderSuccessModal = ({ createdAccount, displayBalance, isDemo, walletCurrencyType }: TCTraderSuccessModal) => {
+const CTraderSuccessModal = ({ createdAccount, isDemo, walletCurrencyType }: TCTraderSuccessModal) => {
     const { data: cTraderAccounts } = useCtraderAccountsList();
     const { isMobile } = useDevice();
     const { hide } = useModal();
+    const cTraderBalance = cTraderAccounts?.find(account => account.login)?.formatted_balance;
 
     const description = isDemo
-        ? `Let's practise trading with ${displayBalance} virtual funds.`
+        ? `Let's practise trading with ${cTraderBalance} virtual funds.`
         : `Transfer funds from your ${walletCurrencyType} Wallet to your ${PlatformDetails.ctrader.title} account to start trading.`;
 
     if (isMobile) {
@@ -34,7 +34,7 @@ const CTraderSuccessModal = ({ createdAccount, displayBalance, isDemo, walletCur
             >
                 <CFDSuccess
                     description={description}
-                    displayBalance={cTraderAccounts?.find(account => account.login)?.formatted_balance}
+                    displayBalance={cTraderBalance}
                     marketType='all'
                     platform='ctrader'
                     renderButton={() => (
@@ -50,7 +50,7 @@ const CTraderSuccessModal = ({ createdAccount, displayBalance, isDemo, walletCur
         <ModalWrapper hideCloseButton>
             <CFDSuccess
                 description={description}
-                displayBalance={cTraderAccounts?.find(account => account.login)?.formatted_balance}
+                displayBalance={cTraderBalance}
                 marketType='all'
                 platform={PlatformDetails.ctrader.platform}
                 renderButton={() => (

--- a/packages/wallets/src/features/cfd/modals/DxtradeEnterPasswordModal/DxtradeEnterPasswordModal.tsx
+++ b/packages/wallets/src/features/cfd/modals/DxtradeEnterPasswordModal/DxtradeEnterPasswordModal.tsx
@@ -54,11 +54,15 @@ const DxtradeEnterPasswordModal = () => {
         }).catch(() => setPassword(''));
     }, [mutateAsync, accountType, password, dxtradePlatform]);
 
+    const dxtradeBalance = useMemo(() => {
+        return dxtradeAccount?.find(account => account.market_type === 'all')?.display_balance;
+    }, [dxtradeAccount]);
+
     const successDescription = useMemo(() => {
         return accountType === 'demo'
-            ? `Let's practise trading with ${activeWallet?.display_balance} virtual funds.`
+            ? `Let's practise trading with ${dxtradeBalance} virtual funds.`
             : `Transfer funds from your ${activeWallet?.currency} Wallet to your ${PlatformDetails.dxtrade.title} account to start trading.`;
-    }, [accountType, activeWallet?.currency, activeWallet?.display_balance]);
+    }, [accountType, activeWallet?.currency, dxtradeBalance]);
 
     useEffect(() => {
         if (!isResetPasswordSuccessful) return;
@@ -76,10 +80,6 @@ const DxtradeEnterPasswordModal = () => {
             );
         }
     }, [dxtradePlatform, hide, isDxtradePasswordNotSet, isMobile, isResetPasswordSuccessful, show]);
-
-    const dxtradeBalance = useMemo(() => {
-        return dxtradeAccount?.find(account => account.market_type === 'all')?.display_balance;
-    }, [dxtradeAccount]);
 
     const renderFooter = useMemo(() => {
         if (isCreateAccountSuccessful) {

--- a/packages/wallets/src/features/cfd/modals/MT5AccountAdded/MT5AccountAdded.tsx
+++ b/packages/wallets/src/features/cfd/modals/MT5AccountAdded/MT5AccountAdded.tsx
@@ -77,16 +77,10 @@ const MT5AccountAdded: FC<TProps> = ({ account, marketType, platform }) => {
 
     const renderSuccessDescription = useMemo(() => {
         if (isDemo) {
-            return `Let's practise trading with ${activeWallet?.display_balance} virtual funds.`;
+            return `Let's practise trading with ${displayBalance} virtual funds.`;
         }
         return `Transfer funds from your ${activeWallet?.wallet_currency_type} Wallet to your ${marketTypeTitle} ${landingCompanyName} account to start trading.`;
-    }, [
-        activeWallet?.display_balance,
-        activeWallet?.wallet_currency_type,
-        isDemo,
-        landingCompanyName,
-        marketTypeTitle,
-    ]);
+    }, [activeWallet?.wallet_currency_type, displayBalance, isDemo, landingCompanyName, marketTypeTitle]);
 
     const renderMainContent = useMemo(() => {
         if (!isSuccess) return null;

--- a/packages/wallets/src/features/cfd/modals/MT5AccountAdded/__tests__/MT5AccountAdded.spec.tsx
+++ b/packages/wallets/src/features/cfd/modals/MT5AccountAdded/__tests__/MT5AccountAdded.spec.tsx
@@ -30,6 +30,9 @@ jest.mock('@deriv/api-v2', () => ({
         })),
         isSuccess: true,
     })),
+    useMT5AccountsList: jest.fn(() => ({
+        data: [{ display_balance: '10,000.00 USD', market_type: 'financial' }],
+    })),
     usePOI: jest.fn(() => ({
         data: {
             current: {
@@ -63,7 +66,7 @@ describe('MT5AccountAdded', () => {
             </APIProvider>
         );
         expect(screen.getByText('Your Financial demo account is ready')).toBeInTheDocument();
-        expect(screen.getByText("Let's practise trading with 10000 USD virtual funds.")).toBeInTheDocument();
+        expect(screen.getByText("Let's practise trading with 10,000.00 USD virtual funds.")).toBeInTheDocument();
         const okButton = screen.getByRole('button', { name: 'OK' });
         expect(okButton).toBeInTheDocument();
         expect(okButton).toBeEnabled();


### PR DESCRIPTION
## Changes:

- fix balance for CFDs success popup (MT5, DerivX, Dxtrade)

### Screenshots:

![Screenshot 2024-05-17 at 15 41 55](https://github.com/binary-com/deriv-app/assets/103181646/60e1d7d1-cd46-4fc8-8939-cb0492b5292c)

