### PR TITLE
[WEBREL] george / WEBREL-2905 / downgrade deriv-com/analytics to v1.5.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "@contentpass/zxcvbn": "^4.4.3",
                 "@datadog/browser-logs": "^5.11.0",
                 "@datadog/browser-rum": "^5.11.0",
-                "@deriv-com/analytics": "1.8.0",
+                "@deriv-com/analytics": "1.5.9",
                 "@deriv-com/quill-tokens": "^2.0.4",
                 "@deriv-com/quill-ui": "^1.11.4",
                 "@deriv-com/translations": "1.3.3",
@@ -2932,12 +2932,12 @@
             }
         },
         "node_modules/@deriv-com/analytics": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@deriv-com/analytics/-/analytics-1.8.0.tgz",
-            "integrity": "sha512-zH4292rOjH6forMCi1EmdpuSjakkBroedix9fj/zqDEb66DjFC3x+CHrdsr0o2vcJFwTlhVrFZkEyGkeDa6klw==",
+            "version": "1.5.9",
+            "resolved": "https://registry.npmjs.org/@deriv-com/analytics/-/analytics-1.5.9.tgz",
+            "integrity": "sha512-t338hI/f3eGVN9AvBFlAf8KrN+jYOPo5atKnjaN8X/FFiuYcvGahAlwvh6XxdJHxP5dxpGnAnpaJ1kGDceXctw==",
             "dependencies": {
-                "@growthbook/growthbook": "^1.0.1",
-                "@rudderstack/analytics-js": "^3.5.1"
+                "@growthbook/growthbook": "^0.36.0",
+                "rudder-sdk-js": "^2.35.0"
             },
             "engines": {
                 "node": "18.x",
@@ -2959,9 +2959,9 @@
             }
         },
         "node_modules/@deriv-com/quill-ui": {
-            "version": "1.13.6",
-            "resolved": "https://registry.npmjs.org/@deriv-com/quill-ui/-/quill-ui-1.13.6.tgz",
-            "integrity": "sha512-rRjpYwUtTaQKqQT7zh0aU178Fu3t9tvgn/FjSY/2rhVkRWVV29R8PSGAK47HHiwEUD1/lHyN61hSlroIexldog==",
+            "version": "1.13.13",
+            "resolved": "https://registry.npmjs.org/@deriv-com/quill-ui/-/quill-ui-1.13.13.tgz",
+            "integrity": "sha512-v5IVlANPKWPvKIh+GfSvS3fBoVubMTVRJ2/aE3Grntt8MGZoT76nudmHfvkWayWzIIiiQsyWBXpMfYYJkIZ2sQ==",
             "dependencies": {
                 "@deriv-com/quill-tokens": "^2.0.7",
                 "@deriv/quill-icons": "^1.22.10",
@@ -3094,9 +3094,9 @@
             }
         },
         "node_modules/@deriv-com/translations/node_modules/glob": {
-            "version": "10.4.4",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.4.tgz",
-            "integrity": "sha512-XsOKvHsu38Xe19ZQupE6N/HENeHQBA05o3hV8labZZT2zYDg1+emxWHnc/Bm9AcCMPXfD6jt+QC7zC5JSFyumw==",
+            "version": "10.4.5",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
             "dependencies": {
                 "foreground-child": "^3.1.0",
                 "jackspeak": "^3.1.2",
@@ -3107,9 +3107,6 @@
             },
             "bin": {
                 "glob": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": "14 >=14.21 || 16 >=16.20 || 18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -3267,9 +3264,9 @@
             }
         },
         "node_modules/@deriv/quill-icons": {
-            "version": "1.23.1",
-            "resolved": "https://registry.npmjs.org/@deriv/quill-icons/-/quill-icons-1.23.1.tgz",
-            "integrity": "sha512-anzuS/0xg35iIoIZMo9wwkbNPRsJtiT85o+MkkUGoSjJRndwGp2EJRak8EolWQsixfd/ylLve0nohFWL8jMVcg==",
+            "version": "1.23.3",
+            "resolved": "https://registry.npmjs.org/@deriv/quill-icons/-/quill-icons-1.23.3.tgz",
+            "integrity": "sha512-xCjtZuFC6EAz0vFljzIkHZfLoKH0YTO9IuollwTCjj8tLY/3Lam998MvPO4zEFU6el1A6/rLjqiqlQXciSKT9w==",
             "peerDependencies": {
                 "react": ">= 16",
                 "react-dom": ">= 16"
@@ -3727,9 +3724,9 @@
             "integrity": "sha512-I7xWjLs2YSVMc5gGx1Z3ZG1lgFpITPndpi8Ku55GeEIKpACCPQNS/OTqQbxgTCfq0Ncvcc+CrFov96itVh6Qvw=="
         },
         "node_modules/@growthbook/growthbook": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@growthbook/growthbook/-/growthbook-1.1.0.tgz",
-            "integrity": "sha512-TBgUnMcYxOVo4dDDZJ8J2Z9DjDy9PlL+J2GpLMMD6SPpw66gSDcnnwGk9H6diHS/IuUmDXNkU+24+L/bXulWww==",
+            "version": "0.36.0",
+            "resolved": "https://registry.npmjs.org/@growthbook/growthbook/-/growthbook-0.36.0.tgz",
+            "integrity": "sha512-5u1x34H7pg5zS5db3UZ1Pn5hL/jj1EOWdUuz5tSIDUfW49TOWtxtrOAx0Qu1B+UmrIcZKE5XJr6TmWdmdOK12g==",
             "dependencies": {
                 "dom-mutator": "^0.6.0"
             },
@@ -3899,7 +3896,6 @@
         },
         "node_modules/@isaacs/string-locale-compare": {
             "version": "1.1.0",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/@istanbuljs/load-nyc-config": {
@@ -7333,7 +7329,6 @@
         },
         "node_modules/@npmcli/arborist": {
             "version": "5.3.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@isaacs/string-locale-compare": "^1.1.0",
@@ -7380,7 +7375,6 @@
         },
         "node_modules/@npmcli/arborist/node_modules/hosted-git-info": {
             "version": "5.2.1",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^7.5.1"
@@ -7391,7 +7385,6 @@
         },
         "node_modules/@npmcli/arborist/node_modules/npm-package-arg": {
             "version": "9.1.2",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "hosted-git-info": "^5.0.0",
@@ -7405,7 +7398,6 @@
         },
         "node_modules/@npmcli/arborist/node_modules/semver": {
             "version": "7.3.8",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -7419,7 +7411,6 @@
         },
         "node_modules/@npmcli/arborist/node_modules/semver/node_modules/lru-cache": {
             "version": "6.0.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -7430,7 +7421,6 @@
         },
         "node_modules/@npmcli/fs": {
             "version": "2.1.2",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@gar/promisify": "^1.1.3",
@@ -7442,7 +7432,6 @@
         },
         "node_modules/@npmcli/fs/node_modules/lru-cache": {
             "version": "6.0.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -7453,7 +7442,6 @@
         },
         "node_modules/@npmcli/fs/node_modules/semver": {
             "version": "7.3.8",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -7467,7 +7455,6 @@
         },
         "node_modules/@npmcli/git": {
             "version": "3.0.2",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/promise-spawn": "^3.0.0",
@@ -7486,7 +7473,6 @@
         },
         "node_modules/@npmcli/git/node_modules/semver": {
             "version": "7.3.8",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -7500,7 +7486,6 @@
         },
         "node_modules/@npmcli/git/node_modules/semver/node_modules/lru-cache": {
             "version": "6.0.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -7511,7 +7496,6 @@
         },
         "node_modules/@npmcli/installed-package-contents": {
             "version": "1.0.7",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "npm-bundled": "^1.1.1",
@@ -7526,7 +7510,6 @@
         },
         "node_modules/@npmcli/map-workspaces": {
             "version": "2.0.4",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/name-from-folder": "^1.0.1",
@@ -7540,7 +7523,6 @@
         },
         "node_modules/@npmcli/map-workspaces/node_modules/brace-expansion": {
             "version": "2.0.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -7548,7 +7530,6 @@
         },
         "node_modules/@npmcli/map-workspaces/node_modules/glob": {
             "version": "8.0.3",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -7566,7 +7547,6 @@
         },
         "node_modules/@npmcli/map-workspaces/node_modules/minimatch": {
             "version": "5.1.1",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
@@ -7577,7 +7557,6 @@
         },
         "node_modules/@npmcli/metavuln-calculator": {
             "version": "3.1.1",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "cacache": "^16.0.0",
@@ -7591,7 +7570,6 @@
         },
         "node_modules/@npmcli/metavuln-calculator/node_modules/lru-cache": {
             "version": "6.0.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -7602,7 +7580,6 @@
         },
         "node_modules/@npmcli/metavuln-calculator/node_modules/semver": {
             "version": "7.3.8",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -7616,7 +7593,6 @@
         },
         "node_modules/@npmcli/move-file": {
             "version": "2.0.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "mkdirp": "^1.0.4",
@@ -7628,12 +7604,10 @@
         },
         "node_modules/@npmcli/name-from-folder": {
             "version": "1.0.1",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/@npmcli/node-gyp": {
             "version": "2.0.0",
-            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -7641,7 +7615,6 @@
         },
         "node_modules/@npmcli/package-json": {
             "version": "2.0.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "json-parse-even-better-errors": "^2.3.1"
@@ -7652,7 +7625,6 @@
         },
         "node_modules/@npmcli/promise-spawn": {
             "version": "3.0.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "infer-owner": "^1.0.4"
@@ -7663,7 +7635,6 @@
         },
         "node_modules/@npmcli/run-script": {
             "version": "4.2.1",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/node-gyp": "^2.0.0",
@@ -10678,11 +10649,6 @@
                 "linux"
             ]
         },
