### PR TITLE
Update deriv-charts to 2.1.23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "@deriv-com/utils": "^0.0.25",
                 "@deriv/api-types": "1.0.172",
                 "@deriv/deriv-api": "^1.0.15",
-                "@deriv/deriv-charts": "^2.1.22",
+                "@deriv/deriv-charts": "^2.1.23",
                 "@deriv/js-interpreter": "^3.0.0",
                 "@deriv/quill-design": "^1.3.2",
                 "@deriv/quill-icons": "^1.22.10",
@@ -3187,9 +3187,9 @@
             }
         },
         "node_modules/@deriv/deriv-charts": {
-            "version": "2.1.22",
-            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.1.22.tgz",
-            "integrity": "sha512-rzyNxYF5wsznmNwrstReg3lruHjtiApdK7ggMnzE4+qSl1GUdj8v5ree6SMVCIrNHAd97QQkv019LNXVkEHmeg==",
+            "version": "2.1.23",
+            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.1.23.tgz",
+            "integrity": "sha512-fwAhMmjLLFWvX1M3g2aC6n3/bmKAZ6g9Zaob3Kvn8CQz6aAlbpvzw7X3zi5QxE2NbAmlFi5lpSKp3C9xBj+1Bg==",
             "dependencies": {
                 "@types/lodash.set": "^4.3.7",
                 "@welldone-software/why-did-you-render": "^3.3.8",

--- a/packages/bot-web-ui/package.json
+++ b/packages/bot-web-ui/package.json
@@ -76,7 +76,7 @@
         "@deriv/api-types": "1.0.172",
         "@deriv/bot-skeleton": "^1.0.0",
         "@deriv/components": "^1.0.0",
-        "@deriv/deriv-charts": "^2.1.22",
+        "@deriv/deriv-charts": "^2.1.23",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",
         "@deriv/translations": "^1.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -111,7 +111,7 @@
         "@deriv/cfd": "^1.0.0",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv/deriv-charts": "^2.1.22",
+        "@deriv/deriv-charts": "^2.1.23",
         "@deriv/hooks": "^1.0.0",
         "@deriv/p2p": "^0.7.3",
         "@deriv/quill-design": "^1.3.2",

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -96,7 +96,7 @@
         "@deriv/api-types": "1.0.172",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv/deriv-charts": "^2.1.22",
+        "@deriv/deriv-charts": "^2.1.23",
         "@deriv/hooks": "^1.0.0",
         "@deriv/reports": "^1.0.0",
         "@deriv/shared": "^1.0.0",


### PR DESCRIPTION
This PR updates @deriv/deriv-charts to 2.1.23