### PR TITLE
[WALL] Aizad/WALL-4436/Refactor Options Multiplier Listings

### DIFF
--- a/packages/wallets/src/components/OptionsAndMultipliersListing/LinkTitle.tsx
+++ b/packages/wallets/src/components/OptionsAndMultipliersListing/LinkTitle.tsx
@@ -1,0 +1,45 @@
+import React, { ComponentProps } from 'react';
+import { getStaticUrl, getUrlBinaryBot, getUrlSmartTrader } from '../../helpers/urls';
+import { WalletMarketIcon } from '../WalletMarketIcon';
+
+const LinkTitle: React.FC<{ platform: ComponentProps<typeof WalletMarketIcon>['icon'] }> = ({ platform }) => {
+    const handleClick = (event: React.KeyboardEvent<HTMLDivElement> | React.MouseEvent<HTMLDivElement>) => {
+        event.persist();
+        switch (platform) {
+            case 'trader':
+                window.open(getStaticUrl(`/dtrader`));
+                break;
+            case 'bot':
+                window.open(getStaticUrl(`/dbot`));
+                break;
+            case 'smarttrader':
+                window.open(getUrlSmartTrader());
+                break;
+            case 'binarybot':
+                window.open(getUrlBinaryBot());
+                break;
+            case 'derivgo':
+                window.open(getStaticUrl('/deriv-go'));
+                break;
+            default:
+                break;
+        }
+    };
+
+    return (
+        <div
+            className='wallets-options-and-multipliers-listing__content__icon'
+            onClick={handleClick}
+            // Fix sonarcloud issue
+            onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) => {
+                if (event.key === 'Enter') {
+                    handleClick(event);
+                }
+            }}
+        >
+            <WalletMarketIcon icon={platform} size='lg' />
+        </div>
+    );
+};
+
+export default LinkTitle;

--- a/packages/wallets/src/components/OptionsAndMultipliersListing/OptionsAndMultipliersListing.tsx
+++ b/packages/wallets/src/components/OptionsAndMultipliersListing/OptionsAndMultipliersListing.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps } from 'react';
+import React from 'react';
 import { Trans } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { useActiveLinkedToTradingAccount } from '@deriv/api-v2';
@@ -10,7 +10,6 @@ import { TSubscribedBalance } from '../../types';
 import { WalletLink, WalletText } from '../Base';
 import { DerivAppsSection } from '../DerivAppsSection';
 import { TradingAccountCard } from '../TradingAccountCard';
-import { WalletMarketIcon } from '../WalletMarketIcon';
 import LinkTitle from './LinkTitle';
 import './OptionsAndMultipliersListing.scss';
 

--- a/packages/wallets/src/components/OptionsAndMultipliersListing/OptionsAndMultipliersListing.tsx
+++ b/packages/wallets/src/components/OptionsAndMultipliersListing/OptionsAndMultipliersListing.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ComponentProps } from 'react';
 import { Trans } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { useActiveLinkedToTradingAccount } from '@deriv/api-v2';
@@ -11,27 +11,27 @@ import { TSubscribedBalance } from '../../types';
 import { WalletLink, WalletText } from '../Base';
 import { DerivAppsSection } from '../DerivAppsSection';
 import { TradingAccountCard } from '../TradingAccountCard';
+import { WalletMarketIcon } from '../WalletMarketIcon';
 import './OptionsAndMultipliersListing.scss';
+import { object } from 'yup';
 
