### PR TITLE
[TRAH] Sergei / TRAH 3496 / Naming correction from "EUSDT" to "eUSDT" and from "TUSDT" to "tUSDT"

### DIFF
--- a/packages/appstore/src/components/currency-switcher-card/real/real-account-card.tsx
+++ b/packages/appstore/src/components/currency-switcher-card/real/real-account-card.tsx
@@ -35,7 +35,7 @@ const RealAccountCard = observer(() => {
             className='demo-account-card'
             title={
                 currency ? (
-                    <BalanceText currency={get_currency} balance={Number(balance)} size='xs' />
+                    <BalanceText currency={currency} balance={Number(balance)} size='xs' />
                 ) : (
                     'No currency assigned'
                 )


### PR DESCRIPTION
## Changes:

Pass currency instead of uppercase currency to `BalanceText` component

### Screenshots:

<img width="314" alt="image" src="https://github.com/binary-com/deriv-app/assets/120570511/8db92297-5435-4aaa-8f9e-ec3c925e7dab">

<img width="319" alt="image" src="https://github.com/binary-com/deriv-app/assets/120570511/6be2ee2d-9426-45d9-80aa-9b6c6b74eb1b">
