### PR TITLE
[WALL] aum / WALL-4307 / Lazy-load-DesktopWalletsList-and-WalletsCarousel

### DIFF
--- a/packages/wallets/src/routes/WalletsListingRoute/WalletsListingRoute.tsx
+++ b/packages/wallets/src/routes/WalletsListingRoute/WalletsListingRoute.tsx
@@ -1,15 +1,12 @@
-import React, { useEffect } from 'react';
+import React, { lazy, useEffect } from 'react';
 import { useAuthorize, useBalanceSubscription } from '@deriv/api-v2';
-import {
-    DesktopWalletsList,
-    WalletListHeader,
-    WalletsAddMoreCarousel,
-    WalletsCarousel,
-    WalletTourGuide,
-} from '../../components';
+import { Loader, WalletListHeader, WalletsAddMoreCarousel, WalletTourGuide } from '../../components';
 import ResetMT5PasswordHandler from '../../features/cfd/ResetMT5PasswordHandler';
 import useDevice from '../../hooks/useDevice';
 import './WalletsListingRoute.scss';
+
+const LazyWalletsCarousel = lazy(() => import('../../components/WalletsCarousel/WalletsCarousel'));
+const LazyDesktopWalletsList = lazy(() => import('../../components/DesktopWalletsList/DesktopWalletsList'));
 
 const WalletsListingRoute: React.FC = () => {
     const { isMobile } = useDevice();
@@ -28,7 +25,15 @@ const WalletsListingRoute: React.FC = () => {
     return (
         <div className='wallets-listing-route'>
             <WalletListHeader />
-            {isMobile ? <WalletsCarousel balance={{ ...rest }} /> : <DesktopWalletsList balance={{ ...rest }} />}
+            {isMobile ? (
+                <React.Suspense fallback={<Loader />}>
+                    <LazyWalletsCarousel balance={{ ...rest }} />
+                </React.Suspense>
+            ) : (
+                <React.Suspense fallback={<Loader />}>
+                    <LazyDesktopWalletsList balance={{ ...rest }} />
+                </React.Suspense>
+            )}
             <WalletsAddMoreCarousel />
             <ResetMT5PasswordHandler />
             <WalletTourGuide />

--- a/packages/wallets/src/routes/WalletsListingRoute/__tests__/WalletsListingRoute.spec.tsx
+++ b/packages/wallets/src/routes/WalletsListingRoute/__tests__/WalletsListingRoute.spec.tsx
@@ -7,15 +7,18 @@ import WalletsListingRoute from '../WalletsListingRoute';
 
 jest.mock('../../../hooks/useDevice', () => jest.fn());
 
-jest.mock('../../../components/', () => {
-    return {
-        DesktopWalletsList: () => <div>DesktopWalletsList</div>,
-        WalletListHeader: () => <div>WalletListHeader</div>,
-        WalletsAddMoreCarousel: () => <div>WalletsAddMoreCarousel</div>,
-        WalletsCarousel: () => <div>WalletsCarousel</div>,
-        WalletTourGuide: () => <div>WalletTourGuide</div>,
-    };
-});
+jest.mock('../../../components', () => ({
+    ...jest.requireActual('../../../components'),
+    WalletListHeader: () => <div>WalletListHeader</div>,
+    WalletsAddMoreCarousel: () => <div>WalletsAddMoreCarousel</div>,
+    WalletTourGuide: () => <div>WalletTourGuide</div>,
+}));
+
+jest.mock('../../../components/DesktopWalletsList/DesktopWalletsList', () =>
+    jest.fn(() => <div>DesktopWalletsList</div>)
+);
+
+jest.mock('../../../components/WalletsCarousel/WalletsCarousel', () => jest.fn(() => <div>WalletsCarousel</div>));
 
 const wrapper = ({ children }: PropsWithChildren) => (
     <APIProvider>
@@ -26,23 +29,23 @@ const wrapper = ({ children }: PropsWithChildren) => (
 );
 
 describe('WalletsListingRoute', () => {
-    it('renders DesktopWalletsList, WalletsAddMoreCarousel and WalletTourGuide correctly on desktop', () => {
+    it('renders DesktopWalletsList, WalletsAddMoreCarousel and WalletTourGuide correctly on desktop', async () => {
         (useDevice as jest.Mock).mockReturnValue({ isMobile: false });
 
         render(<WalletsListingRoute />, { wrapper });
         expect(screen.getByText('WalletListHeader')).toBeInTheDocument();
-        expect(screen.getByText('DesktopWalletsList')).toBeInTheDocument();
         expect(screen.queryByText('WalletsCarousel')).not.toBeInTheDocument();
         expect(screen.getByText('WalletTourGuide')).toBeInTheDocument();
+        expect(await screen.findByText('DesktopWalletsList')).toBeInTheDocument();
     });
 
-    it('renders WalletsCarousel and WalletsAddMoreCarousel correctly on mobile', () => {
+    it('renders WalletsCarousel and WalletsAddMoreCarousel correctly on mobile', async () => {
         (useDevice as jest.Mock).mockReturnValue({ isMobile: true });
 
         render(<WalletsListingRoute />, { wrapper });
         expect(screen.getByText('WalletListHeader')).toBeInTheDocument();
         expect(screen.queryByText('DesktopWalletsList')).not.toBeInTheDocument();
-        expect(screen.getByText('WalletsCarousel')).toBeInTheDocument();
+        expect(await screen.findByText('WalletsCarousel')).toBeInTheDocument();
         expect(screen.queryByText('WalletTourGuide')).toBeInTheDocument();
     });
 });


### PR DESCRIPTION
## Changes:

This is a PR to reduce the load time for wallets with TH by performing code-splitting in WalletsListingRoute component.
Previously, we loaded both the `DesktopWalletsList` (wallets shown in desktop) and `WalletsCarousel` (wallets carousel shown in mobile) regardless of the viewport in which the app was loaded.
Now, we only load `DesktopWalletsList` if the user is accessing app through desktop device and `WalletsCarousel` if accessed through mobile device.
This has helped in performance improvements by shaving-off: 
- `~1 MB` (1000 KB) of extra data loaded for `mobile`
- `~400 KB` of extra data loaded for `desktop`

Before:
<img height="500" alt="Screenshot 2024-06-05 at 4 12 42 PM" src="https://github.com/binary-com/deriv-app/assets/125039206/fd13fbc1-c9b5-4fa5-bb1c-aa585aa8ada1">
After:
<img height="500" alt="Screenshot 2024-06-05 at 4 13 49 PM" src="https://github.com/binary-com/deriv-app/assets/125039206/653ddf90-492b-4867-8bd9-081ea25ef74e"> <img height="500" alt="Screenshot 2024-06-06 at 11 19 15 AM" src="https://github.com/binary-com/deriv-app/assets/125039206/ff36409e-bae7-438e-82ae-e36f849c0f43">
