### PR TITLE
[DTRA] Maryia/DTRA-1234/fix: always show search params in DTrader URL when DTrader is open

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,6 +58,7 @@
         "eslint-plugin-react": "^7.22.0",
         "eslint-plugin-react-hooks": "^4.2.0",
         "file-loader": "^6.2.0",
+        "history": "^5.0.0",
         "gh-pages": "^2.1.1",
         "git-revision-webpack-plugin": "^5.0.0",
         "html-loader": "^1.3.2",

--- a/packages/core/src/App/Components/Layout/Header/platform-dropdown.jsx
+++ b/packages/core/src/App/Components/Layout/Header/platform-dropdown.jsx
@@ -28,6 +28,7 @@ const PlatformDropdownContent = ({ platform, app_routing_history }) => {
                 exact={platform.link_to === routes.trade}
                 className='platform-dropdown__list-platform'
                 isActive={() => getActivePlatform(app_routing_history) === platform.name}
+                onClick={e => window.location.pathname.startsWith(platform.link_to) && e.preventDefault()}
             >
                 <PlatformBox platform={platform} />
             </BinaryLink>

--- a/packages/shared/src/utils/contract/trade-url-params-config.ts
+++ b/packages/shared/src/utils/contract/trade-url-params-config.ts
@@ -10,7 +10,7 @@ type TGetTradeURLParamsArgs = {
 type TTradeUrlParams = {
     contractType?: string;
     chartType?: string;
-    granularity?: number;
+    granularity?: number | null;
     symbol?: string;
 };
 

--- a/packages/trader/src/Stores/Modules/Trading/trade-store.ts
+++ b/packages/trader/src/Stores/Modules/Trading/trade-store.ts
@@ -1564,6 +1564,13 @@ export default class TradeStore extends BaseStore {
     onMount() {
         this.root_store.notifications.removeTradeNotifications();
         if (this.is_trade_component_mounted && this.should_skip_prepost_lifecycle) {
+            const { chart_type, granularity } = this.root_store.contract_trade;
+            setTradeURLParams({
+                chartType: chart_type,
+                granularity,
+                symbol: this.symbol,
+                contractType: this.contract_type,
+            });
             return;
         }
         this.root_store.notifications.setShouldShowPopups(false);


### PR DESCRIPTION
## Changes:

To fix cases when search params (trade params: '?chart_type...) are missing from DTrader URL:
1. When Contract Details page is opened from DTrader, and after that, 'Close' button is pressed to come back to DTrader,
2. When DTrader is already open but a user selects it again from the Platform Switcher in the app Header.