-        "node_modules/@rudderstack/analytics-js": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/@rudderstack/analytics-js/-/analytics-js-3.6.1.tgz",
-            "integrity": "sha512-8RNvrgSbWi/UcafMyLuNOTad0FBrGJnLSnyxQ2eZCZzDsJOaY4Ws5nTQPwmhuC1kT/RRZJQNWIslHY/wQqnx0A=="
-        },
         "node_modules/@sec-ant/readable-stream": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
@@ -10971,9 +10937,9 @@
             }
         },
         "node_modules/@semantic-release/github/node_modules/@octokit/request-error": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.1.tgz",
-            "integrity": "sha512-1mw1gqT3fR/WFvnoVpY/zUM2o/XkMs/2AszUUG9I69xn0JFLv6PGkPhNk5lbfvROs79wiS0bqiJNxfCZcRJJdg==",
+            "version": "6.1.3",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.3.tgz",
+            "integrity": "sha512-Rb70GFnmFv4j/D3eOwv+4g/C0GlUseSgXBsw1f0WPuKwAlzO5ZVOUQW2ictQElhCjX9pCVMkpVB8vYpGXNFw5A==",
             "dependencies": {
                 "@octokit/types": "^13.0.0"
             },
@@ -11350,12 +11316,9 @@
             }
         },
         "node_modules/@semantic-release/npm/node_modules/lru-cache": {
-            "version": "10.4.2",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.2.tgz",
-            "integrity": "sha512-voV4dDrdVZVNz84n39LFKDaRzfwhdzJ7akpyXfTMxCgRUp07U3lcJUXRlhTKP17rgt09sUzLi5iCitpEAr+6ug==",
-            "engines": {
-                "node": "14 || 16 || 18 || 20 || >=22"
-            }
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
         },
         "node_modules/@semantic-release/npm/node_modules/normalize-package-data": {
             "version": "6.0.2",
@@ -11585,12 +11548,9 @@
             }
         },
         "node_modules/@semantic-release/release-notes-generator/node_modules/lru-cache": {
-            "version": "10.4.2",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.2.tgz",
-            "integrity": "sha512-voV4dDrdVZVNz84n39LFKDaRzfwhdzJ7akpyXfTMxCgRUp07U3lcJUXRlhTKP17rgt09sUzLi5iCitpEAr+6ug==",
-            "engines": {
-                "node": "14 || 16 || 18 || 20 || >=22"
-            }
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
         },
         "node_modules/@semantic-release/release-notes-generator/node_modules/meow": {
             "version": "12.1.1",
@@ -19022,11 +18982,11 @@
             }
         },
         "node_modules/@tanstack/react-virtual": {
-            "version": "3.8.2",
-            "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.8.2.tgz",
-            "integrity": "sha512-g78+DA29K0ByAfDkuibfLQqDshf8Aha/zcyEZ+huAX/yS/TWj/CUiEY4IJfDrFacdxIFmsLm0u4VtsLSKTngRw==",
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.8.3.tgz",
+            "integrity": "sha512-9ICwbDUUzN99CJIGc373i8NLoj6zFTKI2Hlcmo0+lCSAhPQ5mxq4dGOMKmLYoEFyHcGQ64Bd6ZVbnPpM6lNK5w==",
             "dependencies": {
-                "@tanstack/virtual-core": "3.8.2"
+                "@tanstack/virtual-core": "3.8.3"
             },
             "funding": {
                 "type": "github",
@@ -19050,9 +19010,9 @@
             }
         },
         "node_modules/@tanstack/virtual-core": {
-            "version": "3.8.2",
-            "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.8.2.tgz",
-            "integrity": "sha512-ffpN6kTaPGwQPoWMcBAHbdv2ZCpj1SugldoYAcY0C4xH+Pej1KCOEUisNeEgbUnXOp8Y/4q6wGPu2tFHthOIQw==",
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.8.3.tgz",
+            "integrity": "sha512-vd2A2TnM5lbnWZnHi9B+L2gPtkSeOtJOAw358JqokIH1+v2J7vUAzFVPwB/wrye12RFOurffXu33plm4uQ+JBQ==",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/tannerlinsley"
@@ -20706,7 +20666,6 @@
         },
         "node_modules/abbrev": {
             "version": "1.1.1",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/accepts": {
@@ -20827,7 +20786,6 @@
         },
         "node_modules/agentkeepalive": {
             "version": "4.2.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "debug": "^4.1.0",
@@ -21047,7 +21005,6 @@
         },
         "node_modules/are-we-there-yet": {
             "version": "3.0.1",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "delegates": "^1.0.0",
@@ -22462,7 +22419,6 @@
         },
         "node_modules/bin-links": {
             "version": "3.0.3",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "cmd-shim": "^5.0.0",
@@ -22478,7 +22434,6 @@
         },
         "node_modules/bin-links/node_modules/npm-normalize-package-bin": {
             "version": "2.0.0",
-            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -22486,7 +22441,6 @@
         },
         "node_modules/bin-links/node_modules/write-file-atomic": {
             "version": "4.0.2",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "imurmurhash": "^0.1.4",
@@ -23330,7 +23284,6 @@
         },
         "node_modules/builtins": {
             "version": "5.0.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "semver": "^7.0.0"
@@ -23338,7 +23291,6 @@
         },
         "node_modules/builtins/node_modules/lru-cache": {
             "version": "6.0.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -23349,7 +23301,6 @@
         },
         "node_modules/builtins/node_modules/semver": {
             "version": "7.3.8",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -23447,7 +23398,6 @@
         },
         "node_modules/cacache": {
             "version": "16.1.3",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/fs": "^2.1.0",
@@ -23475,7 +23425,6 @@
         },
         "node_modules/cacache/node_modules/brace-expansion": {
             "version": "2.0.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -23483,7 +23432,6 @@
         },
         "node_modules/cacache/node_modules/glob": {
             "version": "8.0.3",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -23501,7 +23449,6 @@
         },
         "node_modules/cacache/node_modules/minimatch": {
             "version": "5.1.1",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
@@ -24276,7 +24223,6 @@
         },
         "node_modules/cmd-shim": {
             "version": "5.0.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "mkdirp-infer-owner": "^2.0.0"
@@ -24397,7 +24343,6 @@
         },
         "node_modules/common-ancestor-path": {
             "version": "1.0.1",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/common-tags": {
@@ -26633,7 +26578,6 @@
         },
         "node_modules/debuglog": {
             "version": "1.0.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "*"
@@ -27394,7 +27338,6 @@
         },
         "node_modules/dezalgo": {
             "version": "1.0.4",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "asap": "^2.0.0",
@@ -28192,7 +28135,6 @@
         },
         "node_modules/err-code": {
             "version": "2.0.3",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/errno": {
@@ -31663,7 +31605,6 @@
         },
         "node_modules/gauge": {
             "version": "4.0.4",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "aproba": "^1.0.3 || ^2.0.0",
@@ -32903,7 +32844,6 @@
         },
         "node_modules/hosted-git-info": {
             "version": "4.1.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -32914,7 +32854,6 @@
         },
         "node_modules/hosted-git-info/node_modules/lru-cache": {
             "version": "6.0.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -33322,8 +33261,7 @@
         "node_modules/http-cache-semantics": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-            "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
-            "dev": true
+            "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
         },
         "node_modules/http-deceiver": {
             "version": "1.2.7",
@@ -33563,7 +33501,6 @@
         },
         "node_modules/humanize-ms": {
             "version": "1.2.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.0.0"
@@ -33729,7 +33666,6 @@
         },
         "node_modules/ignore-walk": {
             "version": "5.0.1",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "minimatch": "^5.0.1"
@@ -33740,7 +33676,6 @@
         },
         "node_modules/ignore-walk/node_modules/brace-expansion": {
             "version": "2.0.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -33748,7 +33683,6 @@
         },
         "node_modules/ignore-walk/node_modules/minimatch": {
             "version": "5.1.1",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
@@ -33907,7 +33841,6 @@
         },
         "node_modules/init-package-json": {
             "version": "3.0.2",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "npm-package-arg": "^9.0.1",
@@ -33924,7 +33857,6 @@
         },
         "node_modules/init-package-json/node_modules/hosted-git-info": {
             "version": "5.2.1",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^7.5.1"
@@ -33935,7 +33867,6 @@
         },
         "node_modules/init-package-json/node_modules/npm-package-arg": {
             "version": "9.1.2",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "hosted-git-info": "^5.0.0",
@@ -33949,7 +33880,6 @@
         },
         "node_modules/init-package-json/node_modules/semver": {
             "version": "7.3.8",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -33963,7 +33893,6 @@
         },
         "node_modules/init-package-json/node_modules/semver/node_modules/lru-cache": {
             "version": "6.0.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -34470,7 +34399,6 @@
         },
         "node_modules/is-lambda": {
             "version": "1.0.1",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/is-lite": {
@@ -34964,14 +34892,11 @@
             }
         },
         "node_modules/jackspeak": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.2.tgz",