-type TLinkTitleProps = Pick<typeof optionsAndMultipliersContent[number], 'icon' | 'title'>;
-
-const LinkTitle: React.FC<TLinkTitleProps> = ({ icon, title }) => {
+const LinkTitle: React.FC<{ platform: ComponentProps<typeof WalletMarketIcon>['icon'] }> = ({ platform }) => {
     const handleClick = (event: React.KeyboardEvent<HTMLDivElement> | React.MouseEvent<HTMLDivElement>) => {
         event.persist();
-        switch (title) {
-            case 'Deriv Trader':
+        switch (platform) {
+            case 'trader':
                 window.open(getStaticUrl(`/dtrader`));
                 break;
-            case 'Deriv Bot':
+            case 'bot':
                 window.open(getStaticUrl(`/dbot`));
                 break;
-            case 'SmartTrader':
+            case 'smarttrader':
                 window.open(getUrlSmartTrader());
                 break;
-            case 'Binary Bot':
+            case 'binarybot':
                 window.open(getUrlBinaryBot());
                 break;
-            case 'Deriv GO':
+            case 'derivgo':
                 window.open(getStaticUrl('/deriv-go'));
                 break;
             default:
@@ -50,7 +50,7 @@ const LinkTitle: React.FC<TLinkTitleProps> = ({ icon, title }) => {
                 }
             }}
         >
-            {icon}
+            <WalletMarketIcon icon={platform} size='lg' />
         </div>
     );
 };
@@ -82,18 +82,15 @@ const OptionsAndMultipliersListing: React.FC<TSubscribedBalance> = ({ balance })
             </section>
             <div className='wallets-options-and-multipliers-listing__content'>
                 {optionsAndMultipliersContent.map(account => {
-                    const { description, title } = account;
-
+                    const { description, key, redirect, title } = account;
                     return (
                         <TradingAccountCard
                             {...account}
                             disabled={!activeLinkedToTradingAccount?.loginid}
                             key={`trading-account-card-${title}`}
-                            leading={<LinkTitle icon={account.icon} title={title} />}
+                            leading={<LinkTitle platform={key} />}
                             onClick={() => {
-                                account.isExternal
-                                    ? window.open(account.redirect, '_blank')
-                                    : history.push(account.redirect as TRoute);
+                                account.isExternal ? window.open(redirect, '_blank') : history.push(redirect as TRoute);
                             }}
                             trailing={
                                 activeLinkedToTradingAccount?.loginid ? (

--- a/packages/wallets/src/components/OptionsAndMultipliersListing/OptionsAndMultipliersListing.tsx
+++ b/packages/wallets/src/components/OptionsAndMultipliersListing/OptionsAndMultipliersListing.tsx
@@ -4,7 +4,6 @@ import { useHistory } from 'react-router-dom';
 import { useActiveLinkedToTradingAccount } from '@deriv/api-v2';
 import { LabelPairedChevronRightCaptionRegularIcon } from '@deriv/quill-icons';
 import { optionsAndMultipliersContent } from '../../constants/constants';
-import { getStaticUrl, getUrlBinaryBot, getUrlSmartTrader } from '../../helpers/urls';
 import useDevice from '../../hooks/useDevice';
 import { TRoute } from '../../routes/Router';
 import { TSubscribedBalance } from '../../types';
@@ -12,48 +11,8 @@ import { WalletLink, WalletText } from '../Base';
 import { DerivAppsSection } from '../DerivAppsSection';
 import { TradingAccountCard } from '../TradingAccountCard';
 import { WalletMarketIcon } from '../WalletMarketIcon';
+import LinkTitle from './LinkTitle';
 import './OptionsAndMultipliersListing.scss';
-import { object } from 'yup';
-
-const LinkTitle: React.FC<{ platform: ComponentProps<typeof WalletMarketIcon>['icon'] }> = ({ platform }) => {
-    const handleClick = (event: React.KeyboardEvent<HTMLDivElement> | React.MouseEvent<HTMLDivElement>) => {
-        event.persist();
-        switch (platform) {
-            case 'trader':
-                window.open(getStaticUrl(`/dtrader`));
-                break;
-            case 'bot':
-                window.open(getStaticUrl(`/dbot`));
-                break;
-            case 'smarttrader':
-                window.open(getUrlSmartTrader());
-                break;
-            case 'binarybot':
-                window.open(getUrlBinaryBot());
-                break;
-            case 'derivgo':
-                window.open(getStaticUrl('/deriv-go'));
-                break;
-            default:
-                break;
-        }
-    };
-
-    return (
-        <div
-            className='wallets-options-and-multipliers-listing__content__icon'
-            onClick={handleClick}
-            // Fix sonarcloud issue
-            onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) => {
-                if (event.key === 'Enter') {
-                    handleClick(event);
-                }
-            }}
-        >
-            <WalletMarketIcon icon={platform} size='lg' />
-        </div>
-    );
-};
 
 const OptionsAndMultipliersListing: React.FC<TSubscribedBalance> = ({ balance }) => {
     const { isMobile } = useDevice();

--- a/packages/wallets/src/components/WalletMarketIcon/WalletMarketIcon.tsx
+++ b/packages/wallets/src/components/WalletMarketIcon/WalletMarketIcon.tsx
@@ -9,6 +9,11 @@ import {
     AccountsDmt5DerivedIcon,
     AccountsDmt5FinancialIcon,
     AccountsDmt5SwfIcon,
+    DerivProductDerivBotBrandLightLogoHorizontalIcon,
+    DerivProductDerivGoBrandLightLogoHorizontalIcon,
+    DerivProductDerivTraderBrandLightLogoHorizontalIcon,
+    PartnersProductBinaryBotBrandLightLogoHorizontalIcon,
+    PartnersProductSmarttraderBrandLightLogoIcon,
     PaymentMethodDerivP2pBrandDarkIcon,
     PaymentMethodDerivP2pBrandIcon,
 } from '@deriv/quill-icons';
@@ -26,6 +31,14 @@ const CFDPlatformIcons: TIconTypes = {
     IcWalletDerivX: AccountsDerivXIcon,
 };
 
+const AppIcons = {
+    binarybot: PartnersProductBinaryBotBrandLightLogoHorizontalIcon,
+    bot: DerivProductDerivBotBrandLightLogoHorizontalIcon,
+    derivgo: DerivProductDerivGoBrandLightLogoHorizontalIcon,
+    smarttrader: PartnersProductSmarttraderBrandLightLogoIcon,
+    trader: DerivProductDerivTraderBrandLightLogoHorizontalIcon,
+};
+
 const PlatformIcons: TIconTypes = {
     IcWalletDerivP2P: PaymentMethodDerivP2pBrandIcon,
     IcWalletDerivP2PDark: PaymentMethodDerivP2pBrandDarkIcon,
@@ -34,6 +47,7 @@ const PlatformIcons: TIconTypes = {
 };
 
 const Icons: TIconTypes = {
+    ...AppIcons,
     ...MT5MarketIcons,
     ...CFDPlatformIcons,
     ...PlatformIcons,

--- a/packages/wallets/src/constants/constants.tsx
+++ b/packages/wallets/src/constants/constants.tsx
@@ -1,39 +1,38 @@
-import React from 'react';
 import { getStaticUrl, getUrlBinaryBot, getUrlSmartTrader } from '../helpers/urls';
 import i18n from '../translations/i18n';
 
 export const optionsAndMultipliersContent = [
     {
         description: i18n.t('The options and multipliers trading platform.'),
+        key: 'trader',
         redirect: '/dtrader',
         title: i18n.t('Deriv Trader'),
-        key: 'trader',
     },
     {
         description: i18n.t('The ultimate bot trading platform.'),
+        key: 'bot',
         redirect: '/bot',
         title: i18n.t('Deriv Bot'),
-        key: 'bot',
     },
     {
         description: i18n.t('The legacy options trading platform.'),
         isExternal: true,
+        key: 'smarttrader',
         redirect: getUrlSmartTrader(),
         title: i18n.t('SmartTrader'),
-        key: 'smarttrader',
     },
     {
         description: i18n.t('The legacy bot trading platform.'),
         isExternal: true,
+        key: 'binarybot',
         redirect: getUrlBinaryBot(),
         title: i18n.t('Binary Bot'),
-        key: 'binarybot',
     },
     {
         description: i18n.t('The mobile app for trading multipliers and accumulators.'),
         isExternal: true,
+        key: 'derivgo',
         redirect: getStaticUrl('/deriv-go'),
         title: i18n.t('Deriv GO'),
-        key: 'derivgo',
     },
 ];

--- a/packages/wallets/src/constants/constants.tsx
+++ b/packages/wallets/src/constants/constants.tsx
@@ -1,51 +1,39 @@
 import React from 'react';
-import {
-    DerivProductDerivBotBrandLightLogoHorizontalIcon,
-    DerivProductDerivGoBrandLightLogoHorizontalIcon,
-    DerivProductDerivTraderBrandLightLogoHorizontalIcon,
-    PartnersProductBinaryBotBrandLightLogoHorizontalIcon,
-    PartnersProductSmarttraderBrandLightLogoIcon,
-} from '@deriv/quill-icons';
 import { getStaticUrl, getUrlBinaryBot, getUrlSmartTrader } from '../helpers/urls';
 import i18n from '../translations/i18n';
 
 export const optionsAndMultipliersContent = [
     {
         description: i18n.t('The options and multipliers trading platform.'),
-        icon: <DerivProductDerivTraderBrandLightLogoHorizontalIcon height='48' width='48' />,
         redirect: '/dtrader',
-        smallIcon: <DerivProductDerivTraderBrandLightLogoHorizontalIcon height='32' width='32' />,
         title: i18n.t('Deriv Trader'),
+        key: 'trader',
     },
     {
         description: i18n.t('The ultimate bot trading platform.'),
-        icon: <DerivProductDerivBotBrandLightLogoHorizontalIcon height='48' width='48' />,
         redirect: '/bot',
-        smallIcon: <DerivProductDerivBotBrandLightLogoHorizontalIcon height='32' width='32' />,
         title: i18n.t('Deriv Bot'),
+        key: 'bot',
     },
     {
         description: i18n.t('The legacy options trading platform.'),
-        icon: <PartnersProductSmarttraderBrandLightLogoIcon height='48' width='48' />,
         isExternal: true,
         redirect: getUrlSmartTrader(),
-        smallIcon: <PartnersProductSmarttraderBrandLightLogoIcon height='32' width='32' />,
         title: i18n.t('SmartTrader'),
+        key: 'smarttrader',
     },
     {
         description: i18n.t('The legacy bot trading platform.'),
-        icon: <PartnersProductBinaryBotBrandLightLogoHorizontalIcon height='48' width='48' />,
         isExternal: true,
         redirect: getUrlBinaryBot(),
-        smallIcon: <PartnersProductBinaryBotBrandLightLogoHorizontalIcon height='32' width='32' />,
         title: i18n.t('Binary Bot'),
+        key: 'binarybot',
     },
     {
         description: i18n.t('The mobile app for trading multipliers and accumulators.'),
-        icon: <DerivProductDerivGoBrandLightLogoHorizontalIcon height='48' width='48' />,
         isExternal: true,
         redirect: getStaticUrl('/deriv-go'),
-        smallIcon: <DerivProductDerivGoBrandLightLogoHorizontalIcon height='32' width='32' />,
         title: i18n.t('Deriv GO'),
+        key: 'derivgo',
     },
 ];


### PR DESCRIPTION
## Changes:

- Refactor `OptionsAndMultipliersListing` component
- Use `WalletMarketIcon` component
- Remove imports from constant files and instead import required icons inside of `WalletMarketIcon`
- Separate `LinkTItle` as its own child component
- Remove unused icons

Link to CU: https://app.clickup.com/t/20696747/WALL-4436

### Screenshots:

<img width="1227" alt="Screenshot 2024-06-19 at 1 44 35 PM" src="https://github.com/binary-com/deriv-app/assets/103104395/b7da62f5-6e98-444e-8991-7f6a08f67602">

