### PR TITLE
[WALL]Mitra/WALL-4196/Show onboarding for wallet responsive

### DIFF
--- a/packages/core/src/App/Containers/Layout/header/__tests__/default-mobile-links.spec.tsx
+++ b/packages/core/src/App/Containers/Layout/header/__tests__/default-mobile-links.spec.tsx
@@ -19,6 +19,8 @@ jest.mock('../show-notifications', () =>
     jest.fn(() => <div data-testid='dt_show_notifications'>MockedShowNotifications</div>)
 );
 
+jest.mock('../traders-hub-onboarding', () => jest.fn(() => <div>MockedTradersHubOnboarding</div>));
+
 describe('DefaultMobileLinks', () => {
     let history: BrowserHistory, mock_store: ReturnType<typeof mockStore>;
 
@@ -41,12 +43,20 @@ describe('DefaultMobileLinks', () => {
         );
     };
 
-    it('should render "DefaultMobileLinks" with Notifications & link to Account Settings', () => {
+    it('should render "DefaultMobileLinks" with Onboarding, Notifications & link to Account Settings for wallet', () => {
+        mock_store.client.has_wallet = true;
         render(<DefaultMobileLinks />, { wrapper });
+        expect(screen.getByText('MockedTradersHubOnboarding')).toBeInTheDocument();
         expect(screen.getByText('MockedShowNotifications')).toBeInTheDocument();
         expect(screen.getByText('MockedBinaryLink to Account Settings')).toBeInTheDocument();
     });
 
+    it('should render "DefaultMobileLinks" with Notifications & link to Account Settings for non wallet path', () => {
+        render(<DefaultMobileLinks />, { wrapper });
+        expect(screen.queryByText('MockedTradersHubOnboarding')).not.toBeInTheDocument();
+        expect(screen.getByText('MockedShowNotifications')).toBeInTheDocument();
+        expect(screen.getByText('MockedBinaryLink to Account Settings')).toBeInTheDocument();
+    });
     it('should display the cashier button', () => {
         render(<DefaultMobileLinks />, { wrapper });
         expect(screen.getByRole('button', { name: 'Cashier' })).toBeInTheDocument();

--- a/packages/core/src/App/Containers/Layout/header/default-mobile-links.tsx
+++ b/packages/core/src/App/Containers/Layout/header/default-mobile-links.tsx
@@ -7,6 +7,7 @@ import { useStore } from '@deriv/stores';
 import { Localize } from '@deriv/translations';
 import { BinaryLink } from 'App/Components/Routes';
 import ShowNotifications from './show-notifications';
+import TradersHubOnboarding from './traders-hub-onboarding';
 
 const DefaultMobileLinks = React.memo(() => {
     const { client, ui } = useStore();
@@ -35,6 +36,11 @@ const DefaultMobileLinks = React.memo(() => {
 
     return (
         <React.Fragment>
+            {has_wallet && (
+                <div className='traders-hub-header__menu-right--items--onboarding'>
+                    <TradersHubOnboarding />
+                </div>
+            )}
             <div className='traders-hub-header__menu-right--items--notifications'>
                 <ShowNotifications />
             </div>


### PR DESCRIPTION
## Changes:

To show the tutorial icon for wallet header on responsice

### Screenshots:


<img width="425" alt="Screenshot 2024-05-27 at 3 12 18 PM" src="https://github.com/binary-com/deriv-app/assets/64970259/dd70a0d5-d07c-48e6-9c9b-df85fbea4756">
