### PR TITLE
WEBREL-4 / Kate / Test coverage: composite-calendar, side-list & list-item in Reports

### DIFF
--- a/packages/reports/src/Components/Form/CompositeCalendar/__tests__/composite-calendar.spec.tsx
+++ b/packages/reports/src/Components/Form/CompositeCalendar/__tests__/composite-calendar.spec.tsx
@@ -31,10 +31,12 @@ describe('<CompositeCalendar />', () => {
             <CompositeCalendar {...mockDefaultProps} />
         </StoreProvider>
     );
+
     beforeEach(() => {
         jest.clearAllMocks();
     });
-    it('should render the component with default props', () => {
+
+    it('should render component with default props', () => {
         render(mockPositionsContent());
 
         expect(screen.getByPlaceholderText(inputDataFromPlaceholderText)).toBeInTheDocument();
@@ -65,23 +67,27 @@ describe('<CompositeCalendar />', () => {
         expect(screen.getByText(twoMonthPickerComponent)).toBeInTheDocument();
     });
 
-    it('should call setToDate function click', async () => {
+    it('should call onChange function if user clicks on input "date to"', async () => {
         render(mockPositionsContent());
+
         userEvent.click(screen.getByPlaceholderText(inputDataToPlaceholderText));
         act(() => {
             (TwoMonthPicker as unknown as jest.Mock).mock.calls[0][0].onChange();
         });
+
         await waitFor(() => {
             expect(mockDefaultProps.onChange).toHaveBeenCalled();
         });
     });
 
-    it('should call setFromDate function click', async () => {
+    it('should call onChange function if user clicks on input "date from"', async () => {
         render(mockPositionsContent());
+
         userEvent.click(screen.getByPlaceholderText(inputDataFromPlaceholderText));
         act(() => {
             (TwoMonthPicker as unknown as jest.Mock).mock.calls[0][0].onChange();
         });
+
         await waitFor(() => {
             expect(mockDefaultProps.onChange).toHaveBeenCalled();
         });

--- a/packages/reports/src/Components/Form/CompositeCalendar/__tests__/composite-calendar.spec.tsx
+++ b/packages/reports/src/Components/Form/CompositeCalendar/__tests__/composite-calendar.spec.tsx
@@ -26,7 +26,7 @@ jest.mock('../two-month-picker', () => jest.fn(() => <div>{twoMonthPickerCompone
 Loadable.preloadAll();
 
 describe('<CompositeCalendar />', () => {
-    const mockPositionsContent = () => (
+    const mockCompositeCalendar = () => (
         <StoreProvider store={mockStore({})}>
             <CompositeCalendar {...mockDefaultProps} />
         </StoreProvider>
@@ -37,14 +37,14 @@ describe('<CompositeCalendar />', () => {
     });
 
     it('should render component with default props', () => {
-        render(mockPositionsContent());
+        render(mockCompositeCalendar());
 
         expect(screen.getByPlaceholderText(inputDataFromPlaceholderText)).toBeInTheDocument();
         expect(screen.getByPlaceholderText(inputDataToPlaceholderText)).toBeInTheDocument();
     });
 
-    it('should render side list with options if user clicks on "from date" input', () => {
-        render(mockPositionsContent());
+    it('should render TwoMonthPicker component and side list with options if user clicks on "from date" input', () => {
+        render(mockCompositeCalendar());
 
         sideListLabels.forEach(item => expect(screen.queryByText(item)).not.toBeInTheDocument());
         expect(screen.queryByText(twoMonthPickerComponent)).not.toBeInTheDocument();
@@ -55,8 +55,8 @@ describe('<CompositeCalendar />', () => {
         expect(screen.getByText(twoMonthPickerComponent)).toBeInTheDocument();
     });
 
-    it('should render side list with options if user clicks on "to date" input', () => {
-        render(mockPositionsContent());
+    it('should render TwoMonthPicker component and side list with options if user clicks on "to date" input', () => {
+        render(mockCompositeCalendar());
 
         sideListLabels.forEach(item => expect(screen.queryByText(item)).not.toBeInTheDocument());
         expect(screen.queryByText(twoMonthPickerComponent)).not.toBeInTheDocument();
@@ -67,8 +67,8 @@ describe('<CompositeCalendar />', () => {
         expect(screen.getByText(twoMonthPickerComponent)).toBeInTheDocument();
     });
 
-    it('should call onChange function if user clicks on input "date to"', async () => {
-        render(mockPositionsContent());
+    it('should call onChange function if onChange is triggered from TwoMonthPicker component after user clicks on input "date to"', async () => {
+        render(mockCompositeCalendar());
 
         userEvent.click(screen.getByPlaceholderText(inputDataToPlaceholderText));
         act(() => {
@@ -80,8 +80,8 @@ describe('<CompositeCalendar />', () => {
         });
     });
 
-    it('should call onChange function if user clicks on input "date from"', async () => {
-        render(mockPositionsContent());
+    it('should call onChange function if onChange is triggered from TwoMonthPicker component after user clicks on input "date from"', async () => {
+        render(mockCompositeCalendar());
 
         userEvent.click(screen.getByPlaceholderText(inputDataFromPlaceholderText));
         act(() => {
@@ -94,7 +94,7 @@ describe('<CompositeCalendar />', () => {
     });
 
     it('should call onChange function for "All time" option with correct arguments', () => {
-        render(mockPositionsContent());
+        render(mockCompositeCalendar());
 
         userEvent.click(screen.getByPlaceholderText(inputDataFromPlaceholderText));
         userEvent.click(screen.getByText(sideListLabels[0]));
@@ -108,7 +108,7 @@ describe('<CompositeCalendar />', () => {
     });
 
     it('should call onChange function for "Last 7 days" option with correct arguments', () => {
-        render(mockPositionsContent());
+        render(mockCompositeCalendar());
 
         userEvent.click(screen.getByPlaceholderText(inputDataFromPlaceholderText));
         userEvent.click(screen.getByText(sideListLabels[1]));
@@ -122,7 +122,7 @@ describe('<CompositeCalendar />', () => {
     });
 
     it('should call onChange function for "Last 30 days" option with correct arguments', () => {
-        render(mockPositionsContent());
+        render(mockCompositeCalendar());
 
         userEvent.click(screen.getByPlaceholderText(inputDataFromPlaceholderText));
         userEvent.click(screen.getByText(sideListLabels[2]));
@@ -136,7 +136,7 @@ describe('<CompositeCalendar />', () => {
     });
 
     it('should call onChange function for "Last 60 days" option with correct arguments', () => {
-        render(mockPositionsContent());
+        render(mockCompositeCalendar());
 
         userEvent.click(screen.getByPlaceholderText(inputDataFromPlaceholderText));
         userEvent.click(screen.getByText(sideListLabels[3]));
@@ -150,7 +150,7 @@ describe('<CompositeCalendar />', () => {
     });
 
     it('should call onChange function for "Last quarter" option with correct arguments', () => {
-        render(mockPositionsContent());
+        render(mockCompositeCalendar());
 
         userEvent.click(screen.getByPlaceholderText(inputDataFromPlaceholderText));
         userEvent.click(screen.getByText(sideListLabels[4]));
@@ -164,7 +164,7 @@ describe('<CompositeCalendar />', () => {
     });
 
     it('should disable dates before "from" date in "to input" section ', () => {
-        render(mockPositionsContent());
+        render(mockCompositeCalendar());
         userEvent.click(screen.getByPlaceholderText(inputDataToPlaceholderText));
 
         userEvent.click(screen.getByPlaceholderText(inputDataToPlaceholderText));
@@ -174,7 +174,7 @@ describe('<CompositeCalendar />', () => {
     });
 
     it('should disable dates after "to" date in "from input" section ', () => {
-        render(mockPositionsContent());
+        render(mockCompositeCalendar());
 
         userEvent.click(screen.getByPlaceholderText(inputDataFromPlaceholderText));
 

--- a/packages/reports/src/Components/Form/CompositeCalendar/__tests__/composite-calendar.spec.tsx
+++ b/packages/reports/src/Components/Form/CompositeCalendar/__tests__/composite-calendar.spec.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { toMoment } from '@deriv/shared';
+import { StoreProvider, mockStore } from '@deriv/stores';
+import Loadable from 'react-loadable';
+import TwoMonthPicker from '../two-month-picker';
+import CompositeCalendar from '../composite-calendar';
+
+const twoMonthPickerComponent = 'TwoMonthPicker';
+const inputDataFromPlaceholderText = 'Date from';
+const inputDataToPlaceholderText = 'Date to';
+const sideListLabels = ['All time', 'Last 7 days', 'Last 30 days', 'Last 60 days', 'Last quarter'];
+const endOfTheDay = toMoment().endOf('day');
+const getDateFromNow = (daysFromNow: number) =>
+    daysFromNow ? toMoment().startOf('day').subtract(daysFromNow, 'day').add(1, 's') : undefined;
+const mockDefaultProps = {
+    from: 1696319493,
+    onChange: jest.fn(),
+    to: 1696928512,
+};
+
+jest.mock('../composite-calendar-mobile', () => jest.fn(() => <div>CompositeCalendarMobile</div>));
+jest.mock('../two-month-picker', () => jest.fn(() => <div>{twoMonthPickerComponent}</div>));
+
+Loadable.preloadAll();
+
+describe('<CompositeCalendar />', () => {
+    const mockPositionsContent = () => (
+        <StoreProvider store={mockStore({})}>
+            <CompositeCalendar {...mockDefaultProps} />
+        </StoreProvider>
+    );
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+    it('should render the component with default props', () => {
+        render(mockPositionsContent());
+
+        expect(screen.getByPlaceholderText(inputDataFromPlaceholderText)).toBeInTheDocument();
+        expect(screen.getByPlaceholderText(inputDataToPlaceholderText)).toBeInTheDocument();
+    });
+
+    it('should render side list with options if user clicks on "from date" input', () => {
+        render(mockPositionsContent());
+
+        sideListLabels.forEach(item => expect(screen.queryByText(item)).not.toBeInTheDocument());
+        expect(screen.queryByText(twoMonthPickerComponent)).not.toBeInTheDocument();
+
+        userEvent.click(screen.getByPlaceholderText(inputDataFromPlaceholderText));
+
+        sideListLabels.forEach(item => expect(screen.getByText(item)).toBeInTheDocument());
+        expect(screen.getByText(twoMonthPickerComponent)).toBeInTheDocument();
+    });
+
+    it('should render side list with options if user clicks on "to date" input', () => {
+        render(mockPositionsContent());
+
+        sideListLabels.forEach(item => expect(screen.queryByText(item)).not.toBeInTheDocument());
+        expect(screen.queryByText(twoMonthPickerComponent)).not.toBeInTheDocument();
+
+        userEvent.click(screen.getByPlaceholderText(inputDataToPlaceholderText));
+
+        sideListLabels.forEach(item => expect(screen.getByText(item)).toBeInTheDocument());
+        expect(screen.getByText(twoMonthPickerComponent)).toBeInTheDocument();
+    });
+
+    it('should call setToDate function click', async () => {
+        render(mockPositionsContent());
+        userEvent.click(screen.getByPlaceholderText(inputDataToPlaceholderText));
+        act(() => {
+            (TwoMonthPicker as unknown as jest.Mock).mock.calls[0][0].onChange();
+        });
+        await waitFor(() => {
+            expect(mockDefaultProps.onChange).toHaveBeenCalled();
+        });
+    });
+
+    it('should call setFromDate function click', async () => {
+        render(mockPositionsContent());
+        userEvent.click(screen.getByPlaceholderText(inputDataFromPlaceholderText));
+        act(() => {
+            (TwoMonthPicker as unknown as jest.Mock).mock.calls[0][0].onChange();
+        });
+        await waitFor(() => {
+            expect(mockDefaultProps.onChange).toHaveBeenCalled();
+        });
+    });
+
+    it('should call onChange function for "All time" option with correct arguments', () => {
+        render(mockPositionsContent());
+
+        userEvent.click(screen.getByPlaceholderText(inputDataFromPlaceholderText));
+        userEvent.click(screen.getByText(sideListLabels[0]));
+
+        expect(mockDefaultProps.onChange).toHaveBeenCalled();
+        expect(mockDefaultProps.onChange).toHaveBeenCalledWith({
+            from: getDateFromNow(0),
+            to: endOfTheDay,
+            is_batch: true,
+        });
+    });
+
+    it('should call onChange function for "Last 7 days" option with correct arguments', () => {
+        render(mockPositionsContent());
+
+        userEvent.click(screen.getByPlaceholderText(inputDataFromPlaceholderText));
+        userEvent.click(screen.getByText(sideListLabels[1]));
+
+        expect(mockDefaultProps.onChange).toHaveBeenCalled();
+        expect(mockDefaultProps.onChange).toHaveBeenCalledWith({
+            from: getDateFromNow(7),
+            to: endOfTheDay,
+            is_batch: true,
+        });
+    });
+
+    it('should call onChange function for "Last 30 days" option with correct arguments', () => {
+        render(mockPositionsContent());
+
+        userEvent.click(screen.getByPlaceholderText(inputDataFromPlaceholderText));
+        userEvent.click(screen.getByText(sideListLabels[2]));
+
+        expect(mockDefaultProps.onChange).toHaveBeenCalled();
+        expect(mockDefaultProps.onChange).toHaveBeenCalledWith({
+            from: getDateFromNow(30),
+            to: endOfTheDay,
+            is_batch: true,
+        });
+    });
+
+    it('should call onChange function for "Last 60 days" option with correct arguments', () => {
+        render(mockPositionsContent());
+
+        userEvent.click(screen.getByPlaceholderText(inputDataFromPlaceholderText));
+        userEvent.click(screen.getByText(sideListLabels[3]));
+
+        expect(mockDefaultProps.onChange).toHaveBeenCalled();
+        expect(mockDefaultProps.onChange).toHaveBeenCalledWith({
+            from: getDateFromNow(60),
+            to: endOfTheDay,
+            is_batch: true,
+        });
+    });
+
+    it('should call onChange function for "Last quarter" option with correct arguments', () => {
+        render(mockPositionsContent());
+
+        userEvent.click(screen.getByPlaceholderText(inputDataFromPlaceholderText));
+        userEvent.click(screen.getByText(sideListLabels[4]));
+
+        expect(mockDefaultProps.onChange).toHaveBeenCalled();
+        expect(mockDefaultProps.onChange).toHaveBeenCalledWith({
+            from: getDateFromNow(90),
+            to: endOfTheDay,
+            is_batch: true,
+        });
+    });
+
+    it('should disable dates before "from" date in "to input" section ', () => {
+        render(mockPositionsContent());
+        userEvent.click(screen.getByPlaceholderText(inputDataToPlaceholderText));
+
+        userEvent.click(screen.getByPlaceholderText(inputDataToPlaceholderText));
+        expect(
+            (TwoMonthPicker as unknown as jest.Mock).mock.calls[0][0].isPeriodDisabled(toMoment('1997-09-02'))
+        ).toBeTruthy();
+    });
+
+    it('should disable dates after "to" date in "from input" section ', () => {
+        render(mockPositionsContent());
+
+        userEvent.click(screen.getByPlaceholderText(inputDataFromPlaceholderText));
+
+        expect(
+            (TwoMonthPicker as unknown as jest.Mock).mock.calls[0][0].isPeriodDisabled(toMoment('1997-09-02'))
+        ).toBeFalsy();
+        expect(
+            (TwoMonthPicker as unknown as jest.Mock).mock.calls[0][0].isPeriodDisabled(toMoment('2024-06-06'))
+        ).toBeTruthy();
+    });
+});

--- a/packages/reports/src/Components/Form/CompositeCalendar/__tests__/list-item.spec.tsx
+++ b/packages/reports/src/Components/Form/CompositeCalendar/__tests__/list-item.spec.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ListItem from '../list-item';
+
+const mockDefaultProps = {
+    label: 'Mocked label',
+    is_active: false,
+    onClick: jest.fn(),
+};
+
+describe('ListItem', () => {
+    it('should render component with default props', () => {
+        render(<ListItem {...mockDefaultProps} />);
+
+        expect(screen.getByText('Mocked label')).toBeInTheDocument();
+    });
+
+    it('should apply specific className if is_active === true', () => {
+        render(<ListItem {...mockDefaultProps} is_active />);
+
+        expect(screen.getByRole('listitem')).toHaveClass('composite-calendar__prepopulated-list--is-active');
+    });
+
+    it('should call function onClick from props if user clicks on the component', () => {
+        render(<ListItem {...mockDefaultProps} />);
+
+        expect(mockDefaultProps.onClick).not.toBeCalled();
+        userEvent.click(screen.getByRole('listitem'));
+        expect(mockDefaultProps.onClick).toBeCalled();
+    });
+});

--- a/packages/reports/src/Components/Form/CompositeCalendar/__tests__/side-list.spec.tsx
+++ b/packages/reports/src/Components/Form/CompositeCalendar/__tests__/side-list.spec.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import SideList from '../side-list';
+import { toMoment } from '@deriv/shared';
+
+const mockDefaultProps = {
+    items: [
+        {
+            value: 'all_time',
+            label: 'All time',
+            duration: 0,
+            onClick: jest.fn(),
+        },
+        {
+            value: 'last_7_days',
+            label: 'Last 7 days',
+            duration: 7,
+            onClick: jest.fn(),
+        },
+        {
+            value: 'last_30_days',
+            label: 'Last 30 days',
+            duration: 30,
+            onClick: jest.fn(),
+        },
+        {
+            value: 'last_60_days',
+            label: 'Last 60 days',
+            duration: 60,
+            onClick: jest.fn(),
+        },
+        {
+            value: 'last_quarter',
+            label: 'Last quarter',
+            duration: 90,
+            onClick: jest.fn(),
+        },
+    ],
+    from: 1713398400,
+    to: 1717286399,
+};
+
+describe('SideList', () => {
+    it('should render component with default props', () => {
+        render(<SideList {...mockDefaultProps} />);
+
+        mockDefaultProps.items.forEach(item => expect(screen.getByText(item.label)).toBeInTheDocument());
+    });
+
+    it('should render first list item with specific className if its duration === 0, from === null and to === today (end of the day)', () => {
+        render(<SideList {...mockDefaultProps} from={null} to={toMoment().endOf('day').unix()} />);
+
+        mockDefaultProps.items.forEach(item => expect(screen.getByText(item.label)).toBeInTheDocument());
+        expect(screen.getByText(mockDefaultProps.items[0].label)).toHaveClass(
+            'composite-calendar__prepopulated-list--is-active'
+        );
+    });
+});

--- a/packages/reports/src/Components/Form/CompositeCalendar/side-list.tsx
+++ b/packages/reports/src/Components/Form/CompositeCalendar/side-list.tsx
@@ -10,16 +10,16 @@ type TItem = {
 };
 
 type TSideList = {
-    from: number;
+    from: number | null;
     items: Array<TItem>;
     to: number;
 };
 
-const isActive = (from: number, to: number, flag: number) => {
+const isActive = (from: number | null, to: number, flag: number) => {
     if (flag === 0) {
         return toMoment().endOf('day').unix() === to && from === null;
     }
-    return Math.ceil(to / 86400) - Math.ceil(from / 86400) === flag;
+    return Math.ceil(to / 86400) - Math.ceil(Number(from) / 86400) === flag;
 };
 
 const SideList = ({ items, from, to }: TSideList) => (


### PR DESCRIPTION
## Changes:

- Added tests for composite-calendar, side-list & list-item in Reports package.

### Screenshots:

<img width="1298" alt="Screenshot 2024-06-06 at 4 41 43 PM" src="https://github.com/binary-com/deriv-app/assets/121025168/0750051a-6808-4aa9-ad2a-0c6acb094868">
