### PR TITLE
WEBREL-2777 / shahzaib / go to deriv.com link removal from mobile drawer

### DIFF
--- a/packages/core/src/App/Components/Layout/Header/toggle-menu-drawer.jsx
+++ b/packages/core/src/App/Components/Layout/Header/toggle-menu-drawer.jsx
@@ -414,14 +414,6 @@ const ToggleMenuDrawer = observer(({ platform_config }) => {
                                                 />
                                             </MobileDrawer.Item>
                                         )}
-                                        <MobileDrawer.Item className='header__menu-mobile-theme--trader-hub'>
-                                            <MenuLink
-                                                link_to={getStaticUrl('/')}
-                                                icon='IcDerivOutline'
-                                                text={localize('Go to Deriv.com')}
-                                                onClickLink={toggleDrawer}
-                                            />
-                                        </MobileDrawer.Item>
                                     </React.Fragment>
                                 )}
                                 {liveChat.isReady && cs_chat_whatsapp && (


### PR DESCRIPTION
## Changes:

- Removed `Go to Deriv.com` from mobile drawer

### Screenshots:

<img width="414" alt="Screenshot 2024-05-28 at 2 24 55 PM" src="https://github.com/binary-com/deriv-app/assets/129842155/399dc2bc-ec57-4437-86a5-de8b5fce10db">
