### PR TITLE
[WEBREL] / Ameerul / WEBREL-2858 Order unsuccessful error modal showing in glitch when trying to place order again after market rate change

### DIFF
--- a/packages/p2p/src/components/modal-manager/modals/buy-sell-modal/buy-sell-modal.tsx
+++ b/packages/p2p/src/components/modal-manager/modals/buy-sell-modal/buy-sell-modal.tsx
@@ -109,6 +109,7 @@ const BuySellModal = () => {
             });
         } else {
             submitForm();
+            hideModal({ should_hide_all_modals: true });
         }
     };
 

--- a/packages/p2p/src/stores/buy-sell-store.js
+++ b/packages/p2p/src/stores/buy-sell-store.js
@@ -225,7 +225,6 @@ export default class BuySellStore extends BaseStore {
                     },
                 });
             } else {
-                // if (!general_store.isCurrentModal('BuySellModal'))
                 general_store.showModal({ key: 'BuySellModal', props: {} });
                 this.form_props.setErrorMessage(message);
                 this.setFormErrorCode(code);

--- a/packages/p2p/src/stores/buy-sell-store.js
+++ b/packages/p2p/src/stores/buy-sell-store.js
@@ -207,8 +207,7 @@ export default class BuySellStore extends BaseStore {
                 general_store.showModal({
                     key: 'ErrorModal',
                     props: {
-                        error_message:
-                            'We’re unable to create your order because the market rate has moved too much. Please try creating a new order.',
+                        error_message: message,
                         error_modal_button_text: 'Create new order',
                         error_modal_title: (
                             <Text weight='bold'>
@@ -226,8 +225,8 @@ export default class BuySellStore extends BaseStore {
                     },
                 });
             } else {
-                if (!general_store.isCurrentModal('BuySellModal'))
-                    general_store.showModal({ key: 'BuySellModal', props: {} });
+                // if (!general_store.isCurrentModal('BuySellModal'))
+                general_store.showModal({ key: 'BuySellModal', props: {} });
                 this.form_props.setErrorMessage(message);
                 this.setFormErrorCode(code);
             }

--- a/packages/p2p/src/stores/buy-sell-store.js
+++ b/packages/p2p/src/stores/buy-sell-store.js
@@ -208,7 +208,7 @@ export default class BuySellStore extends BaseStore {
                     key: 'ErrorModal',
                     props: {
                         error_message: message,
-                        error_modal_button_text: 'Create new order',
+                        error_modal_button_text: localize('Create new order'),
                         error_modal_title: (
                             <Text weight='bold'>
                                 <Localize i18n_default_text='Order unsuccessful' />


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- hide modal when user confirms in attention fluctuation modal
- use error message from BE and not from FE side for slippage rate error

### Screenshots:

Please provide some screenshots of the change.
