### PR TITLE
chore: removed pull_request section

### DIFF
--- a/.github/workflows/sync-translations.yml
+++ b/.github/workflows/sync-translations.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-    - master
   schedule:
     - cron: '0 */12 * * *'
 


### PR DESCRIPTION
## Changes:

sync_translation.yml file triggers for PRs from forked repos. This results in failure as the workflow triggered from forked repo dosen't have access to repository secrets and environmental variables.
Hence restricting the workflow to only PRs merged to upstream master
