### PR TITLE
[BOT] Farabi/bot-1900/add strategy name on run edit qs rudderstack

### DIFF
--- a/packages/bot-web-ui/src/analytics/rudderstack-quick-strategy.ts
+++ b/packages/bot-web-ui/src/analytics/rudderstack-quick-strategy.ts
@@ -34,6 +34,7 @@ export const rudderStackSendQsRunStrategyEvent = ({
         action: ACTION.RUN_QUICK_STRATEGY,
         form_name,
         subform_name: 'quick_strategy',
+        strategy_name: getRsStrategyType(selected_strategy),
         ...getTradeParameterData({ form_values, selected_strategy }),
     });
 };
@@ -46,6 +47,7 @@ export const rudderStackSendQsEditStrategyEvent = ({
         action: ACTION.EDIT_QUICK_STRATEGY,
         form_name,
         subform_name: 'quick_strategy',
+        strategy_name: getRsStrategyType(selected_strategy),
         ...getTradeParameterData({ form_values, selected_strategy }),
     });
 };


### PR DESCRIPTION
## Changes:

- Added the strategy name parameters on the run_quick_strategy and edit_quick_strategy actions for quick strategy events