### PR TITLE
[DTRA] Maryia/WEBREL-2873/fix: spacing issue between filters and table in Reports

### DIFF
--- a/packages/reports/src/sass/app/modules/reports.scss
+++ b/packages/reports/src/sass/app/modules/reports.scss
@@ -10,7 +10,6 @@ $side-padding: 1.2em;
         width: 100%;
         display: flex;
         justify-content: space-between;
-
         flex-direction: column-reverse;
 
         &-filter {
@@ -29,7 +28,7 @@ $side-padding: 1.2em;
         }
 
         @include desktop-screen {
-            padding: 0 2.4rem 1.6rem 0;
+            padding: 0 2.4rem 0 0;
             align-items: center;
         }
 


### PR DESCRIPTION
## Changes:

- to fix a spacing issue between filters and table in Reports related to [Tablet view feature](https://github.com/binary-com/deriv-app/pull/15011) 