-            "integrity": "sha512-qH3nOSj8q/8+Eg8LUPOq3C+6HWkpUioIjDsq1+D4zY91oZvpPttw8GwtF1nReRYKXl+1AORyFqtm2f5Q1SB6/Q==",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
             "dependencies": {
                 "@isaacs/cliui": "^8.0.2"
-            },
-            "engines": {
-                "node": "14 >=14.21 || 16 >=16.20 || >=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -38566,7 +38491,6 @@
         },
         "node_modules/json-stringify-nice": {
             "version": "1.1.4",
-            "dev": true,
             "license": "ISC",
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -38695,12 +38619,10 @@
         },
         "node_modules/just-diff": {
             "version": "5.1.1",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/just-diff-apply": {
             "version": "5.4.1",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/just-extend": {
@@ -38956,7 +38878,6 @@
         },
         "node_modules/libnpmaccess": {
             "version": "6.0.4",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "aproba": "^2.0.0",
@@ -38970,7 +38891,6 @@
         },
         "node_modules/libnpmaccess/node_modules/hosted-git-info": {
             "version": "5.2.1",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^7.5.1"
@@ -38981,7 +38901,6 @@
         },
         "node_modules/libnpmaccess/node_modules/npm-package-arg": {
             "version": "9.1.2",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "hosted-git-info": "^5.0.0",
@@ -38995,7 +38914,6 @@
         },
         "node_modules/libnpmaccess/node_modules/semver": {
             "version": "7.3.8",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -39009,7 +38927,6 @@
         },
         "node_modules/libnpmaccess/node_modules/semver/node_modules/lru-cache": {
             "version": "6.0.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -39020,7 +38937,6 @@
         },
         "node_modules/libnpmpublish": {
             "version": "6.0.5",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "normalize-package-data": "^4.0.0",
@@ -39035,7 +38951,6 @@
         },
         "node_modules/libnpmpublish/node_modules/hosted-git-info": {
             "version": "5.2.1",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^7.5.1"
@@ -39046,7 +38961,6 @@
         },
         "node_modules/libnpmpublish/node_modules/normalize-package-data": {
             "version": "4.0.1",
-            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "hosted-git-info": "^5.0.0",
@@ -39060,7 +38974,6 @@
         },
         "node_modules/libnpmpublish/node_modules/npm-package-arg": {
             "version": "9.1.2",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "hosted-git-info": "^5.0.0",
@@ -39074,7 +38987,6 @@
         },
         "node_modules/libnpmpublish/node_modules/semver": {
             "version": "7.3.8",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -39088,7 +39000,6 @@
         },
         "node_modules/libnpmpublish/node_modules/semver/node_modules/lru-cache": {
             "version": "6.0.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -39725,7 +39636,6 @@
         },
         "node_modules/lru-cache": {
             "version": "7.14.1",
-            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">=12"
@@ -39766,7 +39676,6 @@
         },
         "node_modules/make-fetch-happen": {
             "version": "10.2.1",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "agentkeepalive": "^4.2.1",
@@ -40366,7 +40275,6 @@
         },
         "node_modules/minipass-fetch": {
             "version": "2.1.2",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "minipass": "^3.1.6",
@@ -40392,7 +40300,6 @@
         },
         "node_modules/minipass-json-stream": {
             "version": "1.0.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "jsonparse": "^1.3.1",
@@ -40411,7 +40318,6 @@
         },
         "node_modules/minipass-sized": {
             "version": "1.0.3",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "minipass": "^3.0.0"
@@ -40534,7 +40440,6 @@
         },
         "node_modules/mkdirp-infer-owner": {
             "version": "2.0.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "chownr": "^2.0.0",
@@ -40749,7 +40654,6 @@
         },
         "node_modules/mute-stream": {
             "version": "0.0.8",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/mz": {
@@ -41004,7 +40908,6 @@
         },
         "node_modules/node-gyp": {
             "version": "9.3.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "env-paths": "^2.2.0",
@@ -41037,7 +40940,6 @@
         },
         "node_modules/node-gyp/node_modules/lru-cache": {
             "version": "6.0.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -41048,7 +40950,6 @@
         },
         "node_modules/node-gyp/node_modules/nopt": {
             "version": "6.0.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "abbrev": "^1.0.0"
@@ -41062,7 +40963,6 @@
         },
         "node_modules/node-gyp/node_modules/semver": {
             "version": "7.3.8",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -41223,7 +41123,6 @@
         },
         "node_modules/nopt": {
             "version": "5.0.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "abbrev": "1"
@@ -41237,7 +41136,6 @@
         },
         "node_modules/normalize-package-data": {
             "version": "3.0.3",
-            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "hosted-git-info": "^4.0.1",
@@ -41251,7 +41149,6 @@
         },
         "node_modules/normalize-package-data/node_modules/lru-cache": {
             "version": "6.0.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -41262,7 +41159,6 @@
         },
         "node_modules/normalize-package-data/node_modules/semver": {
             "version": "7.3.8",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -41305,9 +41201,9 @@
             }
         },
         "node_modules/npm": {
-            "version": "10.8.1",
-            "resolved": "https://registry.npmjs.org/npm/-/npm-10.8.1.tgz",
-            "integrity": "sha512-Dp1C6SvSMYQI7YHq/y2l94uvI+59Eqbu1EpuKQHQ8p16txXRuRit5gH3Lnaagk2aXDIjg/Iru9pd05bnneKgdw==",
+            "version": "10.8.2",
+            "resolved": "https://registry.npmjs.org/npm/-/npm-10.8.2.tgz",
+            "integrity": "sha512-x/AIjFIKRllrhcb48dqUNAAZl0ig9+qMuN91RpZo3Cb2+zuibfh+KISl6+kVVyktDz230JKc208UkQwwMqyB+w==",
             "bundleDependencies": [
                 "@isaacs/string-locale-compare",
                 "@npmcli/arborist",
@@ -41387,13 +41283,13 @@
             ],
             "dependencies": {
                 "@isaacs/string-locale-compare": "^1.1.0",
-                "@npmcli/arborist": "^7.5.3",
-                "@npmcli/config": "^8.3.3",
+                "@npmcli/arborist": "^7.5.4",
+                "@npmcli/config": "^8.3.4",
                 "@npmcli/fs": "^3.1.1",
                 "@npmcli/map-workspaces": "^3.0.6",
-                "@npmcli/package-json": "^5.1.1",
+                "@npmcli/package-json": "^5.2.0",
                 "@npmcli/promise-spawn": "^7.0.2",
-                "@npmcli/redact": "^2.0.0",
+                "@npmcli/redact": "^2.0.1",
                 "@npmcli/run-script": "^8.1.0",
                 "@sigstore/tuf": "^2.3.4",
                 "abbrev": "^2.0.0",
@@ -41404,7 +41300,7 @@
                 "cli-columns": "^4.0.0",
                 "fastest-levenshtein": "^1.0.16",
                 "fs-minipass": "^3.0.3",
-                "glob": "^10.4.1",
+                "glob": "^10.4.2",
                 "graceful-fs": "^4.2.11",
                 "hosted-git-info": "^7.0.2",
                 "ini": "^4.1.3",
@@ -41412,30 +41308,30 @@
                 "is-cidr": "^5.1.0",
                 "json-parse-even-better-errors": "^3.0.2",
                 "libnpmaccess": "^8.0.6",
-                "libnpmdiff": "^6.1.3",
-                "libnpmexec": "^8.1.2",
-                "libnpmfund": "^5.0.11",
+                "libnpmdiff": "^6.1.4",
+                "libnpmexec": "^8.1.3",
+                "libnpmfund": "^5.0.12",
                 "libnpmhook": "^10.0.5",
                 "libnpmorg": "^6.0.6",
-                "libnpmpack": "^7.0.3",
+                "libnpmpack": "^7.0.4",
                 "libnpmpublish": "^9.0.9",
                 "libnpmsearch": "^7.0.6",
                 "libnpmteam": "^6.0.5",
                 "libnpmversion": "^6.0.3",
                 "make-fetch-happen": "^13.0.1",
-                "minimatch": "^9.0.4",
+                "minimatch": "^9.0.5",
                 "minipass": "^7.1.1",
                 "minipass-pipeline": "^1.2.4",
                 "ms": "^2.1.2",
                 "node-gyp": "^10.1.0",
                 "nopt": "^7.2.1",
-                "normalize-package-data": "^6.0.1",
+                "normalize-package-data": "^6.0.2",
                 "npm-audit-report": "^5.0.0",
                 "npm-install-checks": "^6.3.0",
                 "npm-package-arg": "^11.0.2",
-                "npm-pick-manifest": "^9.0.1",
+                "npm-pick-manifest": "^9.1.0",
                 "npm-profile": "^10.0.0",
-                "npm-registry-fetch": "^17.0.1",
+                "npm-registry-fetch": "^17.1.0",
                 "npm-user-validate": "^2.0.1",
                 "p-map": "^4.0.0",
                 "pacote": "^18.0.6",
@@ -41465,7 +41361,6 @@
         },
         "node_modules/npm-bundled": {
             "version": "1.1.2",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "npm-normalize-package-bin": "^1.0.1"
@@ -41473,7 +41368,6 @@
         },
         "node_modules/npm-install-checks": {
             "version": "5.0.0",
-            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "semver": "^7.1.1"
@@ -41484,7 +41378,6 @@
         },
         "node_modules/npm-install-checks/node_modules/lru-cache": {
             "version": "6.0.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -41495,7 +41388,6 @@
         },
         "node_modules/npm-install-checks/node_modules/semver": {
             "version": "7.3.8",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -41509,12 +41401,10 @@
         },
         "node_modules/npm-normalize-package-bin": {
             "version": "1.0.1",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/npm-package-arg": {
             "version": "8.1.1",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "hosted-git-info": "^3.0.6",
@@ -41527,12 +41417,10 @@
         },
         "node_modules/npm-package-arg/node_modules/builtins": {
             "version": "1.0.3",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/npm-package-arg/node_modules/hosted-git-info": {
             "version": "3.0.8",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -41543,7 +41431,6 @@
         },
         "node_modules/npm-package-arg/node_modules/lru-cache": {
             "version": "6.0.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -41554,7 +41441,6 @@
         },
         "node_modules/npm-package-arg/node_modules/semver": {
             "version": "7.3.8",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -41568,7 +41454,6 @@
         },
         "node_modules/npm-package-arg/node_modules/validate-npm-package-name": {
             "version": "3.0.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "builtins": "^1.0.3"
@@ -41576,7 +41461,6 @@
         },
         "node_modules/npm-packlist": {
             "version": "5.1.3",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "glob": "^8.0.1",
@@ -41593,7 +41477,6 @@
         },
         "node_modules/npm-packlist/node_modules/brace-expansion": {
             "version": "2.0.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -41601,7 +41484,6 @@
         },
         "node_modules/npm-packlist/node_modules/glob": {
             "version": "8.0.3",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -41619,7 +41501,6 @@
         },
         "node_modules/npm-packlist/node_modules/minimatch": {
             "version": "5.1.1",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
@@ -41630,7 +41511,6 @@
         },
         "node_modules/npm-packlist/node_modules/npm-bundled": {
             "version": "2.0.1",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "npm-normalize-package-bin": "^2.0.0"
@@ -41641,7 +41521,6 @@
         },
         "node_modules/npm-packlist/node_modules/npm-normalize-package-bin": {
             "version": "2.0.0",
-            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -41649,7 +41528,6 @@
         },
         "node_modules/npm-pick-manifest": {
             "version": "7.0.2",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "npm-install-checks": "^5.0.0",
@@ -41663,7 +41541,6 @@
         },
         "node_modules/npm-pick-manifest/node_modules/hosted-git-info": {
             "version": "5.2.1",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^7.5.1"
@@ -41674,7 +41551,6 @@
         },
         "node_modules/npm-pick-manifest/node_modules/npm-normalize-package-bin": {
             "version": "2.0.0",
-            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -41682,7 +41558,6 @@
         },
         "node_modules/npm-pick-manifest/node_modules/npm-package-arg": {
             "version": "9.1.2",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "hosted-git-info": "^5.0.0",
@@ -41696,7 +41571,6 @@
         },
         "node_modules/npm-pick-manifest/node_modules/semver": {
             "version": "7.3.8",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -41710,7 +41584,6 @@
         },
         "node_modules/npm-pick-manifest/node_modules/semver/node_modules/lru-cache": {
             "version": "6.0.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -41721,7 +41594,6 @@
         },
         "node_modules/npm-registry-fetch": {
             "version": "13.3.1",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "make-fetch-happen": "^10.0.6",
@@ -41738,7 +41610,6 @@
         },
         "node_modules/npm-registry-fetch/node_modules/hosted-git-info": {
             "version": "5.2.1",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^7.5.1"
@@ -41749,7 +41620,6 @@
         },
         "node_modules/npm-registry-fetch/node_modules/npm-package-arg": {
             "version": "9.1.2",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "hosted-git-info": "^5.0.0",
@@ -41763,7 +41633,6 @@
         },
         "node_modules/npm-registry-fetch/node_modules/semver": {
             "version": "7.3.8",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -41777,7 +41646,6 @@
         },
         "node_modules/npm-registry-fetch/node_modules/semver/node_modules/lru-cache": {
             "version": "6.0.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -41879,7 +41747,7 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/arborist": {
-            "version": "7.5.3",
+            "version": "7.5.4",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -41927,16 +41795,16 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/config": {
-            "version": "8.3.3",
+            "version": "8.3.4",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/map-workspaces": "^3.0.2",
+                "@npmcli/package-json": "^5.1.1",
                 "ci-info": "^4.0.0",
                 "ini": "^4.1.2",
                 "nopt": "^7.2.1",
                 "proc-log": "^4.2.0",
-                "read-package-json-fast": "^3.0.2",
                 "semver": "^7.3.5",
                 "walk-up-path": "^3.0.1"
             },
@@ -41956,11 +41824,12 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/git": {
-            "version": "5.0.7",
+            "version": "5.0.8",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/promise-spawn": "^7.0.0",
+                "ini": "^4.1.3",
                 "lru-cache": "^10.0.1",
                 "npm-pick-manifest": "^9.0.0",
                 "proc-log": "^4.0.0",
@@ -42034,7 +41903,7 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/package-json": {
-            "version": "5.1.1",
+            "version": "5.2.0",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -42073,7 +41942,7 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/redact": {
-            "version": "2.0.0",
+            "version": "2.0.1",
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -42445,7 +42314,7 @@
             }
         },
         "node_modules/npm/node_modules/debug": {
-            "version": "4.3.4",
+            "version": "4.3.5",
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -42519,7 +42388,7 @@
             }
         },
         "node_modules/npm/node_modules/foreground-child": {
-            "version": "3.1.1",
+            "version": "3.2.1",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -42544,16 +42413,8 @@
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
-        "node_modules/npm/node_modules/function-bind": {
-            "version": "1.1.2",
-            "inBundle": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/npm/node_modules/glob": {
-            "version": "10.4.1",
+            "version": "10.4.2",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -42561,6 +42422,7 @@
                 "jackspeak": "^3.1.2",
                 "minimatch": "^9.0.4",
                 "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
                 "path-scurry": "^1.11.1"
             },
             "bin": {
@@ -42577,17 +42439,6 @@
             "version": "4.2.11",
             "inBundle": true,
             "license": "ISC"
-        },
-        "node_modules/npm/node_modules/hasown": {
-            "version": "2.0.2",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "function-bind": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
         },
         "node_modules/npm/node_modules/hosted-git-info": {
             "version": "7.0.2",
@@ -42618,7 +42469,7 @@
             }
         },
         "node_modules/npm/node_modules/https-proxy-agent": {
-            "version": "7.0.4",
+            "version": "7.0.5",
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -42727,17 +42578,6 @@
                 "node": ">=14"
             }
         },
