### PR TITLE
Shontzu/cfds 4248/sf zs patch

### DIFF
--- a/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal-content-wrapper.tsx
+++ b/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal-content-wrapper.tsx
@@ -102,6 +102,7 @@ const JurisdictionModalContentWrapper = observer(({ openPasswordModal }: TJurisd
     const swapfree_available_accounts = trading_platform_available_accounts.filter(
         available_account =>
             available_account.market_type === MARKET_TYPE.ALL &&
+            available_account.product === 'swap_free' &&
             (show_eu_related_content
                 ? available_account.shortcode === JURISDICTION.MALTA_INVEST
                 : available_account.shortcode !== JURISDICTION.MALTA_INVEST)

--- a/packages/stores/types.ts
+++ b/packages/stores/types.ts
@@ -237,6 +237,7 @@ type TActiveAccount = TAccount & {
 type TTradingPlatformAvailableAccount = {
     market_type: 'financial' | 'gaming' | 'all';
     name: string;
+    product?: string;
     requirements: {
         after_first_deposit: {
             financial_assessment: string[];


### PR DESCRIPTION
## Changes:

- The root cause of this issue is that in the swap-free jurisdiction model, we are only filtering for `market_type = "all"`
- it is not unique to swap-free / zero-spread
- use `product` to uniquely identify swap-free


### Screenshots:

<img width="1062" alt="image" src="https://github.com/binary-com/deriv-app/assets/108507236/9d4c2212-2415-47a7-accd-b998fc63cfbf">

<img width="1060" alt="image" src="https://github.com/binary-com/deriv-app/assets/108507236/fd6068e5-9556-4b65-b817-43fdae87dbf4">
