### PR TITLE
[WALL] Lubega / WALL-3902 / Safari transactions toggle ui fix

### DIFF
--- a/packages/wallets/src/components/ToggleSwitch/ToggleSwitch.scss
+++ b/packages/wallets/src/components/ToggleSwitch/ToggleSwitch.scss
@@ -9,8 +9,7 @@
     }
 
     & > input {
-        width: 0;
-        height: 0;
+        visibility: hidden;
     }
 
     &__slider {

--- a/packages/wallets/src/components/WalletListHeader/WalletListHeader.scss
+++ b/packages/wallets/src/components/WalletListHeader/WalletListHeader.scss
@@ -27,9 +27,7 @@
         border-radius: 0.8rem;
 
         &-input {
-            width: 0;
-            height: 0;
-            opacity: 0;
+            visibility: hidden;
         }
 
         &:hover {


### PR DESCRIPTION
## Changes:

- [x] Hide default input checkbox for transactions toggle switch

### Bug:
![Screenshot 2024-06-27 at 4 15 22 PM](https://github.com/binary-com/deriv-app/assets/142860499/479c2973-9f6d-4625-aeb4-b517c6bcf107)

### Fix:
Safari:
![safari](https://github.com/binary-com/deriv-app/assets/142860499/2b6db446-2577-4a01-b9d4-1394e10507e4)
Chrome:
![chrome](https://github.com/binary-com/deriv-app/assets/142860499/529a99ff-8866-42ab-b8d4-c290bd4e1a80)
Firefox:
![firefox](https://github.com/binary-com/deriv-app/assets/142860499/eca144b5-b4e3-4e5a-a807-12dba4490a76)
