### PR TITLE
DTRA / Kate / DTRA-1533 / Reset default button and link tags' style in DTrader V-2

### DIFF
--- a/packages/core/src/sass/app/_common/layout/header.scss
+++ b/packages/core/src/sass/app/_common/layout/header.scss
@@ -438,6 +438,7 @@
         }
 
         &__wrapper {
+            all: unset;
             display: flex;
             justify-content: center;
             align-items: center;

--- a/packages/trader/src/AppV2/Components/BottomNav/bottom-nav.scss
+++ b/packages/trader/src/AppV2/Components/BottomNav/bottom-nav.scss
@@ -19,6 +19,7 @@
     }
 
     &-item {
+        all: unset;
         display: flex;
         flex-direction: column;
         align-items: center;

--- a/packages/trader/src/AppV2/Components/ContractCard/contract-card.scss
+++ b/packages/trader/src/AppV2/Components/ContractCard/contract-card.scss
@@ -9,6 +9,8 @@
     height: 10.4rem;
     transform: translateX(0);
     transition: transform var(--core-motion-duration-200) var(--motion-easing-inandout);
+    text-decoration: none;
+    color: unset;
 
     .dc-icon {
         display: flex;
@@ -82,6 +84,7 @@
         transition: opacity var(--core-motion-duration-200) var(--motion-easing-inandout);
 
         button {
+            all: unset;
             display: flex;
             justify-content: center;
             align-items: center;

--- a/packages/trader/src/AppV2/Components/Filter/filter.scss
+++ b/packages/trader/src/AppV2/Components/Filter/filter.scss
@@ -36,6 +36,7 @@
 
 .custom-time-filter {
     &__wrapper {
+        all: unset;
         display: flex;
         gap: var(--core-spacing-400);
         margin-block: var(--core-spacing-400);

--- a/packages/trader/src/AppV2/Components/Guide/guide.scss
+++ b/packages/trader/src/AppV2/Components/Guide/guide.scss
@@ -13,6 +13,10 @@
         white-space: nowrap;
         -ms-overflow-style: none;
         scrollbar-width: none;
+
+        button {
+            background-color: transparent;
+        }
     }
 
     &__wrapper {


### PR DESCRIPTION
## Changes:

Reset default button and link tags style in DTrader-V-2:
1) Account switcher
2) Bottom navigation
3) Time Filter (custom section)
4) Both open and closed Positions (card+buttons, that appear on swipe)
5) Guide (chips)

### Screenshots:

https://github.com/user-attachments/assets/84137718-211a-4821-9088-6d76489d3025
