### PR TITLE
Rupato/fix: getBlocksInStatement trackjs error

### DIFF
--- a/packages/bot-skeleton/src/scratch/backward-compatibility.js
+++ b/packages/bot-skeleton/src/scratch/backward-compatibility.js
@@ -356,8 +356,8 @@ export default class BlockConversion {
         // For old "market" blocks, move everything in "Trade options" except "DURATION"
         // to "Run once at start". Legacy "market" blocks had no such thing as "Run once at start"
         // not moving everything would kill Martingale strategies as they'd be reinitialised each run.
-        const trade_definition_block = this.workspace.getTradeDefinitionBlock();
-        const has_initialization_block = trade_definition_block.getBlocksInStatement('INITIALIZATION').length > 0;
+        const trade_definition_block = this.workspace?.getTradeDefinitionBlock();
+        const has_initialization_block = trade_definition_block?.getBlocksInStatement('INITIALIZATION').length > 0;
         if (trade_definition_block) {
             trade_definition_block.getBlocksInStatement('SUBMARKET').forEach(block => {
                 if (
@@ -505,8 +505,7 @@ export default class BlockConversion {
 
         this.workspace.getAllBlocks(true).forEach(block => {
             block.initSvg();
-            // keep this commneted to fix backward compatibility issue
-            // block.render();
+            block.renderEfficiently();
         });
 
         this.workspace.cleanUp();

--- a/packages/bot-skeleton/src/scratch/blocks/Binary/Before Purchase/purchase.js
+++ b/packages/bot-skeleton/src/scratch/blocks/Binary/Before Purchase/purchase.js
@@ -2,10 +2,6 @@ import { localize } from '@deriv/translations';
 import { getContractTypeOptions } from '../../../shared';
 import { modifyContextMenu } from '../../../utils';
 
-Blockly.Workspace.prototype.getTradeDefinitionBlock = function () {
-    return this.getAllBlocks(true).find(b => b.type === 'trade_definition');
-};
-
 Blockly.Blocks.purchase = {
     init() {
         this.jsonInit(this.definition());


### PR DESCRIPTION
Fixing the getBlocksInStatement Error

The getBlocksInStatement error occurred because, in the Binary Bot system, we used to load the workspace when we uploaded an XML file. This approach allowed the system to handle blocks that were not present by ensuring they were properly loaded into the workspace. However, in the Deriv Bot system, we now directly load the XML file without initializing the workspace first. As a result, blocks that are referenced in the XML but are not present can lead to errors.

To fix this issue, you need to ensure that the system correctly handles blocks that are missing or not yet loaded when processing the XML. This might involve initializing the workspace or implementing logic to handle missing blocks gracefully.