### PR TITLE
WEBREL-17/ Kate / Add tests for reports files and change jest config for absolute path

### DIFF
--- a/packages/reports/jest.config.js
+++ b/packages/reports/jest.config.js
@@ -10,6 +10,7 @@ module.exports = {
         '^App/(.*)$': '<rootDir>/src/App/$1',
         '^Assets/(.*)$': '<rootDir>/src/Assets/$1',
         '^Components/(.*)$': '<rootDir>/src/Components/$1',
+        '^Containers/(.*)$': '<rootDir>/src/Containers/$1',
         '^Constants/(.*)$': '<rootDir>/src/Constants/$1',
         '^Constants$': '<rootDir>/src/Constants/index.js',
         '^Documents/(.*)$': '<rootDir>/src/Documents/$1',

--- a/packages/reports/src/Stores/__tests__/use-reports-stores.spec.tsx
+++ b/packages/reports/src/Stores/__tests__/use-reports-stores.spec.tsx
@@ -5,7 +5,7 @@ import { useReportsStore } from 'Stores/useReportsStores';
 import ReportsProviders from '../../reports-providers';
 
 describe('useReportsStore', () => {
-    it('useReportsStore should return the store if used inside ReportsProviders', () => {
+    it('useReportsStore should return the store if it was used inside ReportsProviders', () => {
         const wrapper = ({ children }: { children: JSX.Element }) => (
             <ReportsProviders store={mockStore({})}>{children}</ReportsProviders>
         );
@@ -18,7 +18,7 @@ describe('useReportsStore', () => {
         expect(current.statement).toBeTruthy();
     });
 
-    it('useReportsStore should throw error if used outside of ReportsProviders', () => {
+    it('useReportsStore should throw error if it was used outside of ReportsProviders', () => {
         const { result } = renderHook(() => useReportsStore());
 
         expect(result.error).toEqual(new Error('useReportsStore must be used within ReportsStoreProvider'));

--- a/packages/reports/src/Stores/__tests__/use-reports-stores.spec.tsx
+++ b/packages/reports/src/Stores/__tests__/use-reports-stores.spec.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { mockStore } from '@deriv/stores';
+import { renderHook } from '@testing-library/react-hooks';
+import { useReportsStore } from 'Stores/useReportsStores';
+import ReportsProviders from '../../reports-providers';
+
+describe('useReportsStore', () => {
+    it('useReportsStore should return the store if used inside ReportsProviders', () => {
+        const wrapper = ({ children }: { children: JSX.Element }) => (
+            <ReportsProviders store={mockStore({})}>{children}</ReportsProviders>
+        );
+
+        const {
+            result: { current },
+        } = renderHook(() => useReportsStore(), { wrapper });
+
+        expect(current.profit_table).toBeTruthy();
+        expect(current.statement).toBeTruthy();
+    });
+
+    it('useReportsStore should throw error if used outside of ReportsProviders', () => {
+        const { result } = renderHook(() => useReportsStore());
+
+        expect(result.error).toEqual(new Error('useReportsStore must be used within ReportsStoreProvider'));
+    });
+});

--- a/packages/reports/src/__tests__/app.spec.tsx
+++ b/packages/reports/src/__tests__/app.spec.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { mockStore } from '@deriv/stores';
+import Loadable from 'react-loadable';
+import App from '../app';
+
+const root_store = mockStore({});
+const routes = 'Routes';
+const trade_modals = 'Trade Modals';
+
+jest.mock('../Containers/routes', () => jest.fn(() => <div>{routes}</div>));
+jest.mock('../Components/Modals/trade-modals.tsx', () => jest.fn(() => <div>{trade_modals}</div>));
+
+describe('App', () => {
+    it('should render the component without Trade Modals if it was not load', () => {
+        render(<App passthrough={{ root_store }} />);
+
+        expect(screen.getByText(routes)).toBeInTheDocument();
+        expect(screen.queryByText(trade_modals)).not.toBeInTheDocument();
+    });
+
+    it('should render the component', async () => {
+        render(<App passthrough={{ root_store }} />);
+
+        await waitFor(() => Loadable.preloadReady());
+
+        expect(screen.getByText(routes)).toBeInTheDocument();
+        expect(screen.getByText(trade_modals)).toBeInTheDocument();
+    });
+});

--- a/packages/reports/src/__tests__/app.spec.tsx
+++ b/packages/reports/src/__tests__/app.spec.tsx
@@ -12,7 +12,7 @@ jest.mock('../Containers/routes', () => jest.fn(() => <div>{routes}</div>));
 jest.mock('../Components/Modals/trade-modals.tsx', () => jest.fn(() => <div>{trade_modals}</div>));
 
 describe('App', () => {
-    it('should render the component without Trade Modals if it was not load', () => {
+    it('should render the component without Trade Modals if it was not loaded', () => {
         render(<App passthrough={{ root_store }} />);
 
         expect(screen.getByText(routes)).toBeInTheDocument();

--- a/packages/reports/src/__tests__/app.spec.tsx
+++ b/packages/reports/src/__tests__/app.spec.tsx
@@ -19,7 +19,7 @@ describe('App', () => {
         expect(screen.queryByText(trade_modals)).not.toBeInTheDocument();
     });
 
-    it('should render the component', async () => {
+    it('should render the component with Trade Modals', async () => {
         render(<App passthrough={{ root_store }} />);
 
         await waitFor(() => Loadable.preloadReady());

--- a/packages/reports/src/__tests__/reports-providers.spec.tsx
+++ b/packages/reports/src/__tests__/reports-providers.spec.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { mockStore } from '@deriv/stores';
+import { render, screen } from '@testing-library/react';
+import ReportsProviders from '../reports-providers';
+
+describe('ReportsProviders', () => {
+    it('should render ReportsProviders with children', () => {
+        const mock_child = 'Mock Child';
+        render(
+            <ReportsProviders store={mockStore({})}>
+                <div>{mock_child}</div>
+            </ReportsProviders>
+        );
+
+        expect(screen.getByText(mock_child)).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Changes:

- Added tests for packages/reports/src/app.tsx
- Added tests for packages/reports/src/reports-providers.tsx
- Added tests for packages/reports/src/Stores/useReportsStores.tsx
- Changed jest config in order to support absolute path for Containers folder

### Screenshots:

<img width="1721" alt="Screenshot 2024-07-08 at 1 56 26 PM" src="https://github.com/binary-com/deriv-app/assets/121025168/2900b606-4e54-429e-994b-f9945d2cd05d">
<img width="1721" alt="Screenshot 2024-07-08 at 12 11 27 PM" src="https://github.com/binary-com/deriv-app/assets/121025168/de3d2746-8999-4e0a-b297-e3ed0354a3be">
<img width="1721" alt="Screenshot 2024-07-08 at 11 04 42 AM" src="https://github.com/binary-com/deriv-app/assets/121025168/69068edc-d7ec-42b0-8c7a-d2f3801d58aa">
