### PR TITLE
[COJ]/likhith/[coj-1131]chore: remove account-v2 checks from CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,22 +37,16 @@ jobs:
       run: npx tsc --project packages/wallets/tsconfig.json -noEmit
     - name: Check TypeScript for @deriv/tradershub
       run: npx tsc --project packages/tradershub/tsconfig.json -noEmit
-    - name: Check TypeScript for @deriv/account-v2
-      run: npx tsc --project packages/account-v2/tsconfig.json -noEmit
     - name: Check TypeScript for @deriv/cashier-v2
       run: npx tsc --project packages/cashier-v2/tsconfig.json -noEmit
     - name: Check ESLint for @deriv/wallets
       run: npx eslint --fix --ignore-path packages/wallets/.eslintignore --config packages/wallets/.eslintrc.js packages/wallets
     - name: Check ESLint for @deriv/tradershub
       run: npx eslint --fix --ignore-path packages/tradershub/.eslintignore --config packages/tradershub/.eslintrc.js packages/tradershub
-    - name: Check ESLint for @deriv/account-v2
-      run: npx eslint --fix --ignore-path packages/account-v2/.eslintignore --config packages/account-v2/.eslintrc.js packages/account-v2
     - name: Check ESLint for @deriv/cashier-v2
       run: npx eslint --fix --ignore-path packages/cashier-v2/.eslintignore --config packages/cashier-v2/.eslintrc.js packages/cashier-v2
     - name: Check Stylelint for @deriv/wallets
       run: npx stylelint packages/wallets/**/*.scss
-    - name: Check Stylelint for @deriv/account-v2
-      run: npx stylelint packages/account-v2/**/*.scss
     - name: Check Stylelint for @deriv/cashier-v2
       run: npx stylelint packages/cashier-v2/**/*.scss
     - name: Check tests for @deriv/hooks

--- a/analyze.html
+++ b/analyze.html
@@ -57,9 +57,6 @@
                             </button>
 
                             <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                                <button class="dropdown-item" href="#" onclick="updateIframe('account-v2')">
-                                    account-v2
-                                </button>
                                 <button class="dropdown-item" href="#" onclick="updateIframe('account')">
                                     account
                                 </button>

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -18,5 +18,5 @@ module.exports = {
     transformIgnorePatterns: ['/node_modules/(?!(@enykeev/react-virtualized|@simplewebauthn/browser)).+\\.js$'],
     setupFiles: ['<rootDir>/../../jest.setup.js'],
     setupFilesAfterEnv: ['<rootDir>/../../setupTests.js'],
-    testPathIgnorePatterns: ['/integration-tests/', '/component-tests/'],
+    testPathIgnorePatterns: ['/integration-tests/', '/component-tests/', '/account-v2/'],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,5 +18,5 @@ module.exports = {
     },
     testRegex: '(/__tests__/.*|(\\.)(test|spec))\\.(js|jsx|tsx|ts)?$',
     transformIgnorePatterns: ['/node_modules/(?!(@enykeev/react-virtualized|@simplewebauthn/browser)).+\\.js$'],
-    testPathIgnorePatterns: ['/integration-tests/'],
+    testPathIgnorePatterns: ['/integration-tests/', '/account-v2/'],
 };

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "independent",
-  "npmClient": "npm",
-  "packages": ["packages/*", "packages/account-v2/src/modules"]
+    "version": "independent",
+    "npmClient": "npm",
+    "packages": ["packages/*"]
 }

