### PR TITLE
[TRAH] Sergei / TRAHH - 3666 / Investigate get_limits being triggered many times

### DIFF
--- a/packages/account/src/Sections/Security/SelfExclusion/__tests__/self-exclusion.spec.tsx
+++ b/packages/account/src/Sections/Security/SelfExclusion/__tests__/self-exclusion.spec.tsx
@@ -53,6 +53,10 @@ const mock = {
         is_switching: false,
         landing_company_shortcode: '',
         logout: jest.fn(),
+        getLimits: () =>
+            Promise.resolve({
+                get_limits: {},
+            }),
     },
     ui: {
         is_tablet: false,
@@ -80,6 +84,7 @@ describe('<SelfExclusion />', () => {
     it('should render SelfExclusion component for virtual account', () => {
         store = mockStore({
             client: {
+                ...mock.client,
                 is_virtual: true,
             },
         });
@@ -132,6 +137,7 @@ describe('<SelfExclusion />', () => {
     it('Should trigger session_duration_limit input and show error if the value is greater than 60480 or does not show if less than 60480', async () => {
         store = mockStore({
             client: {
+                ...mock.client,
                 is_eu: true,
             },
         });

--- a/packages/account/src/Sections/Security/SelfExclusion/self-exclusion.tsx
+++ b/packages/account/src/Sections/Security/SelfExclusion/self-exclusion.tsx
@@ -71,7 +71,16 @@ type TResponse = {
 
 const SelfExclusion = observer(({ is_app_settings, overlay_ref, setIsOverlayShown }: TSelfExclusion) => {
     const { client, ui } = useStore();
-    const { currency, is_virtual, is_switching, standpoint, is_eu, logout, landing_company_shortcode } = client;
+    const {
+        currency,
+        is_virtual,
+        is_switching,
+        standpoint,
+        is_eu,
+        logout,
+        landing_company_shortcode,
+        getLimits: getLimitsFromStore,
+    } = client;
     const { is_tablet } = ui;
     const is_wrapper_bypassed = false;
     const is_mf = landing_company_shortcode === 'maltainvest';
@@ -384,7 +393,7 @@ const SelfExclusion = observer(({ is_app_settings, overlay_ref, setIsOverlayShow
     const getLimits = () => {
         setState({ is_loading: true });
 
-        WS.authorized.getLimits({ get_limits: 1 }).then((limits: FormikValues) => {
+        getLimitsFromStore().then((limits: FormikValues) => {
             exclusion_limits.current = limits;
         });
     };

--- a/packages/cashier/src/pages/withdrawal/withdrawal.tsx
+++ b/packages/cashier/src/pages/withdrawal/withdrawal.tsx
@@ -85,6 +85,7 @@ const Withdrawal = observer(() => {
         is_switching,
         verification_code: { payment_withdraw: verification_code },
         setVerificationCode,
+        account_limits,
     } = client;
     const { withdraw, transaction_history } = useCashierStore();
     const { is_transactions_crypto_visible } = transaction_history;
@@ -106,7 +107,7 @@ const Withdrawal = observer(() => {
 
     React.useEffect(() => {
         check10kLimit();
-    }, [check10kLimit]);
+    }, [check10kLimit, account_limits?.remainder]);
 
     React.useEffect(() => {
         return () => setVerificationCode('', 'payment_withdraw');

--- a/packages/cashier/src/stores/__tests__/withdraw-store.spec.ts
+++ b/packages/cashier/src/stores/__tests__/withdraw-store.spec.ts
@@ -43,6 +43,9 @@ describe('WithdrawStore', () => {
                         },
                     };
                 },
+                account_limits: {
+                    remainder: 80,
+                },
                 loginid: 'CR9000000',
                 setVerificationCode: jest.fn(),
             },
@@ -90,6 +93,7 @@ describe('WithdrawStore', () => {
             },
             cryptoConfig: () => Promise.resolve(),
             cryptoWithdraw: jest.fn(() => Promise.resolve({})),
+            wait: jest.fn(() => Promise.resolve()),
         };
 
         withdraw_store = new WithdrawStore(WS as TWebSocket, root_store);

--- a/packages/cashier/src/stores/withdraw-store.ts
+++ b/packages/cashier/src/stores/withdraw-store.ts
@@ -281,7 +281,9 @@ export default class WithdrawStore {
     async check10kLimit() {
         const { client } = this.root_store;
 
-        const remainder = (await client.getLimits())?.get_limits?.remainder;
+        await this.WS.wait('get_limits');
+
+        const remainder = client.account_limits?.remainder;
         this.setMaxWithdrawAmount(Number(remainder));
         const min_withdrawal = getMinWithdrawal(client.currency);
         const is_limit_reached = !!(typeof remainder !== 'undefined' && +remainder < min_withdrawal);

--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -1040,7 +1040,7 @@ export default class ClientStore extends BaseStore {
 
     getLimits() {
         return new Promise(resolve => {
-            WS.authorized.cache.getLimits({ get_limits: 1, loginid: this.loginid }).then(data => {
+            WS.authorized.storage.getLimits().then(data => {
                 runInAction(() => {
                     if (data.error) {
                         this.account_limits = {
@@ -1837,8 +1837,6 @@ export default class ClientStore extends BaseStore {
 
         // broadcastAccountChange is already called after new connection is authorized
         if (!should_switch_socket_connection) this.broadcastAccountChange();
-
-        if (!this.is_virtual) this.getLimits();
 
         runInAction(() => (this.is_switching = false));
     }

--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -1040,7 +1040,7 @@ export default class ClientStore extends BaseStore {
 
     getLimits() {
         return new Promise(resolve => {
-            WS.authorized.storage.getLimits().then(data => {
+            WS.authorized.cache.getLimits({ get_limits: 1, loginid: this.loginid }).then(data => {
                 runInAction(() => {
                     if (data.error) {
                         this.account_limits = {


### PR DESCRIPTION
## Changes:

- Add WS.wait("get_limits") to the withdraw store
- Remove `get_limits` calling from `switchAccountHandler` in client store because it calls init() where we are calling `get_limits` again
- Change `WS.authorized.getLimits` to `getLimits` from store in `SelfExclusion` component

## Video:

https://github.com/binary-com/deriv-app/assets/120570511/52672b5e-a012-4f74-8461-1ceba931f1ee
