### PR TITLE
[WALL] aum/WALL-4364/fix-MT5TradeModal-broker-name

### DIFF
--- a/packages/wallets/src/features/cfd/screens/MT5TradeScreen/MT5TradeScreen.tsx
+++ b/packages/wallets/src/features/cfd/screens/MT5TradeScreen/MT5TradeScreen.tsx
@@ -138,9 +138,9 @@ const MT5TradeScreen: FC<MT5TradeScreenProps> = ({ mt5Account }) => {
                 </div>
 
                 <div className='wallets-mt5-trade-screen__details-clipboards'>
-                    {getModalState('platform') === mt5Platform && (
+                    {getModalState('platform') === mt5Platform && details?.platform === mt5Platform && (
                         <Fragment>
-                            <MT5TradeDetailsItem label='Broker' value='Deriv Holdings (Guernsey) Ltd' />
+                            <MT5TradeDetailsItem label='Broker' value={details?.landing_company ?? ''} />
                             <MT5TradeDetailsItem
                                 label='Server'
                                 value={details?.server_info?.environment ?? 'Deriv-Server'}


### PR DESCRIPTION
## Changes:

Replace the hard-coded value for broker name in MT5TradeModal with name received under `landing_company` key from BE.

### Screenshots

https://github.com/binary-com/deriv-app/assets/125039206/f58ff45a-2c72-4a15-90bd-e3f5ba3ccaa4



https://github.com/binary-com/deriv-app/assets/125039206/368f0360-bb44-4cad-b492-0c9778eaa1c4

