### PR TITLE
[WALL] [Jest] Rostislav / WALL-3050 / Unit tests for `<WalletClipboard />`

### DIFF
--- a/packages/wallets/src/components/Base/WalletClipboard/WalletClipboard.tsx
+++ b/packages/wallets/src/components/Base/WalletClipboard/WalletClipboard.tsx
@@ -39,7 +39,11 @@ const WalletClipboard = ({
     return (
         <Tooltip alignment='right' isVisible={isHovered && !isMobile} message={isCopied ? 'Copied!' : 'Copy'}>
             <button className='wallets-clipboard' onClick={onClick} ref={hoverRef}>
-                {isCopied ? <LegacyWonIcon iconSize='xs' /> : <LegacyCopy1pxIcon iconSize='xs' />}
+                {isCopied ? (
+                    <LegacyWonIcon data-testid='dt_legacy_won_icon' iconSize='xs' />
+                ) : (
+                    <LegacyCopy1pxIcon data-testid='dt_legacy_copy_icon' iconSize='xs' />
+                )}
             </button>
         </Tooltip>
     );

--- a/packages/wallets/src/components/Base/WalletClipboard/__tests__/WalletClipboard.spec.tsx
+++ b/packages/wallets/src/components/Base/WalletClipboard/__tests__/WalletClipboard.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useCopyToClipboard, useHover } from 'usehooks-ts';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import useDevice from '../../../../hooks/useDevice';
 import WalletClipboard from '../WalletClipboard';
 
@@ -36,17 +37,17 @@ describe('WalletClipboard', () => {
         expect(button).toBeInTheDocument();
         expect(screen.getByTestId('dt_legacy_copy_icon')).toBeInTheDocument();
     });
-    it('should render the button with won icon when copied', () => {
+    it('should render the button with won icon when copied', async () => {
         render(<WalletClipboard textCopy='Sample text to copy' />);
         const button = screen.getByRole('button');
-        fireEvent.click(button);
+        await userEvent.click(button);
 
         expect(screen.getByTestId('dt_legacy_won_icon')).toBeInTheDocument();
     });
-    it('should call copy function with textCopy when button is clicked', () => {
+    it('should call copy function with textCopy when button is clicked', async () => {
         render(<WalletClipboard textCopy='Sample text to copy' />);
         const button = screen.getByRole('button');
-        fireEvent.click(button);
+        await userEvent.click(button);
 
         expect(mockCopy).toHaveBeenCalledWith('Sample text to copy');
     });
@@ -56,39 +57,39 @@ describe('WalletClipboard', () => {
 
         expect(screen.getByText('Copy')).toBeInTheDocument();
     });
-    it('should show tooltip with "Copied!" message when clicked and hovered', () => {
+    it('should show tooltip with "Copied!" message when clicked and hovered', async () => {
         (useHover as jest.Mock).mockReturnValue(true);
         render(<WalletClipboard textCopy='Sample text to copy' />);
         const button = screen.getByRole('button');
-        fireEvent.click(button);
+        await userEvent.click(button);
 
         expect(screen.getByText('Copied!')).toBeInTheDocument();
     });
-    it('should clear timeout on unmount', () => {
+    it('should clear timeout on unmount', async () => {
         jest.useFakeTimers();
         const { unmount } = render(<WalletClipboard textCopy='Sample text to copy' />);
-        fireEvent.click(screen.getByRole('button'));
+        await userEvent.click(screen.getByRole('button'));
         unmount();
 
         jest.runAllTimers();
         expect(clearTimeout).toHaveBeenCalled();
     });
-    it('should not show tooltip on mobile', () => {
+    it('should not show tooltip on mobile', async () => {
         mockUseDevice.mockReturnValue({ isMobile: true });
         render(<WalletClipboard textCopy='Sample text to copy' />);
         const button = screen.getByRole('button');
-        fireEvent.click(button);
+        await userEvent.click(button);
 
         expect(screen.queryByText('Copy')).not.toBeInTheDocument();
         expect(screen.queryByText('Copied!')).not.toBeInTheDocument();
     });
-    it('should reset the icon and message after 2 seconds', () => {
+    it('should reset the icon and message after 2 seconds', async () => {
         jest.useFakeTimers();
         (useHover as jest.Mock).mockReturnValue(true);
         render(<WalletClipboard textCopy='Sample text to copy' />);
         const button = screen.getByRole('button');
 
-        fireEvent.click(button);
+        await userEvent.click(button);
 
         expect(screen.getByText('Copied!')).toBeInTheDocument();
         expect(screen.getByTestId('dt_legacy_won_icon')).toBeInTheDocument();

--- a/packages/wallets/src/components/Base/WalletClipboard/__tests__/WalletClipboard.spec.tsx
+++ b/packages/wallets/src/components/Base/WalletClipboard/__tests__/WalletClipboard.spec.tsx
@@ -18,12 +18,14 @@ jest.mock('../../../../hooks/useDevice', () => ({
 describe('WalletClipboard', () => {
     let mockCopy: jest.Mock;
     const mockUseDevice = useDevice as jest.Mock;
+    const mockUseHover = useHover as jest.Mock;
+    const mockUseCopyToClipboard = useCopyToClipboard as jest.Mock;
     const renderComponent = () => render(<WalletClipboard textCopy='Sample text to copy' />);
 
     beforeEach(() => {
         mockCopy = jest.fn();
-        (useCopyToClipboard as jest.Mock).mockReturnValue([null, mockCopy]);
-        (useHover as jest.Mock).mockReturnValue(false);
+        mockUseCopyToClipboard.mockReturnValue([null, mockCopy]);
+        mockUseHover.mockReturnValue(false);
         mockUseDevice.mockReturnValue({ isMobile: false });
     });
 
@@ -42,7 +44,7 @@ describe('WalletClipboard', () => {
 
     describe('when hovered', () => {
         it('shows tooltip with "Copy" message', async () => {
-            (useHover as jest.Mock).mockReturnValue(true);
+            mockUseHover.mockReturnValue(true);
             renderComponent();
 
             await waitFor(() => {
@@ -53,7 +55,7 @@ describe('WalletClipboard', () => {
 
     describe('when hovered and clicked', () => {
         it('renders the button with won icon', async () => {
-            (useHover as jest.Mock).mockReturnValue(true);
+            mockUseHover.mockReturnValue(true);
             renderComponent();
             const button = await screen.findByRole('button');
             await userEvent.click(button);
@@ -63,7 +65,7 @@ describe('WalletClipboard', () => {
             });
         });
         it('calls copy function with textCopy', async () => {
-            (useHover as jest.Mock).mockReturnValue(true);
+            mockUseHover.mockReturnValue(true);
             renderComponent();
             const button = await screen.findByRole('button');
             await userEvent.click(button);
@@ -71,7 +73,7 @@ describe('WalletClipboard', () => {
             expect(mockCopy).toHaveBeenCalledWith('Sample text to copy');
         });
         it('shows tooltip with "Copied!" message', async () => {
-            (useHover as jest.Mock).mockReturnValue(true);
+            mockUseHover.mockReturnValue(true);
             renderComponent();
             const button = await screen.findByRole('button');
             await userEvent.click(button);
@@ -104,7 +106,7 @@ describe('WalletClipboard', () => {
         });
         it('resets the icon and message after 2 seconds', async () => {
             jest.useFakeTimers();
-            (useHover as jest.Mock).mockReturnValue(true);
+            mockUseHover.mockReturnValue(true);
             renderComponent();
             const button = await screen.findByRole('button');
 

--- a/packages/wallets/src/components/Base/WalletClipboard/__tests__/WalletClipboard.spec.tsx
+++ b/packages/wallets/src/components/Base/WalletClipboard/__tests__/WalletClipboard.spec.tsx
@@ -84,6 +84,7 @@ describe('WalletClipboard', () => {
         });
         it('clears timeout on unmount', async () => {
             jest.useFakeTimers();
+            mockUseHover.mockReturnValue(true);
             const { unmount } = renderComponent();
             const button = await screen.findByRole('button');
             await userEvent.click(button);
@@ -95,6 +96,7 @@ describe('WalletClipboard', () => {
         });
         it("doesn't show tooltip on mobile", async () => {
             mockUseDevice.mockReturnValue({ isMobile: true });
+            mockUseHover.mockReturnValue(true);
             renderComponent();
             const button = await screen.findByRole('button');
             await userEvent.click(button);

--- a/packages/wallets/src/components/Base/WalletClipboard/__tests__/WalletClipboard.spec.tsx
+++ b/packages/wallets/src/components/Base/WalletClipboard/__tests__/WalletClipboard.spec.tsx
@@ -41,6 +41,15 @@ describe('WalletClipboard', () => {
             expect(screen.queryByTestId('dt_legacy_copy_icon')).toBeInTheDocument();
         });
     });
+    it('clears timeout on unmount', async () => {
+        jest.useFakeTimers();
+        const { unmount } = await renderComponent();
+        unmount();
+
+        jest.runAllTimers();
+
+        expect(clearTimeout).toHaveBeenCalled();
+    });
 
     describe('when hovered', () => {
         it('shows tooltip with "Copy" message', async () => {
@@ -54,52 +63,37 @@ describe('WalletClipboard', () => {
     });
 
     describe('when hovered and clicked', () => {
-        it('renders the button with won icon', async () => {
+        const renderScenario = async () => {
             mockUseHover.mockReturnValue(true);
-            renderComponent();
+            const { unmount } = renderComponent();
             const button = await screen.findByRole('button');
             await userEvent.click(button);
+
+            return { unmount };
+        };
+
+        it('renders the button with won icon', async () => {
+            await renderScenario();
 
             await waitFor(() => {
                 expect(screen.queryByTestId('dt_legacy_won_icon')).toBeInTheDocument();
             });
         });
         it('calls copy function with textCopy', async () => {
-            mockUseHover.mockReturnValue(true);
-            renderComponent();
-            const button = await screen.findByRole('button');
-            await userEvent.click(button);
+            await renderScenario();
 
             expect(mockCopy).toHaveBeenCalledWith('Sample text to copy');
         });
         it('shows tooltip with "Copied!" message', async () => {
-            mockUseHover.mockReturnValue(true);
-            renderComponent();
-            const button = await screen.findByRole('button');
-            await userEvent.click(button);
+            await renderScenario();
 
             await waitFor(() => {
                 expect(screen.queryByText('Copied!')).toBeInTheDocument();
             });
         });
-        it('clears timeout on unmount', async () => {
-            jest.useFakeTimers();
-            mockUseHover.mockReturnValue(true);
-            const { unmount } = renderComponent();
-            const button = await screen.findByRole('button');
-            await userEvent.click(button);
-            unmount();
-
-            jest.runAllTimers();
-
-            expect(clearTimeout).toHaveBeenCalled();
-        });
         it("doesn't show tooltip on mobile", async () => {
             mockUseDevice.mockReturnValue({ isMobile: true });
-            mockUseHover.mockReturnValue(true);
-            renderComponent();
-            const button = await screen.findByRole('button');
-            await userEvent.click(button);
+            await renderScenario();
 
             await waitFor(() => {
                 expect(screen.queryByText('Copy')).not.toBeInTheDocument();
@@ -108,11 +102,7 @@ describe('WalletClipboard', () => {
         });
         it('resets the icon and message after 2 seconds', async () => {
             jest.useFakeTimers();
-            mockUseHover.mockReturnValue(true);
-            renderComponent();
-            const button = await screen.findByRole('button');
-
-            await userEvent.click(button);
+            await renderScenario();
 
             await waitFor(() => {
                 expect(screen.queryByText('Copied!')).toBeInTheDocument();

--- a/packages/wallets/src/components/Base/WalletClipboard/__tests__/WalletClipboard.spec.tsx
+++ b/packages/wallets/src/components/Base/WalletClipboard/__tests__/WalletClipboard.spec.tsx
@@ -82,4 +82,20 @@ describe('WalletClipboard', () => {
         expect(screen.queryByText('Copy')).not.toBeInTheDocument();
         expect(screen.queryByText('Copied!')).not.toBeInTheDocument();
     });
+    it('should reset the icon and message after 2 seconds', () => {
+        jest.useFakeTimers();
+        (useHover as jest.Mock).mockReturnValue(true);
+        render(<WalletClipboard textCopy='Sample text to copy' />);
+        const button = screen.getByRole('button');
+
+        fireEvent.click(button);
+
+        expect(screen.getByText('Copied!')).toBeInTheDocument();
+        expect(screen.getByTestId('dt_legacy_won_icon')).toBeInTheDocument();
+
+        jest.advanceTimersByTime(2000);
+
+        expect(screen.queryByText('Copied!')).not.toBeInTheDocument();
+        expect(screen.getByTestId('dt_legacy_copy_icon')).toBeInTheDocument();
+    });
 });

--- a/packages/wallets/src/components/Base/WalletClipboard/__tests__/WalletClipboard.spec.tsx
+++ b/packages/wallets/src/components/Base/WalletClipboard/__tests__/WalletClipboard.spec.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { useCopyToClipboard, useHover } from 'usehooks-ts';
+import { fireEvent, render, screen } from '@testing-library/react';
+import useDevice from '../../../../hooks/useDevice';
+import WalletClipboard from '../WalletClipboard';
+
+jest.mock('usehooks-ts', () => ({
+    useCopyToClipboard: jest.fn(),
+    useHover: jest.fn(),
+}));
+
+jest.mock('../../../../hooks/useDevice', () => ({
+    __esModule: true,
+    default: jest.fn(),
+}));
+
+describe('WalletClipboard', () => {
+    let mockCopy: jest.Mock;
+    const mockUseDevice = useDevice as jest.Mock;
+
+    beforeEach(() => {
+        mockCopy = jest.fn();
+        (useCopyToClipboard as jest.Mock).mockReturnValue([null, mockCopy]);
+        (useHover as jest.Mock).mockReturnValue(false);
+        mockUseDevice.mockReturnValue({ isMobile: false });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should render the button with copy icon initially', () => {
+        render(<WalletClipboard textCopy='Sample text to copy' />);
+        const button = screen.getByRole('button');
+
+        expect(button).toBeInTheDocument();
+        expect(screen.getByTestId('dt_legacy_copy_icon')).toBeInTheDocument();
+    });
+    it('should render the button with won icon when copied', () => {
+        render(<WalletClipboard textCopy='Sample text to copy' />);
+        const button = screen.getByRole('button');
+        fireEvent.click(button);
+
+        expect(screen.getByTestId('dt_legacy_won_icon')).toBeInTheDocument();
+    });
+    it('should call copy function with textCopy when button is clicked', () => {
+        render(<WalletClipboard textCopy='Sample text to copy' />);
+        const button = screen.getByRole('button');
+        fireEvent.click(button);
+
+        expect(mockCopy).toHaveBeenCalledWith('Sample text to copy');
+    });
+    it('should show tooltip with "Copy" message when hovered', () => {
+        (useHover as jest.Mock).mockReturnValue(true);
+        render(<WalletClipboard textCopy='Sample text to copy' />);
+
+        expect(screen.getByText('Copy')).toBeInTheDocument();
+    });
+    it('should show tooltip with "Copied!" message when clicked and hovered', () => {
+        (useHover as jest.Mock).mockReturnValue(true);
+        render(<WalletClipboard textCopy='Sample text to copy' />);
+        const button = screen.getByRole('button');
+        fireEvent.click(button);
+
+        expect(screen.getByText('Copied!')).toBeInTheDocument();
+    });
+    it('should clear timeout on unmount', () => {
+        jest.useFakeTimers();
+        const { unmount } = render(<WalletClipboard textCopy='Sample text to copy' />);
+        fireEvent.click(screen.getByRole('button'));
+        unmount();
+
+        jest.runAllTimers();
+        expect(clearTimeout).toHaveBeenCalled();
+    });
+    it('should not show tooltip on mobile', () => {
+        mockUseDevice.mockReturnValue({ isMobile: true });
+        render(<WalletClipboard textCopy='Sample text to copy' />);
+        const button = screen.getByRole('button');
+        fireEvent.click(button);
+
+        expect(screen.queryByText('Copy')).not.toBeInTheDocument();
+        expect(screen.queryByText('Copied!')).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Changes:

- [x] add unit tests for `<WalletClipboard />`

### Screenshots:

<img width="1728" alt="Screenshot 2024-05-23 at 07 05 53" src="https://github.com/binary-com/deriv-app/assets/119863957/42c53740-8afc-434f-8059-7e7e8974b050">

