### PR TITLE
[WEBREL] Sergei / WEBREL - 2898 / Found an extra symbol of semicolon on the NEW! label for MT5 Zero Spread account on Trader's Hub Real/Demo site

### DIFF
--- a/packages/appstore/src/components/containers/trading-app-card.tsx
+++ b/packages/appstore/src/components/containers/trading-app-card.tsx
@@ -183,7 +183,7 @@ const TradingAppCard = ({
                         </Text>
                         {is_new && name === CFD_PRODUCTS_TITLE.ZEROSPREAD && (
                             <Text className='trading-app-card__details__new' weight='bolder' size='xxs' line_height='s'>
-                                <Localize i18n_default_text='NEW!' />;
+                                <Localize i18n_default_text='NEW!' />
                             </Text>
                         )}
                     </div>


### PR DESCRIPTION
## Changes:

- Remove semicolon

### Screenshots:

<img width="379" alt="image" src="https://github.com/binary-com/deriv-app/assets/120570511/d12c67d7-24c2-41f9-8bcb-83234e4bb086">

