### PR TITLE
[WALL] Lubega / WALL-4163/4165 / Compare accounts and jurisdiction fixes

### DIFF
--- a/packages/wallets/src/features/cfd/modals/MT5PasswordModal/MT5PasswordModal.tsx
+++ b/packages/wallets/src/features/cfd/modals/MT5PasswordModal/MT5PasswordModal.tsx
@@ -243,6 +243,7 @@ const MT5PasswordModal: React.FC<TProps> = ({ marketType, platform }) => {
             <EnterPassword
                 isLoading={tradingPlatformPasswordChangeLoading || createMT5AccountLoading}
                 marketType={marketType}
+                modalTitle='Enter your Deriv MT5 password'
                 onPasswordChange={e => setPassword(e.target.value)}
                 onPrimaryClick={onSubmit}
                 onSecondaryClick={() => sendEmailVerification()}

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/compareAccountsConfig.ts
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/compareAccountsConfig.ts
@@ -171,6 +171,7 @@ const getJurisdictionDescription = (shortcode?: string) => {
                 regulator: 'Labuan Financial Services Authority',
                 regulator_description: 'Regulator/External dispute resolution',
                 regulator_license: '(License no. MB/18/0024)',
+                spread: '1.4 pips',
             };
         case MARKET_TYPE_SHORTCODE.FINANCIAL_MALTAINVEST:
             return {

--- a/packages/wallets/src/features/cfd/screens/Jurisdiction/JurisdictionCard/JurisdictionCardRow.scss
+++ b/packages/wallets/src/features/cfd/screens/Jurisdiction/JurisdictionCard/JurisdictionCardRow.scss
@@ -27,7 +27,6 @@
         height: 10.2rem;
     }
 
-    &--leverage,
     &--verifications,
     &--regulator {
         height: 8.4rem;

--- a/packages/wallets/src/features/cfd/screens/Jurisdiction/jurisdiction-contents/jurisdiction-svg-contents.ts
+++ b/packages/wallets/src/features/cfd/screens/Jurisdiction/jurisdiction-contents/jurisdiction-svg-contents.ts
@@ -4,7 +4,7 @@ export const getJurisdictionSvgContents = (): TJurisdictionCardItems => ({
     contents: {
         all: [
             {
-                description: 'Synthetics, Forex, Stocks, Stock Indices, Cryptocurrencies, and ETFs',
+                description: 'Forex, stocks, stock indices, commodities, cryptocurrencies, ETFs and synthetic indices',
                 key: 'assets',
                 title: 'Assets',
                 titleIndicators: {


### PR DESCRIPTION
## Changes:

- [x] Fixed wrong PIP for Financial Labuan in compare accounts modal
- [x] Fixed missing header in Deriv MT5 enter password modal
- [x] Fix small design/content issues with Swap-Free jurisdiction popup modal

### Screenshots:

Please provide some screenshots of the change.
<img width="1301" alt="Screenshot 2024-05-23 at 6 11 43 PM" src="https://github.com/binary-com/deriv-app/assets/142860499/f2f0d375-2341-4b3b-9be8-2e53bd5c64c2">

<img width="1301" alt="Screenshot 2024-05-23 at 6 12 05 PM" src="https://github.com/binary-com/deriv-app/assets/142860499/02700499-25e7-4b7b-bae7-7411e488cb79">
<img width="1301" alt="Screenshot 2024-05-23 at 6 13 07 PM" src="https://github.com/binary-com/deriv-app/assets/142860499/b9f479ec-a155-4559-a87d-b3f21498a62d">

