### PR TITLE
Hirad/wall-4485/ swap-free and compare accounts fix

### DIFF
--- a/packages/api-v2/types.ts
+++ b/packages/api-v2/types.ts
@@ -1625,6 +1625,10 @@ type TPrivateSocketEndpoints = {
                        */
                       name?: string;
                       /**
+                       * This needs to be removed after updating api-types version
+                       */
+                      product?: 'zero_spread' | 'swap_free' | 'standard';
+                      /**
                        * Legal requirements for the Landing Company
                        */
                       requirements?: {

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/CompareAccountsScreen.tsx
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/CompareAccountsScreen.tsx
@@ -22,7 +22,6 @@ const CompareAccountsScreen = () => {
                 <CompareAccountsCarousel>
                     {mt5Accounts?.map(
                         item =>
-                            // @ts-ignore
                             item.product !== 'zero_spread' && (
                                 <CompareAccountsCard
                                     isDemo={isDemo}

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/CompareAccountsScreen.tsx
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/CompareAccountsScreen.tsx
@@ -20,17 +20,21 @@ const CompareAccountsScreen = () => {
             <CompareAccountsHeader isDemo={isDemo} isEuRegion={isEuRegion} />
             <div className='wallets-compare-accounts__card-list'>
                 <CompareAccountsCarousel>
-                    {mt5Accounts?.map(item => (
-                        <CompareAccountsCard
-                            isDemo={isDemo}
-                            isEuRegion={isEuRegion}
-                            isEuUser={isEuUser}
-                            key={`${item?.market_type} ${item?.shortcode}`}
-                            marketType={item?.market_type}
-                            platform={item?.platform}
-                            shortCode={item?.shortcode}
-                        />
-                    ))}
+                    {mt5Accounts?.map(
+                        item =>
+                            // @ts-ignore
+                            item.product !== 'zero_spread' && (
+                                <CompareAccountsCard
+                                    isDemo={isDemo}
+                                    isEuRegion={isEuRegion}
+                                    isEuUser={isEuUser}
+                                    key={`${item?.market_type} ${item?.shortcode}`}
+                                    marketType={item?.market_type}
+                                    platform={item?.platform}
+                                    shortCode={item?.shortcode}
+                                />
+                            )
+                    )}
                     {/* Renders cTrader data */}
                     {mt5Accounts?.length && hasCTraderAccountAvailable && ctraderAccount && (
                         <CompareAccountsCard

--- a/packages/wallets/src/features/cfd/screens/Jurisdiction/JurisdictionScreen.tsx
+++ b/packages/wallets/src/features/cfd/screens/Jurisdiction/JurisdictionScreen.tsx
@@ -31,7 +31,11 @@ const JurisdictionScreen: FC<TJurisdictionScreenProps> = ({
     const { isDynamicLeverageVisible } = useDynamicLeverageModalState();
     const [isJurisdictionScreenHidden] = useDebounceValue(isDynamicLeverageVisible, 600);
     const jurisdictions = useMemo(
-        () => data?.filter(account => account.market_type === marketType).map(account => account.shortcode) || [],
+        () =>
+            data
+                // @ts-ignore
+                ?.filter(account => account.market_type === marketType && account.product !== 'zero_spread')
+                .map(account => account.shortcode) || [],
         [data, marketType]
     );
     const addedJurisdictions = useMemo(

--- a/packages/wallets/src/features/cfd/screens/Jurisdiction/JurisdictionScreen.tsx
+++ b/packages/wallets/src/features/cfd/screens/Jurisdiction/JurisdictionScreen.tsx
@@ -33,7 +33,6 @@ const JurisdictionScreen: FC<TJurisdictionScreenProps> = ({
     const jurisdictions = useMemo(
         () =>
             data
-                // @ts-ignore
                 ?.filter(account => account.market_type === marketType && account.product !== 'zero_spread')
                 .map(account => account.shortcode) || [],
         [data, marketType]


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
There are 2 Swap-free accounts under compare accounts and There is an additional BVI card in the modal.

### Screenshots:

Please provide some screenshots of the change.
<img width="560" alt="image" src="https://github.com/binary-com/deriv-app/assets/91878582/34ab1ac3-3fe2-42b8-a9e6-25b27255efcb">

