### PR TITLE
Aizad/WEBREL-2778/Remove Cashier Trader Link from Wallets Responsive

### DIFF
--- a/packages/core/src/App/Components/Layout/Header/toggle-menu-drawer.jsx
+++ b/packages/core/src/App/Components/Layout/Header/toggle-menu-drawer.jsx
@@ -66,7 +66,7 @@ const ToggleMenuDrawer = observer(({ platform_config }) => {
     const location = useLocation();
 
     const is_trading_hub_category =
-        route.startsWith(routes.traders_hub) || route.startsWith(routes.cashier) || route.startsWith(routes.account);
+        route === routes.traders_hub || route.startsWith(routes.cashier) || route.startsWith(routes.account);
 
     const should_hide_platform_switcher = location.pathname === routes.traders_hub;
 
@@ -108,12 +108,12 @@ const ToggleMenuDrawer = observer(({ platform_config }) => {
             const routes_config = getRoutesConfig();
             let primary_routes = [];
 
-            const location = window.location.pathname;
-
-            if (location === is_trading_hub_category) {
+            if (is_trading_hub_category) {
                 primary_routes = has_wallet ? [routes.reports, routes.account] : [routes.account, routes.cashier];
             } else {
-                primary_routes = [routes.reports, routes.account, routes.cashier];
+                primary_routes = has_wallet
+                    ? [routes.reports, routes.account]
+                    : [routes.reports, routes.account, routes.cashier];
             }
             setPrimaryRoutesConfig(getFilteredRoutesConfig(routes_config, primary_routes));
         };
@@ -354,7 +354,7 @@ const ToggleMenuDrawer = observer(({ platform_config }) => {
                                         />
                                     </MobileDrawer.Item>
                                 )}
-                                {
+                                {route !== routes.traders_hub && (
                                     <MobileDrawer.Item>
                                         <MenuLink
                                             link_to={routes.trade}
@@ -364,7 +364,7 @@ const ToggleMenuDrawer = observer(({ platform_config }) => {
                                             is_active={route === routes.trade}
                                         />
                                     </MobileDrawer.Item>
-                                }
+                                )}
                                 {primary_routes_config.map((route_config, idx) =>
                                     getRoutesWithSubMenu(route_config, idx)
                                 )}


### PR DESCRIPTION
## Changes:

- Remove Cashier link from responsive menu if Wallets is enabled
- Remove Trader link from responsive menu if is not at the root directory.

### Screenshots:

Tradershub [Wallet enabled] homepage:
<img width="354" alt="image" src="https://github.com/binary-com/deriv-app/assets/103104395/36310171-f4db-4bd8-a8f2-0ad3cd33ea94">

On the Trade page [Wallet enabled] or any other page than the homepage:
<img width="354" alt="image" src="https://github.com/binary-com/deriv-app/assets/103104395/052d8541-f0e0-4c4d-8943-3311923629e9">


