### PR TITLE
Update deriv-charts to 2.1.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "@deriv-com/utils": "^0.0.20",
                 "@deriv/api-types": "^1.0.172",
                 "@deriv/deriv-api": "^1.0.15",
-                "@deriv/deriv-charts": "^2.1.17",
+                "@deriv/deriv-charts": "^2.1.18",
                 "@deriv/js-interpreter": "^3.0.0",
                 "@deriv/quill-design": "^1.3.2",
                 "@deriv/quill-icons": "^1.22.7",
@@ -3192,9 +3192,9 @@
             }
         },
         "node_modules/@deriv/deriv-charts": {
-            "version": "2.1.17",
-            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.1.17.tgz",
-            "integrity": "sha512-qNQ1cFvasuK45Wp47wcqeBaFlYn6yMMt6RCwe4amZttVQFd0fnX1HzvPLIbWkkekzIHmLiJT0AH1O+0BFpM2jQ==",
+            "version": "2.1.18",
+            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.1.18.tgz",
+            "integrity": "sha512-g3ZwtG2/4nyUcgUoux50ohxuS7gmAW7ltSth9z54hxS5z6bJsE8FsJYFe6p/JMiH2kkjORg72rA+qXmYMIcZOQ==",
             "dependencies": {
                 "@types/lodash.set": "^4.3.7",
                 "@welldone-software/why-did-you-render": "^3.3.8",
@@ -3978,6 +3978,7 @@
         },
         "node_modules/@isaacs/string-locale-compare": {
             "version": "1.1.0",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/@istanbuljs/load-nyc-config": {
@@ -7481,6 +7482,7 @@
         },
         "node_modules/@npmcli/arborist": {
             "version": "5.3.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@isaacs/string-locale-compare": "^1.1.0",
@@ -7527,6 +7529,7 @@
         },
         "node_modules/@npmcli/arborist/node_modules/hosted-git-info": {
             "version": "5.2.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^7.5.1"
@@ -7537,6 +7540,7 @@
         },
         "node_modules/@npmcli/arborist/node_modules/npm-package-arg": {
             "version": "9.1.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "hosted-git-info": "^5.0.0",
@@ -7550,6 +7554,7 @@
         },
         "node_modules/@npmcli/arborist/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -7563,6 +7568,7 @@
         },
         "node_modules/@npmcli/arborist/node_modules/semver/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -7573,6 +7579,7 @@
         },
         "node_modules/@npmcli/fs": {
             "version": "2.1.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@gar/promisify": "^1.1.3",
@@ -7584,6 +7591,7 @@
         },
         "node_modules/@npmcli/fs/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -7594,6 +7602,7 @@
         },
         "node_modules/@npmcli/fs/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -7607,6 +7616,7 @@
         },
         "node_modules/@npmcli/git": {
             "version": "3.0.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/promise-spawn": "^3.0.0",
@@ -7625,6 +7635,7 @@
         },
         "node_modules/@npmcli/git/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -7638,6 +7649,7 @@
         },
         "node_modules/@npmcli/git/node_modules/semver/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -7648,6 +7660,7 @@
         },
         "node_modules/@npmcli/installed-package-contents": {
             "version": "1.0.7",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "npm-bundled": "^1.1.1",
@@ -7662,6 +7675,7 @@
         },
         "node_modules/@npmcli/map-workspaces": {
             "version": "2.0.4",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/name-from-folder": "^1.0.1",
@@ -7675,6 +7689,7 @@
         },
         "node_modules/@npmcli/map-workspaces/node_modules/brace-expansion": {
             "version": "2.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -7682,6 +7697,7 @@
         },
         "node_modules/@npmcli/map-workspaces/node_modules/glob": {
             "version": "8.0.3",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -7699,6 +7715,7 @@
         },
         "node_modules/@npmcli/map-workspaces/node_modules/minimatch": {
             "version": "5.1.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
@@ -7709,6 +7726,7 @@
         },
         "node_modules/@npmcli/metavuln-calculator": {
             "version": "3.1.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "cacache": "^16.0.0",
@@ -7722,6 +7740,7 @@
         },
         "node_modules/@npmcli/metavuln-calculator/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -7732,6 +7751,7 @@
         },
         "node_modules/@npmcli/metavuln-calculator/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -7745,6 +7765,7 @@
         },
         "node_modules/@npmcli/move-file": {
             "version": "2.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "mkdirp": "^1.0.4",
@@ -7756,10 +7777,12 @@
         },
         "node_modules/@npmcli/name-from-folder": {
             "version": "1.0.1",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/@npmcli/node-gyp": {
             "version": "2.0.0",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -7767,6 +7790,7 @@
         },
         "node_modules/@npmcli/package-json": {
             "version": "2.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "json-parse-even-better-errors": "^2.3.1"
@@ -7777,6 +7801,7 @@
         },
         "node_modules/@npmcli/promise-spawn": {
             "version": "3.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "infer-owner": "^1.0.4"
@@ -7787,6 +7812,7 @@
         },
         "node_modules/@npmcli/run-script": {
             "version": "4.2.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/node-gyp": "^2.0.0",
@@ -21110,6 +21136,7 @@
         },
         "node_modules/abbrev": {
             "version": "1.1.1",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/accepts": {
@@ -21227,6 +21254,7 @@
         },
         "node_modules/agentkeepalive": {
             "version": "4.2.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "debug": "^4.1.0",
@@ -21434,6 +21462,7 @@
         },
         "node_modules/are-we-there-yet": {
             "version": "3.0.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "delegates": "^1.0.0",
@@ -22836,6 +22865,7 @@
         },
         "node_modules/bin-links": {
             "version": "3.0.3",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "cmd-shim": "^5.0.0",
@@ -22851,6 +22881,7 @@
         },
         "node_modules/bin-links/node_modules/npm-normalize-package-bin": {
             "version": "2.0.0",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -22858,6 +22889,7 @@
         },
         "node_modules/bin-links/node_modules/write-file-atomic": {
             "version": "4.0.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "imurmurhash": "^0.1.4",
@@ -23699,6 +23731,7 @@
         },
         "node_modules/builtins": {
             "version": "5.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "semver": "^7.0.0"
@@ -23706,6 +23739,7 @@
         },
         "node_modules/builtins/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -23716,6 +23750,7 @@
         },
         "node_modules/builtins/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -23813,6 +23848,7 @@
         },
         "node_modules/cacache": {
             "version": "16.1.3",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/fs": "^2.1.0",
@@ -23840,6 +23876,7 @@
         },
         "node_modules/cacache/node_modules/brace-expansion": {
             "version": "2.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -23847,6 +23884,7 @@
         },
         "node_modules/cacache/node_modules/glob": {
             "version": "8.0.3",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -23864,6 +23902,7 @@
         },
         "node_modules/cacache/node_modules/minimatch": {
             "version": "5.1.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
@@ -24644,6 +24683,7 @@
         },
         "node_modules/cmd-shim": {
             "version": "5.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "mkdirp-infer-owner": "^2.0.0"
@@ -24764,6 +24804,7 @@
         },
         "node_modules/common-ancestor-path": {
             "version": "1.0.1",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/common-path-prefix": {
@@ -26910,6 +26951,7 @@
         },
         "node_modules/debuglog": {
             "version": "1.0.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "*"
@@ -27665,6 +27707,7 @@
         },
         "node_modules/dezalgo": {
             "version": "1.0.4",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "asap": "^2.0.0",
@@ -28460,6 +28503,7 @@
         },
         "node_modules/err-code": {
             "version": "2.0.3",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/errno": {
@@ -31942,6 +31986,7 @@
         },
         "node_modules/gauge": {
             "version": "4.0.4",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "aproba": "^1.0.3 || ^2.0.0",
@@ -33195,6 +33240,7 @@
         },
         "node_modules/hosted-git-info": {
             "version": "4.1.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -33205,6 +33251,7 @@
         },
         "node_modules/hosted-git-info/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -33612,7 +33659,8 @@
         "node_modules/http-cache-semantics": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-            "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
