### PR TITLE
[BOT] Farabi/bot-529/remove limits from multiplier block

### DIFF
--- a/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/trade_definition_multiplier.js
+++ b/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/trade_definition_multiplier.js
@@ -134,7 +134,6 @@ Blockly.Blocks.trade_definition_multiplier = {
 
         if (event.type === Blockly.Events.BLOCK_CREATE && event.ids.includes(this.id)) {
             this.setCurrency();
-            this.updateAmountLimits();
             if (is_load_event) {
                 // Do NOT touch any values when a strategy is being loaded.
                 this.updateMultiplierInput(false);
@@ -161,14 +160,12 @@ Blockly.Blocks.trade_definition_multiplier = {
                 }
             } else if (event.name === 'SYMBOL_LIST' || event.name === 'TRADETYPE_LIST') {
                 this.updateMultiplierInput(true);
-                this.updateAmountLimits();
             }
             return;
         }
 
         if (event.type === Blockly.Events.END_DRAG) {
             this.setCurrency();
-            this.updateAmountLimits();
             this.validateBlocksInStatement();
             if (event.blockId === this.id) {
                 // Ensure this block is populated after initial drag from flyout.
@@ -182,7 +179,7 @@ Blockly.Blocks.trade_definition_multiplier = {
             }
         }
     },
-    updateAmountLimits: Blockly.Blocks.trade_definition_tradeoptions.updateAmountLimits,
+
     updateMultiplierInput(should_use_default_value) {
         const { contracts_for } = ApiHelpers.instance;
 

--- a/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/trade_definition_tradeoptions.js
+++ b/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/trade_definition_tradeoptions.js
@@ -236,7 +236,7 @@ Blockly.Blocks.trade_definition_tradeoptions = {
             }
             this.amount_limits = limits;
             const { max_payout, min_stake } = limits;
-            if (max_payout && min_stake) {
+            if (max_payout && min_stake && this.selected_trade_type !== 'multiplier') {
                 runIrreversibleEvents(() => {
                     this.setFieldValue(
                         localize('(min: {{min_stake}} - max: {{max_payout}})', {


### PR DESCRIPTION
## Changes:

- Removed the stake amount limit of min and max value on trade options block for multiplier

### Screenshots:

<img width="1099" alt="Screenshot 2024-07-03 at 4 14 02 PM" src="https://github.com/binary-com/deriv-app/assets/102643568/fa0e68dd-c229-4592-b919-41ef6c9bf1a0">
