### PR TITLE
[WALL] Aizad/WALL-4421/Replace Reset With Transfer Icon inside of Demo Wallet

### DIFF
--- a/packages/wallets/src/components/DerivAppsSection/DerivAppsTradingAccount.tsx
+++ b/packages/wallets/src/components/DerivAppsSection/DerivAppsTradingAccount.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useHistory } from 'react-router-dom';
 import { useActiveLinkedToTradingAccount, useActiveWalletAccount, useAuthorize } from '@deriv/api-v2';
 import { displayMoney } from '@deriv/api-v2/src/utils';
-import { LabelPairedArrowsRotateSmBoldIcon, LabelPairedArrowUpArrowDownSmBoldIcon } from '@deriv/quill-icons';
+import { LabelPairedArrowUpArrowDownSmBoldIcon } from '@deriv/quill-icons';
 import useDevice from '../../hooks/useDevice';
 import { TSubscribedBalance } from '../../types';
 import { WalletText } from '../Base';
@@ -48,18 +48,12 @@ const DerivAppsTradingAccount: React.FC<TSubscribedBalance> = ({ balance }) => {
             <button
                 className='wallets-deriv-apps-section__button'
                 onClick={() => {
-                    activeWallet?.is_virtual
-                        ? history.push('/wallet/reset-balance')
-                        : history.push('/wallet/account-transfer', {
-                              toAccountLoginId: activeLinkedToTradingAccount?.loginid,
-                          });
+                    history.push('/wallet/account-transfer', {
+                        toAccountLoginId: activeLinkedToTradingAccount?.loginid,
+                    });
                 }}
             >
-                {activeWallet?.is_virtual ? (
-                    <LabelPairedArrowsRotateSmBoldIcon />
-                ) : (
-                    <LabelPairedArrowUpArrowDownSmBoldIcon />
-                )}
+                <LabelPairedArrowUpArrowDownSmBoldIcon />
             </button>
         </div>
     );


### PR DESCRIPTION
## Changes:

- replace reset balance icon with transfer icon inside of Demo Wallets
- redirect to transfer page instead of reset balance page when pressing on the icon
- changes is applied on both desktop and mobile

### Screenshots:

<img width="377" alt="image" src="https://github.com/binary-com/deriv-app/assets/103104395/6a2a7606-924a-465f-8e70-ada02a90c043">
<img width="1489" alt="image" src="https://github.com/binary-com/deriv-app/assets/103104395/8557b4ef-71f3-4abf-9609-6d01662d38a3">