--- a/package.json
+++ b/package.json
@@ -58,10 +58,10 @@
     "scripts": {
         "analyze:build": "nx run-many --target=analyze:build",
         "analyze:stats": "nx run-many --target=analyze:stats",
-        "build:all": "nx build @deriv/components --skip-nx-cache && nx build @deriv/account  --skip-nx-cache && nx build @deriv/bot-web-ui --skip-nx-cache && nx run-many --target=build",
+        "build:all": "nx build @deriv/components --skip-nx-cache && nx build @deriv/account  --skip-nx-cache && nx build @deriv/bot-web-ui --skip-nx-cache && nx run-many --exclude=@deriv/account-v2,@deriv-lib/account-v2-lib --target=build",
         "build:one": "f () { nx build @deriv/$1 $2 ;}; f",
         "build:since": "nx affected --target=build",
-        "test:eslint-all": "nx run-many --target=test:eslint",
+        "test:eslint-all": "nx run-many --exclude=@deriv/account-v2,@deriv-lib/account-v2-lib --target=test:eslint",
         "test:eslint-one": "f () { nx test @deriv/$1 --target=test:eslint ;}; f",
         "test:eslint-since": "f () { nx affected --target=eslint ;}; f",
         "bootstrap:ci": "f () { lerna link && lerna bootstrap --ci --hoist --strict && lerna link ;}; f",

--- a/packages/core/build/config.js
+++ b/packages/core/build/config.js
@@ -100,10 +100,6 @@ const copyConfig = base => {
             to: 'tradershub',
         },
         {
-            from: path.resolve(__dirname, '../node_modules/@deriv/account-v2/dist/account-v2'),
-            to: 'account-v2',
-        },
-        {
             from: path.resolve(__dirname, '../node_modules/@deriv/cashier-v2/dist/cashier-v2'),
             to: 'cashier-v2',
         },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -101,7 +101,6 @@
         "@deriv-com/translations": "^1.2.3",
         "@deriv-com/utils": "^0.0.20",
         "@deriv/account": "^1.0.0",
-        "@deriv/account-v2": "^1.0.0",
         "@deriv/api": "^1.0.0",
         "@deriv/appstore": "^0.0.4",
         "@deriv/bot-web-ui": "^1.0.0",

--- a/packages/core/src/App/Components/Routes/route-with-sub-routes.jsx
+++ b/packages/core/src/App/Components/Routes/route-with-sub-routes.jsx
@@ -9,7 +9,7 @@ import { useFeatureFlags } from '@deriv/hooks';
 const RouteWithSubRoutes = observer(route => {
     const { common } = useStore();
 
-    const { is_next_account_enabled, is_next_cashier_enabled, is_next_tradershub_enabled } = useFeatureFlags();
+    const { is_next_cashier_enabled, is_next_tradershub_enabled } = useFeatureFlags();
     const { checkAppId } = common;
     const validateRoute = pathname => {
         if (pathname.startsWith('/cashier') && !pathname.includes('p2p') && !!route.routes) {
@@ -21,9 +21,7 @@ const RouteWithSubRoutes = observer(route => {
                     ? routes.p2p_buy_sell
                     : cashier_subroutes?.routes.find(({ path }) => pathname === path);
 
-            return route.path === pathname || !!p2p_subroutes;
-        } else if (pathname.includes(routes.account_v2) && !is_next_account_enabled) {
-            return false;
+            return route.path === pathname || !!p2p_subroutes
         } else if (pathname.includes(routes.cashier_v2) && !is_next_cashier_enabled) {
             return false;
         } else if (

--- a/packages/core/src/App/Constants/routes-config.js
+++ b/packages/core/src/App/Constants/routes-config.js
@@ -88,13 +88,6 @@ const P2P_V2 = React.lazy(() =>
     })
 );
 
-const Account_V2 = React.lazy(() =>
-    moduleLoader(() => {
-        // eslint-disable-next-line import/no-unresolved
-        return import(/* webpackChunkName: "account-v2" */ '@deriv/account-v2');
-    })
-);
-
 const Cashier_V2 = React.lazy(() =>
     moduleLoader(() => {
         // eslint-disable-next-line import/no-unresolved
@@ -306,12 +299,6 @@ const getModules = () => {
             component: TradersHub,
             is_authenticated: true,
             getTitle: () => localize('Trader’s Hub V2'),
-        },
-        {
-            path: routes.account_v2,
-            component: Account_V2,
-            is_authenticated: true,
-            getTitle: () => localize('Account V2'),
         },
         {
             path: routes.cashier_v2,

--- a/packages/core/src/root_files/robots.txt
+++ b/packages/core/src/root_files/robots.txt
@@ -6,6 +6,5 @@ Disallow: */reports/*
 Disallow: */account/*
 Disallow: */cashier-v2/*
 Disallow: */p2p-v2/*
-Disallow: */account-v2/*
 Disallow: */endpoint*
 Disallow: */tradershub/*

--- a/packages/shared/src/utils/routes/routes.ts
+++ b/packages/shared/src/utils/routes/routes.ts
@@ -90,9 +90,6 @@ export const routes = {
     traders_hub_v2: '/traders-hub',
     compare_accounts: '/traders-hub/compare-accounts',
 
-    // Account V2
-    account_v2: '/account-v2',
-
     // Cashier V2
     cashier_v2: '/cashier-v2',
 };

--- a/packages/stores/src/stores/FeatureFlagsStore.ts
+++ b/packages/stores/src/stores/FeatureFlagsStore.ts
@@ -2,7 +2,6 @@ import BaseStore from './BaseStore';
 
 const FLAGS = {
     dtrader_v2: false,
-    next_account: false,
     next_cashier: false,
     next_tradershub: false,
     next_wallet: false,

--- a/packages/tradershub/package.json
+++ b/packages/tradershub/package.json
@@ -16,7 +16,6 @@
     },
     "dependencies": {
         "@deriv/api-v2": "^1.0.0",
-        "@deriv-lib/account-v2-lib": "1.0.0",
         "@deriv/quill-icons": "^1.22.7",
         "@deriv-com/ui": "^1.14.5",
         "@deriv-com/utils": "^0.0.20",

--- a/packages/tradershub/tsconfig.json
+++ b/packages/tradershub/tsconfig.json
@@ -6,9 +6,7 @@
         "paths": {
             "@deriv/*": ["../*/src"],
             "@/*": ["src/*"],
-            "@cfd/*": ["src/features/cfd/*"],
-            "@deriv-lib/account-v2-lib": ["../account-v2/src/modules"],
-
+            "@cfd/*": ["src/features/cfd/*"]
         }
     },
     "include": ["src", "./declarations.d.ts", "../../utils.d.ts"],

--- a/packages/tradershub/webpack.config.js
+++ b/packages/tradershub/webpack.config.js
@@ -186,7 +186,6 @@ module.exports = function (env) {
             alias: {
                 '@': path.resolve(__dirname, 'src'),
                 '@cfd': path.resolve(__dirname, 'src/features/cfd'),
-                '@deriv-lib/account-v2-lib': path.resolve(__dirname, '../account-v2/src/modules'),
             },
             extensions: ['.js', '.jsx', '.ts', '.tsx'],
         },


### PR DESCRIPTION
## Changes:

Development on account-v2 package has been deprioritized. Hence all checks on this package can be removed to speed up CI during deployments

-  Remove CI instructions from test.yml
-  Remove is_next_account_enabled flag
- Remove /account-v2 route
- Remove usage of @deriv/account-v2 and @deriv/account-v2-lib
- Exclude account-v2 & account-v2-lib from `build:all`, `test:eslint-all`
- Exclude account-v2 from jest