### PR TITLE
[WALL] Aizad/WALL-4228/Consistent Icons Across Wallet Overlay and TH Main Page

### DIFF
--- a/packages/wallets/src/components/WalletsCarouselHeader/WalletsCarouselHeader.scss
+++ b/packages/wallets/src/components/WalletsCarouselHeader/WalletsCarouselHeader.scss
@@ -3,8 +3,9 @@
 .wallets-carousel-header {
     background: var(--system-light-8-primary-background, #fff);
     border-bottom: 1px solid var(--general-section-1, #f2f3f4);
-    display: flex;
     height: 6.1rem;
+    display: flex;
+    align-items: center;
     justify-content: space-between;
     padding: 1rem 1.6rem 1rem 0.8rem;
     position: absolute;
@@ -34,5 +35,10 @@
     &__details {
         display: flex;
         flex-direction: column;
+    }
+
+    &__button {
+        border-radius: 1.2rem;
+        border: 0.1rem solid var(--text-general, #333333);
     }
 }

--- a/packages/wallets/src/components/WalletsCarouselHeader/WalletsCarouselHeader.tsx
+++ b/packages/wallets/src/components/WalletsCarouselHeader/WalletsCarouselHeader.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import { useHistory } from 'react-router-dom';
-import { LegacyTransferIcon } from '@deriv/quill-icons';
+import { LabelPairedArrowUpArrowDownSmBoldIcon } from '@deriv/quill-icons';
 import { IconButton, WalletText } from '../Base';
 import { WalletCurrencyCard } from '../WalletCurrencyCard';
 import './WalletsCarouselHeader.scss';
@@ -38,14 +38,13 @@ const WalletsCarouselHeader: React.FC<TProps> = ({ balance, currency, hidden, is
                 </div>
             </div>
             <IconButton
-                color='transparent'
+                aria-label='Transfer'
+                className='wallets-carousel-header__button'
+                color='white'
                 data-testid='dt_wallets_carousel_header_button'
-                icon={<LegacyTransferIcon iconSize='xs' />}
-                iconSize='lg'
-                onClick={() => {
-                    history.push('/wallet/account-transfer');
-                }}
-                size='lg'
+                icon={<LabelPairedArrowUpArrowDownSmBoldIcon />}
+                onClick={() => history.push('/wallet/account-transfer')}
+                size='md'
             />
         </div>
     );

--- a/packages/wallets/src/features/cashier/components/WalletCashierHeader/WalletCashierHeader.scss
+++ b/packages/wallets/src/features/cashier/components/WalletCashierHeader/WalletCashierHeader.scss
@@ -137,8 +137,6 @@
     }
 
     &__tab-icon {
-        width: 1.6rem;
-        height: 1.6rem;
         &--system-dark-2-general-text {
             path {
                 fill: var(--system-dark-2-general-text, #c2c2c2);

--- a/packages/wallets/src/features/cashier/components/WalletCashierHeader/WalletCashierHeader.tsx
+++ b/packages/wallets/src/features/cashier/components/WalletCashierHeader/WalletCashierHeader.tsx
@@ -4,12 +4,12 @@ import { useHistory, useLocation } from 'react-router-dom';
 import { useActiveWalletAccount, useBalanceSubscription } from '@deriv/api-v2';
 import { displayMoney } from '@deriv/api-v2/src/utils';
 import {
+    LabelPairedArrowsRotateMdRegularIcon,
+    LabelPairedArrowUpArrowDownMdRegularIcon,
+    LabelPairedMinusMdRegularIcon,
+    LabelPairedPlusMdRegularIcon,
+    LabelPairedSquareListMdRegularIcon,
     LegacyClose2pxIcon,
-    LegacyDepositIcon,
-    LegacyPlus1pxIcon,
-    LegacyStatementIcon,
-    LegacyTransferIcon,
-    LegacyWithdrawalIcon,
 } from '@deriv/quill-icons';
 import { WalletCurrencyIcon, WalletGradientBackground, WalletText } from '../../../../components';
 import { WalletListCardBadge } from '../../../../components/WalletListCardBadge';
@@ -23,22 +23,22 @@ type TProps = {
 
 const realAccountTabs = [
     {
-        icon: <LegacyDepositIcon iconSize='xs' />,
+        icon: <LabelPairedPlusMdRegularIcon />,
         path: 'deposit',
         text: i18n.t('Deposit'),
     },
     {
-        icon: <LegacyWithdrawalIcon iconSize='xs' />,
+        icon: <LabelPairedMinusMdRegularIcon />,
         path: 'withdrawal',
         text: i18n.t('Withdraw'),
     },
     {
-        icon: <LegacyTransferIcon iconSize='xs' />,
+        icon: <LabelPairedArrowUpArrowDownMdRegularIcon />,
         path: 'account-transfer',
         text: i18n.t('Transfer'),
     },
     {
-        icon: <LegacyStatementIcon iconSize='xs' />,
+        icon: <LabelPairedSquareListMdRegularIcon />,
         path: 'transactions',
         text: i18n.t('Transactions'),
     },
@@ -46,19 +46,19 @@ const realAccountTabs = [
 
 const virtualAccountTabs = [
     {
-        icon: <LegacyPlus1pxIcon iconSize='xs' />,
-        path: 'reset-balance',
-        text: i18n.t('Reset Balance'),
-    },
-    {
-        icon: <LegacyTransferIcon iconSize='xs' />,
+        icon: <LabelPairedArrowUpArrowDownMdRegularIcon />,
         path: 'account-transfer',
         text: i18n.t('Transfer'),
     },
     {
-        icon: <LegacyStatementIcon iconSize='xs' />,
+        icon: <LabelPairedSquareListMdRegularIcon />,
         path: 'transactions',
         text: i18n.t('Transactions'),
+    },
+    {
+        icon: <LabelPairedArrowsRotateMdRegularIcon />,
+        path: 'reset-balance',
+        text: i18n.t('Reset Balance'),
     },
 ] as const;
 
@@ -168,7 +168,7 @@ const WalletCashierHeader: React.FC<TProps> = ({ hideWalletDetails }) => {
                                 ref={isActiveTab ? activeTabRef : null}
                             >
                                 <div
-                                    className={classNames('wallets-cashier-header__tab-icon', {
+                                    className={classNames({
                                         'wallets-cashier-header__tab-icon--system-dark-2-general-text':
                                             activeWallet?.is_virtual && !isActiveTab,
                                     })}


### PR DESCRIPTION
## Changes:

- Replace old icons with new ones based on latest design changes in the Transfer page for both Real and Demo Wallets
- Replace old icon with new one on the sticky header

### Screenshots:

<img width="1494" alt="image" src="https://github.com/binary-com/deriv-app/assets/103104395/c9722125-e62b-4a92-b254-5b7bbb879d98">

<img width="426" alt="image" src="https://github.com/binary-com/deriv-app/assets/103104395/9a803111-7c90-432f-91ec-450ec72acf71">

<img width="426" alt="image" src="https://github.com/binary-com/deriv-app/assets/103104395/c295d8f5-b8ed-4292-b775-e2c867c02a94">


