### PR TITLE
Remove `@deriv/reports` from DTrader dependencies

### DIFF
--- a/packages/trader/build/webpack.config.js
+++ b/packages/trader/build/webpack.config.js
@@ -45,7 +45,6 @@ module.exports = function (env) {
                 '@deriv/components': '@deriv/components',
                 '@deriv/translations': '@deriv/translations',
                 '@deriv/account': '@deriv/account',
-                '@deriv/reports': '@deriv/reports',
                 '@deriv/deriv-charts': '@deriv/deriv-charts',
                 '@deriv-com/analytics': `@deriv-com/analytics`,
             },

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -98,7 +98,6 @@
         "@deriv/deriv-api": "^1.0.15",
         "@deriv/deriv-charts": "^2.1.23",
         "@deriv/hooks": "^1.0.0",
-        "@deriv/reports": "^1.0.0",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",
         "@deriv/translations": "^1.0.0",


### PR DESCRIPTION
# Description
`@deriv/reports` is not used inside deriv-app, so it can be safely removed

# Cards
* no cards :)