+            "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
+            "dev": true
         },
         "node_modules/http-deceiver": {
             "version": "1.2.7",
@@ -33852,6 +33900,7 @@
         },
         "node_modules/humanize-ms": {
             "version": "1.2.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.0.0"
@@ -33992,6 +34041,7 @@
         },
         "node_modules/ignore-walk": {
             "version": "5.0.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "minimatch": "^5.0.1"
@@ -34002,6 +34052,7 @@
         },
         "node_modules/ignore-walk/node_modules/brace-expansion": {
             "version": "2.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -34009,6 +34060,7 @@
         },
         "node_modules/ignore-walk/node_modules/minimatch": {
             "version": "5.1.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
@@ -34167,6 +34219,7 @@
         },
         "node_modules/init-package-json": {
             "version": "3.0.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "npm-package-arg": "^9.0.1",
@@ -34183,6 +34236,7 @@
         },
         "node_modules/init-package-json/node_modules/hosted-git-info": {
             "version": "5.2.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^7.5.1"
@@ -34193,6 +34247,7 @@
         },
         "node_modules/init-package-json/node_modules/npm-package-arg": {
             "version": "9.1.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "hosted-git-info": "^5.0.0",
@@ -34206,6 +34261,7 @@
         },
         "node_modules/init-package-json/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -34219,6 +34275,7 @@
         },
         "node_modules/init-package-json/node_modules/semver/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -34717,6 +34774,7 @@
         },
         "node_modules/is-lambda": {
             "version": "1.0.1",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/is-lite": {
@@ -38829,6 +38887,7 @@
         },
         "node_modules/json-stringify-nice": {
             "version": "1.1.4",
+            "dev": true,
             "license": "ISC",
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -38957,10 +39016,12 @@
         },
         "node_modules/just-diff": {
             "version": "5.1.1",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/just-diff-apply": {
             "version": "5.4.1",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/just-extend": {
@@ -39204,6 +39265,7 @@
         },
         "node_modules/libnpmaccess": {
             "version": "6.0.4",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "aproba": "^2.0.0",
@@ -39217,6 +39279,7 @@
         },
         "node_modules/libnpmaccess/node_modules/hosted-git-info": {
             "version": "5.2.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^7.5.1"
@@ -39227,6 +39290,7 @@
         },
         "node_modules/libnpmaccess/node_modules/npm-package-arg": {
             "version": "9.1.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "hosted-git-info": "^5.0.0",
@@ -39240,6 +39304,7 @@
         },
         "node_modules/libnpmaccess/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -39253,6 +39318,7 @@
         },
         "node_modules/libnpmaccess/node_modules/semver/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -39263,6 +39329,7 @@
         },
         "node_modules/libnpmpublish": {
             "version": "6.0.5",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "normalize-package-data": "^4.0.0",
@@ -39277,6 +39344,7 @@
         },
         "node_modules/libnpmpublish/node_modules/hosted-git-info": {
             "version": "5.2.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^7.5.1"
@@ -39287,6 +39355,7 @@
         },
         "node_modules/libnpmpublish/node_modules/normalize-package-data": {
             "version": "4.0.1",
+            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "hosted-git-info": "^5.0.0",
@@ -39300,6 +39369,7 @@
         },
         "node_modules/libnpmpublish/node_modules/npm-package-arg": {
             "version": "9.1.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "hosted-git-info": "^5.0.0",
@@ -39313,6 +39383,7 @@
         },
         "node_modules/libnpmpublish/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -39326,6 +39397,7 @@
         },
         "node_modules/libnpmpublish/node_modules/semver/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -39962,6 +40034,7 @@
         },
         "node_modules/lru-cache": {
             "version": "7.14.1",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">=12"
@@ -40002,6 +40075,7 @@
         },
         "node_modules/make-fetch-happen": {
             "version": "10.2.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "agentkeepalive": "^4.2.1",
@@ -40598,6 +40672,7 @@
         },
         "node_modules/minipass-fetch": {
             "version": "2.1.2",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "minipass": "^3.1.6",
@@ -40623,6 +40698,7 @@
         },
         "node_modules/minipass-json-stream": {
             "version": "1.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "jsonparse": "^1.3.1",
@@ -40641,6 +40717,7 @@
         },
         "node_modules/minipass-sized": {
             "version": "1.0.3",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "minipass": "^3.0.0"
@@ -40763,6 +40840,7 @@
         },
         "node_modules/mkdirp-infer-owner": {
             "version": "2.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "chownr": "^2.0.0",
@@ -41361,6 +41439,7 @@
         },
         "node_modules/node-gyp": {
             "version": "9.3.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "env-paths": "^2.2.0",
@@ -41393,6 +41472,7 @@
         },
         "node_modules/node-gyp/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -41403,6 +41483,7 @@
         },
         "node_modules/node-gyp/node_modules/nopt": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "abbrev": "^1.0.0"