-        "node_modules/npm/node_modules/is-core-module": {
-            "version": "2.13.1",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "hasown": "^2.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/npm/node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
             "inBundle": true,
@@ -42757,7 +42597,7 @@
             "license": "ISC"
         },
         "node_modules/npm/node_modules/jackspeak": {
-            "version": "3.1.2",
+            "version": "3.4.0",
             "inBundle": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -42825,11 +42665,11 @@
             }
         },
         "node_modules/npm/node_modules/libnpmdiff": {
-            "version": "6.1.3",
+            "version": "6.1.4",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^7.5.3",
+                "@npmcli/arborist": "^7.5.4",
                 "@npmcli/installed-package-contents": "^2.1.0",
                 "binary-extensions": "^2.3.0",
                 "diff": "^5.1.0",
@@ -42843,11 +42683,11 @@
             }
         },
         "node_modules/npm/node_modules/libnpmexec": {
-            "version": "8.1.2",
+            "version": "8.1.3",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^7.5.3",
+                "@npmcli/arborist": "^7.5.4",
                 "@npmcli/run-script": "^8.1.0",
                 "ci-info": "^4.0.0",
                 "npm-package-arg": "^11.0.2",
@@ -42863,11 +42703,11 @@
             }
         },
         "node_modules/npm/node_modules/libnpmfund": {
-            "version": "5.0.11",
+            "version": "5.0.12",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^7.5.3"
+                "@npmcli/arborist": "^7.5.4"
             },
             "engines": {
                 "node": "^16.14.0 || >=18.0.0"
@@ -42898,11 +42738,11 @@
             }
         },
         "node_modules/npm/node_modules/libnpmpack": {
-            "version": "7.0.3",
+            "version": "7.0.4",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^7.5.3",
+                "@npmcli/arborist": "^7.5.4",
                 "@npmcli/run-script": "^8.1.0",
                 "npm-package-arg": "^11.0.2",
                 "pacote": "^18.0.6"
@@ -42998,7 +42838,7 @@
             }
         },
         "node_modules/npm/node_modules/minimatch": {
-            "version": "9.0.4",
+            "version": "9.0.5",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -43058,26 +42898,6 @@
             }
         },
         "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-            "version": "3.3.6",
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/npm/node_modules/minipass-json-stream": {
-            "version": "1.0.1",
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "jsonparse": "^1.3.1",
-                "minipass": "^3.0.0"
-            }
-        },
-        "node_modules/npm/node_modules/minipass-json-stream/node_modules/minipass": {
             "version": "3.3.6",
             "inBundle": true,
             "license": "ISC",
@@ -43233,12 +43053,11 @@
             }
         },
         "node_modules/npm/node_modules/normalize-package-data": {
-            "version": "6.0.1",
+            "version": "6.0.2",
             "inBundle": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "hosted-git-info": "^7.0.0",
-                "is-core-module": "^2.8.1",
                 "semver": "^7.3.5",
                 "validate-npm-package-license": "^3.0.4"
             },
