### PR TITLE
[WALL] farrah/WALL-4530/fixed iframe height in withdrawal

### DIFF
--- a/packages/cashier/src/components/cashier-container/real/real.scss
+++ b/packages/cashier/src/components/cashier-container/real/real.scss
@@ -7,13 +7,13 @@
     &__iframe {
         @include mobile {
             position: absolute;
-            height: calc(100% - 1.6rem);
+            height: calc(100% - 3.2rem);
             inset-inline-end: 0;
             padding: 0 1.6rem;
 
             + .page-container__sidebar--right {
                 position: relative;
-                top: calc(100% + 3.2rem);
+                top: calc(100% + 1.6rem);
                 padding-bottom: 1.6rem;
                 flex: none;
             }

--- a/packages/cashier/src/components/cashier-container/real/real.scss
+++ b/packages/cashier/src/components/cashier-container/real/real.scss
@@ -3,4 +3,20 @@
         width: 100%;
         height: 80vh;
     }
+
+    &__iframe {
+        @include mobile {
+            position: absolute;
+            height: calc(100% - 1.6rem);
+            inset-inline-end: 0;
+            padding: 0 1.6rem;
+
+            + .page-container__sidebar--right {
+                position: relative;
+                top: calc(100% + 3.2rem);
+                padding-bottom: 1.6rem;
+                flex: none;
+            }
+        }
+    }
 }

--- a/packages/cashier/src/components/cashier-container/real/real.tsx
+++ b/packages/cashier/src/components/cashier-container/real/real.tsx
@@ -29,7 +29,7 @@ const Real = observer(() => {
             {should_show_loader && <Loading className='real__loader' />}
             {iframe_url && (
                 <iframe
-                    className='cashier__content'
+                    className='cashier__content real__iframe'
                     height={iframe_height}
                     src={`${iframe_url}&DarkMode=${is_dark_mode_on ? 'on' : 'off'}`}
                     frameBorder='0'


### PR DESCRIPTION
## Changes:

Fixed the iframe height in withdrawal page for mobile devices to make the payment methods visible.

### Screenshots:

Before:
<img width="393" alt="Screenshot 2024-07-11 at 8 06 11 AM" src="https://github.com/binary-com/deriv-app/assets/82315152/dda35bdd-1ebf-4444-8e9c-71f8105a2f6c">

After:
<img width="396" alt="Screenshot 2024-07-11 at 8 10 01 AM" src="https://github.com/binary-com/deriv-app/assets/82315152/3cbfe1d4-8a2c-4561-b30c-e26c2bb32c1b">



