### PR TITLE
Footer issue in POi aligned in Desktop view

### DIFF
--- a/packages/core/src/sass/app/_common/components/account-common.scss
+++ b/packages/core/src/sass/app/_common/components/account-common.scss
@@ -897,6 +897,9 @@
         justify-content: flex-end;
         bottom: 0;
 
+        @include desktop-screen {
+            max-width: 68.2rem;
+        }
         @include mobile-or-tablet-screen {
             flex-direction: row;
             width: 100%;


### PR DESCRIPTION
## Changes:
issue :
Footer in Desktop view is not aligned to the content of the page which doesnt match the design 

### Screenshots:
issue :
<img width="792" alt="Screenshot 2024-07-10 at 12 18 28 PM" src="https://github.com/binary-com/deriv-app/assets/158162395/60e9a5ad-ccf2-4b52-9323-73acb98954f1">

fix:
<img width="792" alt="Screenshot 2024-07-10 at 12 18 45 PM" src="https://github.com/binary-com/deriv-app/assets/158162395/0c6a7677-d185-48e6-bb69-d73c2eda1117">


