### PR TITLE
[WALL] Aizad/WALL-4223/Error When Receiving Demo Derived & Financial MT5 for Demo Account

### DIFF
--- a/packages/wallets/src/features/cfd/modals/MT5PasswordModal/MT5PasswordModal.tsx
+++ b/packages/wallets/src/features/cfd/modals/MT5PasswordModal/MT5PasswordModal.tsx
@@ -66,7 +66,6 @@ const MT5PasswordModal: React.FC<TProps> = ({ marketType, platform }) => {
     const isMT5PasswordNotSet = accountStatusData?.is_mt5_password_not_set;
     const hasMT5Account = mt5AccountsData?.find(account => account.login);
     const isDemo = activeWalletData?.is_virtual;
-    const selectedJurisdiction = isDemo ? JURISDICTION.SVG : getModalState('selectedJurisdiction');
     const { platform: mt5Platform, title: mt5Title } = PlatformDetails.mt5;
 
     const updateMT5Password =
@@ -75,13 +74,14 @@ const MT5PasswordModal: React.FC<TProps> = ({ marketType, platform }) => {
             createMT5AccountError?.error?.code === 'IncorrectMT5PasswordFormat');
 
     const onSubmit = useCallback(async () => {
-        const accountType = marketType === MARKET_TYPE.SYNTHETIC ? 'gaming' : marketType;
-        const categoryAccountType = isDemo ? 'demo' : accountType;
-
         // ====== Create MT5 Account ======
         // In order to create account, we need to set a password through trading_platform_password_change endpoint first,
         // then only mt5_create_account can be called, otherwise it will response an error for password required.
         // =================================
+
+        const selectedJurisdiction = isDemo ? JURISDICTION.SVG : getModalState('selectedJurisdiction');
+        const accountType = marketType === MARKET_TYPE.SYNTHETIC ? 'gaming' : marketType;
+        const categoryAccountType = isDemo ? 'demo' : accountType;
 
         if (isMT5PasswordNotSet) {
             await tradingPasswordChangeMutateAsync({
@@ -100,18 +100,20 @@ const MT5PasswordModal: React.FC<TProps> = ({ marketType, platform }) => {
                 email: settingsData?.email ?? '',
                 leverage: availableMT5AccountsData?.find(acc => acc.market_type === marketType)?.leverage ?? 500,
                 mainPassword: password,
-                ...(marketType === 'financial' && { mt5_account_type: 'financial' }),
+                ...(marketType === MARKET_TYPE.FINANCIAL && { mt5_account_type: MARKET_TYPE.FINANCIAL }),
                 ...(selectedJurisdiction &&
-                    (selectedJurisdiction !== 'labuan'
+                    (selectedJurisdiction !== JURISDICTION.LABUAN
                         ? {
                               account_type: categoryAccountType,
-                              ...(selectedJurisdiction === 'financial' && { mt5_account_type: 'financial' }),
+                              ...(selectedJurisdiction === MARKET_TYPE.FINANCIAL && {
+                                  mt5_account_type: MARKET_TYPE.FINANCIAL,
+                              }),
                           }
                         : {
-                              account_type: 'financial',
+                              account_type: MARKET_TYPE.FINANCIAL,
                               mt5_account_type: 'financial_stp',
                           })),
-                ...(marketType === 'all' && { sub_account_category: 'swap_free' }),
+                ...(marketType === MARKET_TYPE.ALL && { sub_account_category: 'swap_free' }),
                 name: settingsData?.first_name ?? '',
                 phone: settingsData?.phone ?? '',
                 state: settingsData?.address_state ?? '',
@@ -121,12 +123,12 @@ const MT5PasswordModal: React.FC<TProps> = ({ marketType, platform }) => {
     }, [
         availableMT5AccountsData,
         createMT5AccountMutate,
+        getModalState,
         isDemo,
         isMT5PasswordNotSet,
         marketType,
         mt5Platform,
         password,
-        selectedJurisdiction,
         settingsData?.address_city,
         settingsData?.address_line_1,
         settingsData?.address_postcode,

--- a/packages/wallets/src/features/cfd/modals/MT5PasswordModal/MT5PasswordModal.tsx
+++ b/packages/wallets/src/features/cfd/modals/MT5PasswordModal/MT5PasswordModal.tsx
@@ -16,11 +16,11 @@ import useDevice from '../../../../hooks/useDevice';
 import { TMarketTypes, TPlatforms } from '../../../../types';
 import { platformPasswordResetRedirectLink } from '../../../../utils/cfd';
 import { validPassword, validPasswordMT5 } from '../../../../utils/password-validation';
-import { CFD_PLATFORMS, PlatformDetails } from '../../constants';
+import { CFD_PLATFORMS, JURISDICTION, MARKET_TYPE, PlatformDetails } from '../../constants';
 import { CreatePassword, EnterPassword, MT5ResetPasswordModal } from '../../screens';
 import MT5AccountAdded from '../MT5AccountAdded/MT5AccountAdded';
-import { MT5PasswordModalFooter, SuccessModalFooter } from './MT5PasswordModalFooters';
 import { PasswordLimitExceededModal } from '../PasswordLimitExceededModal';
+import { MT5PasswordModalFooter, SuccessModalFooter } from './MT5PasswordModalFooters';
 
 type TProps = {
     marketType: TMarketTypes.SortedMT5Accounts;
@@ -66,7 +66,7 @@ const MT5PasswordModal: React.FC<TProps> = ({ marketType, platform }) => {
     const isMT5PasswordNotSet = accountStatusData?.is_mt5_password_not_set;
     const hasMT5Account = mt5AccountsData?.find(account => account.login);
     const isDemo = activeWalletData?.is_virtual;
-    const selectedJurisdiction = getModalState('selectedJurisdiction');
+    const selectedJurisdiction = isDemo ? JURISDICTION.SVG : getModalState('selectedJurisdiction');
     const { platform: mt5Platform, title: mt5Title } = PlatformDetails.mt5;
 
     const updateMT5Password =
@@ -75,8 +75,8 @@ const MT5PasswordModal: React.FC<TProps> = ({ marketType, platform }) => {
             createMT5AccountError?.error?.code === 'IncorrectMT5PasswordFormat');
 
     const onSubmit = useCallback(async () => {
-        const accountType = marketType === 'synthetic' ? 'gaming' : marketType;
-        const categoryAccountType = activeWalletData?.is_virtual ? 'demo' : accountType;
+        const accountType = marketType === MARKET_TYPE.SYNTHETIC ? 'gaming' : marketType;
+        const categoryAccountType = isDemo ? 'demo' : accountType;
 
         // ====== Create MT5 Account ======
         // In order to create account, we need to set a password through trading_platform_password_change endpoint first,
@@ -119,9 +119,9 @@ const MT5PasswordModal: React.FC<TProps> = ({ marketType, platform }) => {
             },
         });
     }, [
-        activeWalletData?.is_virtual,
         availableMT5AccountsData,
         createMT5AccountMutate,
+        isDemo,
         isMT5PasswordNotSet,
         marketType,
         mt5Platform,


### PR DESCRIPTION
## Changes:

- The issue arises because the company field passed to the Demo account must always be `svg`. If it is not, the error specified in the card will occur.
- Added a condition where if the account type is demo then it will return `svg`.
- Replace hard coded values with values from constant file.

### Screenshots:
**Before:**
![image](https://github.com/binary-com/deriv-app/assets/103104395/f1a5b52a-871c-459e-a41a-995e1cea4bb8)

**After:**
![image](https://github.com/binary-com/deriv-app/assets/103104395/3d0d689e-c96b-45dc-a98f-2c8ec17a24ec)