@@ -43310,7 +43129,7 @@
             }
         },
         "node_modules/npm/node_modules/npm-pick-manifest": {
-            "version": "9.0.1",
+            "version": "9.1.0",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -43336,15 +43155,15 @@
             }
         },
         "node_modules/npm/node_modules/npm-registry-fetch": {
-            "version": "17.0.1",
+            "version": "17.1.0",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/redact": "^2.0.0",
+                "jsonparse": "^1.3.1",
                 "make-fetch-happen": "^13.0.0",
                 "minipass": "^7.0.2",
                 "minipass-fetch": "^3.0.0",
-                "minipass-json-stream": "^1.0.1",
                 "minizlib": "^2.1.2",
                 "npm-package-arg": "^11.0.0",
                 "proc-log": "^4.0.0"
@@ -43374,6 +43193,11 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/npm/node_modules/package-json-from-dist": {
+            "version": "1.0.0",
+            "inBundle": true,
+            "license": "BlueOak-1.0.0"
         },
         "node_modules/npm/node_modules/pacote": {
             "version": "18.0.6",
@@ -43645,13 +43469,13 @@
             }
         },
         "node_modules/npm/node_modules/socks-proxy-agent": {
-            "version": "8.0.3",
+            "version": "8.0.4",
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
                 "agent-base": "^7.1.1",
                 "debug": "^4.3.4",
-                "socks": "^2.7.1"
+                "socks": "^2.8.3"
             },
             "engines": {
                 "node": ">= 14"
@@ -44040,7 +43864,6 @@
         },
         "node_modules/npmlog": {
             "version": "6.0.2",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "are-we-there-yet": "^3.0.0",
@@ -45036,7 +44859,6 @@
         },
         "node_modules/pacote": {
             "version": "13.6.2",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/git": "^3.0.0",
@@ -45070,7 +44892,6 @@
         },
         "node_modules/pacote/node_modules/hosted-git-info": {
             "version": "5.2.1",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^7.5.1"
@@ -45081,7 +44902,6 @@
         },
         "node_modules/pacote/node_modules/npm-package-arg": {
             "version": "9.1.2",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "hosted-git-info": "^5.0.0",
@@ -45095,7 +44915,6 @@
         },
         "node_modules/pacote/node_modules/semver": {
             "version": "7.3.8",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -45109,7 +44928,6 @@
         },
         "node_modules/pacote/node_modules/semver/node_modules/lru-cache": {
             "version": "6.0.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -45202,7 +45020,6 @@
         },
         "node_modules/parse-conflict-json": {
             "version": "2.0.2",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "json-parse-even-better-errors": "^2.3.1",
@@ -45397,12 +45214,9 @@
             }
         },
         "node_modules/path-scurry/node_modules/lru-cache": {
-            "version": "10.4.2",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.2.tgz",
-            "integrity": "sha512-voV4dDrdVZVNz84n39LFKDaRzfwhdzJ7akpyXfTMxCgRUp07U3lcJUXRlhTKP17rgt09sUzLi5iCitpEAr+6ug==",
-            "engines": {
-                "node": "14 || 16 || 18 || 20 || >=22"
-            }
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
         },
         "node_modules/path-scurry/node_modules/minipass": {
             "version": "7.1.2",
@@ -47372,7 +47186,6 @@
         },
         "node_modules/proc-log": {
             "version": "2.0.1",
-            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -47408,7 +47221,6 @@
         },
         "node_modules/promise-all-reject-late": {
             "version": "1.0.1",
-            "dev": true,
             "license": "ISC",
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -47416,7 +47228,6 @@
         },
         "node_modules/promise-call-limit": {
             "version": "1.0.1",
-            "dev": true,
             "license": "ISC",
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -47433,7 +47244,6 @@
         },
         "node_modules/promise-retry": {
             "version": "2.0.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "err-code": "^2.0.2",
@@ -47493,7 +47303,6 @@
         },
         "node_modules/promzard": {
             "version": "0.3.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "read": "1"
@@ -48863,7 +48672,6 @@
         },
         "node_modules/read": {
             "version": "1.0.7",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "mute-stream": "~0.0.4"
@@ -48874,7 +48682,6 @@
         },
         "node_modules/read-cmd-shim": {
             "version": "3.0.1",
-            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -48882,7 +48689,6 @@
         },
         "node_modules/read-package-json": {
             "version": "5.0.2",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "glob": "^8.0.1",
@@ -48896,7 +48702,6 @@
         },
         "node_modules/read-package-json-fast": {
             "version": "2.0.3",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "json-parse-even-better-errors": "^2.3.0",
@@ -48908,7 +48713,6 @@
         },
         "node_modules/read-package-json/node_modules/brace-expansion": {
             "version": "2.0.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -48916,7 +48720,6 @@
         },
         "node_modules/read-package-json/node_modules/glob": {
             "version": "8.0.3",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -48934,7 +48737,6 @@
         },
         "node_modules/read-package-json/node_modules/hosted-git-info": {
             "version": "5.2.1",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^7.5.1"
@@ -48945,7 +48747,6 @@
         },
         "node_modules/read-package-json/node_modules/minimatch": {
             "version": "5.1.1",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
@@ -48956,7 +48757,6 @@
         },
         "node_modules/read-package-json/node_modules/normalize-package-data": {
             "version": "4.0.1",
-            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "hosted-git-info": "^5.0.0",
@@ -48970,7 +48770,6 @@
         },
         "node_modules/read-package-json/node_modules/npm-normalize-package-bin": {
             "version": "2.0.0",
-            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -48978,7 +48777,6 @@
         },
         "node_modules/read-package-json/node_modules/semver": {
             "version": "7.3.8",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -48992,7 +48790,6 @@
         },
         "node_modules/read-package-json/node_modules/semver/node_modules/lru-cache": {
             "version": "6.0.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -49031,13 +48828,10 @@
             }
         },
         "node_modules/read-package-up/node_modules/lru-cache": {
-            "version": "10.4.2",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.2.tgz",
-            "integrity": "sha512-voV4dDrdVZVNz84n39LFKDaRzfwhdzJ7akpyXfTMxCgRUp07U3lcJUXRlhTKP17rgt09sUzLi5iCitpEAr+6ug==",
-            "peer": true,
-            "engines": {
-                "node": "14 || 16 || 18 || 20 || >=22"
-            }
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "peer": true
         },
         "node_modules/read-package-up/node_modules/normalize-package-data": {
             "version": "6.0.2",
@@ -49324,7 +49118,6 @@
         },
         "node_modules/readdir-scoped-modules": {
             "version": "1.1.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "debuglog": "^1.0.1",
@@ -50370,6 +50163,11 @@
                 "node": ">=12.0.0"
             }
         },
