### PR TITLE
[BOT] Farabi/bot-1723/unable to scroll transactions details modal on firefox

### DIFF
--- a/packages/bot-web-ui/src/components/draggable/draggable.tsx
+++ b/packages/bot-web-ui/src/components/draggable/draggable.tsx
@@ -70,6 +70,7 @@ const Draggable: React.FC<TDraggableProps> = ({
         const initialSelfBottom = draggableRef.current?.getBoundingClientRect()?.bottom ?? size.height;
 
         let previousStyle = {};
+        let previousPointerEvent = 'unset';
         const draggableContentBody = draggableRef.current?.querySelector(
             '#draggable-content-body'
         ) as HTMLElement | null;
@@ -78,6 +79,7 @@ const Draggable: React.FC<TDraggableProps> = ({
             const { style } = draggableContentBody;
             if (style && style.pointerEvents !== 'none') {
                 previousStyle = { ...style };
+                previousPointerEvent = style.pointerEvents;
                 style.pointerEvents = 'none';
             }
         }
@@ -177,7 +179,7 @@ const Draggable: React.FC<TDraggableProps> = ({
             isResizing.current = false;
             if (draggableContentBody?.style) {
                 Object.assign(draggableContentBody.style, previousStyle);
-                draggableContentBody.style.pointerEvents = '';
+                draggableContentBody.style.pointerEvents = previousPointerEvent ?? 'unset';
             }
             if (boundaryRef) {
                 window.removeEventListener('mousemove', handleMouseMove);

--- a/packages/bot-web-ui/src/components/draggable/draggable.tsx
+++ b/packages/bot-web-ui/src/components/draggable/draggable.tsx
@@ -177,6 +177,7 @@ const Draggable: React.FC<TDraggableProps> = ({
             isResizing.current = false;
             if (draggableContentBody?.style) {
                 Object.assign(draggableContentBody.style, previousStyle);
+                draggableContentBody.style.pointerEvents = '';
             }
             if (boundaryRef) {
                 window.removeEventListener('mousemove', handleMouseMove);


### PR DESCRIPTION
## Changes:

- Fixed the issue where transactions detail modal was not scrolling on firefox browser upon dragging or resizing the modal

### Screenshots:

https://github.com/binary-com/deriv-app/assets/102643568/65be47a9-71ce-4a6d-9804-be1e7dd221be