### PR TITLE
[WEBREL] Sergei / WEBREL - 2866, 2867 / TradersHub title is not aligned with real/demo switcher as in production and change TH container size

### DIFF
--- a/packages/appstore/src/components/main-title-bar/account-type-dropdown.scss
+++ b/packages/appstore/src/components/main-title-bar/account-type-dropdown.scss
@@ -13,6 +13,7 @@
             &-container {
                 min-width: 7.1rem;
                 width: auto;
+                margin-top: unset;
             }
         }
 

--- a/packages/appstore/src/modules/traders-hub/traders-hub.scss
+++ b/packages/appstore/src/modules/traders-hub/traders-hub.scss
@@ -1,7 +1,7 @@
 .traders-hub {
-    max-width: 128rem;
+    max-width: 123.2rem;
     margin: auto;
-    padding: 4rem;
+    padding: 5rem 0;
 
     &:has(.wallets-banner__container) {
         padding-top: 0;


### PR DESCRIPTION
## Changes:

- Unset `margin-top`
- set TH `width` as on production

### Screenshots:

<img width="341" alt="image" src="https://github.com/binary-com/deriv-app/assets/120570511/44b76d0a-da23-4674-a419-a73b06c323b2">
