### PR TITLE
fix: dashboard shortcuts on tablet view

### DIFF
--- a/packages/bot-web-ui/src/pages/dashboard/dashboard.scss
+++ b/packages/bot-web-ui/src/pages/dashboard/dashboard.scss
@@ -330,8 +330,10 @@
                     @include mobile-or-tablet-screen {
                         display: flex;
                         flex-flow: unset;
-                        justify-content: space-around;
                         padding: 2.4rem 0 1.6rem;
+                    }
+                    @include mobile-screen {
+                        justify-content: space-around;
                     }
                 }
             }
@@ -365,8 +367,9 @@
                 }
 
                 &--minimized {
-                    width: 6.4rem;
-
+                    @include mobile-screen {
+                        width: 6.4rem;
+                    }
                     & .dc-text {
                         width: 8rem;
                         text-align: center;

--- a/packages/bot-web-ui/src/pages/dashboard/load-bot-preview/index.scss
+++ b/packages/bot-web-ui/src/pages/dashboard/load-bot-preview/index.scss
@@ -368,8 +368,12 @@
     }
 
     &__table {
-        height: calc(100vh - 46rem);
+        height: calc(100vh - 57rem);
         overflow: auto;
+
+        @include mobile-screen {
+            height: calc(100vh - 46rem);
+        }
     }
 
     &__title {


### PR DESCRIPTION
## Changes:

Fix dashboard shortcuts icons alignment when the your bots list is populated on tablet view

### Screenshots:

<img width="1061" alt="Screenshot 2024-07-02 at 3 41 10 PM" src="https://github.com/binary-com/deriv-app/assets/102643568/50f4dff3-0325-4683-807d-1e6325b7a851">
