### PR TITLE
[WALL] Lubega / WALL-4162 / Account creation success message fix

### DIFF
--- a/packages/wallets/src/components/WalletGradientBackground/WalletGradientBackground.scss
+++ b/packages/wallets/src/components/WalletGradientBackground/WalletGradientBackground.scss
@@ -31,7 +31,7 @@
 
     &[class*='desktop-header'],
     &[class*='mobile-header'] {
-        border-radius: 0;
+        border-radius: unset;
     }
 
     &--USD {

--- a/packages/wallets/src/components/WalletGradientBackground/WalletGradientBackground.scss
+++ b/packages/wallets/src/components/WalletGradientBackground/WalletGradientBackground.scss
@@ -1,6 +1,7 @@
 .wallets-gradient {
     position: relative;
     display: inline-block;
+    border-radius: 0.8rem;
 
     &__content {
         position: relative;
@@ -28,9 +29,9 @@
         }
     }
 
-    &[class*='desktop-card'],
-    &[class*='mobile-card'] {
-        border-radius: 0.8rem;
+    &[class*='desktop-header'],
+    &[class*='mobile-header'] {
+        border-radius: 0;
     }
 
     &--USD {

--- a/packages/wallets/src/features/cfd/modals/MT5PasswordModal/MT5PasswordModal.tsx
+++ b/packages/wallets/src/features/cfd/modals/MT5PasswordModal/MT5PasswordModal.tsx
@@ -9,7 +9,7 @@ import {
     useTradingPlatformPasswordChange,
     useVerifyEmail,
 } from '@deriv/api-v2';
-import { SentEmailContent, WalletError, WalletSuccessResetMT5Password } from '../../../../components';
+import { SentEmailContent, WalletError } from '../../../../components';
 import { ModalStepWrapper, ModalWrapper, WalletButton } from '../../../../components/Base';
 import { useModal } from '../../../../components/ModalProvider';
 import useDevice from '../../../../hooks/useDevice';
@@ -43,7 +43,6 @@ const MT5PasswordModal: React.FC<TProps> = ({ marketType, platform }) => {
     const {
         error: tradingPasswordChangeError,
         isLoading: tradingPlatformPasswordChangeLoading,
-        isSuccess: tradingPasswordChangeSuccess,
         mutateAsync: tradingPasswordChangeMutateAsync,
     } = useTradingPlatformPasswordChange();
     const { data: accountStatusData } = useAccountStatus();
@@ -56,7 +55,7 @@ const MT5PasswordModal: React.FC<TProps> = ({ marketType, platform }) => {
     } = useVerifyEmail();
     const { data: mt5AccountsData } = useMT5AccountsList();
     const { isMobile } = useDevice();
-    const { getModalState, hide, show } = useModal();
+    const { getModalState, hide } = useModal();
     const { data: settingsData } = useSettings();
 
     const { email } = settingsData;
@@ -283,20 +282,6 @@ const MT5PasswordModal: React.FC<TProps> = ({ marketType, platform }) => {
             <ModalWrapper isFullscreen={isMobile}>
                 <SentEmailContent platform={CFD_PLATFORMS.MT5} />
             </ModalWrapper>
-        );
-    }
-
-    if (tradingPasswordChangeSuccess) {
-        return (
-            <WalletSuccessResetMT5Password
-                onClickSuccess={async () => {
-                    await onSubmit();
-                    show(
-                        <MT5AccountAdded account={createMT5AccountData} marketType={marketType} platform={platform} />
-                    );
-                }}
-                title={mt5Title}
-            />
         );
     }
 


### PR DESCRIPTION
## Changes:

- [x] Removed success reset mt5 password modal from account creation flow as it is not needed in this component and check is already done in WalletsResetMT5Password component
- [x] Fixed border radius issue for wallet gradient background by setting border radius to 0 only for header components

### Screenshots:

Account creation flow:

https://github.com/binary-com/deriv-app/assets/142860499/b08c22e9-42a2-4194-8d9c-ef72202fcb10

MT5 reset password flow:

https://github.com/binary-com/deriv-app/assets/142860499/9ba820a2-1e37-42d6-9830-3b21526ddaf1

