### PR TITLE
fix: V20240606_0 hotfix/Password reset popup not opening for DerivX and MT5

### DIFF
--- a/packages/core/src/App/Containers/Redirect/redirect.jsx
+++ b/packages/core/src/App/Containers/Redirect/redirect.jsx
@@ -15,6 +15,7 @@ const Redirect = observer(() => {
 
     const {
         openRealAccountSignup,
+        setCFDPasswordResetModal,
         setResetTradingPasswordModalOpen,
         toggleAccountSignupModal,
         toggleResetPasswordModal,
@@ -111,6 +112,7 @@ const Redirect = observer(() => {
                         break;
                     case '3':
                         pathname = routes.passwords;
+                        setCFDPasswordResetModal(true);
                         break;
                     default:
                         break;


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.

### demo video for prod (qa10) 

https://github.com/binary-com/deriv-app/assets/108507236/3ef06ee2-8f65-4fe3-898d-ecef6adf1e74


### demo video for Wallets (qa29)

https://github.com/binary-com/deriv-app/assets/108507236/753d8d90-0f4f-416e-9c22-22dc1ae24dca


