### PR TITLE
[WEBREL]/Mitra/[WEBREL-2753] remove crypto subheader

### DIFF
--- a/packages/account/src/Components/currency-selector/__tests__/currency-selector.spec.tsx
+++ b/packages/account/src/Components/currency-selector/__tests__/currency-selector.spec.tsx
@@ -34,7 +34,6 @@ describe('<CurrencySelector/>', () => {
         expect(screen.getByRole('radio', { name: /us dollar \(usd\)/i })).toBeInTheDocument();
         expect(screen.getByRole('radio', { name: /euro \(eur\)/i })).toBeInTheDocument();
 
-        expect(screen.getByRole('heading', { name: /cryptocurrencies/i })).toBeInTheDocument();
         expect(screen.getByRole('radio', { name: /tether erc20 \(eusdt\)/i })).toBeInTheDocument();
         expect(screen.getByRole('radio', { name: /usd coin \(usdc\)/i })).toBeInTheDocument();
 
@@ -348,7 +347,6 @@ describe('<CurrencySelector/>', () => {
             set_currency: true,
         };
         renderComponent({ props: new_props });
-        expect(screen.getByRole('heading', { name: /cryptocurrencies/i })).toBeInTheDocument();
         expect(screen.getByRole('radio', { name: /tether erc20 \(eusdt\)/i })).toBeInTheDocument();
         expect(screen.getByRole('radio', { name: /usd coin \(usdc\)/i })).toBeInTheDocument();
 

--- a/packages/account/src/Components/currency-selector/currency-selector.tsx
+++ b/packages/account/src/Components/currency-selector/currency-selector.tsx
@@ -217,8 +217,8 @@ const CurrencySelector = observer(
                                             ?.length && (
                                             <React.Fragment>
                                                 <RadioButtonGroup
+                                                    is_title_enabled={false}
                                                     className='currency-selector__radio-group currency-selector__radio-group--with-margin'
-                                                    label={localize('Cryptocurrencies')}
                                                     item_count={
                                                         reorderCurrencies(
                                                             crypto as keyof typeof reorderCurrencies,

--- a/packages/account/src/Components/currency-selector/radio-button-group.tsx
+++ b/packages/account/src/Components/currency-selector/radio-button-group.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import classNames from 'classnames';
 
 export type TRadioButtonGroup = {


### PR DESCRIPTION
## Changes:

As per figma design, in staging Cryptocurrencies subheading is not removed in the Account Creation modal while adding a real deriv account.

### Screenshots:

![image](https://github.com/binary-com/deriv-app/assets/64970259/e1374e42-742b-4e35-ab4b-bc73dbc738e9)

