### PR TITLE
DTRA-1368 / Kate /  Position and Contract Details Page refactor: add CALLE/PUTE filtration

### DIFF
--- a/packages/trader/src/AppV2/Containers/Positions/positions-content.tsx
+++ b/packages/trader/src/AppV2/Containers/Positions/positions-content.tsx
@@ -64,14 +64,9 @@ const PositionsContent = observer(({ hasButtonsDemo, isClosedTab, setHasButtonsD
     const shouldShowLoading = isClosedTab ? isFetchingClosedPositions : is_loading;
     const shouldShowTakeProfit = !isClosedTab || !!(timeFilter || customTimeRangeFilter);
 
-    const onScroll = React.useCallback(
-        (e: React.UIEvent<HTMLDivElement>) => {
-            if (isClosedTab) {
-                handleScroll(e, true);
-            }
-        },
-        [handleScroll, isClosedTab]
-    );
+    const onScroll = (e: React.UIEvent<HTMLDivElement>) => {
+        if (isClosedTab) handleScroll(e, true);
+    };
 
     const contractCards = isClosedTab ? (
         <ContractCardsSections

--- a/packages/trader/src/AppV2/Utils/__tests__/contract-details-config.spec.ts
+++ b/packages/trader/src/AppV2/Utils/__tests__/contract-details-config.spec.ts
@@ -1,0 +1,22 @@
+import { CONTRACT_TYPES } from '@deriv/shared';
+import { getContractDetailsConfig } from '../contract-details-config';
+
+describe('getContractDetailsConfig', () => {
+    it('should return correct part of config for contract type which is among configs keys', () => {
+        expect(getContractDetailsConfig(CONTRACT_TYPES.ACCUMULATOR)).toEqual({
+            isTakeProfitVisible: true,
+            isDealCancellationVisible: false,
+            isStopLossVisible: false,
+            isTpHistoryVisible: true,
+        });
+    });
+
+    it('should return default config for contract type which is not among configs keys', () => {
+        expect(getContractDetailsConfig(CONTRACT_TYPES.CALL)).toEqual({
+            isTakeProfitVisible: false,
+            isDealCancellationVisible: false,
+            isStopLossVisible: false,
+            isTpHistoryVisible: false,
+        });
+    });
+});

--- a/packages/trader/src/AppV2/Utils/__tests__/positions-utils.spec.ts
+++ b/packages/trader/src/AppV2/Utils/__tests__/positions-utils.spec.ts
@@ -287,8 +287,9 @@ const mockedActivePositions = [
 ] as TPortfolioPosition[];
 
 describe('getFilteredContractTypes', () => {
-    it('should return empty array if filters are empty', () => {
+    it('should return empty array if filters are empty or undefined', () => {
         expect(getFilteredContractTypes([])).toEqual([]);
+        expect(getFilteredContractTypes()).toEqual([]);
     });
 
     it('should return empty array if contract type filter does not exist in config', () => {

--- a/packages/trader/src/AppV2/Utils/__tests__/positions-utils.spec.ts
+++ b/packages/trader/src/AppV2/Utils/__tests__/positions-utils.spec.ts
@@ -300,18 +300,29 @@ describe('getFilteredContractTypes', () => {
             CONTRACT_TYPES.VANILLA.CALL,
             CONTRACT_TYPES.VANILLA.PUT,
         ]);
-        expect(getFilteredContractTypes(['Rise/Fall'])).toEqual([CONTRACT_TYPES.CALL, CONTRACT_TYPES.PUT]);
+        expect(getFilteredContractTypes(['Rise/Fall'])).toEqual([
+            CONTRACT_TYPES.CALL,
+            CONTRACT_TYPES.PUT,
+            CONTRACT_TYPES.CALLE,
+            CONTRACT_TYPES.PUTE,
+        ]);
     });
 
     it('should return array with contract type filters without duplicates', () => {
         expect(getFilteredContractTypes(['Rise/Fall', 'Higher/Lower'])).toEqual([
             CONTRACT_TYPES.CALL,
             CONTRACT_TYPES.PUT,
+            CONTRACT_TYPES.CALLE,
+            CONTRACT_TYPES.PUTE,
         ]);
     });
 });
 
 describe('filterPositions', () => {
+    it('should return positions if filter array was empty', () => {
+        expect(filterPositions(mockedActivePositions, [])).toEqual(mockedActivePositions);
+    });
+
     it('should filter positions based on passed filter array', () => {
         expect(filterPositions(mockedActivePositions, ['Multipliers'])).toEqual([mockedActivePositions[1]]);
 

--- a/packages/trader/src/AppV2/Utils/positions-utils.ts
+++ b/packages/trader/src/AppV2/Utils/positions-utils.ts
@@ -9,6 +9,7 @@ export const DEFAULT_DATE_FORMATTING_CONFIG = {
 } as Record<string, string>;
 
 export const filterPositions = (positions: (TPortfolioPosition | TClosedPosition)[], filter: string[]) => {
+    if (!filter.length) return positions;
     // Split contract type names with '/' (e.g. Rise/Fall)
     const splittedFilter = filter.map(option => (option.includes('/') ? option.split('/') : option)).flat();
 
@@ -25,7 +26,7 @@ const contractTypesConfig = {
     Vanillas: [CONTRACT_TYPES.VANILLA.CALL, CONTRACT_TYPES.VANILLA.PUT],
     Turbos: [CONTRACT_TYPES.TURBOS.LONG, CONTRACT_TYPES.TURBOS.SHORT],
     Multipliers: [CONTRACT_TYPES.MULTIPLIER.DOWN, CONTRACT_TYPES.MULTIPLIER.UP],
-    'Rise/Fall': [CONTRACT_TYPES.CALL, CONTRACT_TYPES.PUT],
+    'Rise/Fall': [CONTRACT_TYPES.CALL, CONTRACT_TYPES.PUT, CONTRACT_TYPES.CALLE, CONTRACT_TYPES.PUTE],
     'Higher/Lower': [CONTRACT_TYPES.CALL, CONTRACT_TYPES.PUT],
     'Touch/No touch': [CONTRACT_TYPES.TOUCH.NO_TOUCH, CONTRACT_TYPES.TOUCH.ONE_TOUCH],
     'Matches/Differs': [CONTRACT_TYPES.MATCH_DIFF.DIFF, CONTRACT_TYPES.MATCH_DIFF.MATCH],


### PR DESCRIPTION
## Changes:

- Added CALLE/PUTE  to config in order to send it together with CALL/PUT in the array of contract_type to profit_table request, when user applies 'Rise/Fall' filter.
- Refactor existing tests

### Screenshots:

![Screenshot 2024-06-25 at 11 23 37 AM](https://github.com/binary-com/deriv-app/assets/121025168/c41f40ff-365a-4014-b5ed-7083ce6fcbbb)
