### PR TITLE
[WALL] aum/WALL-4241/fix-dob-format-verify-document-details

### DIFF
--- a/packages/wallets/src/components/DatePicker/DatePicker.tsx
+++ b/packages/wallets/src/components/DatePicker/DatePicker.tsx
@@ -9,6 +9,7 @@ import 'react-calendar/dist/Calendar.css';
 import './DatePicker.scss';
 
 interface TDatePickerProps extends TFlowFieldProps {
+    displayFormat?: string;
     maxDate?: Date;
     minDate?: Date;
     mobileAlignment?: 'above' | 'below';
@@ -18,6 +19,7 @@ interface TDatePickerProps extends TFlowFieldProps {
 const DatePicker = ({
     defaultValue,
     disabled,
+    displayFormat = 'YYYY-MM-DD',
     label,
     maxDate,
     message,
@@ -77,7 +79,7 @@ const DatePicker = ({
                 showMessage
                 type='text'
                 validationSchema={validationSchema}
-                value={selectedDate !== null ? unixToDateString(selectedDate) : ''}
+                value={selectedDate !== null ? unixToDateString(selectedDate, displayFormat) : ''}
             />
             {isCalendarOpen && (
                 <div

--- a/packages/wallets/src/features/accounts/screens/VerifyDocumentDetails/VerifyDocumentDetails.tsx
+++ b/packages/wallets/src/features/accounts/screens/VerifyDocumentDetails/VerifyDocumentDetails.tsx
@@ -88,6 +88,7 @@ const VerifyDocumentDetails = () => {
                     <DatePicker
                         defaultValue={unixToDateString(formattedDateOfBirth)}
                         disabled={formValues.verifiedDocumentDetails}
+                        displayFormat='DD-MM-YYYY'
                         label='Date of birth*'
                         maxDate={moment().subtract(18, 'years').toDate()}
                         message='Your date of birth as in your identity document'

--- a/packages/wallets/src/features/accounts/screens/VerifyDocumentDetails/__tests__/VerifyDocumentDetails.spec.tsx
+++ b/packages/wallets/src/features/accounts/screens/VerifyDocumentDetails/__tests__/VerifyDocumentDetails.spec.tsx
@@ -41,7 +41,7 @@ describe('IDVDocumentUploadDetails', () => {
 
         expect(screen.getByLabelText('First name*')).toHaveValue('John');
         expect(screen.getByLabelText('Last name*')).toHaveValue('Doe');
-        expect(screen.getByLabelText('Date of birth*')).toHaveValue('1970-01-01');
+        expect(screen.getByLabelText('Date of birth*')).toHaveValue('01-01-1970');
         expect(
             screen.getByLabelText(/I confirm that the name and date of birth above match my chosen identity document/)
         ).toBeInTheDocument();
@@ -76,7 +76,7 @@ describe('IDVDocumentUploadDetails', () => {
         expect(screen.getByLabelText('First name*')).toHaveValue('John');
         expect(screen.getByLabelText('Last name*')).toHaveValue('Doe');
         expect(screen.getByLabelText('Date of birth*')).toHaveValue(
-            moment().subtract(25, 'years').format('YYYY-MM-DD')
+            moment().subtract(25, 'years').format('DD-MM-YYYY')
         );
         expect(
             screen.getByLabelText(/I confirm that the name and date of birth above match my chosen identity document/)

--- a/packages/wallets/src/utils/utils.ts
+++ b/packages/wallets/src/utils/utils.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
-export default function unixToDateString(date: Date) {
-    const formattedDate = moment(date).format('YYYY-MM-DD');
+export default function unixToDateString(date: Date, format = 'YYYY-MM-DD') {
+    const formattedDate = moment(date).format(format);
 
     return formattedDate;
 }


### PR DESCRIPTION
## Changes:

- Added format param to `unixToDateString` util function.
- Added `displayFormat` prop to DatePicker.
- Added custom format of `DD-MM-YYYY` as displayFormat to DatePicker used in VerifyDocumentDetails form to make it consistent with prod.

### Screenshots:

<img width="1048" alt="Screenshot 2024-05-30 at 11 02 34 AM" src="https://github.com/binary-com/deriv-app/assets/125039206/59420786-86f4-4db4-8f8b-ffedbf98dc6a">

