### PR TITLE
WEBREL/Mitra/[WEBREL-2776]/Remove platform switcher from tradershub route logged out

### DIFF
--- a/packages/components/src/components/mobile-drawer/mobile-drawer.scss
+++ b/packages/components/src/components/mobile-drawer/mobile-drawer.scss
@@ -238,6 +238,10 @@
         color: var(--text-prominent);
         overflow-y: auto;
         overflow-x: hidden;
+
+        &.no-padding {
+            padding-top: 0;
+        }
     }
     &__item {
         padding: 0 1.6rem 0 4.8rem;

--- a/packages/core/src/App/Components/Layout/Header/toggle-menu-drawer.jsx
+++ b/packages/core/src/App/Components/Layout/Header/toggle-menu-drawer.jsx
@@ -340,17 +340,17 @@ const ToggleMenuDrawer = observer(({ platform_config }) => {
                                         onClickLink={toggleDrawer}
                                     />
                                 </MobileDrawer.Item>
-
-                                <MobileDrawer.Item>
-                                    <MenuLink
-                                        link_to={routes.traders_hub}
-                                        icon={TradersHubIcon}
-                                        text={localize("Trader's Hub")}
-                                        onClickLink={toggleDrawer}
-                                        is_active={route === routes.traders_hub}
-                                    />
-                                </MobileDrawer.Item>
-
+                                {is_logged_in && (
+                                    <MobileDrawer.Item>
+                                        <MenuLink
+                                            link_to={routes.traders_hub}
+                                            icon={TradersHubIcon}
+                                            text={localize("Trader's Hub")}
+                                            onClickLink={toggleDrawer}
+                                            is_active={route === routes.traders_hub}
+                                        />
+                                    </MobileDrawer.Item>
+                                )}
                                 {
                                     <MobileDrawer.Item>
                                         <MenuLink

--- a/packages/core/src/App/Components/Layout/Header/toggle-menu-drawer.jsx
+++ b/packages/core/src/App/Components/Layout/Header/toggle-menu-drawer.jsx
@@ -63,9 +63,12 @@ const ToggleMenuDrawer = observer(({ platform_config }) => {
     const { is_p2p_enabled } = useIsP2PEnabled();
 
     const { pathname: route } = useLocation();
+    const location = useLocation();
 
     const is_trading_hub_category =
         route.startsWith(routes.traders_hub) || route.startsWith(routes.cashier) || route.startsWith(routes.account);
+
+    const should_hide_platform_switcher = location.pathname === routes.traders_hub;
 
     const isMounted = useIsMounted();
     const { data } = useRemoteConfig(isMounted());
@@ -310,7 +313,7 @@ const ToggleMenuDrawer = observer(({ platform_config }) => {
                 <Div100vhContainer height_offset='40px'>
                     <div className='header__menu-mobile-body-wrapper'>
                         <React.Fragment>
-                            {is_logged_in && (
+                            {!should_hide_platform_switcher && (
                                 <MobileDrawer.SubHeader
                                     className={classNames({
                                         'dc-mobile-drawer__subheader--hidden': is_submenu_expanded,
@@ -330,7 +333,7 @@ const ToggleMenuDrawer = observer(({ platform_config }) => {
                                 </MobileDrawer.SubHeader>
                             )}
 
-                            <MobileDrawer.Body className={!is_logged_in ? 'no-padding' : ''}>
+                            <MobileDrawer.Body className={should_hide_platform_switcher ? 'no-padding' : ''}>
                                 <div className='header__menu-mobile-platform-switcher' id='mobile_platform_switcher' />
                                 <MobileDrawer.Item>
                                     <MenuLink

--- a/packages/core/src/App/Components/Layout/Header/toggle-menu-drawer.jsx
+++ b/packages/core/src/App/Components/Layout/Header/toggle-menu-drawer.jsx
@@ -310,7 +310,7 @@ const ToggleMenuDrawer = observer(({ platform_config }) => {
                 <Div100vhContainer height_offset='40px'>
                     <div className='header__menu-mobile-body-wrapper'>
                         <React.Fragment>
-                            {
+                            {is_logged_in && (
                                 <MobileDrawer.SubHeader
                                     className={classNames({
                                         'dc-mobile-drawer__subheader--hidden': is_submenu_expanded,
@@ -328,8 +328,9 @@ const ToggleMenuDrawer = observer(({ platform_config }) => {
                                         setTogglePlatformType={setTogglePlatformType}
                                     />
                                 </MobileDrawer.SubHeader>
-                            }
-                            <MobileDrawer.Body>
+                            )}
+
+                            <MobileDrawer.Body className={!is_logged_in ? 'no-padding' : ''}>
                                 <div className='header__menu-mobile-platform-switcher' id='mobile_platform_switcher' />
                                 <MobileDrawer.Item>
                                     <MenuLink
@@ -339,7 +340,7 @@ const ToggleMenuDrawer = observer(({ platform_config }) => {
                                         onClickLink={toggleDrawer}
                                     />
                                 </MobileDrawer.Item>
-                                {is_logged_in && (
+                                {
                                     <MobileDrawer.Item>
                                         <MenuLink
                                             link_to={routes.traders_hub}
@@ -349,7 +350,7 @@ const ToggleMenuDrawer = observer(({ platform_config }) => {
                                             is_active={route === routes.traders_hub}
                                         />
                                     </MobileDrawer.Item>
-                                )}
+                                }
                                 {
                                     <MobileDrawer.Item>
                                         <MenuLink

--- a/packages/core/src/App/Components/Layout/Header/toggle-menu-drawer.jsx
+++ b/packages/core/src/App/Components/Layout/Header/toggle-menu-drawer.jsx
@@ -340,17 +340,17 @@ const ToggleMenuDrawer = observer(({ platform_config }) => {
                                         onClickLink={toggleDrawer}
                                     />
                                 </MobileDrawer.Item>
-                                {
-                                    <MobileDrawer.Item>
-                                        <MenuLink
-                                            link_to={routes.traders_hub}
-                                            icon={TradersHubIcon}
-                                            text={localize("Trader's Hub")}
-                                            onClickLink={toggleDrawer}
-                                            is_active={route === routes.traders_hub}
-                                        />
-                                    </MobileDrawer.Item>
-                                }
+
+                                <MobileDrawer.Item>
+                                    <MenuLink
+                                        link_to={routes.traders_hub}
+                                        icon={TradersHubIcon}
+                                        text={localize("Trader's Hub")}
+                                        onClickLink={toggleDrawer}
+                                        is_active={route === routes.traders_hub}
+                                    />
+                                </MobileDrawer.Item>
+
                                 {
                                     <MobileDrawer.Item>
                                         <MenuLink

--- a/packages/core/src/App/Containers/Layout/header/__tests__/default-header.spec.tsx
+++ b/packages/core/src/App/Containers/Layout/header/__tests__/default-header.spec.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { StoreProvider, mockStore } from '@deriv/stores';
 import { render, screen } from '@testing-library/react';
+import { useLocation } from 'react-router-dom';
 import DefaultHeader from '../default-header';
+import { routes } from '@deriv/shared';
 
 jest.mock('App/Components/Layout/Header', () => ({
     MenuLinks: jest.fn(() => <div>Mocked Menu Links</div>),
@@ -11,6 +13,11 @@ jest.mock('App/Containers/RealAccountSignup', () => jest.fn(() => <div>Mocked Re
 jest.mock('App/Components/Layout/Header/toggle-menu-drawer.jsx', () =>
     jest.fn(() => <div>Mocked Toggle Menu Drawer</div>)
 );
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useLocation: jest.fn().mockReturnValue({ pathname: '' }),
+}));
 jest.mock('../header-account-actions', () => jest.fn(() => <div>Mocked Header Account Action</div>));
 jest.mock('../deriv-short-logo', () => jest.fn(() => <div>Deriv Short Logo</div>));
 
@@ -23,9 +30,23 @@ describe('DefaultHeader', () => {
             </StoreProvider>
         );
 
-    it('should render Platform switcher, Menu Links, Account action and Real Account SignUp components, in Desktop view', () => {
+    it('should render Platform switcher, Menu Links, Account action and Real Account SignUp components, in Desktop view for non-tradershub route', () => {
+        (useLocation as jest.Mock).mockReturnValue({
+            pathname: routes.bot,
+        });
         renderComponent();
         expect(screen.getByText('Mocked Platform Switcher')).toBeInTheDocument();
+        expect(screen.getByText('Mocked Menu Links')).toBeInTheDocument();
+        expect(screen.getByText('Mocked Header Account Action')).toBeInTheDocument();
+        expect(screen.getByText('Mocked Real Account SignUp')).toBeInTheDocument();
+    });
+
+    it('should render Menu Links, Account action and Real Account SignUp components, in Desktop view for tradershub route', () => {
+        (useLocation as jest.Mock).mockReturnValue({
+            pathname: routes.traders_hub,
+        });
+        renderComponent();
+        expect(screen.queryByText('Mocked Platform Switcher')).not.toBeInTheDocument();
         expect(screen.getByText('Mocked Menu Links')).toBeInTheDocument();
         expect(screen.getByText('Mocked Header Account Action')).toBeInTheDocument();
         expect(screen.getByText('Mocked Real Account SignUp')).toBeInTheDocument();

--- a/packages/core/src/App/Containers/Layout/header/default-header.tsx
+++ b/packages/core/src/App/Containers/Layout/header/default-header.tsx
@@ -9,7 +9,7 @@ import RealAccountSignup from 'App/Containers/RealAccountSignup';
 import SetAccountCurrencyModal from 'App/Containers/SetAccountCurrencyModal';
 import ToggleMenuDrawer from 'App/Components/Layout/Header/toggle-menu-drawer.jsx';
 import platform_config from 'App/Constants/platform-config';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import HeaderAccountActions from './header-account-actions';
 import DerivShortLogo from './deriv-short-logo';
 
@@ -38,6 +38,8 @@ const DefaultHeader = observer(() => {
     } = ui;
 
     const history = useHistory();
+    const location = useLocation();
+    const should_hide_platform_switcher = location.pathname === routes.traders_hub;
 
     const addUpdateNotification = () => addNotificationMessage(client_notifications?.new_version_available);
     const removeUpdateNotification = React.useCallback(
@@ -91,6 +93,17 @@ const DefaultHeader = observer(() => {
                         <React.Fragment>
                             <DerivShortLogo />
                             <div className='header__divider' />
+                            {!should_hide_platform_switcher && (
+                                <PlatformSwitcher
+                                    app_routing_history={app_routing_history}
+                                    is_landing_company_loaded={is_landing_company_loaded}
+                                    is_logged_in={is_logged_in}
+                                    is_logging_in={is_logging_in}
+                                    platform_config={filterPlatformsForClients(platform_config)}
+                                    setTogglePlatformType={setTogglePlatformType}
+                                    current_language={current_language}
+                                />
+                            )}
                         </React.Fragment>
                     )}
                     <MenuLinks />

--- a/packages/core/src/App/Containers/Layout/header/default-header.tsx
+++ b/packages/core/src/App/Containers/Layout/header/default-header.tsx
@@ -91,15 +91,6 @@ const DefaultHeader = observer(() => {
                         <React.Fragment>
                             <DerivShortLogo />
                             <div className='header__divider' />
-                            <PlatformSwitcher
-                                app_routing_history={app_routing_history}
-                                is_landing_company_loaded={is_landing_company_loaded}
-                                is_logged_in={is_logged_in}
-                                is_logging_in={is_logging_in}
-                                platform_config={filterPlatformsForClients(platform_config)}
-                                setTogglePlatformType={setTogglePlatformType}
-                                current_language={current_language}
-                            />
                         </React.Fragment>
                     )}
                     <MenuLinks />


### PR DESCRIPTION
## Changes:

Platform switchers are showing for logged-out user in Tradershub. This doesn't match with the design provided


### Screenshots:

Before:

![image](https://github.com/binary-com/deriv-app/assets/64970259/e40d9d5c-9f58-4d1b-bfac-570ecf8635cd)
