### PR TITLE
[BOT] Farabi/bot 1900/fix qs run and edit rudderstack event

### DIFF
--- a/packages/bot-web-ui/src/analytics/rudderstack-quick-strategy.ts
+++ b/packages/bot-web-ui/src/analytics/rudderstack-quick-strategy.ts
@@ -34,6 +34,7 @@ export const rudderStackSendQsRunStrategyEvent = ({
         action: ACTION.RUN_QUICK_STRATEGY,
         form_name,
         subform_name: 'quick_strategy',
+        strategy_name: getRsStrategyType(selected_strategy),
         ...getTradeParameterData({ form_values, selected_strategy }),
     });
 };
@@ -46,6 +47,7 @@ export const rudderStackSendQsEditStrategyEvent = ({
         action: ACTION.EDIT_QUICK_STRATEGY,
         form_name,
         subform_name: 'quick_strategy',
+        strategy_name: getRsStrategyType(selected_strategy),
         ...getTradeParameterData({ form_values, selected_strategy }),
     });
 };

--- a/packages/bot-web-ui/src/analytics/utils.ts
+++ b/packages/bot-web-ui/src/analytics/utils.ts
@@ -32,6 +32,8 @@ export const getSubpageName = () => {
 };
 
 export const getTradeParameterData = ({ form_values }: TFormStrategy) => {
+    if (!form_values) return;
+
     const { symbol, tradetype, type, stake } = form_values;
     const stored_texts = getRsDropdownTextFromLocalStorage();
 

--- a/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/form-wrappers/__tests__/useQsSubmitHandler.spec.tsx
+++ b/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/form-wrappers/__tests__/useQsSubmitHandler.spec.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
+import { Formik } from 'formik';
 import { mockStore, StoreProvider } from '@deriv/stores';
+import { renderHook } from '@testing-library/react-hooks';
 import { mock_ws } from 'Utils/mock';
 import RootStore from 'Stores/root-store';
 import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
 import useQsSubmitHandler from '../useQsSubmitHandler';
-import { renderHook } from '@testing-library/react-hooks';
-import { Formik } from 'formik';
 
 jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => jest.fn());
 

--- a/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/form-wrappers/desktop-form-wrapper.tsx
+++ b/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/form-wrappers/desktop-form-wrapper.tsx
@@ -48,25 +48,21 @@ const FormWrapper: React.FC<TDesktopFormWrapper> = observer(({ children, onClick
     };
 
     const onEdit = async () => {
-        rudderStackSendQsEditStrategyEvent({
-            form_values: values,
-            selected_strategy,
-            quick_strategy_tab: getQsActiveTabString(activeTab),
-        });
         await setFieldValue('action', 'EDIT');
         validateForm();
         submitForm().then((form_data: TFormData | void) => {
             if (isValid && form_data) {
+                rudderStackSendQsEditStrategyEvent({
+                    form_values: values,
+                    selected_strategy,
+                    quick_strategy_tab: getQsActiveTabString(activeTab),
+                });
                 onSubmit(form_data); // true to load and run the bot
             }
         });
     };
 
     const onRun = () => {
-        rudderStackSendQsRunStrategyEvent({
-            form_values: values,
-            selected_strategy,
-        });
         handleSubmit();
     };
 

--- a/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/form-wrappers/desktop-form-wrapper.tsx
+++ b/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/form-wrappers/desktop-form-wrapper.tsx
@@ -8,7 +8,6 @@ import { localize } from '@deriv/translations';
 import { useDBotStore } from 'Stores/useDBotStore';
 import {
     rudderStackSendQsEditStrategyEvent,
-    rudderStackSendQsRunStrategyEvent,
     rudderStackSendQsSelectedTabEvent,
 } from '../../../../analytics/rudderstack-quick-strategy';
 import { getQsActiveTabString } from '../../../../analytics/utils';

--- a/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/form-wrappers/useQsSubmitHandler.tsx
+++ b/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/form-wrappers/useQsSubmitHandler.tsx
@@ -1,14 +1,21 @@
 import { useFormikContext } from 'formik';
 import { useStore } from '@deriv/stores';
 import { useDBotStore } from 'Stores/useDBotStore';
-import { TFormData } from '../types';
+import { rudderStackSendQsRunStrategyEvent } from '../../../../analytics/rudderstack-quick-strategy';
+import { TFormValues } from '../types';
 
 const useQsSubmitHandler = () => {
     const { client } = useStore();
     const { currency, balance, is_logged_in } = client;
-    const { submitForm, setFieldValue, values, isValid, validateForm } = useFormikContext<TFormData>();
+    const { submitForm, setFieldValue, values, isValid, validateForm } = useFormikContext<TFormValues>();
     const { quick_strategy, run_panel } = useDBotStore();
-    const { toggleStopBotDialog, setLossThresholdWarningData, loss_threshold_warning_data, onSubmit } = quick_strategy;
+    const {
+        toggleStopBotDialog,
+        setLossThresholdWarningData,
+        selected_strategy,
+        loss_threshold_warning_data,
+        onSubmit,
+    } = quick_strategy;
 
     const handleSubmit = async () => {
         const loss_amount = Number(values?.loss ?? 0);
@@ -38,11 +45,19 @@ const useQsSubmitHandler = () => {
             validateForm();
             submitForm();
             toggleStopBotDialog();
+            rudderStackSendQsRunStrategyEvent({
+                form_values: values,
+                selected_strategy,
+            });
         } else {
             await setFieldValue('action', 'RUN');
             validateForm();
-            submitForm().then((form_data: TFormData | void) => {
+            submitForm().then((form_data: TFormValues | void) => {
                 if (isValid && form_data) {
+                    rudderStackSendQsRunStrategyEvent({
+                        form_values: values,
+                        selected_strategy,
+                    });
                     onSubmit(form_data);
                 }
             });


### PR DESCRIPTION
## Changes:

- Fixed the trigger of rudderstack event for run strategy and edit strategy from quick strategy form to send only after form validation is completed
