### PR TITLE
fix: :ambulance: fix test time execution

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -16,7 +16,7 @@ module.exports = {
     testRegex: '(/__tests__/.*|(\\.)(test|spec))\\.(js|jsx|tsx|ts)?$',
     // This is needed to transform es modules imported from node_modules of the target component.
     transformIgnorePatterns: [
-        '/node_modules/(?!(@enykeev/react-virtualized|@simplewebauthn/browser|@deriv/quill-design|@deriv/quill-icons|@deriv-com/ui|@deriv-com/translations)).+\\.js$',
+        '/node_modules/(?!(@enykeev/react-virtualized|@simplewebauthn/browser|@deriv-com/ui|@deriv-com/quill-ui|@sendbird/chat)).+\\.js$',
     ],
     setupFiles: ['<rootDir>/../../jest.setup.js'],
     setupFilesAfterEnv: ['<rootDir>/../../setupTests.js'],

--- a/packages/cashier-v2/jest.config.ts
+++ b/packages/cashier-v2/jest.config.ts
@@ -8,5 +8,4 @@ export default {
         '\\.s(c|a)ss$': '<rootDir>/../../__mocks__/styleMock.js',
         '^.+\\.svg$': '<rootDir>/../../__mocks__/fileMock.js',
     },
-    transformIgnorePatterns: ['/node_modules/(?!(@deriv-com/ui)).+\\.js$'],
 };

--- a/packages/components/jest.config.js
+++ b/packages/components/jest.config.js
@@ -8,5 +8,4 @@ module.exports = {
         '^.+\\.svg$': '<rootDir>/../../__mocks__/styleMock.js',
     },
     modulePathIgnorePatterns: ['/icon/', '/.out/'],
-    transformIgnorePatterns: ['/node_modules/(?!(@deriv-com/ui)).+\\.js$'],
 };

--- a/packages/p2p-v2/jest.config.js
+++ b/packages/p2p-v2/jest.config.js
@@ -9,5 +9,4 @@ module.exports = {
         '\\.s(c|a)ss$': '<rootDir>/../../__mocks__/styleMock.js',
         '^.+\\.svg$': '<rootDir>/../../__mocks__/fileMock.js',
     },
-    transformIgnorePatterns: ['/node_modules/(?!(@deriv-com/ui|@sendbird/chat)).+\\.js$'],
 };

--- a/packages/p2p/jest.config.js
+++ b/packages/p2p/jest.config.js
@@ -33,5 +33,4 @@ module.exports = {
         '<rootDir>/coverage/lcov-report',
         '<rootDir>/dist',
     ],
-    transformIgnorePatterns: ['/node_modules/(?!(@sendbird/chat|@simplewebauthn/browser|@deriv-com/ui)).+\\.js$'],
 };

--- a/packages/trader/jest.config.js
+++ b/packages/trader/jest.config.js
@@ -18,5 +18,4 @@ module.exports = {
         '^Services/(.*)$': '<rootDir>/src/Services/$1',
         '^Stores/(.*)$': '<rootDir>/src/Stores/$1',
     },
-    transformIgnorePatterns: ['/node_modules/(?!(@deriv-com/quill-ui|@deriv-com/ui|@simplewebauthn/browser)).+\\.js$'],
 };


### PR DESCRIPTION
## Changes:

- extending `transformIgnorePatterns` from base jest config
- remove `@deriv/quill-design|@deriv/quill-icons|@deriv-com/translations` packages from `transformIgnorePatterns` that could also slowdown test execution

### Screenshots:

Previous test time execution:

![Screenshot 2024-06-26 at 17 09 37](https://github.com/binary-com/deriv-app/assets/103181646/da80f55e-1fbf-4a85-ad68-30dc577c35ba)

Current time execution:

![Screenshot 2024-06-26 at 17 09 15](https://github.com/binary-com/deriv-app/assets/103181646/dcc3c5ee-e45e-4b49-9ec7-931bfce00888)


