### PR TITLE
Akmal / fix: pass currency across closed positions and contract details

### DIFF
--- a/packages/trader/src/AppV2/Components/ContractCard/contract-cards-sections.tsx
+++ b/packages/trader/src/AppV2/Components/ContractCard/contract-cards-sections.tsx
@@ -10,9 +10,10 @@ type TContractCardsSections = {
     isLoadingMore?: boolean;
     hasBottomMargin?: boolean;
     positions?: TClosedPosition[];
+    currency?: string;
 };
 
-const ContractCardsSections = ({ isLoadingMore, hasBottomMargin, positions }: TContractCardsSections) => {
+const ContractCardsSections = ({ isLoadingMore, hasBottomMargin, positions, currency }: TContractCardsSections) => {
     const formatTime = (time: number) => toMoment(time).format('DD MMM YYYY');
 
     const dates = positions?.map(element => {
@@ -41,6 +42,7 @@ const ContractCardsSections = ({ isLoadingMore, hasBottomMargin, positions }: TC
                                 const purchaseTime = position.contract_info.purchase_time_unix;
                                 return purchaseTime && formatTime(purchaseTime) === date;
                             })}
+                            currency={currency}
                         />
                     </div>
                 ))}

--- a/packages/trader/src/AppV2/Components/ContractDetailsFooter/contract-details-footer.tsx
+++ b/packages/trader/src/AppV2/Components/ContractDetailsFooter/contract-details-footer.tsx
@@ -83,7 +83,7 @@ const ContractDetailsFooter = observer(({ contract_info }: ContractInfoProps) =>
                     label={
                         is_valid_to_sell
                             ? `${cardLabels.CLOSE} @ ${FormatUtils.formatMoney(bid_price || 0, {
-                                  currency: currency as any,
+                                  currency: currency as any, // currency types mismatched between utils and shared
                               })} ${currency}`
                             : cardLabels.RESALE_NOT_OFFERED
                     }

--- a/packages/trader/src/AppV2/Components/ContractDetailsFooter/contract-details-footer.tsx
+++ b/packages/trader/src/AppV2/Components/ContractDetailsFooter/contract-details-footer.tsx
@@ -82,7 +82,9 @@ const ContractDetailsFooter = observer(({ contract_info }: ContractInfoProps) =>
                 <Button
                     label={
                         is_valid_to_sell
-                            ? `${cardLabels.CLOSE} @ ${FormatUtils.formatMoney(bid_price || 0)} ${currency}`
+                            ? `${cardLabels.CLOSE} @ ${FormatUtils.formatMoney(bid_price || 0, {
+                                  currency: currency as any,
+                              })} ${currency}`
                             : cardLabels.RESALE_NOT_OFFERED
                     }
                     isLoading={is_sell_requested && is_valid_to_sell}

--- a/packages/trader/src/AppV2/Containers/ContractDetails/contract-details.tsx
+++ b/packages/trader/src/AppV2/Containers/ContractDetails/contract-details.tsx
@@ -84,7 +84,7 @@ const ContractDetails = observer(() => {
                 })}
             >
                 <div className='contract-card-wrapper'>
-                    <ContractCard contractInfo={contract_info} serverTime={server_time} />
+                    <ContractCard contractInfo={contract_info} serverTime={server_time} currency={currency} />
                 </div>
                 <ChartPlaceholder />
                 <DealCancellation />

--- a/packages/trader/src/AppV2/Containers/Positions/positions-content.tsx
+++ b/packages/trader/src/AppV2/Containers/Positions/positions-content.tsx
@@ -70,6 +70,7 @@ const PositionsContent = observer(({ hasButtonsDemo, isClosedTab, setHasButtonsD
 
     const contractCards = isClosedTab ? (
         <ContractCardsSections
+            currency={currency}
             positions={filteredPositions as TClosedPosition[]}
             isLoadingMore={isFetchingClosedPositions}
             hasBottomMargin={shouldShowTakeProfit}


### PR DESCRIPTION
## Changes:

This fix ensures that the currency information is consistently passed across closed positions and contract details, maintaining accuracy and coherence throughout the platform.

- Closed Positions: Update the logic to correctly pass and display the currency information in the closed positions section.
- Contract Details: Ensure that currency details are accurately reflected in the contract details, providing users with clear and consistent information.

By addressing this issue, users will experience improved accuracy and clarity in currency-related information, enhancing their overall interaction with closed positions and contract details.
