### PR TITLE
Nijil / wall-4221 / Fix rapid button click issues

### DIFF
--- a/packages/wallets/src/components/DerivAppsSection/DerivAppsGetAccount.tsx
+++ b/packages/wallets/src/components/DerivAppsSection/DerivAppsGetAccount.tsx
@@ -20,6 +20,7 @@ const DerivAppsGetAccount: React.FC = () => {
     const { data: activeWallet } = useActiveWalletAccount();
     const {
         data: newTradingAccountData,
+        isLoading: isAccountCreationLoading,
         isSuccess: isAccountCreationSuccess,
         mutate: createNewRealAccount,
     } = useCreateNewRealAccount();
@@ -84,7 +85,7 @@ const DerivAppsGetAccount: React.FC = () => {
                     </WalletText>
                     <WalletText size={isDesktop ? '2xs' : 'xs'}>One options account for all platforms.</WalletText>
                 </div>
-                <WalletButton color='primary-light' onClick={createTradingAccount}>
+                <WalletButton color='primary-light' disabled={isAccountCreationLoading} onClick={createTradingAccount}>
                     Get
                 </WalletButton>
             </div>

--- a/packages/wallets/src/components/WalletsAddMoreCardBanner/WalletsAddMoreCardBanner.tsx
+++ b/packages/wallets/src/components/WalletsAddMoreCardBanner/WalletsAddMoreCardBanner.tsx
@@ -19,7 +19,14 @@ const WalletsAddMoreCardBanner: React.FC<TWalletCarouselItem> = ({
 }) => {
     const switchWalletAccount = useWalletAccountSwitcher();
 
-    const { data, error, isSuccess: isMutateSuccess, mutate, status } = useCreateWallet();
+    const {
+        data,
+        error,
+        isLoading: isWalletCreationLoading,
+        isSuccess: isMutateSuccess,
+        mutate,
+        status,
+    } = useCreateWallet();
     const { isMobile } = useDevice();
     const history = useHistory();
     const modal = useModal();
@@ -64,7 +71,7 @@ const WalletsAddMoreCardBanner: React.FC<TWalletCarouselItem> = ({
             </div>
             <WalletButton
                 color='white'
-                disabled={isAdded}
+                disabled={isAdded || isWalletCreationLoading}
                 icon={
                     // TODO: Replace hex colors with values from Deriv UI
                     isAdded ? (

--- a/packages/wallets/src/features/cfd/flows/CTrader/AvailableCTraderAccountsList/AvailableCTraderAccountsList.tsx
+++ b/packages/wallets/src/features/cfd/flows/CTrader/AvailableCTraderAccountsList/AvailableCTraderAccountsList.tsx
@@ -11,7 +11,13 @@ import './AvailableCTraderAccountsList.scss';
 
 const AvailableCTraderAccountsList: React.FC = () => {
     const { hide, show } = useModal();
-    const { data: createdAccount, error, mutate, status } = useCreateOtherCFDAccount();
+    const {
+        data: createdAccount,
+        error,
+        isLoading: isCFDAccountCreationLoading,
+        mutate,
+        status,
+    } = useCreateOtherCFDAccount();
     const { data: activeWallet } = useActiveWalletAccount();
     const { t } = useTranslation();
 
@@ -51,6 +57,7 @@ const AvailableCTraderAccountsList: React.FC = () => {
 
     return (
         <TradingAccountCard
+            disabled={isCFDAccountCreationLoading}
             leading={<div className='wallets-available-ctrader__icon'>{PlatformDetails.ctrader.icon}</div>}
             onClick={() => {
                 onSubmit();

--- a/packages/wallets/src/features/cfd/flows/CTrader/AvailableCTraderAccountsList/AvailableCTraderAccountsList.tsx
+++ b/packages/wallets/src/features/cfd/flows/CTrader/AvailableCTraderAccountsList/AvailableCTraderAccountsList.tsx
@@ -15,6 +15,7 @@ const AvailableCTraderAccountsList: React.FC = () => {
         data: createdAccount,
         error,
         isLoading: isCFDAccountCreationLoading,
+        isSuccess: isCFDAccountCreationSuccess,
         mutate,
         status,
     } = useCreateOtherCFDAccount();
@@ -57,11 +58,9 @@ const AvailableCTraderAccountsList: React.FC = () => {
 
     return (
         <TradingAccountCard
-            disabled={isCFDAccountCreationLoading}
+            disabled={isCFDAccountCreationLoading || isCFDAccountCreationSuccess}
             leading={<div className='wallets-available-ctrader__icon'>{PlatformDetails.ctrader.icon}</div>}
-            onClick={() => {
-                onSubmit();
-            }}
+            onClick={onSubmit}
             trailing={
                 <div className='wallets-available-ctrader__icon'>
                     <LabelPairedChevronRightCaptionRegularIcon width={16} />


### PR DESCRIPTION
## Changes:

Fix the below mentioned issues when tapping buttons in quick succession
- Quickly tap on `Add` button in `Add more wallets` section multiple times throws error.
- For a client without CTrader account, quickly tap on `CTrader` in CFDs section multiple times creates multiple CTrader accounts.
- For a Wallet without Options account, quickly tap on `Get` button in Options account section crashes the application.
