### PR TITLE
DTRA-1366 / Kate / Fix: console error on the test links for DTrader-V2

### DIFF
--- a/packages/trader/src/AppV2/Components/Filter/contract-type-filter.tsx
+++ b/packages/trader/src/AppV2/Components/Filter/contract-type-filter.tsx
@@ -5,7 +5,7 @@ import { Localize } from '@deriv/translations';
 type TContractTypeFilter = {
     contractTypeFilter: string[] | [];
     onApplyContractTypeFilter: (filterValues: string[]) => void;
-    id: string;
+    id?: string;
 };
 
 const availableContracts = [

--- a/packages/trader/src/AppV2/Components/Filter/contract-type-filter.tsx
+++ b/packages/trader/src/AppV2/Components/Filter/contract-type-filter.tsx
@@ -5,6 +5,7 @@ import { Localize } from '@deriv/translations';
 type TContractTypeFilter = {
     contractTypeFilter: string[] | [];
     onApplyContractTypeFilter: (filterValues: string[]) => void;
+    id: string;
 };
 
 const availableContracts = [
@@ -20,7 +21,7 @@ const availableContracts = [
     <Localize i18n_default_text='Over/Under' key='Over/Under' />,
 ];
 
-const ContractTypeFilter = ({ contractTypeFilter, onApplyContractTypeFilter }: TContractTypeFilter) => {
+const ContractTypeFilter = ({ contractTypeFilter, onApplyContractTypeFilter, id }: TContractTypeFilter) => {
     const [isDropdownOpen, setIsDropdownOpen] = React.useState(false);
     const [changedOptions, setChangedOptions] = React.useState<string[]>(contractTypeFilter);
 
@@ -56,6 +57,7 @@ const ContractTypeFilter = ({ contractTypeFilter, onApplyContractTypeFilter }: T
                 onClick={() => setIsDropdownOpen(!isDropdownOpen)}
                 selected={!!changedOptions.length}
                 size='md'
+                key={id}
             />
             <ActionSheet.Root isOpen={isDropdownOpen} onClose={onActionSheetClose} position='left'>
                 <ActionSheet.Portal shouldCloseOnDrag>

--- a/packages/trader/src/AppV2/Components/Filter/contract-type-filter.tsx
+++ b/packages/trader/src/AppV2/Components/Filter/contract-type-filter.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { ActionSheet, Checkbox, Chip } from '@deriv-com/quill-ui';
+import { ActionSheet, Checkbox, Chip, Text } from '@deriv-com/quill-ui';
 import { Localize } from '@deriv/translations';
 
 type TContractTypeFilter = {
     contractTypeFilter: string[] | [];
     onApplyContractTypeFilter: (filterValues: string[]) => void;
-    id?: string;
 };
 
 const availableContracts = [
@@ -21,7 +20,7 @@ const availableContracts = [
     <Localize i18n_default_text='Over/Under' key='Over/Under' />,
 ];
 
-const ContractTypeFilter = ({ contractTypeFilter, onApplyContractTypeFilter, id }: TContractTypeFilter) => {
+const ContractTypeFilter = ({ contractTypeFilter, onApplyContractTypeFilter }: TContractTypeFilter) => {
     const [isDropdownOpen, setIsDropdownOpen] = React.useState(false);
     const [changedOptions, setChangedOptions] = React.useState<string[]>(contractTypeFilter);
 
@@ -53,14 +52,11 @@ const ContractTypeFilter = ({ contractTypeFilter, onApplyContractTypeFilter, id 
                 className='filter__chip'
                 dropdown
                 isDropdownOpen={isDropdownOpen}
-                // label={getChipLabel()}
                 onClick={() => setIsDropdownOpen(!isDropdownOpen)}
                 selected={!!changedOptions.length}
                 size='md'
-                key={id}
-                id={id}
             >
-                {getChipLabel()}
+                <Text size='sm'>{getChipLabel()}</Text>
             </Chip.Standard>
             <ActionSheet.Root isOpen={isDropdownOpen} onClose={onActionSheetClose} position='left'>
                 <ActionSheet.Portal shouldCloseOnDrag>

--- a/packages/trader/src/AppV2/Components/Filter/contract-type-filter.tsx
+++ b/packages/trader/src/AppV2/Components/Filter/contract-type-filter.tsx
@@ -58,6 +58,7 @@ const ContractTypeFilter = ({ contractTypeFilter, onApplyContractTypeFilter, id 
                 selected={!!changedOptions.length}
                 size='md'
                 key={id}
+                id={id}
             />
             <ActionSheet.Root isOpen={isDropdownOpen} onClose={onActionSheetClose} position='left'>
                 <ActionSheet.Portal shouldCloseOnDrag>

--- a/packages/trader/src/AppV2/Components/Filter/contract-type-filter.tsx
+++ b/packages/trader/src/AppV2/Components/Filter/contract-type-filter.tsx
@@ -8,16 +8,16 @@ type TContractTypeFilter = {
 };
 
 const availableContracts = [
-    { tradeType: <Localize i18n_default_text='Accumulators' />, id: 'Accumulators' },
-    { tradeType: <Localize i18n_default_text='Vanillas' />, id: 'Vanillas' },
-    { tradeType: <Localize i18n_default_text='Turbos' />, id: 'Turbos' },
-    { tradeType: <Localize i18n_default_text='Multipliers' />, id: 'Multipliers' },
-    { tradeType: <Localize i18n_default_text='Rise/Fall' />, id: 'Rise/Fall' },
-    { tradeType: <Localize i18n_default_text='Higher/Lower' />, id: 'Higher/Lower' },
-    { tradeType: <Localize i18n_default_text='Touch/No touch' />, id: 'Touch/No touch' },
-    { tradeType: <Localize i18n_default_text='Matches/Differs' />, id: 'Matches/Differs' },
-    { tradeType: <Localize i18n_default_text='Even/Odd' />, id: 'Even/Odd' },
-    { tradeType: <Localize i18n_default_text='Over/Under' />, id: 'Over/Under' },
+    <Localize i18n_default_text='Accumulators' key='Accumulators' />,
+    <Localize i18n_default_text='Vanillas' key='Vanillas' />,
+    <Localize i18n_default_text='Turbos' key='Turbos' />,
+    <Localize i18n_default_text='Multipliers' key='Multipliers' />,
+    <Localize i18n_default_text='Rise/Fall' key='Rise/Fall' />,
+    <Localize i18n_default_text='Higher/Lower' key='Higher/Lower' />,
+    <Localize i18n_default_text='Touch/No touch' key='Touch/No touch' />,
+    <Localize i18n_default_text='Matches/Differs' key='Matches/Differs' />,
+    <Localize i18n_default_text='Even/Odd' key='Even/Odd' />,
+    <Localize i18n_default_text='Over/Under' key='Over/Under' />,
 ];
 
 const ContractTypeFilter = ({ contractTypeFilter, onApplyContractTypeFilter }: TContractTypeFilter) => {
@@ -42,7 +42,7 @@ const ContractTypeFilter = ({ contractTypeFilter, onApplyContractTypeFilter }: T
     const getChipLabel = () => {
         const arrayLength = contractTypeFilter.length;
         if (!arrayLength) return <Localize i18n_default_text='All trade types' />;
-        if (arrayLength === 1) return availableContracts.find(type => type.id === contractTypeFilter[0])?.tradeType;
+        if (arrayLength === 1) return availableContracts.find(type => type.key === contractTypeFilter[0])?.key;
         return <Localize i18n_default_text='{{amount}} trade types' values={{ amount: arrayLength }} />;
     };
 
@@ -62,14 +62,14 @@ const ContractTypeFilter = ({ contractTypeFilter, onApplyContractTypeFilter }: T
                 <ActionSheet.Portal shouldCloseOnDrag>
                     <ActionSheet.Header title={<Localize i18n_default_text='Filter by trade types' />} />
                     <ActionSheet.Content className='filter__item__wrapper'>
-                        {availableContracts.map(({ tradeType, id }) => (
+                        {availableContracts.map(contract => (
                             <Checkbox
-                                checked={changedOptions.includes(id)}
+                                checked={changedOptions.includes(contract.key as string)}
                                 checkboxPosition='right'
                                 className='filter__item'
-                                id={id}
-                                key={id}
-                                label={tradeType}
+                                id={contract.key as string}
+                                key={contract.key}
+                                label={contract}
                                 onChange={onChange}
                                 size='md'
                             />

--- a/packages/trader/src/AppV2/Components/Filter/contract-type-filter.tsx
+++ b/packages/trader/src/AppV2/Components/Filter/contract-type-filter.tsx
@@ -49,6 +49,7 @@ const ContractTypeFilter = ({ contractTypeFilter, onApplyContractTypeFilter }: T
     return (
         <React.Fragment>
             <Chip.Standard
+                key='filter__chip'
                 className='filter__chip'
                 dropdown
                 isDropdownOpen={isDropdownOpen}

--- a/packages/trader/src/AppV2/Components/Filter/contract-type-filter.tsx
+++ b/packages/trader/src/AppV2/Components/Filter/contract-type-filter.tsx
@@ -42,9 +42,9 @@ const ContractTypeFilter = ({ contractTypeFilter, onApplyContractTypeFilter, id 
 
     const getChipLabel = () => {
         const arrayLength = contractTypeFilter.length;
-        if (!arrayLength) return <Localize i18n_default_text='All trade types' />;
+        if (!arrayLength) return <Localize i18n_default_text='All trade types' key='All trade types' />;
         if (arrayLength === 1) return availableContracts.find(type => type.key === contractTypeFilter[0])?.key;
-        return <Localize i18n_default_text='{{amount}} trade types' values={{ amount: arrayLength }} />;
+        return <Localize i18n_default_text='{{amount}} trade types' values={{ amount: arrayLength }} key='Amount' />;
     };
 
     return (

--- a/packages/trader/src/AppV2/Components/Filter/contract-type-filter.tsx
+++ b/packages/trader/src/AppV2/Components/Filter/contract-type-filter.tsx
@@ -53,13 +53,15 @@ const ContractTypeFilter = ({ contractTypeFilter, onApplyContractTypeFilter, id 
                 className='filter__chip'
                 dropdown
                 isDropdownOpen={isDropdownOpen}
-                label={getChipLabel()}
+                // label={getChipLabel()}
                 onClick={() => setIsDropdownOpen(!isDropdownOpen)}
                 selected={!!changedOptions.length}
                 size='md'
                 key={id}
                 id={id}
-            />
+            >
+                {getChipLabel()}
+            </Chip.Standard>
             <ActionSheet.Root isOpen={isDropdownOpen} onClose={onActionSheetClose} position='left'>
                 <ActionSheet.Portal shouldCloseOnDrag>
                     <ActionSheet.Header title={<Localize i18n_default_text='Filter by trade types' />} />

--- a/packages/trader/src/AppV2/Components/Filter/contract-type-filter.tsx
+++ b/packages/trader/src/AppV2/Components/Filter/contract-type-filter.tsx
@@ -49,7 +49,6 @@ const ContractTypeFilter = ({ contractTypeFilter, onApplyContractTypeFilter }: T
     return (
         <React.Fragment>
             <Chip.Standard
-                key='filter__chip'
                 className='filter__chip'
                 dropdown
                 isDropdownOpen={isDropdownOpen}

--- a/packages/trader/src/AppV2/Components/Filter/time-filter.tsx
+++ b/packages/trader/src/AppV2/Components/Filter/time-filter.tsx
@@ -124,13 +124,15 @@ const TimeFilter = ({
                 className='filter__chip'
                 dropdown
                 isDropdownOpen={isDropdownOpen}
-                label={getChipLabel()}
+                // label={getChipLabel()}
                 onClick={() => setIsDropdownOpen(!isDropdownOpen)}
                 selected={isChipSelected}
                 size='md'
                 key='time_filter'
                 id='time_filter'
-            />
+            >
+                {getChipLabel()}
+            </Chip.Standard>
             <ActionSheet.Root isOpen={isDropdownOpen} onClose={() => setIsDropdownOpen(false)} position='left'>
                 <ActionSheet.Portal shouldCloseOnDrag>
                     <ActionSheet.Header title={<Localize i18n_default_text='Filter by trade types' />} />

--- a/packages/trader/src/AppV2/Components/Filter/time-filter.tsx
+++ b/packages/trader/src/AppV2/Components/Filter/time-filter.tsx
@@ -128,6 +128,7 @@ const TimeFilter = ({
                 onClick={() => setIsDropdownOpen(!isDropdownOpen)}
                 selected={isChipSelected}
                 size='md'
+                key='time_filter'
             />
             <ActionSheet.Root isOpen={isDropdownOpen} onClose={() => setIsDropdownOpen(false)} position='left'>
                 <ActionSheet.Portal shouldCloseOnDrag>

--- a/packages/trader/src/AppV2/Components/Filter/time-filter.tsx
+++ b/packages/trader/src/AppV2/Components/Filter/time-filter.tsx
@@ -129,6 +129,7 @@ const TimeFilter = ({
                 selected={isChipSelected}
                 size='md'
                 key='time_filter'
+                id='time_filter'
             />
             <ActionSheet.Root isOpen={isDropdownOpen} onClose={() => setIsDropdownOpen(false)} position='left'>
                 <ActionSheet.Portal shouldCloseOnDrag>

--- a/packages/trader/src/AppV2/Components/Filter/time-filter.tsx
+++ b/packages/trader/src/AppV2/Components/Filter/time-filter.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import moment from 'moment';
 import { toMoment } from '@deriv/shared';
-import { ActionSheet, Chip, RadioGroup } from '@deriv-com/quill-ui';
+import { ActionSheet, Chip, RadioGroup, Text } from '@deriv-com/quill-ui';
 import { Localize } from '@deriv/translations';
 import CustomDateFilterButton from './custom-time-filter-button';
 import DateRangePicker from 'AppV2/Components/DatePicker';
@@ -124,14 +124,11 @@ const TimeFilter = ({
                 className='filter__chip'
                 dropdown
                 isDropdownOpen={isDropdownOpen}
-                // label={getChipLabel()}
                 onClick={() => setIsDropdownOpen(!isDropdownOpen)}
                 selected={isChipSelected}
                 size='md'
-                key='time_filter'
-                id='time_filter'
             >
-                {getChipLabel()}
+                <Text size='sm'>{getChipLabel()}</Text>
             </Chip.Standard>
             <ActionSheet.Root isOpen={isDropdownOpen} onClose={() => setIsDropdownOpen(false)} position='left'>
                 <ActionSheet.Portal shouldCloseOnDrag>

--- a/packages/trader/src/AppV2/Containers/Positions/positions-content.tsx
+++ b/packages/trader/src/AppV2/Containers/Positions/positions-content.tsx
@@ -61,7 +61,7 @@ const PositionsContent = observer(({ hasButtonsDemo, isClosedTab, setHasButtonsD
     const shouldShowEmptyMessage = hasNoPositions || noMatchesFound;
     const shouldShowContractCards =
         !!filteredPositions.length && (isClosedTab || (filteredPositions[0]?.contract_info as TContractInfo)?.status);
-    const shouldShowLoading = isClosedTab ? isFetchingClosedPositions : is_loading;
+    const shouldShowLoading = isClosedTab ? isFetchingClosedPositions && !filterPositions.length : is_loading;
     const shouldShowTakeProfit = !isClosedTab || !!(timeFilter || customTimeRangeFilter);
 
     const onScroll = React.useCallback(

--- a/packages/trader/src/AppV2/Containers/Positions/positions-content.tsx
+++ b/packages/trader/src/AppV2/Containers/Positions/positions-content.tsx
@@ -139,13 +139,12 @@ const PositionsContent = observer(({ hasButtonsDemo, isClosedTab, setHasButtonsD
                             customTimeRangeFilter={customTimeRangeFilter}
                             setCustomTimeRangeFilter={setCustomTimeRangeFilter}
                             setNoMatchesFound={setNoMatchesFound}
-                            key='time_filter'
                         />
                     )}
                     <ContractTypeFilter
                         contractTypeFilter={contractTypeFilter}
                         onApplyContractTypeFilter={onApplyContractTypeFilter}
-                        key={isClosedTab ? 'contract_close' : 'contract_open'}
+                        id={isClosedTab ? 'contract_close' : 'contract_open'}
                     />
                 </div>
             )}

--- a/packages/trader/src/AppV2/Containers/Positions/positions-content.tsx
+++ b/packages/trader/src/AppV2/Containers/Positions/positions-content.tsx
@@ -144,7 +144,6 @@ const PositionsContent = observer(({ hasButtonsDemo, isClosedTab, setHasButtonsD
                     <ContractTypeFilter
                         contractTypeFilter={contractTypeFilter}
                         onApplyContractTypeFilter={onApplyContractTypeFilter}
-                        id={isClosedTab ? 'contract_close' : 'contract_open'}
                     />
                 </div>
             )}

--- a/packages/trader/src/AppV2/Containers/Positions/positions-content.tsx
+++ b/packages/trader/src/AppV2/Containers/Positions/positions-content.tsx
@@ -139,11 +139,13 @@ const PositionsContent = observer(({ hasButtonsDemo, isClosedTab, setHasButtonsD
                             customTimeRangeFilter={customTimeRangeFilter}
                             setCustomTimeRangeFilter={setCustomTimeRangeFilter}
                             setNoMatchesFound={setNoMatchesFound}
+                            key='time_filter'
                         />
                     )}
                     <ContractTypeFilter
                         contractTypeFilter={contractTypeFilter}
                         onApplyContractTypeFilter={onApplyContractTypeFilter}
+                        key={isClosedTab ? 'contract_close' : 'contract_open'}
                     />
                 </div>
             )}


### PR DESCRIPTION
## Changes:

- Console error was visible only on tests links. Issue is coming from Quill library: in `Chip` component `label` should accept only `string`, but according to type it can be `React.ReactNode`. Because of that, when we are passing `ReactNode` and during cloning element we will get an error here:
`{label &&. React.cloneElement(LabelTextSizes[size], {children: label})}`
- Refactor existing config with Localized filters
- Added additional condition for `shouldShowLoading` in order to fix fetching loader

### Screenshots:

https://github.com/binary-com/deriv-app/assets/121025168/f5b8ac6f-697e-4ce9-b196-16d43d6d187f



