### PR TITLE
[WALL] george / WALL-4422 / Wallet header showing 0.00 for split second if click wallet's related button from Trader's hub home

### DIFF
--- a/packages/wallets/src/components/SkeletonLoader/SkeletonLoader.scss
+++ b/packages/wallets/src/components/SkeletonLoader/SkeletonLoader.scss
@@ -1,5 +1,6 @@
 .wallets-skeleton {
     background-color: #e2e5e7;
+    opacity: 0.3;
     background-image: linear-gradient(90deg, rgba(#fff, 0), rgba(#fff, 0.5), rgba(#fff, 0));
     background-size: 4rem 100%;
     background-repeat: no-repeat;

--- a/packages/wallets/src/features/cashier/components/WalletCashierHeader/WalletCashierHeader.scss
+++ b/packages/wallets/src/features/cashier/components/WalletCashierHeader/WalletCashierHeader.scss
@@ -16,6 +16,16 @@
         height: fit-content;
     }
 
+    &__loader {
+        width: 14rem;
+        height: 3.6rem;
+
+        @include mobile {
+            width: 12rem;
+            height: 2.6rem;
+        }
+    }
+
     &__info {
         display: flex;
         justify-content: space-between;

--- a/packages/wallets/src/features/cashier/components/WalletCashierHeader/WalletCashierHeader.tsx
+++ b/packages/wallets/src/features/cashier/components/WalletCashierHeader/WalletCashierHeader.tsx
@@ -64,7 +64,7 @@ const virtualAccountTabs = [
 
 const WalletCashierHeader: React.FC<TProps> = ({ hideWalletDetails }) => {
     const { data: activeWallet } = useActiveWalletAccount();
-    const { data: balanceData, subscribe, unsubscribe } = useBalanceSubscription();
+    const { data: balanceData, isLoading, subscribe, unsubscribe } = useBalanceSubscription();
     const { isMobile } = useDevice();
     const activeTabRef = useRef<HTMLButtonElement>(null);
     const history = useHistory();
@@ -116,11 +116,15 @@ const WalletCashierHeader: React.FC<TProps> = ({ hideWalletDetails }) => {
                                 />
                             )}
                         </div>
-                        <WalletText color={activeWallet?.is_virtual ? 'white' : 'general'} size='xl' weight='bold'>
-                            {displayMoney?.(balanceData?.balance ?? 0, activeWallet?.currency || '', {
-                                fractional_digits: activeWallet?.currency_config?.fractional_digits,
-                            })}
-                        </WalletText>
+                        {isLoading ? (
+                            <div className='wallets-skeleton wallets-cashier-header__loader' />
+                        ) : (
+                            <WalletText color={activeWallet?.is_virtual ? 'white' : 'general'} size='xl' weight='bold'>
+                                {displayMoney?.(balanceData?.balance ?? 0, activeWallet?.currency || '', {
+                                    fractional_digits: activeWallet?.currency_config?.fractional_digits,
+                                })}
+                            </WalletText>
+                        )}
                     </div>
                     <div className='wallets-cashier-header__top-right-info'>
                         {activeWallet?.wallet_currency_type && (


### PR DESCRIPTION
## Changes:

- Add skeleton loader for balance in header cashier overlay
- Add `0.3 opacity` to skeleton loader

### Screenshots:


https://github.com/binary-com/deriv-app/assets/103181646/fb9486be-b0b0-49a5-a3b7-3338e910d882

