### PR TITLE
[WEBREL] Sergei / WEBREL - 2869 / Spacing between fields and container size is different in Financial assessment page

### DIFF
--- a/packages/account/src/Styles/account.scss
+++ b/packages/account/src/Styles/account.scss
@@ -210,6 +210,10 @@ $MIN_HEIGHT_FLOATING: calc(
                 .account-form__fieldset {
                     margin-top: 0.8rem;
                     margin-bottom: 2rem;
+
+                    .dc-dropdown-container {
+                        margin-top: unset;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Changes:

Unset `margin-top` for `financial-assessment` 

### Screenshots:

<img width="1057" alt="image" src="https://github.com/binary-com/deriv-app/assets/120570511/00150929-baf5-43e0-93f2-e75e78510215">