+        "node_modules/rudder-sdk-js": {
+            "version": "2.48.12",
+            "resolved": "https://registry.npmjs.org/rudder-sdk-js/-/rudder-sdk-js-2.48.12.tgz",
+            "integrity": "sha512-/3AIq8l9tb+I6z1Q5BBQvfeYumE44IeQ2tQzjFw0NKzxrcf6WPBd7K0Rj+mQE9y5phseImPx42U6eyV/eLtzGA=="
+        },
         "node_modules/run-async": {
             "version": "2.4.1",
             "dev": true,
@@ -50736,9 +50534,9 @@
             }
         },
         "node_modules/sass": {
-            "version": "1.77.6",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.6.tgz",
-            "integrity": "sha512-ByXE1oLD79GVq9Ht1PeHWCPMPB8XHpBuz1r85oByKHjZY6qV6rWnQovQzXJXuQ/XyE1Oj3iPk3lo28uzaRA2/Q==",
+            "version": "1.77.7",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.7.tgz",
+            "integrity": "sha512-9ywH75cO+rLjbrZ6en3Gp8qAMwPGBapFtlsMJoDTkcMU/bSe5a6cjKVUn5Jr4Gzg5GbP3HE8cm+02pLCgcoMow==",
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
                 "immutable": "^4.0.0",
@@ -50949,9 +50747,9 @@
             "license": "MIT"
         },
         "node_modules/scratch-blocks": {
-            "version": "1.1.175",
-            "resolved": "https://registry.npmjs.org/scratch-blocks/-/scratch-blocks-1.1.175.tgz",
-            "integrity": "sha512-wzIpP4cfjpe+J1OeXZRacXsuDKOlzzuMhm4NfzCwTDeDKTAI0xbNcn81R5Bml4Bf1WjaPYKY6DiYJY1GSwUOgA==",
+            "version": "1.1.179",
+            "resolved": "https://registry.npmjs.org/scratch-blocks/-/scratch-blocks-1.1.179.tgz",
+            "integrity": "sha512-5VRGO6bmQjvcrjO4YwYLHvz9OzQQerRptS8kJkx01Zg9BvP4N9toi8uEURmkT2a0hy79zOzkir9RxI1ZJ06/1Q==",
             "dependencies": {
                 "exports-loader": "^0.7.0",
                 "google-closure-library": "^20190301.0.0",
@@ -50960,9 +50758,9 @@
             }
         },
         "node_modules/scratch-l10n": {
-            "version": "3.18.211",
-            "resolved": "https://registry.npmjs.org/scratch-l10n/-/scratch-l10n-3.18.211.tgz",
-            "integrity": "sha512-4Kb6chQWQ7tO8DnzBNfJmjkLO9Lra2vQKrfBjN4vl7Fu+xIOIH8qHoJTnOUIrDfolL3jmt10BbIz9KQKOjfTGQ==",
+            "version": "3.18.215",
+            "resolved": "https://registry.npmjs.org/scratch-l10n/-/scratch-l10n-3.18.215.tgz",
+            "integrity": "sha512-7Kk67EPNhKquu3TABaWXj4qMHkZWn7wLk3ATJsN3S/PTuxzElZ5Ki6YICNqL1ghF/pnJ2U9c8ckg8B6cFv3pLw==",
             "bin": {
                 "build-i18n-src": "scripts/build-i18n-src.js",
                 "tx-push-src": "scripts/tx-push-src.js"
@@ -51405,13 +51203,10 @@
             }
         },
         "node_modules/semantic-release/node_modules/lru-cache": {
-            "version": "10.4.2",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.2.tgz",
-            "integrity": "sha512-voV4dDrdVZVNz84n39LFKDaRzfwhdzJ7akpyXfTMxCgRUp07U3lcJUXRlhTKP17rgt09sUzLi5iCitpEAr+6ug==",
-            "peer": true,
-            "engines": {
-                "node": "14 || 16 || 18 || 20 || >=22"
-            }
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "peer": true
         },
         "node_modules/semantic-release/node_modules/marked": {
             "version": "12.0.2",
@@ -52201,7 +51996,6 @@
         },
         "node_modules/smart-buffer": {
             "version": "4.2.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 6.0.0",
@@ -52425,7 +52219,6 @@
         },
         "node_modules/socks": {
             "version": "2.7.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ip": "^2.0.0",
@@ -52438,7 +52231,6 @@
         },
         "node_modules/socks-proxy-agent": {
             "version": "7.0.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "agent-base": "^6.0.2",
@@ -52711,7 +52503,6 @@
         },
         "node_modules/ssri": {
             "version": "9.0.1",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "minipass": "^3.1.1"
@@ -54668,8 +54459,7 @@
         },
         "node_modules/text-table": {
             "version": "0.2.0",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/thenify": {
             "version": "3.3.1",
@@ -54917,7 +54707,6 @@
         },
         "node_modules/treeverse": {
             "version": "2.0.0",
-            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -55596,7 +55385,6 @@
         },
         "node_modules/unique-filename": {
             "version": "2.0.1",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "unique-slug": "^3.0.0"
@@ -55607,7 +55395,6 @@
         },
         "node_modules/unique-slug": {
             "version": "3.0.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "imurmurhash": "^0.1.4"
@@ -56126,7 +55913,6 @@
         },
         "node_modules/validate-npm-package-name": {
             "version": "4.0.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "builtins": "^5.0.0"
@@ -56252,7 +56038,6 @@
         },
         "node_modules/walk-up-path": {
             "version": "1.0.0",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/walker": {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     },
     "dependencies": {
         "@babel/preset-typescript": "^7.16.5",
-        "@deriv-com/analytics": "1.8.0",
+        "@deriv-com/analytics": "1.5.9",
         "@sendbird/chat": "^4.9.7",
         "@types/react-transition-group": "^4.4.4",
         "babel-jest": "^27.3.1",

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@binary-com/binary-document-uploader": "^2.4.8",
-        "@deriv-com/analytics": "1.8.0",
+        "@deriv-com/analytics": "1.5.9",
         "@deriv-com/translations": "1.3.3",
         "@deriv-com/utils": "^0.0.25",
         "@deriv-com/ui": "^1.28.3",

--- a/packages/api-v2/package.json
+++ b/packages/api-v2/package.json
@@ -15,7 +15,7 @@
         "uuid": "^9.0.1"
     },
     "devDependencies": {
-        "@deriv-com/analytics": "1.8.0",
+        "@deriv-com/analytics": "1.5.9",
         "@deriv/api-types": "1.0.172",
         "@testing-library/react": "^12.0.0",
         "@testing-library/react-hooks": "^7.0.2",

--- a/packages/appstore/package.json
+++ b/packages/appstore/package.json
@@ -26,7 +26,7 @@
     "author": "Deriv",
     "license": "Apache-2.0",
     "dependencies": {
-        "@deriv-com/analytics": "1.8.0",
+        "@deriv-com/analytics": "1.5.9",
         "@deriv-com/translations": "1.3.3",
         "@deriv/account": "^1.0.0",
         "@deriv/cashier": "^1.0.0",

--- a/packages/cfd/package.json
+++ b/packages/cfd/package.json
@@ -84,7 +84,7 @@
         "webpack-node-externals": "^2.5.2"
     },
     "dependencies": {
-        "@deriv-com/analytics": "1.8.0",
+        "@deriv-com/analytics": "1.5.9",
         "@deriv-com/ui": "^1.28.3",
         "@deriv-com/translations": "1.3.3",
         "@deriv-com/utils": "^0.0.25",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -96,7 +96,7 @@
     "dependencies": {
         "@babel/polyfill": "^7.4.4",
         "@datadog/browser-rum": "^5.11.0",
-        "@deriv-com/analytics": "1.8.0",
+        "@deriv-com/analytics": "1.5.9",
         "@deriv-com/quill-tokens": "^2.0.4",
         "@deriv-com/quill-ui": "^1.11.4",
         "@deriv-com/translations": "1.3.3",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -6,7 +6,7 @@
     "sideEffects": false,
     "dependencies": {
         "@binary-com/binary-document-uploader": "^2.4.8",
-        "@deriv-com/analytics": "1.8.0",
+        "@deriv-com/analytics": "1.5.9",
         "@deriv/api": "^1.0.0",
         "@deriv/stores": "^1.0.0",
         "@deriv/utils": "^1.0.0",

--- a/packages/reports/package.json
+++ b/packages/reports/package.json
@@ -77,7 +77,7 @@
         "webpack-node-externals": "^2.5.2"
     },
     "dependencies": {
-        "@deriv-com/analytics": "1.8.0",
+        "@deriv-com/analytics": "1.5.9",
         "@deriv-com/ui": "^1.28.3",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -46,7 +46,7 @@
         "typescript": "^4.6.3"
     },
     "dependencies": {
-        "@deriv-com/analytics": "1.8.0",
+        "@deriv-com/analytics": "1.5.9",
         "@deriv/quill-icons": "^1.22.12",
         "@deriv/api-types": "1.0.172",
         "@deriv/translations": "^1.0.0",

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -88,7 +88,7 @@
     },
     "dependencies": {
         "@cloudflare/stream-react": "^1.9.1",
-        "@deriv-com/analytics": "1.8.0",
+        "@deriv-com/analytics": "1.5.9",
         "@deriv-com/quill-tokens": "^2.0.4",
         "@deriv-com/quill-ui": "^1.11.4",
         "@deriv-com/utils": "^0.0.25",

--- a/packages/wallets/package.json
+++ b/packages/wallets/package.json
@@ -15,7 +15,6 @@
         "translate": "sh ./scripts/update-translations.sh"
     },
     "dependencies": {
-        "@deriv-com/analytics": "1.8.0",
         "@deriv-com/ui": "^1.28.3",
         "@deriv-com/utils": "^0.0.25",
         "@deriv/api-v2": "^1.0.0",


### PR DESCRIPTION
## Changes:

- Downgrade `@deriv-com/analytics` package to v1.5.9 to avoid `@rudderstack/analytics-js` version inconsistency between deriv-app and deriv-com apps.