### PR TITLE
Niloofar/Fix TrustPilot Reviews Not Updating

### DIFF
--- a/packages/appstore/webpack.config.js
+++ b/packages/appstore/webpack.config.js
@@ -1,5 +1,7 @@
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
+const DefinePlugin = require('webpack').DefinePlugin;
+const Dotenv = require('dotenv-webpack');
 // const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 // const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const path = require('path');
@@ -65,6 +67,12 @@ module.exports = function (env) {
             },
             extensions: ['.ts', '.tsx', '.js'],
         },
+        plugins: [
+            new Dotenv(),
+            new DefinePlugin({
+                'process.env.TRUSTPILOT_API_KEY': JSON.stringify(process.env.TRUSTPILOT_API_KEY),
+            }),
+        ],
         module: {
             rules: [
                 {


### PR DESCRIPTION
## Changes:

The logged-out version of the `Deriv app` shows 47,748 reviews on the website, while TrustPilot displays 49,868 reviews.
This PR addresses the discrepancy by correcting an oversight in our `env` setup. This change should resolve the issue.

### Screenshots:
<img width="758" alt="image" src="https://github.com/binary-com/deriv-app/assets/93518187/65273eb8-ed66-4b50-8cc9-64dbfa25e0c5">
<img width="1727" alt="Screenshot 2024-07-02 at 4 20 47 PM" src="https://github.com/binary-com/deriv-app/assets/93518187/1e2c3a28-7e1c-4b45-8c29-588ce908f827">

