### PR TITLE
Aizad/WALL-2937/Unit test for AvailableDxtradeAccountsList in DxTrade flow

### DIFF
--- a/packages/wallets/src/features/cfd/flows/OtherCFDs/Dxtrade/AvailableDxtradeAccountsList/AvailableDxtradeAccountsList.tsx
+++ b/packages/wallets/src/features/cfd/flows/OtherCFDs/Dxtrade/AvailableDxtradeAccountsList/AvailableDxtradeAccountsList.tsx
@@ -15,7 +15,7 @@ const AvailableDxtradeAccountsList: React.FC = () => {
     return (
         <TradingAccountCard
             leading={
-                <div className='wallets-available-dxtrade__icon' data-testid='dt_icon-dxtrade'>
+                <div className='wallets-available-dxtrade__icon' data-testid='dt_icon_dxtrade'>
                     {PlatformDetails.dxtrade.icon}
                 </div>
             }

--- a/packages/wallets/src/features/cfd/flows/OtherCFDs/Dxtrade/AvailableDxtradeAccountsList/AvailableDxtradeAccountsList.tsx
+++ b/packages/wallets/src/features/cfd/flows/OtherCFDs/Dxtrade/AvailableDxtradeAccountsList/AvailableDxtradeAccountsList.tsx
@@ -14,7 +14,11 @@ const AvailableDxtradeAccountsList: React.FC = () => {
 
     return (
         <TradingAccountCard
-            leading={<div className='wallets-available-dxtrade__icon'>{PlatformDetails.dxtrade.icon}</div>}
+            leading={
+                <div className='wallets-available-dxtrade__icon' data-testid='dt_icon-dxtrade'>
+                    {PlatformDetails.dxtrade.icon}
+                </div>
+            }
             onClick={() => show(<DxtradeEnterPasswordModal />)}
             trailing={
                 <div className='wallets-available-dxtrade__icon'>

--- a/packages/wallets/src/features/cfd/flows/OtherCFDs/Dxtrade/AvailableDxtradeAccountsList/__test__/AvailableDxtradeAccountsList.spec.tsx
+++ b/packages/wallets/src/features/cfd/flows/OtherCFDs/Dxtrade/AvailableDxtradeAccountsList/__test__/AvailableDxtradeAccountsList.spec.tsx
@@ -24,13 +24,13 @@ const wrapper = ({ children }: PropsWithChildren) => (
 );
 
 describe('AvailableDxtradeAccountsList', () => {
-    it('should render', () => {
+    it('render component', () => {
         render(<AvailableDxtradeAccountsList />, { wrapper });
         expect(screen.getByTestId('dt_icon-dxtrade')).toBeInTheDocument();
         expect(screen.getByText('Deriv X')).toBeInTheDocument();
     });
 
-    it('should call show modal when clicked', () => {
+    it('show modal popup upon clicking on the component', () => {
         render(<AvailableDxtradeAccountsList />, { wrapper });
         const tradingAccountCard = screen.getByRole('button');
         userEvent.click(tradingAccountCard);

--- a/packages/wallets/src/features/cfd/flows/OtherCFDs/Dxtrade/AvailableDxtradeAccountsList/__test__/AvailableDxtradeAccountsList.spec.tsx
+++ b/packages/wallets/src/features/cfd/flows/OtherCFDs/Dxtrade/AvailableDxtradeAccountsList/__test__/AvailableDxtradeAccountsList.spec.tsx
@@ -1,0 +1,56 @@
+import React, { PropsWithChildren } from 'react';
+import { APIProvider } from '@deriv/api-v2';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import WalletsAuthProvider from '../../../../../../../AuthProvider';
+import { ModalProvider } from '../../../../../../../components/ModalProvider';
+import AvailableDxtradeAccountsList from '../AvailableDxtradeAccountsList';
+
+const mockShow = jest.fn();
+jest.mock('../../../../../../../components/ModalProvider', () => ({
+    ...jest.requireActual('../../../../../../../components/ModalProvider'),
+    useModal: jest.fn(() => ({
+        ...jest.requireActual('../../../../../../../components/ModalProvider').useModal(),
+        show: mockShow,
+    })),
+}));
+
+const wrapper = ({ children }: PropsWithChildren) => (
+    <APIProvider>
+        <WalletsAuthProvider>
+            <ModalProvider>{children}</ModalProvider>
+        </WalletsAuthProvider>
+    </APIProvider>
+);
+
+describe('AvailableDxtradeAccountsList', () => {
+    let $root: HTMLDivElement, $modalContainer: HTMLDivElement;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        $root = document.createElement('div');
+        $root.id = 'root';
+        $modalContainer = document.createElement('div');
+        $modalContainer.id = 'wallets_modal_root';
+        document.body.appendChild($root);
+        document.body.appendChild($modalContainer);
+    });
+
+    afterEach(() => {
+        document.body.removeChild($root);
+        document.body.removeChild($modalContainer);
+    });
+    it('should render', () => {
+        render(<AvailableDxtradeAccountsList />, { wrapper });
+        expect(screen.getByTestId('dt_icon-dxtrade')).toBeInTheDocument();
+        expect(screen.getByText('Deriv X')).toBeInTheDocument();
+    });
+
+    it('should call show modal when clicked', () => {
+        render(<AvailableDxtradeAccountsList />, { wrapper });
+        const tradingAccountCard = screen.getByRole('button');
+        userEvent.click(tradingAccountCard);
+        expect(mockShow).toHaveBeenCalled();
+    });
+});

--- a/packages/wallets/src/features/cfd/flows/OtherCFDs/Dxtrade/AvailableDxtradeAccountsList/__test__/AvailableDxtradeAccountsList.spec.tsx
+++ b/packages/wallets/src/features/cfd/flows/OtherCFDs/Dxtrade/AvailableDxtradeAccountsList/__test__/AvailableDxtradeAccountsList.spec.tsx
@@ -24,13 +24,13 @@ const wrapper = ({ children }: PropsWithChildren) => (
 );
 
 describe('AvailableDxtradeAccountsList', () => {
-    it('render component', () => {
+    it('render AvailableDxtradeAccountsList component', () => {
         render(<AvailableDxtradeAccountsList />, { wrapper });
-        expect(screen.getByTestId('dt_icon-dxtrade')).toBeInTheDocument();
+        expect(screen.getByTestId('dt_icon_dxtrade')).toBeInTheDocument();
         expect(screen.getByText('Deriv X')).toBeInTheDocument();
     });
 
-    it('show modal popup upon clicking on the component', () => {
+    it('shows DxtradeEnterPasswordModal upon clicking on the TradingAccountCard component', () => {
         render(<AvailableDxtradeAccountsList />, { wrapper });
         const tradingAccountCard = screen.getByRole('button');
         userEvent.click(tradingAccountCard);

--- a/packages/wallets/src/features/cfd/flows/OtherCFDs/Dxtrade/AvailableDxtradeAccountsList/__test__/AvailableDxtradeAccountsList.spec.tsx
+++ b/packages/wallets/src/features/cfd/flows/OtherCFDs/Dxtrade/AvailableDxtradeAccountsList/__test__/AvailableDxtradeAccountsList.spec.tsx
@@ -24,23 +24,6 @@ const wrapper = ({ children }: PropsWithChildren) => (
 );
 
 describe('AvailableDxtradeAccountsList', () => {
-    let $root: HTMLDivElement, $modalContainer: HTMLDivElement;
-
-    beforeEach(() => {
-        jest.clearAllMocks();
-
-        $root = document.createElement('div');
-        $root.id = 'root';
-        $modalContainer = document.createElement('div');
-        $modalContainer.id = 'wallets_modal_root';
-        document.body.appendChild($root);
-        document.body.appendChild($modalContainer);
-    });
-
-    afterEach(() => {
-        document.body.removeChild($root);
-        document.body.removeChild($modalContainer);
-    });
     it('should render', () => {
         render(<AvailableDxtradeAccountsList />, { wrapper });
         expect(screen.getByTestId('dt_icon-dxtrade')).toBeInTheDocument();


### PR DESCRIPTION
## Changes:

Added unit test for `AvailableMT5AccountsList`

### Screenshots:

<img width="1495" alt="image" src="https://github.com/binary-com/deriv-app/assets/103104395/85fdbedb-aeb4-41c9-9c33-b980eb59ee75">

