### PR TITLE
[TRAH] Sergei / TRAH - 3825 / UI Issues related to Tablet view for traders hub

### DIFF
--- a/packages/components/src/components/tabs/tabs.tsx
+++ b/packages/components/src/components/tabs/tabs.tsx
@@ -70,13 +70,23 @@ const Tabs = ({
     };
 
     const setActiveLineStyle = React.useCallback(() => {
+        const html = document.querySelector('html');
+        const is_screen_rotated = html?.classList.contains('tablet-landscape');
+
         const tabs_wrapper_bounds = tabs_wrapper_ref?.current?.getBoundingClientRect();
         const active_tab_bounds = active_tab_ref?.current?.getBoundingClientRect();
         if (tabs_wrapper_bounds && active_tab_bounds) {
-            updateActiveLineStyle({
-                left: active_tab_bounds.left - tabs_wrapper_bounds.left,
-                width: active_tab_bounds.width,
-            });
+            updateActiveLineStyle(
+                is_screen_rotated
+                    ? {
+                          left: tabs_wrapper_bounds.bottom - active_tab_bounds.bottom,
+                          width: active_tab_bounds.height,
+                      }
+                    : {
+                          left: active_tab_bounds.left - tabs_wrapper_bounds.left,
+                          width: active_tab_bounds.width,
+                      }
+            );
         } else {
             setTimeout(() => {
                 setActiveLineStyle();

--- a/packages/core/src/sass/add-or-manage.scss
+++ b/packages/core/src/sass/add-or-manage.scss
@@ -108,7 +108,7 @@
             border: 2px solid var(--general-section-1);
 
             button {
-                width: 100%;
+                min-width: 100%;
             }
         }
     }

--- a/packages/core/src/sass/add-or-manage.scss
+++ b/packages/core/src/sass/add-or-manage.scss
@@ -76,6 +76,8 @@
         }
         .currency-selector__radio-group--with-margin {
             margin-bottom: 3rem;
+            max-width: 60rem;
+            margin-inline: auto;
         }
         & .change-currency {
             .currency-list__items {

--- a/packages/core/src/sass/app/_common/components/account-switcher.scss
+++ b/packages/core/src/sass/app/_common/components/account-switcher.scss
@@ -575,6 +575,8 @@
 
 .dc-modal__container_accounts-switcher {
     @include tablet-screen {
-        inset-inline-start: 1.6rem;
+        inset-inline: 0;
+        max-width: 60rem;
+        margin: auto;
     }
 }


### PR DESCRIPTION
## Changes:

- Add `max-width` for account switcher in tablet view
- Add `min-width` for button in `Add or manage account` modal in tablet view
- Fix highlight tab issue on DTrader when the content rotated on 90 degrees

### Screenshots:

![Screenshot 2024-07-29 at 15 09 56](https://github.com/user-attachments/assets/882fbd29-0790-4b42-8911-380b959b6e29)

![image](https://github.com/user-attachments/assets/6f72a15b-3264-4f7c-8170-1ad813a3dc62)

![Screenshot 2024-07-29 at 15 37 57](https://github.com/user-attachments/assets/d66785c8-b791-4613-864c-f715b56e4483)

![Screenshot 2024-07-29 at 15 38 10](https://github.com/user-attachments/assets/20b38e5f-727b-447f-811a-b86c458254bf)
