### PR TITLE
[DTRA]fix: fixed the issue of digit contract tick count value getting truncated in responsive view

### DIFF
--- a/packages/trader/src/sass/app/modules/contract/digits.scss
+++ b/packages/trader/src/sass/app/modules/contract/digits.scss
@@ -235,7 +235,7 @@
                 top: 1.6rem;
                 left: 0;
                 right: 0;
-                margin-top: 4.8rem;
+                margin-top: 6rem;
                 pointer-events: none;
 
                 &-value,


### PR DESCRIPTION
## Changes:

Fixed the issue of digit contract tick count value getting truncated in responsive view

### Screenshots:

![Screenshot 2024-07-18 at 11 04 20 AM](https://github.com/user-attachments/assets/e060be88-1b39-48f0-abd4-84a6520ac496)

