### PR TITLE
FEQ-2313 / Kate / Android tablet- Long code message content is showing in smaller size

### DIFF
--- a/packages/trader/src/Modules/Contract/Components/InfoBox/info-box-longcode.tsx
+++ b/packages/trader/src/Modules/Contract/Components/InfoBox/info-box-longcode.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import React from 'react';
 import { Icon, Text, Modal, Button } from '@deriv/components';
 import { Localize } from '@deriv/translations';
-import { TContractInfo } from '@deriv/shared';
+import { TContractInfo, isTabletOs } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
 
 type TInfoBoxLongcode = { contract_info: TContractInfo };
@@ -37,6 +37,7 @@ const InfoBoxLongcode = observer(({ contract_info }: TInfoBoxLongcode) => {
                     size='xs'
                     className={classNames('info-box-longcode-text', {
                         'info-box-longcode-text--collapsed': is_collapsed || is_mobile,
+                        'info-box-longcode-text--collapsed--fixed-height': !isTabletOs && (is_collapsed || is_mobile),
                     })}
                 >
                     {contract_info.longcode}

--- a/packages/trader/src/sass/app/modules/contract.scss
+++ b/packages/trader/src/sass/app/modules/contract.scss
@@ -44,11 +44,6 @@ $CONTRACT_INFO_BOX_PADDING: 1.6em;
 
                 a {
                     color: var(--brand-red-coral);
-
-                    @media only screen and (max-height: 667px) {
-                        font-size: 1rem;
-                        line-height: 1.5rem;
-                    }
                 }
             }
             &-text {
@@ -73,8 +68,6 @@ $CONTRACT_INFO_BOX_PADDING: 1.6em;
                     &--collapsed {
                         display: block;
                         overflow: hidden;
-                        font-size: 1rem;
-                        line-height: 1.5rem;
                         height: 2.8rem;
 
                         &:after {

--- a/packages/trader/src/sass/app/modules/contract.scss
+++ b/packages/trader/src/sass/app/modules/contract.scss
@@ -68,6 +68,7 @@ $CONTRACT_INFO_BOX_PADDING: 1.6em;
                     &--collapsed {
                         display: block;
                         overflow: hidden;
+                        line-height: 1.5rem;
                         height: 2.8rem;
 
                         &:after {

--- a/packages/trader/src/sass/app/modules/contract.scss
+++ b/packages/trader/src/sass/app/modules/contract.scss
@@ -65,9 +65,10 @@ $CONTRACT_INFO_BOX_PADDING: 1.6em;
                 }
                 /* iPhone SE screen height fixes due to UI space restrictions */
                 @media only screen and (max-height: 667px) {
-                    &--collapsed {
+                    &--collapsed--fixed-height {
                         display: block;
                         overflow: hidden;
+                        font-size: 1rem;
                         line-height: 1.5rem;
                         height: 2.8rem;
 

--- a/packages/trader/src/sass/app/modules/contract.scss
+++ b/packages/trader/src/sass/app/modules/contract.scss
@@ -44,6 +44,11 @@ $CONTRACT_INFO_BOX_PADDING: 1.6em;
 
                 a {
                     color: var(--brand-red-coral);
+
+                    @media only screen and (max-height: 667px) {
+                        font-size: 1rem;
+                        line-height: 1.5rem;
+                    }
                 }
             }
             &-text {


### PR DESCRIPTION
## Changes:

For small Android tablets in landscape view we were applying className for IPhone SE, which rewritten font-size. Add check for detecting Tablet OS

### Screenshots:

IPhone SE is still the same
<img width="771" alt="Screenshot 2024-06-04 at 10 37 37 AM" src="https://github.com/binary-com/deriv-app/assets/121025168/090dda18-3e53-4236-98f4-97f3b7756c86">

Android Tablet (Tab 9)
<img width="1705" alt="Screenshot 2024-06-04 at 10 44 43 AM" src="https://github.com/binary-com/deriv-app/assets/121025168/9315fab6-18f3-4593-a899-65f28ccfee92">

Android Tablet (Tab 8)
<img width="1705" alt="Screenshot 2024-06-04 at 10 47 25 AM" src="https://github.com/binary-com/deriv-app/assets/121025168/1eff3db4-048d-4585-8763-dad83bad2535">
