### PR TITLE
[WALL][CFDS] shontzu/CFDS-3999/Create-New-password-modal-reappears-on-manage-account-settings

### DIFF
--- a/packages/account/src/Components/reset-trading-password-modal/reset-trading-password-modal.tsx
+++ b/packages/account/src/Components/reset-trading-password-modal/reset-trading-password-modal.tsx
@@ -176,7 +176,12 @@ const ResetTradingPassword = ({
                                         />
                                     </Text>
                                     <Text as='p' size='xs' className='reset-trading-password__details'>
-                                        {localize('You can use this password for all your Deriv MT5 accounts.')}
+                                        <Localize
+                                            i18n_default_text='You can use this password for all your {{platform}} accounts.'
+                                            values={{
+                                                platform: getCFDPlatformLabel(platform),
+                                            }}
+                                        />
                                     </Text>
                                     <fieldset className='reset-trading-password__input-field'>
                                         <PasswordMeter

--- a/packages/account/src/Containers/reset-trading-password.tsx
+++ b/packages/account/src/Containers/reset-trading-password.tsx
@@ -7,13 +7,7 @@ import { TPlatforms } from '../Types';
 
 const ResetTradingPassword = observer(() => {
     const { ui, client } = useStore();
-    const {
-        enableApp,
-        disableApp,
-        is_reset_trading_password_modal_visible,
-        is_loading,
-        setResetTradingPasswordModalOpen,
-    } = ui;
+    const { enableApp, disableApp, is_reset_trading_password_modal_visible, is_loading, setCFDPasswordResetModal } = ui;
     const location = useLocation();
     const platform = React.useRef('');
     const query_params = new URLSearchParams(location.search);
@@ -35,7 +29,7 @@ const ResetTradingPassword = observer(() => {
             platform={platform.current as TPlatforms}
             enableApp={enableApp}
             disableApp={disableApp}
-            toggleResetTradingPasswordModal={setResetTradingPasswordModalOpen}
+            toggleResetTradingPasswordModal={setCFDPasswordResetModal}
             is_visible={is_reset_trading_password_modal_visible}
             is_loading={is_loading}
             verification_code={verification_code}

--- a/packages/appstore/src/components/modals/modal-manager.tsx
+++ b/packages/appstore/src/components/modals/modal-manager.tsx
@@ -212,7 +212,7 @@ const ModalManager = () => {
         enableApp,
         disableApp,
         is_reset_trading_password_modal_visible,
-        setResetTradingPasswordModalOpen,
+        setCFDPasswordResetModal,
         is_cfd_reset_password_modal_enabled,
         is_top_up_virtual_open,
         is_top_up_virtual_success,
@@ -330,7 +330,7 @@ const ModalManager = () => {
                     platform={trading_platform_dxtrade_password_reset ? 'dxtrade' : 'mt5'}
                     enableApp={enableApp}
                     disableApp={disableApp}
-                    toggleResetTradingPasswordModal={setResetTradingPasswordModalOpen}
+                    toggleResetTradingPasswordModal={setCFDPasswordResetModal}
                     is_visible={is_reset_trading_password_modal_visible}
                     is_loading={is_populating_mt5_account_list}
                     verification_code={trading_platform_dxtrade_password_reset || trading_platform_mt5_password_reset}

--- a/packages/core/src/App/Containers/Redirect/redirect.jsx
+++ b/packages/core/src/App/Containers/Redirect/redirect.jsx
@@ -15,7 +15,7 @@ const Redirect = observer(() => {
 
     const {
         openRealAccountSignup,
-        setResetTradingPasswordModalOpen,
+        setCFDPasswordResetModal,
         toggleAccountSignupModal,
         toggleResetPasswordModal,
         toggleResetEmailModal,
@@ -126,7 +126,7 @@ const Redirect = observer(() => {
                 }
             }
 
-            setResetTradingPasswordModalOpen(true);
+            setCFDPasswordResetModal(true);
             break;
         }
         case 'payment_deposit': {

--- a/packages/core/src/Stores/ui-store.js
+++ b/packages/core/src/Stores/ui-store.js
@@ -386,7 +386,6 @@ export default class UIStore extends BaseStore {
             setPWAPromptEvent: action.bound,
             setRealAccountSignupEnd: action.bound,
             setRealAccountSignupParams: action.bound,
-            setResetTradingPasswordModalOpen: action.bound,
             setRouteModal: action.bound,
             setScamMessageLocalStorage: action.bound,
             setShouldShowAppropriatenessWarningModal: action.bound,
@@ -785,10 +784,6 @@ export default class UIStore extends BaseStore {
         this.is_update_email_modal_visible = state_change;
     }
 
-    setResetTradingPasswordModalOpen(is_reset_trading_password_modal_visible) {
-        this.is_reset_trading_password_modal_visible = is_reset_trading_password_modal_visible;
-    }
-
     setRealAccountSignupParams(params) {
         this.real_account_signup = {
             ...this.real_account_signup,
@@ -941,8 +936,8 @@ export default class UIStore extends BaseStore {
         this.is_need_real_account_for_cashier_modal_visible = !this.is_need_real_account_for_cashier_modal_visible;
     }
 
-    setCFDPasswordResetModal(val) {
-        this.is_cfd_reset_password_modal_enabled = !!val;
+    setCFDPasswordResetModal() {
+        this.is_cfd_reset_password_modal_enabled = !this.is_cfd_reset_password_modal_enabled;
     }
 
     setSubSectionIndex(index) {

--- a/packages/stores/src/mockStore.ts
+++ b/packages/stores/src/mockStore.ts
@@ -453,7 +453,6 @@ const mock = (): TStores & { is_mock: boolean } => {
             openTopUpModal: jest.fn(),
             toggleShouldShowRealAccountsList: jest.fn(),
             is_reset_trading_password_modal_visible: false,
-            setResetTradingPasswordModalOpen: jest.fn(),
             setIsMFVericationPendingModal: jest.fn(),
             setMT5MigrationModalEnabled: jest.fn(),
             toggleMT5MigrationModal: jest.fn(),

--- a/packages/stores/types.ts
+++ b/packages/stores/types.ts
@@ -776,7 +776,6 @@ type TUiStore = {
     is_reset_trading_password_modal_visible: boolean;
     real_account_signup: RealAccountSignupSettings;
     resetRealAccountSignupParams: () => void;
-    setResetTradingPasswordModalOpen: () => void;
     populateHeaderExtensions: (header_items: JSX.Element | null) => void;
     populateSettingsExtensions: (menu_items: Array<TPopulateSettingsExtensionsMenuItem> | null) => void;
     purchase_states: boolean[];


### PR DESCRIPTION
# WIP

## Changes:

- there are two conflicting visibility states in `ui-store` causing inconsistency in modal behaviour
- `/account` is using `setResetTradingPasswordModalOpen` and `/cfd` is using `setCFDPasswordResetModal`
- both these states are used for visibility of `ResetTradingPassword` Modal
- removed `setResetTradingPasswordModalOpen` 
- the component visibility is now using `ResetTradingPassword` in both cfd and account

<!--
⚠️ Check this fix on wallets (qa29) and prod (qa10)
todo: fix prod verification_code is null
<img width="454" alt="image" src="https://github.com/binary-com/deriv-app/assets/108507236/21a8151f-40eb-4c1c-9ff0-3fabaac14c99">
-->

### Screenshots:

Below are demo video for Wallets and Prod

https://github.com/binary-com/deriv-app/assets/108507236/22cb652c-acc8-431d-8492-5a73223bedba

https://github.com/binary-com/deriv-app/assets/108507236/ffc566f3-3db6-4071-8cb0-03924dee0b1f


