### PR TITLE
fix: scroll to top when tutorial tab switch on mobile

### DIFF
--- a/packages/bot-web-ui/src/pages/tutorials/quick-strategy-content/quick-strategy-guides-details.tsx
+++ b/packages/bot-web-ui/src/pages/tutorials/quick-strategy-content/quick-strategy-guides-details.tsx
@@ -25,8 +25,8 @@ const QuickStrategyGuidesDetail = observer(
         const { is_mobile } = ui;
         const text_size = is_mobile ? 'xs' : 's';
 
-        const qs_guide = document.querySelector('.tutorials-mobile__qs-guide');
         const scrollToTop = () => {
+            const qs_guide = document.querySelector('.tutorials-mobile__qs-guide');
             if (qs_guide) {
                 qs_guide.scrollTop = 0;
             }

--- a/packages/bot-web-ui/src/pages/tutorials/quick-strategy-content/quick-strategy-guides-details.tsx
+++ b/packages/bot-web-ui/src/pages/tutorials/quick-strategy-content/quick-strategy-guides-details.tsx
@@ -25,6 +25,13 @@ const QuickStrategyGuidesDetail = observer(
         const { is_mobile } = ui;
         const text_size = is_mobile ? 'xs' : 's';
 
+        const qs_guide = document.querySelector('.tutorials-mobile__qs-guide');
+        const scrollToTop = () => {
+            if (qs_guide) {
+                qs_guide.scrollTop = 0;
+            }
+        };
+
         return (
             <>
                 {tutorial_selected_strategy === '' ? (
@@ -36,6 +43,7 @@ const QuickStrategyGuidesDetail = observer(
                                 onClick={() => {
                                     setTutorialSelectedStrategy(qs_name);
                                     rudderStackSendSelectQsStrategyGuideEvent({ selected_strategy: qs_name });
+                                    scrollToTop();
                                 }}
                                 tabIndex={index}
                                 data-testid={'dt_quick_strategy_guides_details'}

--- a/packages/bot-web-ui/src/pages/tutorials/tutorials-tab-mobile.tsx
+++ b/packages/bot-web-ui/src/pages/tutorials/tutorials-tab-mobile.tsx
@@ -21,6 +21,7 @@ const TutorialsTabMobile = observer(({ tutorial_tabs, prev_active_tutorials }: T
     const initialSelectedTab: TTutorialsTabItem = { label: '', content: undefined };
     const [selectedTab, setSelectedTab] = React.useState(initialSelectedTab);
     const [showSearchBar, setShowSearchBar] = React.useState(false);
+    const scroll_ref = React.useRef<HTMLDivElement & SVGSVGElement>(null);
 
     React.useEffect(() => {
         if (search) setShowSearchBar(true);
@@ -29,6 +30,12 @@ const TutorialsTabMobile = observer(({ tutorial_tabs, prev_active_tutorials }: T
     }, [tutorial_tabs]);
 
     const onFocusSearch = () => setActiveTabTutorial(3);
+
+    const scrollToTop = () => {
+        if (scroll_ref.current) {
+            scroll_ref.current.scrollTop = 0;
+        }
+    };
 
     const onChangeHandle = React.useCallback(
         ({ target }: React.ChangeEvent<HTMLSelectElement>) =>
@@ -109,7 +116,10 @@ const TutorialsTabMobile = observer(({ tutorial_tabs, prev_active_tutorials }: T
                     value={selectedTab.label}
                     label=''
                     should_show_empty_option={false}
-                    onChange={onChangeHandle}
+                    onChange={e => {
+                        onChangeHandle(e);
+                        scrollToTop();
+                    }}
                 />
                 <Icon onClick={onHandleChangeMobile} className='search-icon' icon='IcSearch' />
             </div>
@@ -120,6 +130,7 @@ const TutorialsTabMobile = observer(({ tutorial_tabs, prev_active_tutorials }: T
                     'tutorials-mobile__qs-guide': active_tab_tutorials === 2,
                     'tutorials-mobile__search': active_tab_tutorials === 3,
                 })}
+                ref={scroll_ref}
             >
                 {selectedTab.content}
             </div>


### PR DESCRIPTION
## Changes:

- Fixed issue with content scroll to top on tutorial tabs switching on mobile

### Screenshots:

<img width="410" alt="Screenshot 2024-06-27 at 6 26 25 PM" src="https://github.com/binary-com/deriv-app/assets/102643568/23832e26-21d4-4499-9364-dba587428fb7">
