### PR TITLE
[WALL] Aizad/WALL-2899/WalletMarketCurrencyIcon-test-case

### DIFF
--- a/packages/wallets/src/components/WalletMarketCurrencyIcon/WalletMarketCurrencyIcon.tsx
+++ b/packages/wallets/src/components/WalletMarketCurrencyIcon/WalletMarketCurrencyIcon.tsx
@@ -32,7 +32,7 @@ const WalletMarketCurrencyIcon: FC<TWalletMarketCurrencyIconProps> = ({ currency
     } else MarketTypeIcon = 'IcWalletOptionsLight';
 
     return (
-        <div className='wallets-market-currency-icon'>
+        <div className='wallets-market-currency-icon' data-testid='dt_wallet_market_icon'>
             <div className='wallets-market-currency-icon__container'>
                 <WalletMarketIcon
                     className='wallets-market-currency-icon__market-icon'

--- a/packages/wallets/src/components/WalletMarketCurrencyIcon/__test__/WalletMarketCurrencyIcon.spec.tsx
+++ b/packages/wallets/src/components/WalletMarketCurrencyIcon/__test__/WalletMarketCurrencyIcon.spec.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { CFD_PLATFORMS, MARKET_TYPE } from '../../../features/cfd/constants';
+import WalletMarketCurrencyIcon from '../WalletMarketCurrencyIcon';
+import '@testing-library/jest-dom';
+
+const defaultProps = {
+    currency: 'USD',
+    isDemo: false,
+};
+describe('WalletMarketCurrencyIcon', () => {
+    it('renders MT5 Financial Icon', () => {
+        render(
+            <WalletMarketCurrencyIcon
+                {...defaultProps}
+                marketType={MARKET_TYPE.FINANCIAL}
+                platform={CFD_PLATFORMS.MT5}
+            />
+        );
+        const marketIcon = screen.getByTestId('dt_wallet_icon');
+        const currencyIcon = screen.getByTestId('dt_wallet_currency_icon');
+        expect(screen.getByTestId('dt_wallet_market_icon')).toBeInTheDocument();
+        expect(marketIcon).toBeInTheDocument();
+        expect(currencyIcon).toBeInTheDocument();
+    });
+
+    it('renders DXTrade icon', () => {
+        render(
+            <WalletMarketCurrencyIcon {...defaultProps} marketType={MARKET_TYPE.ALL} platform={CFD_PLATFORMS.DXTRADE} />
+        );
+        const marketIcon = screen.getByTestId('dt_wallet_icon');
+        const currencyIcon = screen.getByTestId('dt_wallet_currency_icon');
+        expect(screen.getByTestId('dt_wallet_market_icon')).toBeInTheDocument();
+        expect(marketIcon).toBeInTheDocument();
+        expect(currencyIcon).toBeInTheDocument();
+    });
+
+    it('renders Options icon', () => {
+        render(<WalletMarketCurrencyIcon {...defaultProps} marketType={undefined} platform={undefined} />);
+        const marketIcon = screen.getByTestId('dt_wallet_icon');
+        const currencyIcon = screen.getByTestId('dt_wallet_currency_icon');
+        expect(screen.getByTestId('dt_wallet_market_icon')).toBeInTheDocument();
+        expect(marketIcon).toBeInTheDocument();
+        expect(currencyIcon).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Changes:

- added test case for WalletMarketCurrencyIcon

### Screenshots:

<img width="1492" alt="image" src="https://github.com/binary-com/deriv-app/assets/103104395/0e96174f-a8af-4704-b530-b72ad5239f48">
