### PR TITLE
Update deriv-charts to 2.1.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "@deriv-com/utils": "^0.0.25",
                 "@deriv/api-types": "1.0.172",
                 "@deriv/deriv-api": "^1.0.15",
-                "@deriv/deriv-charts": "^2.1.20",
+                "@deriv/deriv-charts": "^2.1.21",
                 "@deriv/js-interpreter": "^3.0.0",
                 "@deriv/quill-design": "^1.3.2",
                 "@deriv/quill-icons": "^1.22.10",
@@ -84,7 +84,6 @@
                 "bowser": "^2.9.0",
                 "canvas-toBlob": "^1.0.0",
                 "circular-dependency-plugin": "^5.2.2",
-                "class-variance-authority": "^0.7.0",
                 "classnames": "^2.2.6",
                 "clean-webpack-plugin": "^3.0.0",
                 "clsx": "^2.1.1",
@@ -206,7 +205,6 @@
                 "svg-sprite-loader": "^6.0.11",
                 "svgo": "^2.8.0",
                 "svgo-loader": "^3.0.0",
-                "tailwind-merge": "^1.14.0",
                 "tailwindcss": "^3.3.6",
                 "terser-webpack-plugin": "^5.1.1",
                 "typescript": "^4.6.3",
@@ -3191,9 +3189,9 @@
             }
         },
         "node_modules/@deriv/deriv-charts": {
-            "version": "2.1.20",
-            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.1.20.tgz",
-            "integrity": "sha512-g/6mWudO6gToR3WvYYOCmCjt2Q8EiO2U3mCAysl9Nm7XxqUp1kHcl1yImOuo9YbIQY1rEg0Yxw1+9ikPgrVF+Q==",
+            "version": "2.1.21",
+            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.1.21.tgz",
+            "integrity": "sha512-kYGtCVKgDnSXBkFHoVulC6qMQi5OqrTBOmLUKJf9AVgxISiCvP8xDZy91c1G1SUGQZ7n1/B2UXYg9QJsyD5NpQ==",
             "dependencies": {
                 "@types/lodash.set": "^4.3.7",
                 "@welldone-software/why-did-you-render": "^3.3.8",
@@ -24213,6 +24211,7 @@
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.0.tgz",
             "integrity": "sha512-jFI8IQw4hczaL4ALINxqLEXQbWcNjoSkloa4IaufXCJr6QawJyw7tuRysRsrE8w2p/4gGaxKIt/hX3qz/IbD1A==",
+            "peer": true,
             "dependencies": {
                 "clsx": "2.0.0"
             },
@@ -24224,6 +24223,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
             "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -55225,6 +55225,7 @@
             "version": "1.14.0",
             "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-1.14.0.tgz",
             "integrity": "sha512-3mFKyCo/MBcgyOTlrY8T7odzZFx+w+qKSMAmdFzRvqBfLlSigU6TZnlFHK0lkMwj9Bj8OYU+9yW9lmGuS0QEnQ==",
+            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/dcastil"

--- a/packages/bot-web-ui/package.json
+++ b/packages/bot-web-ui/package.json
@@ -76,7 +76,7 @@
         "@deriv/api-types": "1.0.172",
         "@deriv/bot-skeleton": "^1.0.0",
         "@deriv/components": "^1.0.0",
-        "@deriv/deriv-charts": "^2.1.20",
+        "@deriv/deriv-charts": "^2.1.21",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",
         "@deriv/translations": "^1.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -109,7 +109,7 @@
         "@deriv/cfd": "^1.0.0",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv/deriv-charts": "^2.1.20",
+        "@deriv/deriv-charts": "^2.1.21",
         "@deriv/hooks": "^1.0.0",
         "@deriv/p2p": "^0.7.3",
         "@deriv/p2p-v2": "^1.0.0",

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -95,7 +95,7 @@
         "@deriv/api-types": "1.0.172",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv/deriv-charts": "^2.1.20",
+        "@deriv/deriv-charts": "^2.1.21",
         "@deriv/hooks": "^1.0.0",
         "@deriv/reports": "^1.0.0",
         "@deriv/shared": "^1.0.0",


### PR DESCRIPTION
This PR updates @deriv/deriv-charts to 2.1.21