### PR TITLE
fix: :fire: replaced section message with custom comp

### DIFF
--- a/packages/bot-web-ui/src/components/load-modal/load-modal.scss
+++ b/packages/bot-web-ui/src/components/load-modal/load-modal.scss
@@ -166,27 +166,3 @@
         margin: 0;
     }
 }
-
-.load-strategy__section_message {
-    margin-top: -16px;
-    margin-bottom: 8px;
-    display: flex;
-    align-items: center;
-
-    svg {
-        display: flex;
-    }
-
-    @include mobile-or-tablet-screen {
-        margin-top: -8px;
-        margin-bottom: 8px;
-        margin-inline: -1.6rem;
-        border-radius: 0px;
-    }
-}
-.load-strategy__section_message + .load-strategy__local-dropzone-area {
-    height: calc(100% - 68px);
-    @include mobile-or-tablet-screen {
-        height: calc(100% - 76px);
-    }
-}

--- a/packages/bot-web-ui/src/components/load-modal/local.tsx
+++ b/packages/bot-web-ui/src/components/load-modal/local.tsx
@@ -3,11 +3,11 @@ import classNames from 'classnames';
 import { Button, Icon } from '@deriv/components';
 import { observer, useStore } from '@deriv/stores';
 import { Localize, localize } from '@deriv/translations';
-import { SectionMessage } from '@deriv-com/quill-ui';
 import { botNotification } from 'Components/bot-notification/bot-notification';
 import { notification_message } from 'Components/bot-notification/bot-notification-utils';
 import { useDBotStore } from 'Stores/useDBotStore';
 import LocalFooter from './local-footer';
+import SectionMessage from './section-message';
 import WorkspaceControl from './workspace-control';
 
 const LocalComponent = observer(() => {
@@ -81,8 +81,7 @@ const LocalComponent = observer(() => {
                     message={localize(
                         'Importing XML files from Binary Bot and other third-party platforms may take longer.'
                     )}
-                    size='sm'
-                    status='warning'
+                    icon='IcInfoOutline'
                     className='load-strategy__section_message'
                 />
 

--- a/packages/bot-web-ui/src/components/load-modal/section-message/index.ts
+++ b/packages/bot-web-ui/src/components/load-modal/section-message/index.ts
@@ -1,0 +1,4 @@
+import SectionMessage from './section-message';
+import './section-message.scss';
+
+export default SectionMessage;

--- a/packages/bot-web-ui/src/components/load-modal/section-message/section-message.scss
+++ b/packages/bot-web-ui/src/components/load-modal/section-message/section-message.scss
@@ -1,0 +1,40 @@
+.load-strategy__section_message {
+    --bg-section-message-warning: rgba(255, 156, 19, 0.08);
+
+    margin-top: -16px;
+    margin-bottom: 8px;
+    display: flex;
+    align-items: center;
+
+    padding: 16px;
+    border-radius: 16px;
+    background-color: var(--bg-section-message-warning);
+
+    .icon {
+        .dc-icon {
+            --fill-color1: rgb(225 141 0);
+        }
+
+        height: 16px;
+        width: 16px;
+        margin-right: 8px;
+    }
+
+    .text {
+        width: calc(100% - 24px);
+    }
+
+    @include mobile-or-tablet-screen {
+        margin-top: -8px;
+        margin-bottom: 8px;
+        margin-inline: -1.6rem;
+        border-radius: 0px;
+    }
+}
+
+.load-strategy__section_message + .load-strategy__local-dropzone-area {
+    height: calc(100% - 68px);
+    @include mobile-or-tablet-screen {
+        height: calc(100% - 76px);
+    }
+}

--- a/packages/bot-web-ui/src/components/load-modal/section-message/section-message.tsx
+++ b/packages/bot-web-ui/src/components/load-modal/section-message/section-message.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Icon, Text } from '@deriv/components';
+
+type TSectionMessage = {
+    icon: string;
+    message: string;
+    className?: string;
+};
+
+const SectionMessage: React.FC<TSectionMessage> = ({ icon, message, className }) => {
+    return (
+        <div className={className}>
+            {icon && (
+                <span className='icon'>
+                    <Icon icon={icon} />
+                </span>
+            )}
+            <span className='text'>
+                <Text size='xs'>{message}</Text>
+            </span>
+        </div>
+    );
+};
+
+export default SectionMessage;


### PR DESCRIPTION
## Changes:

- Replaced quill-ui SectionMessage with custom SectionMessage component to mitigate the style override issue in the icons.

### Screenshots:

Mobile
<img width="505" alt="Screenshot 2024-07-08 at 6 12 02 PM" src="https://github.com/binary-com/deriv-app/assets/90243468/5dfa3c19-91bd-400a-b8bb-7535f0958c52">


Desktop
<img width="1073" alt="Screenshot 2024-07-08 at 6 12 27 PM" src="https://github.com/binary-com/deriv-app/assets/90243468/f10eeb0d-72a3-4697-a438-e7947c406923">