@@ -41416,6 +41497,7 @@
         },
         "node_modules/node-gyp/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -41589,6 +41671,7 @@
         },
         "node_modules/nopt": {
             "version": "5.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "abbrev": "1"
@@ -41602,6 +41685,7 @@
         },
         "node_modules/normalize-package-data": {
             "version": "3.0.3",
+            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "hosted-git-info": "^4.0.1",
@@ -41615,6 +41699,7 @@
         },
         "node_modules/normalize-package-data/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -41625,6 +41710,7 @@
         },
         "node_modules/normalize-package-data/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -41834,6 +41920,7 @@
         },
         "node_modules/npm-bundled": {
             "version": "1.1.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "npm-normalize-package-bin": "^1.0.1"
@@ -41841,6 +41928,7 @@
         },
         "node_modules/npm-install-checks": {
             "version": "5.0.0",
+            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "semver": "^7.1.1"
@@ -41851,6 +41939,7 @@
         },
         "node_modules/npm-install-checks/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -41861,6 +41950,7 @@
         },
         "node_modules/npm-install-checks/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -41874,10 +41964,12 @@
         },
         "node_modules/npm-normalize-package-bin": {
             "version": "1.0.1",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/npm-package-arg": {
             "version": "8.1.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "hosted-git-info": "^3.0.6",
@@ -41890,10 +41982,12 @@
         },
         "node_modules/npm-package-arg/node_modules/builtins": {
             "version": "1.0.3",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/npm-package-arg/node_modules/hosted-git-info": {
             "version": "3.0.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -41904,6 +41998,7 @@
         },
         "node_modules/npm-package-arg/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -41914,6 +42009,7 @@
         },
         "node_modules/npm-package-arg/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -41927,6 +42023,7 @@
         },
         "node_modules/npm-package-arg/node_modules/validate-npm-package-name": {
             "version": "3.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "builtins": "^1.0.3"
@@ -41934,6 +42031,7 @@
         },
         "node_modules/npm-packlist": {
             "version": "5.1.3",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "glob": "^8.0.1",
@@ -41950,6 +42048,7 @@
         },
         "node_modules/npm-packlist/node_modules/brace-expansion": {
             "version": "2.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -41957,6 +42056,7 @@
         },
         "node_modules/npm-packlist/node_modules/glob": {
             "version": "8.0.3",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -41974,6 +42074,7 @@
         },
         "node_modules/npm-packlist/node_modules/minimatch": {
             "version": "5.1.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
@@ -41984,6 +42085,7 @@
         },
         "node_modules/npm-packlist/node_modules/npm-bundled": {
             "version": "2.0.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "npm-normalize-package-bin": "^2.0.0"
@@ -41994,6 +42096,7 @@
         },
         "node_modules/npm-packlist/node_modules/npm-normalize-package-bin": {
             "version": "2.0.0",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -42001,6 +42104,7 @@
         },
         "node_modules/npm-pick-manifest": {
             "version": "7.0.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "npm-install-checks": "^5.0.0",
@@ -42014,6 +42118,7 @@
         },
         "node_modules/npm-pick-manifest/node_modules/hosted-git-info": {
             "version": "5.2.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^7.5.1"
@@ -42024,6 +42129,7 @@
         },
         "node_modules/npm-pick-manifest/node_modules/npm-normalize-package-bin": {
             "version": "2.0.0",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -42031,6 +42137,7 @@
         },
         "node_modules/npm-pick-manifest/node_modules/npm-package-arg": {
             "version": "9.1.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "hosted-git-info": "^5.0.0",
@@ -42044,6 +42151,7 @@
         },
         "node_modules/npm-pick-manifest/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -42057,6 +42165,7 @@
         },
         "node_modules/npm-pick-manifest/node_modules/semver/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -42067,6 +42176,7 @@
         },
         "node_modules/npm-registry-fetch": {
             "version": "13.3.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "make-fetch-happen": "^10.0.6",
@@ -42083,6 +42193,7 @@
         },
         "node_modules/npm-registry-fetch/node_modules/hosted-git-info": {
             "version": "5.2.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^7.5.1"
@@ -42093,6 +42204,7 @@
         },
         "node_modules/npm-registry-fetch/node_modules/npm-package-arg": {
             "version": "9.1.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "hosted-git-info": "^5.0.0",
@@ -42106,6 +42218,7 @@
         },
         "node_modules/npm-registry-fetch/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -42119,6 +42232,7 @@
         },
         "node_modules/npm-registry-fetch/node_modules/semver/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -44381,6 +44495,7 @@
         },
         "node_modules/npmlog": {
             "version": "6.0.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "are-we-there-yet": "^3.0.0",
@@ -45360,6 +45475,7 @@
         },
         "node_modules/pacote": {
             "version": "13.6.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/git": "^3.0.0",
@@ -45393,6 +45509,7 @@
         },
         "node_modules/pacote/node_modules/hosted-git-info": {
             "version": "5.2.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^7.5.1"
@@ -45403,6 +45520,7 @@
         },
         "node_modules/pacote/node_modules/npm-package-arg": {
             "version": "9.1.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "hosted-git-info": "^5.0.0",
@@ -45416,6 +45534,7 @@
         },
         "node_modules/pacote/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -45429,6 +45548,7 @@
         },
         "node_modules/pacote/node_modules/semver/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -45521,6 +45641,7 @@
         },
         "node_modules/parse-conflict-json": {
             "version": "2.0.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "json-parse-even-better-errors": "^2.3.1",
@@ -47739,6 +47860,7 @@
         },
         "node_modules/proc-log": {
             "version": "2.0.1",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -47774,6 +47896,7 @@
         },
         "node_modules/promise-all-reject-late": {
             "version": "1.0.1",
+            "dev": true,
             "license": "ISC",
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -47781,6 +47904,7 @@
         },
         "node_modules/promise-call-limit": {
             "version": "1.0.1",
+            "dev": true,
             "license": "ISC",
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -47797,6 +47921,7 @@
         },
         "node_modules/promise-retry": {
             "version": "2.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "err-code": "^2.0.2",
@@ -47856,6 +47981,7 @@
         },
         "node_modules/promzard": {
             "version": "0.3.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "read": "1"
@@ -49264,6 +49390,7 @@
         },
         "node_modules/read": {
             "version": "1.0.7",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "mute-stream": "~0.0.4"
@@ -49290,6 +49417,7 @@
         },
         "node_modules/read-cmd-shim": {
             "version": "3.0.1",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -49297,6 +49425,7 @@
         },
         "node_modules/read-package-json": {
             "version": "5.0.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "glob": "^8.0.1",
@@ -49310,6 +49439,7 @@
         },
         "node_modules/read-package-json-fast": {
             "version": "2.0.3",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "json-parse-even-better-errors": "^2.3.0",
@@ -49321,6 +49451,7 @@
         },
         "node_modules/read-package-json/node_modules/brace-expansion": {
             "version": "2.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -49328,6 +49459,7 @@
         },
         "node_modules/read-package-json/node_modules/glob": {
             "version": "8.0.3",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -49345,6 +49477,7 @@
         },
         "node_modules/read-package-json/node_modules/hosted-git-info": {
             "version": "5.2.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^7.5.1"
@@ -49355,6 +49488,7 @@
         },
         "node_modules/read-package-json/node_modules/minimatch": {
             "version": "5.1.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
@@ -49365,6 +49499,7 @@
         },
         "node_modules/read-package-json/node_modules/normalize-package-data": {
             "version": "4.0.1",
+            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "hosted-git-info": "^5.0.0",
@@ -49378,6 +49513,7 @@
         },
         "node_modules/read-package-json/node_modules/npm-normalize-package-bin": {
             "version": "2.0.0",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -49385,6 +49521,7 @@
         },
         "node_modules/read-package-json/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -49398,6 +49535,7 @@
         },
         "node_modules/read-package-json/node_modules/semver/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -49730,6 +49868,7 @@
         },
         "node_modules/readdir-scoped-modules": {
             "version": "1.1.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "debuglog": "^1.0.1",
@@ -52524,6 +52663,7 @@
         },
         "node_modules/smart-buffer": {
             "version": "4.2.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 6.0.0",
@@ -52747,6 +52887,7 @@
         },
         "node_modules/socks": {
             "version": "2.7.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ip": "^2.0.0",
@@ -52759,6 +52900,7 @@
         },
         "node_modules/socks-proxy-agent": {
             "version": "7.0.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "agent-base": "^6.0.2",
@@ -53030,6 +53172,7 @@
         },
         "node_modules/ssri": {
             "version": "9.0.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "minipass": "^3.1.1"
@@ -55185,7 +55328,8 @@
         },
         "node_modules/text-table": {
             "version": "0.2.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/thenify": {
             "version": "3.3.1",
@@ -55430,6 +55574,7 @@
         },
         "node_modules/treeverse": {
             "version": "2.0.0",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -56133,6 +56278,7 @@
         },
         "node_modules/unique-filename": {
             "version": "2.0.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "unique-slug": "^3.0.0"
@@ -56143,6 +56289,7 @@
         },
         "node_modules/unique-slug": {
             "version": "3.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "imurmurhash": "^0.1.4"
@@ -56679,6 +56826,7 @@
         },
         "node_modules/validate-npm-package-name": {
             "version": "4.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "builtins": "^5.0.0"
@@ -56804,6 +56952,7 @@
         },
         "node_modules/walk-up-path": {
             "version": "1.0.0",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/walker": {

--- a/packages/bot-web-ui/package.json
+++ b/packages/bot-web-ui/package.json
@@ -76,7 +76,7 @@
         "@deriv/api-types": "^1.0.172",
         "@deriv/bot-skeleton": "^1.0.0",
         "@deriv/components": "^1.0.0",
-        "@deriv/deriv-charts": "^2.1.17",
+        "@deriv/deriv-charts": "^2.1.18",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",
         "@deriv/translations": "^1.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -110,7 +110,7 @@
         "@deriv/cfd": "^1.0.0",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv/deriv-charts": "^2.1.17",
+        "@deriv/deriv-charts": "^2.1.18",
         "@deriv/hooks": "^1.0.0",
         "@deriv/p2p": "^0.7.3",
         "@deriv/p2p-v2": "^1.0.0",

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -95,7 +95,7 @@
         "@deriv/api-types": "^1.0.172",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv/deriv-charts": "^2.1.17",
+        "@deriv/deriv-charts": "^2.1.18",
         "@deriv/hooks": "^1.0.0",
         "@deriv/reports": "^1.0.0",
         "@deriv/shared": "^1.0.0",


### PR DESCRIPTION
This PR updates @deriv/deriv-charts to 2.1.18