### PR TITLE
[WALL][CFDS] shontzu/CFDS-3999/Create-New-password-modal-reappears-on-manage-account-settings

### DIFF
--- a/packages/account/src/Components/reset-trading-password-modal/reset-trading-password-modal.tsx
+++ b/packages/account/src/Components/reset-trading-password-modal/reset-trading-password-modal.tsx
@@ -176,7 +176,12 @@ const ResetTradingPassword = ({
                                         />
                                     </Text>
                                     <Text as='p' size='xs' className='reset-trading-password__details'>
-                                        {localize('You can use this password for all your Deriv MT5 accounts.')}
+                                        <Localize
+                                            i18n_default_text='You can use this password for all your {{platform}} accounts.'
+                                            values={{
+                                                platform: getCFDPlatformLabel(platform),
+                                            }}
+                                        />
                                     </Text>
                                     <fieldset className='reset-trading-password__input-field'>
                                         <PasswordMeter

--- a/packages/account/src/Containers/reset-trading-password.tsx
+++ b/packages/account/src/Containers/reset-trading-password.tsx
@@ -7,14 +7,8 @@ import { TPlatforms } from '../Types';
 
 const ResetTradingPassword = observer(() => {
     const { ui, client } = useStore();
-    const {
-        enableApp,
-        disableApp,
-        is_reset_trading_password_modal_visible,
-        is_loading,
-        setResetTradingPasswordModalOpen,
-        is_cfd_reset_password_modal_enabled,
-    } = ui;
+    const { enableApp, disableApp, is_loading, setResetTradingPasswordModalOpen, is_cfd_reset_password_modal_enabled } =
+        ui;
     const location = useLocation();
     const platform = React.useRef('');
     const query_params = new URLSearchParams(location.search);

--- a/packages/account/src/Containers/reset-trading-password.tsx
+++ b/packages/account/src/Containers/reset-trading-password.tsx
@@ -7,8 +7,7 @@ import { TPlatforms } from '../Types';
 
 const ResetTradingPassword = observer(() => {
     const { ui, client } = useStore();
-    const { enableApp, disableApp, is_loading, setResetTradingPasswordModalOpen, is_cfd_reset_password_modal_enabled } =
-        ui;
+    const { enableApp, disableApp, is_loading, setCFDPasswordResetModal, is_cfd_reset_password_modal_enabled } = ui;
     const location = useLocation();
     const platform = React.useRef('');
     const query_params = new URLSearchParams(location.search);
@@ -30,7 +29,7 @@ const ResetTradingPassword = observer(() => {
             platform={platform.current as TPlatforms}
             enableApp={enableApp}
             disableApp={disableApp}
-            toggleResetTradingPasswordModal={setResetTradingPasswordModalOpen}
+            toggleResetTradingPasswordModal={setCFDPasswordResetModal}
             is_visible={is_cfd_reset_password_modal_enabled}
             is_loading={is_loading}
             verification_code={verification_code}

--- a/packages/account/src/Containers/reset-trading-password.tsx
+++ b/packages/account/src/Containers/reset-trading-password.tsx
@@ -38,7 +38,6 @@ const ResetTradingPassword = observer(() => {
             disableApp={disableApp}
             toggleResetTradingPasswordModal={setResetTradingPasswordModalOpen}
             is_visible={is_cfd_reset_password_modal_enabled}
-            // is_visible={is_reset_trading_password_modal_visible}
             is_loading={is_loading}
             verification_code={verification_code}
         />

--- a/packages/account/src/Containers/reset-trading-password.tsx
+++ b/packages/account/src/Containers/reset-trading-password.tsx
@@ -13,6 +13,7 @@ const ResetTradingPassword = observer(() => {
         is_reset_trading_password_modal_visible,
         is_loading,
         setResetTradingPasswordModalOpen,
+        is_cfd_reset_password_modal_enabled,
     } = ui;
     const location = useLocation();
     const platform = React.useRef('');
@@ -36,7 +37,8 @@ const ResetTradingPassword = observer(() => {
             enableApp={enableApp}
             disableApp={disableApp}
             toggleResetTradingPasswordModal={setResetTradingPasswordModalOpen}
-            is_visible={is_reset_trading_password_modal_visible}
+            is_visible={is_cfd_reset_password_modal_enabled}
+            // is_visible={is_reset_trading_password_modal_visible}
             is_loading={is_loading}
             verification_code={verification_code}
         />

--- a/packages/appstore/src/components/modals/modal-manager.tsx
+++ b/packages/appstore/src/components/modals/modal-manager.tsx
@@ -212,8 +212,7 @@ const ModalManager = () => {
         enableApp,
         disableApp,
         is_reset_trading_password_modal_visible,
-        setResetTradingPasswordModalOpen,
-        is_cfd_reset_password_modal_enabled,
+        setCFDPasswordResetModal,
         is_top_up_virtual_open,
         is_top_up_virtual_success,
         is_mt5_migration_modal_open,
@@ -223,7 +222,6 @@ const ModalManager = () => {
         is_account_transfer_modal_open,
         toggleAccountTransferModal,
         is_real_wallets_upgrade_on,
-        is_account_type_modal_visible,
         is_failed_verification_modal_visible,
         is_regulators_compare_modal_visible,
         is_wallet_migration_failed,
@@ -330,7 +328,7 @@ const ModalManager = () => {
                     platform={trading_platform_dxtrade_password_reset ? 'dxtrade' : 'mt5'}
                     enableApp={enableApp}
                     disableApp={disableApp}
-                    toggleResetTradingPasswordModal={setResetTradingPasswordModalOpen}
+                    toggleResetTradingPasswordModal={setCFDPasswordResetModal}
                     is_visible={is_reset_trading_password_modal_visible}
                     is_loading={is_populating_mt5_account_list}
                     verification_code={trading_platform_dxtrade_password_reset || trading_platform_mt5_password_reset}

--- a/packages/core/src/Stores/ui-store.js
+++ b/packages/core/src/Stores/ui-store.js
@@ -49,7 +49,6 @@ export default class UIStore extends BaseStore {
     is_reset_trading_password_modal_visible = false;
     is_mf_verification_pending_modal_visible = false;
     // @observable is_purchase_lock_on       = false;
-
     // SmartCharts Controls
     // TODO: enable asset information
     // @observable is_chart_asset_info_visible = true;
@@ -785,8 +784,8 @@ export default class UIStore extends BaseStore {
         this.is_update_email_modal_visible = state_change;
     }
 
-    setResetTradingPasswordModalOpen(is_reset_trading_password_modal_visible) {
-        this.is_reset_trading_password_modal_visible = is_reset_trading_password_modal_visible;
+    setResetTradingPasswordModalOpen(val) {
+        this.is_reset_trading_password_modal_visible = val;
     }
 
     setRealAccountSignupParams(params) {

--- a/packages/core/src/Stores/ui-store.js
+++ b/packages/core/src/Stores/ui-store.js
@@ -942,6 +942,7 @@ export default class UIStore extends BaseStore {
 
     setCFDPasswordResetModal(val) {
         this.is_cfd_reset_password_modal_enabled = !!val;
+        this.is_reset_trading_password_modal_visible = !!val;
     }
 
     setSubSectionIndex(index) {

--- a/packages/core/src/Stores/ui-store.js
+++ b/packages/core/src/Stores/ui-store.js
@@ -784,8 +784,8 @@ export default class UIStore extends BaseStore {
         this.is_update_email_modal_visible = state_change;
     }
 
-    setResetTradingPasswordModalOpen(val) {
-        this.is_reset_trading_password_modal_visible = val;
+    setResetTradingPasswordModalOpen(is_reset_trading_password_modal_visible) {
+        this.is_reset_trading_password_modal_visible = is_reset_trading_password_modal_visible;
     }
 
     setRealAccountSignupParams(params) {

--- a/packages/wallets/src/components/WalletsResetMT5Password/WalletSuccessResetMT5Password.tsx
+++ b/packages/wallets/src/components/WalletsResetMT5Password/WalletSuccessResetMT5Password.tsx
@@ -3,35 +3,36 @@ import { Trans } from 'react-i18next';
 import { DerivLightIcMt5PasswordUpdatedIcon, DerivLightMt5SuccessPasswordResetIcon } from '@deriv/quill-icons';
 import useDevice from '../../hooks/useDevice';
 import { ModalStepWrapper, WalletButton } from '../Base';
-import { useModal } from '../ModalProvider';
+// import { useModal } from '../ModalProvider';
 import { WalletsActionScreen } from '../WalletsActionScreen';
 
 type WalletSuccessResetMT5PasswordProps = {
     isInvestorPassword?: boolean;
-    onClickSuccess?: () => void;
+    onClick: () => void;
+    // onClickSuccess?: () => void; // what is this for??
     title: string;
 };
 
 const WalletSuccessResetMT5Password: FC<WalletSuccessResetMT5PasswordProps> = ({
     isInvestorPassword = false,
-    onClickSuccess,
+    onClick,
     title,
 }) => {
-    const { hide } = useModal();
+    // const { hide } = useModal();
     const { isMobile } = useDevice();
 
-    const handleSuccess = useCallback(() => {
-        onClickSuccess?.();
-        hide();
-    }, [onClickSuccess, hide]);
+    // const handleSuccess = useCallback(() => {
+    //     onClickSuccess?.(); // what is this for tho?
+    //     hide();
+    // }, [onClickSuccess, hide]);
 
     const renderButtons = useCallback(() => {
         return (
-            <WalletButton isFullWidth={isMobile} onClick={handleSuccess} size='lg'>
+            <WalletButton isFullWidth={isMobile} onClick={onClick} size='lg'>
                 {isInvestorPassword ? <Trans defaults='Ok' /> : <Trans defaults='Done' />}
             </WalletButton>
         );
-    }, [handleSuccess, isInvestorPassword, isMobile]);
+    }, [isInvestorPassword, isMobile, onClick]);
 
     return (
         <ModalStepWrapper

--- a/packages/wallets/src/components/WalletsResetMT5Password/WalletSuccessResetMT5Password.tsx
+++ b/packages/wallets/src/components/WalletsResetMT5Password/WalletSuccessResetMT5Password.tsx
@@ -3,13 +3,11 @@ import { Trans } from 'react-i18next';
 import { DerivLightIcMt5PasswordUpdatedIcon, DerivLightMt5SuccessPasswordResetIcon } from '@deriv/quill-icons';
 import useDevice from '../../hooks/useDevice';
 import { ModalStepWrapper, WalletButton } from '../Base';
-// import { useModal } from '../ModalProvider';
 import { WalletsActionScreen } from '../WalletsActionScreen';
 
 type WalletSuccessResetMT5PasswordProps = {
     isInvestorPassword?: boolean;
     onClick: () => void;
-    // onClickSuccess?: () => void; // what is this for??
     title: string;
 };
 
@@ -18,13 +16,7 @@ const WalletSuccessResetMT5Password: FC<WalletSuccessResetMT5PasswordProps> = ({
     onClick,
     title,
 }) => {
-    // const { hide } = useModal();
     const { isMobile } = useDevice();
-
-    // const handleSuccess = useCallback(() => {
-    //     onClickSuccess?.(); // what is this for tho?
-    //     hide();
-    // }, [onClickSuccess, hide]);
 
     const renderButtons = useCallback(() => {
         return (

--- a/packages/wallets/src/components/WalletsResetMT5Password/WalletsResetMT5Password.tsx
+++ b/packages/wallets/src/components/WalletsResetMT5Password/WalletsResetMT5Password.tsx
@@ -75,7 +75,9 @@ const WalletsResetMT5Password = ({
     useEffect(() => {
         if (isChangePasswordSuccess) {
             localStorage.removeItem(`verification_code.${actionParams}`); // TODO:Remove verification code from local storage
-            show(<WalletSuccessResetMT5Password title={title} />, { defaultRootId: 'wallets_modal_root' });
+            show(<WalletSuccessResetMT5Password onClick={hide} title={title} />, {
+                defaultRootId: 'wallets_modal_root',
+            });
         } else if (isChangePasswordError) {
             show(
                 <WalletError
@@ -91,7 +93,7 @@ const WalletsResetMT5Password = ({
     useEffect(() => {
         if (isChangeInvestorPasswordSuccess) {
             localStorage.removeItem(`verification_code.${actionParams}`); // TODO:Remove verification code from local storage
-            show(<WalletSuccessResetMT5Password isInvestorPassword title={title} />, {
+            show(<WalletSuccessResetMT5Password isInvestorPassword onClick={hide} title={title} />, {
                 defaultRootId: 'wallets_modal_root',
             });
         } else if (isChangeInvestorPasswordError) {


### PR DESCRIPTION
## Issue:
- after clicking the email link to reset password on TradersHub, the password modal still popup when user navigate to accounts setting

## Changes:

- there are two conflicting visibility states in `ui-store` causing inconsistency in modal behaviour
- `/account` is using `is_reset_trading_password_modal_visible` && `setResetTradingPasswordModalOpen`
- `/cfd` is using `is_cfd_reset_password_modal_enabled` && `setCFDPasswordResetModal`
- they are duplicated
- both these actions and observers handle `ResetTradingPassword` Modal  visibility

<!--
- `/account` is using `setResetTradingPasswordModalOpen` and `is_reset_trading_password_modal_visible`
- `/cfd` is using `setCFDPasswordResetModal` and `is_cfd_reset_password_modal_enabled`
- -->

<!--
⚠️ Check this fix on wallets (qa29) and prod (qa10)
todo: fix prod verification_code is null
<img width="454" alt="image" src="https://github.com/binary-com/deriv-app/assets/108507236/21a8151f-40eb-4c1c-9ff0-3fabaac14c99">
-->

### Screenshots:

Below are demo video for Wallets and Prod after the fix

https://github.com/binary-com/deriv-app/assets/108507236/22cb652c-acc8-431d-8492-5a73223bedba

https://github.com/binary-com/deriv-app/assets/108507236/ffc566f3-3db6-4071-8cb0-03924dee0b1f


