### PR TITLE
[WALL] [Fix] Rostislav / WALL-4135 / Fix wallet name in wallet account switcher looking odd in-between switches

### DIFF
--- a/packages/wallets/src/components/WalletListCardDetails/WalletListCardDetails.tsx
+++ b/packages/wallets/src/components/WalletListCardDetails/WalletListCardDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Trans } from 'react-i18next';
 import { useActiveWalletAccount } from '@deriv/api-v2';
 import { WalletText } from '../Base';
@@ -9,11 +9,14 @@ import './WalletListCardDetails.scss';
 
 const WalletListCardDetails: React.FC = () => {
     const { data: activeWallet } = useActiveWalletAccount();
-    const isDemo: boolean = useMemo(() => {
+    const [isDemo, setIsDemo] = useState<boolean>(activeWallet?.is_virtual ?? false);
+
+    useEffect(() => {
+        // update isDemo only when receiving a new defined is_virtual value
+        // ignore intermediate undefined state when fetching / loading
         if (typeof activeWallet?.is_virtual === 'boolean') {
-            return activeWallet.is_virtual;
+            setIsDemo(activeWallet.is_virtual);
         }
-        return isDemo || false;
     }, [activeWallet?.is_virtual]);
 
     return (

--- a/packages/wallets/src/components/WalletListCardDetails/WalletListCardDetails.tsx
+++ b/packages/wallets/src/components/WalletListCardDetails/WalletListCardDetails.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Trans } from 'react-i18next';
 import { useActiveWalletAccount } from '@deriv/api-v2';
 import { WalletText } from '../Base';
@@ -8,12 +8,17 @@ import WalletListCardDropdown from '../WalletListCardDropdown/WalletListCardDrop
 import './WalletListCardDetails.scss';
 
 const WalletListCardDetails: React.FC = () => {
-    const { data: activeWallet, isLoading } = useActiveWalletAccount();
-    const isDemo = activeWallet?.is_virtual;
+    const { data: activeWallet } = useActiveWalletAccount();
+    const isDemo: boolean = useMemo(() => {
+        if (typeof activeWallet?.is_virtual === 'boolean') {
+            return activeWallet.is_virtual;
+        }
+        return isDemo || false;
+    }, [activeWallet?.is_virtual]);
 
     return (
         <div className='wallets-list-details__container'>
-            {isDemo && !isLoading ? (
+            {isDemo ? (
                 <WalletText>
                     <Trans defaults='USD Demo Wallet' />
                 </WalletText>


### PR DESCRIPTION
## Changes:

- [x] switch `isDemo` between true and false only when the underlying data is received

### Screenshots:

https://github.com/binary-com/deriv-app/assets/119863957/bf555647-6ace-48bb-b678-67e5fb1e8872


