### PR TITLE
chore: fix description crop

### DIFF
--- a/packages/core/src/sass/app/modules/notifications-dialog.scss
+++ b/packages/core/src/sass/app/modules/notifications-dialog.scss
@@ -193,8 +193,9 @@
         &__cta-button {
             padding: 0.3rem 0.8rem;
             margin: 0.8rem 0 0.8rem auto;
-            height: 2.4rem;
+            height: auto;
             width: auto;
+            white-space: normal;
 
             @include mobile-screen {
                 margin: 0.8rem 0 1.6rem auto;


### PR DESCRIPTION
## Changes:

Fixes the overflow of button description text in notification tray

### Screenshots:

<img width="447" alt="Screenshot 2024-06-27 at 5 19 17 PM" src="https://github.com/binary-com/deriv-app/assets/125863995/41525a66-05e3-4362-bc29-61d8275a6f49">
