### PR TITLE
[WALL] Jim/WALL-4213/ add missing modal in MT5

### DIFF
--- a/packages/wallets/src/features/cfd/modals/MT5PasswordModal/MT5PasswordModal.tsx
+++ b/packages/wallets/src/features/cfd/modals/MT5PasswordModal/MT5PasswordModal.tsx
@@ -20,6 +20,7 @@ import { CFD_PLATFORMS, PlatformDetails } from '../../constants';
 import { CreatePassword, EnterPassword, MT5ResetPasswordModal } from '../../screens';
 import MT5AccountAdded from '../MT5AccountAdded/MT5AccountAdded';
 import { MT5PasswordModalFooter, SuccessModalFooter } from './MT5PasswordModalFooters';
+import { PasswordLimitExceededModal } from '../PasswordLimitExceededModal';
 
 type TProps = {
     marketType: TMarketTypes.SortedMT5Accounts;
@@ -288,7 +289,13 @@ const MT5PasswordModal: React.FC<TProps> = ({ marketType, platform }) => {
     if (createMT5AccountSuccess && !isMT5PasswordNotSet) {
         return <MT5AccountAdded account={createMT5AccountData} marketType={marketType} platform={platform} />;
     }
-
+    if (
+        createMT5AccountStatus === 'error' &&
+        createMT5AccountError?.error?.code === 'PasswordReset' &&
+        !updateMT5Password
+    ) {
+        return <PasswordLimitExceededModal onPrimaryClick={hide} onSecondaryClick={() => sendEmailVerification()} />;
+    }
     if (
         createMT5AccountStatus === 'error' &&
         createMT5AccountError?.error?.code !== 'PasswordError' &&


### PR DESCRIPTION
## Changes:

- Added `PasswordLimit` exceeded modal to MT5

### Screenshots:

<img width="1675" alt="PasswordLimit" src="https://github.com/binary-com/deriv-app/assets/104334373/0bbab2d7-53a9-4cff-80c3-86faa86e32d6">

<img width="372" alt="PasswordLimit Mobile" src="https://github.com/binary-com/deriv-app/assets/104334373/8fbe4823-f0c9-423e-a473-977ac47620be">
