### PR TITLE
[BOT] Farabi/bot-1499/dbot tours tutorials test coverage 

### DIFF
--- a/packages/bot-web-ui/src/pages/tutorials/dbot-tours/__tests__/tour-content.spec.tsx
+++ b/packages/bot-web-ui/src/pages/tutorials/dbot-tours/__tests__/tour-content.spec.tsx
@@ -6,12 +6,7 @@ import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
 import OnboardingTourMobile from '../onboarding-tour/onboarding-tour-mobile';
 import { DBOT_ONBOARDING_MOBILE } from '../tour-content';
 
-jest.mock('@deriv/bot-skeleton/src/scratch/blockly', () => jest.fn());
 jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => jest.fn());
-jest.mock('@deriv/bot-skeleton/src/scratch/hooks/block_svg', () => jest.fn());
-jest.mock('@deriv/deriv-charts', () => ({
-    setSmartChartsPublicPath: jest.fn(),
-}));
 
 describe('Tour Content', () => {
     let wrapper: ({ children }: { children: JSX.Element }) => JSX.Element;

--- a/packages/bot-web-ui/src/pages/tutorials/dbot-tours/bot-builder-tour/__tests__/bot-builder-tour-desktop.spec.tsx
+++ b/packages/bot-web-ui/src/pages/tutorials/dbot-tours/bot-builder-tour/__tests__/bot-builder-tour-desktop.spec.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { mockStore, StoreProvider } from '@deriv/stores';
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { DBOT_TABS } from 'Constants/bot-contents';
 import { mock_ws } from 'Utils/mock';
 import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';

--- a/packages/bot-web-ui/src/pages/tutorials/dbot-tours/bot-builder-tour/__tests__/bot-builder-tour-desktop.spec.tsx
+++ b/packages/bot-web-ui/src/pages/tutorials/dbot-tours/bot-builder-tour/__tests__/bot-builder-tour-desktop.spec.tsx
@@ -7,12 +7,7 @@ import { mock_ws } from 'Utils/mock';
 import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
 import BotBuilderTourDesktop from '../bot-builder-tour-desktop';
 
-jest.mock('@deriv/bot-skeleton/src/scratch/blockly', () => jest.fn());
 jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => jest.fn());
-jest.mock('@deriv/bot-skeleton/src/scratch/hooks/block_svg', () => jest.fn());
-jest.mock('@deriv/deriv-charts', () => ({
-    setSmartChartsPublicPath: jest.fn(),
-}));
 
 describe('Bot Builder Tour Desktop', () => {
     let wrapper: ({ children }: { children: JSX.Element }) => JSX.Element;

--- a/packages/bot-web-ui/src/pages/tutorials/dbot-tours/bot-builder-tour/__tests__/bot-builder-tour-desktop.spec.tsx
+++ b/packages/bot-web-ui/src/pages/tutorials/dbot-tours/bot-builder-tour/__tests__/bot-builder-tour-desktop.spec.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { mockStore, StoreProvider } from '@deriv/stores';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DBOT_TABS } from 'Constants/bot-contents';
+import { mock_ws } from 'Utils/mock';
+import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
+import BotBuilderTourDesktop from '../bot-builder-tour-desktop';
+
+jest.mock('@deriv/bot-skeleton/src/scratch/blockly', () => jest.fn());
+jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => jest.fn());
+jest.mock('@deriv/bot-skeleton/src/scratch/hooks/block_svg', () => jest.fn());
+jest.mock('@deriv/deriv-charts', () => ({
+    setSmartChartsPublicPath: jest.fn(),
+}));
+
+describe('Bot Builder Tour Desktop', () => {
+    let wrapper: ({ children }: { children: JSX.Element }) => JSX.Element;
+    const mock_store = mockStore({});
+    const mock_DBot_store = mockDBotStore(mock_store, mock_ws);
+
+    beforeAll(() => {
+        wrapper = ({ children }: { children: JSX.Element }) => (
+            <StoreProvider store={mock_store}>
+                <DBotStoreProvider ws={mock_ws} mock={mock_DBot_store}>
+                    {children}
+                </DBotStoreProvider>
+            </StoreProvider>
+        );
+    });
+    it('should render BotBuilderTourDesktop component with tour start dialog', () => {
+        mock_store.ui.is_desktop = true;
+        mock_DBot_store.dashboard.setTourDialogVisibility(true);
+        mock_DBot_store.dashboard.setActiveTab(DBOT_TABS.BOT_BUILDER);
+
+        render(<BotBuilderTourDesktop />, {
+            wrapper,
+        });
+
+        expect(screen.getByText("Let's build a Bot!")).toBeInTheDocument();
+    });
+
+    it('should render BotBuilderTourDesktop component with tour end dialog', () => {
+        mock_store.ui.is_desktop = true;
+        mock_DBot_store.dashboard.setTourDialogVisibility(true);
+        mock_DBot_store.dashboard.setActiveTab(DBOT_TABS.BOT_BUILDER);
+        mock_DBot_store.dashboard.setActiveTour('bot_builder');
+
+        render(<BotBuilderTourDesktop />, {
+            wrapper,
+        });
+
+        expect(screen.getByText('Congratulations')).toBeInTheDocument();
+    });
+});

--- a/packages/bot-web-ui/src/pages/tutorials/dbot-tours/bot-builder-tour/__tests__/bot-builder-tour-handler.spec.tsx
+++ b/packages/bot-web-ui/src/pages/tutorials/dbot-tours/bot-builder-tour/__tests__/bot-builder-tour-handler.spec.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { mockStore, StoreProvider } from '@deriv/stores';
+import { render, screen } from '@testing-library/react';
+import { mock_ws } from 'Utils/mock';
+import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
+import BotBuilderTourHandler from '../index';
+
+jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => jest.fn());
+
+jest.mock('../bot-builder-tour-desktop', () => jest.fn(() => <div>BotBuilderTourDesktop</div>));
+jest.mock('../bot-builder-tour-mobile', () => jest.fn(() => <div>BotBuilderTourMobile</div>));
+
+describe('BotBuilderTourHandler', () => {
+    let wrapper: ({ children }: { children: JSX.Element }) => JSX.Element;
+    const mock_store = mockStore({});
+    const mock_DBot_store = mockDBotStore(mock_store, mock_ws);
+
+    beforeEach(() => {
+        wrapper = ({ children }: { children: JSX.Element }) => (
+            <StoreProvider store={mock_store}>
+                <DBotStoreProvider ws={mock_ws} mock={mock_DBot_store}>
+                    {children}
+                </DBotStoreProvider>
+            </StoreProvider>
+        );
+    });
+
+    it('should render BotBuilderTourDesktop when is_mobile is false', () => {
+        render(<BotBuilderTourHandler is_mobile={false} />, {
+            wrapper,
+        });
+
+        expect(screen.getByText('BotBuilderTourDesktop')).toBeInTheDocument();
+        expect(screen.queryByText('BotBuilderTourMobile')).not.toBeInTheDocument();
+    });
+
+    it('should render BotBuilderTourMobile when is_mobile is true', () => {
+        render(<BotBuilderTourHandler is_mobile={true} />);
+
+        expect(screen.getByText('BotBuilderTourMobile')).toBeInTheDocument();
+        expect(screen.queryByText('BotBuilderTourDesktop')).not.toBeInTheDocument();
+    });
+});

--- a/packages/bot-web-ui/src/pages/tutorials/dbot-tours/bot-builder-tour/__tests__/bot-builder-tour-mobile.spec.tsx
+++ b/packages/bot-web-ui/src/pages/tutorials/dbot-tours/bot-builder-tour/__tests__/bot-builder-tour-mobile.spec.tsx
@@ -7,12 +7,7 @@ import { mock_ws } from 'Utils/mock';
 import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
 import BotBuilderTourMobile from '../bot-builder-tour-mobile';
 
-jest.mock('@deriv/bot-skeleton/src/scratch/blockly', () => jest.fn());
 jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => jest.fn());
-jest.mock('@deriv/bot-skeleton/src/scratch/hooks/block_svg', () => jest.fn());
-jest.mock('@deriv/deriv-charts', () => ({
-    setSmartChartsPublicPath: jest.fn(),
-}));
 
 describe('BotBuilder Tour Mobile', () => {
     let wrapper: ({ children }: { children: JSX.Element }) => JSX.Element;

--- a/packages/bot-web-ui/src/pages/tutorials/dbot-tours/bot-builder-tour/__tests__/bot-builder-tour-mobile.spec.tsx
+++ b/packages/bot-web-ui/src/pages/tutorials/dbot-tours/bot-builder-tour/__tests__/bot-builder-tour-mobile.spec.tsx
@@ -46,4 +46,30 @@ describe('BotBuilder Tour Mobile', () => {
 
         expect(screen.getByTestId('botbuilder-tour-mobile')).toBeInTheDocument();
     });
+
+    it('should render BotBuilderTourMobile steps with Next and Previous buttons', () => {
+        render(<BotBuilderTourMobile />, {
+            wrapper,
+        });
+
+        const next_button = screen.getByRole('button', { name: 'Next' });
+        userEvent.click(next_button);
+        expect(screen.getByRole('button', { name: 'Previous' })).toBeInTheDocument();
+
+        const previous_button = screen.getByRole('button', { name: 'Previous' });
+        userEvent.click(previous_button);
+        expect(screen.getByRole('button', { name: 'Next' })).toBeInTheDocument();
+    });
+
+    it('should render BotBuilderTourMobile steps with Next and Previous buttons', () => {
+        render(<BotBuilderTourMobile />, {
+            wrapper,
+        });
+
+        const next_button = screen.getByRole('button', { name: 'Next' });
+        userEvent.click(next_button);
+        userEvent.click(next_button);
+
+        expect(screen.getByRole('button', { name: 'Finish' })).toBeInTheDocument();
+    });
 });

--- a/packages/bot-web-ui/src/pages/tutorials/dbot-tours/bot-builder-tour/__tests__/bot-builder-tour-mobile.spec.tsx
+++ b/packages/bot-web-ui/src/pages/tutorials/dbot-tours/bot-builder-tour/__tests__/bot-builder-tour-mobile.spec.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { mockStore, StoreProvider } from '@deriv/stores';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DBOT_TABS } from 'Constants/bot-contents';
 import { mock_ws } from 'Utils/mock';
 import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
-import OnboardingTourMobile from '../onboarding-tour/onboarding-tour-mobile';
-import { DBOT_ONBOARDING_MOBILE } from '../tour-content';
+import BotBuilderTourMobile from '../bot-builder-tour-mobile';
 
 jest.mock('@deriv/bot-skeleton/src/scratch/blockly', () => jest.fn());
 jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => jest.fn());
@@ -13,12 +14,12 @@ jest.mock('@deriv/deriv-charts', () => ({
     setSmartChartsPublicPath: jest.fn(),
 }));
 
-describe('Tour Content', () => {
+describe('BotBuilder Tour Mobile', () => {
     let wrapper: ({ children }: { children: JSX.Element }) => JSX.Element;
     const mock_store = mockStore({});
     const mock_DBot_store = mockDBotStore(mock_store, mock_ws);
 
-    beforeEach(() => {
+    beforeAll(() => {
         wrapper = ({ children }: { children: JSX.Element }) => (
             <StoreProvider store={mock_store}>
                 <DBotStoreProvider ws={mock_ws} mock={mock_DBot_store}>
@@ -27,11 +28,27 @@ describe('Tour Content', () => {
             </StoreProvider>
         );
     });
-    it('DBOT_ONBOARDING_MOBILE is called', () => {
-        render(<OnboardingTourMobile />, {
+    it('should render BotBuilderTourMobile component', () => {
+        mock_DBot_store.dashboard.setTourDialogVisibility(true);
+        mock_DBot_store.dashboard.setActiveTab(DBOT_TABS.BOT_BUILDER);
+
+        render(<BotBuilderTourMobile />, {
             wrapper,
         });
-        const first_step = DBOT_ONBOARDING_MOBILE[0];
-        expect(screen.getByText(first_step.header)).toBeInTheDocument();
+        expect(screen.getByText('Bot Builder guide')).toBeInTheDocument();
+    });
+
+    it('should render BotBuilderTourMobile when active tour is set to bot builder and tour dialog is false', () => {
+        mock_DBot_store.dashboard.active_tour = 'bot_builder';
+        mock_DBot_store.dashboard.setShowMobileTourDialog(false);
+
+        render(<BotBuilderTourMobile />, {
+            wrapper,
+        });
+
+        const start_button = screen.getByRole('button', { name: 'Start' });
+        userEvent.click(start_button);
+
+        expect(screen.getByTestId('botbuilder-tour-mobile')).toBeInTheDocument();
     });
 });

--- a/packages/bot-web-ui/src/pages/tutorials/dbot-tours/bot-builder-tour/bot-builder-tour-desktop.tsx
+++ b/packages/bot-web-ui/src/pages/tutorials/dbot-tours/bot-builder-tour/bot-builder-tour-desktop.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
-
 import { observer } from '@deriv/stores';
-
-import { useDBotStore } from 'Stores/useDBotStore';
 import { getSetting } from 'Utils/settings';
-
+import { useDBotStore } from 'Stores/useDBotStore';
 import ReactJoyrideWrapper from '../common/react-joyride-wrapper';
 import TourEndDialog from '../common/tour-end-dialog';
 import TourStartDialog from '../common/tour-start-dialog';

--- a/packages/bot-web-ui/src/pages/tutorials/dbot-tours/common/__tests__/tour-button.spec.tsx
+++ b/packages/bot-web-ui/src/pages/tutorials/dbot-tours/common/__tests__/tour-button.spec.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
-
 import { fireEvent, render, screen } from '@testing-library/react';
-
 import TourButton from '../tour-button';
 
 const mocked_props = {

--- a/packages/bot-web-ui/src/pages/tutorials/dbot-tours/common/__tests__/tour-end-dialog.spec.tsx
+++ b/packages/bot-web-ui/src/pages/tutorials/dbot-tours/common/__tests__/tour-end-dialog.spec.tsx
@@ -7,12 +7,7 @@ import { mock_ws } from 'Utils/mock';
 import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
 import TourEndDialog from '../tour-end-dialog';
 
-jest.mock('@deriv/bot-skeleton/src/scratch/blockly', () => jest.fn());
 jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => jest.fn());
-jest.mock('@deriv/bot-skeleton/src/scratch/hooks/block_svg', () => jest.fn());
-jest.mock('@deriv/deriv-charts', () => ({
-    setSmartChartsPublicPath: jest.fn(),
-}));
 
 describe('Tour End Dialog', () => {
     let wrapper: ({ children }: { children: JSX.Element }) => JSX.Element;

--- a/packages/bot-web-ui/src/pages/tutorials/dbot-tours/common/__tests__/tour-end-dialog.spec.tsx
+++ b/packages/bot-web-ui/src/pages/tutorials/dbot-tours/common/__tests__/tour-end-dialog.spec.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { mockStore, StoreProvider } from '@deriv/stores';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DBOT_TABS } from 'Constants/bot-contents';
+import { mock_ws } from 'Utils/mock';
+import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
+import TourEndDialog from '../tour-end-dialog';
+
+jest.mock('@deriv/bot-skeleton/src/scratch/blockly', () => jest.fn());
+jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => jest.fn());
+jest.mock('@deriv/bot-skeleton/src/scratch/hooks/block_svg', () => jest.fn());
+jest.mock('@deriv/deriv-charts', () => ({
+    setSmartChartsPublicPath: jest.fn(),
+}));
+
+describe('Tour End Dialog', () => {
+    let wrapper: ({ children }: { children: JSX.Element }) => JSX.Element;
+    const mock_store = mockStore({});
+    const mock_DBot_store = mockDBotStore(mock_store, mock_ws);
+
+    beforeEach(() => {
+        wrapper = ({ children }: { children: JSX.Element }) => (
+            <StoreProvider store={mock_store}>
+                <DBotStoreProvider ws={mock_ws} mock={mock_DBot_store}>
+                    {children}
+                </DBotStoreProvider>
+            </StoreProvider>
+        );
+    });
+
+    it('render TourEndDialog component for bot builder tour', () => {
+        mock_DBot_store.dashboard.setActiveTab(DBOT_TABS.BOT_BUILDER);
+        mock_DBot_store.dashboard.setTourDialogVisibility(true);
+
+        render(<TourEndDialog />, { wrapper });
+        expect(screen.getByText('Congratulations')).toBeInTheDocument();
+    });
+
+    it('render TourEndDialog component to have title with text size xs', () => {
+        mock_DBot_store.dashboard.setActiveTab(DBOT_TABS.BOT_BUILDER);
+        mock_DBot_store.dashboard.setTourDialogVisibility(true);
+
+        render(<TourEndDialog />, { wrapper });
+
+        const title = screen.getByText('Congratulations');
+        expect(title).toHaveStyle('--text-size: var(--text-size-xs)');
+        expect(screen.getByTestId('tour-success-message')).toBeInTheDocument();
+    });
+
+    it('render TourEndDialog component to have title with text size s on desktop', () => {
+        mock_store.ui.is_desktop = true;
+        mock_DBot_store.dashboard.setActiveTab(DBOT_TABS.BOT_BUILDER);
+        mock_DBot_store.dashboard.setTourDialogVisibility(true);
+
+        render(<TourEndDialog />, { wrapper });
+
+        const title = screen.getByText('Congratulations');
+        expect(title).toHaveStyle('--text-size: var(--text-size-s)');
+        expect(screen.getByTestId('tour-success-message')).toBeInTheDocument();
+    });
+
+    it('render TourEndDialog component to be closed for bot builder tour after clicking OK', () => {
+        mock_DBot_store.dashboard.setActiveTab(DBOT_TABS.BOT_BUILDER);
+        mock_DBot_store.dashboard.setTourDialogVisibility(true);
+
+        render(<TourEndDialog />, { wrapper });
+        const start_button = screen.getByRole('button', { name: 'OK' });
+        userEvent.click(start_button);
+
+        expect(mock_DBot_store.dashboard.is_tour_dialog_visible).toBeFalsy();
+    });
+});

--- a/packages/bot-web-ui/src/pages/tutorials/dbot-tours/common/__tests__/tour-start-dialog.spec.tsx
+++ b/packages/bot-web-ui/src/pages/tutorials/dbot-tours/common/__tests__/tour-start-dialog.spec.tsx
@@ -7,12 +7,7 @@ import { mock_ws } from 'Utils/mock';
 import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
 import TourStartDialog from '../tour-start-dialog';
 
-jest.mock('@deriv/bot-skeleton/src/scratch/blockly', () => jest.fn());
 jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => jest.fn());
-jest.mock('@deriv/bot-skeleton/src/scratch/hooks/block_svg', () => jest.fn());
-jest.mock('@deriv/deriv-charts', () => ({
-    setSmartChartsPublicPath: jest.fn(),
-}));
 
 describe('Tour Start Dialog', () => {
     let wrapper: ({ children }: { children: JSX.Element }) => JSX.Element;

--- a/packages/bot-web-ui/src/pages/tutorials/dbot-tours/common/__tests__/tour-start-dialog.spec.tsx
+++ b/packages/bot-web-ui/src/pages/tutorials/dbot-tours/common/__tests__/tour-start-dialog.spec.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { mockStore, StoreProvider } from '@deriv/stores';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DBOT_TABS } from 'Constants/bot-contents';
+import { mock_ws } from 'Utils/mock';
+import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
+import TourStartDialog from '../tour-start-dialog';
+
+jest.mock('@deriv/bot-skeleton/src/scratch/blockly', () => jest.fn());
+jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => jest.fn());
+jest.mock('@deriv/bot-skeleton/src/scratch/hooks/block_svg', () => jest.fn());
+jest.mock('@deriv/deriv-charts', () => ({
+    setSmartChartsPublicPath: jest.fn(),
+}));
+
+describe('Tour Start Dialog', () => {
+    let wrapper: ({ children }: { children: JSX.Element }) => JSX.Element;
+    const mock_store = mockStore({});
+    const mock_DBot_store = mockDBotStore(mock_store, mock_ws);
+
+    beforeEach(() => {
+        wrapper = ({ children }: { children: JSX.Element }) => (
+            <StoreProvider store={mock_store}>
+                <DBotStoreProvider ws={mock_ws} mock={mock_DBot_store}>
+                    {children}
+                </DBotStoreProvider>
+            </StoreProvider>
+        );
+    });
+
+    it('render TourStartDialog component for onboarding tour', () => {
+        mock_DBot_store.dashboard.setTourDialogVisibility(true);
+        mock_DBot_store.dashboard.setActiveTab(DBOT_TABS.DASHBOARD);
+
+        render(<TourStartDialog />, { wrapper });
+        expect(screen.getByText('Get started on Deriv Bot')).toBeInTheDocument();
+    });
+
+    it('render TourStartDialog component for bot builder tour in mobile', () => {
+        mock_DBot_store.dashboard.setTourDialogVisibility(true);
+        mock_DBot_store.dashboard.setActiveTab(DBOT_TABS.BOT_BUILDER);
+
+        render(<TourStartDialog />, { wrapper });
+        expect(screen.getByText('Bot Builder guide')).toBeInTheDocument();
+    });
+
+    it('render TourStartDialog component for bot builder tour in desktop', () => {
+        mock_store.ui.is_desktop = true;
+        mock_DBot_store.dashboard.setTourDialogVisibility(true);
+        mock_DBot_store.dashboard.setActiveTab(DBOT_TABS.BOT_BUILDER);
+
+        render(<TourStartDialog />, { wrapper });
+        expect(screen.getByText("Let's build a Bot!")).toBeInTheDocument();
+    });
+
+    it('render TourStartDialog component with active tour as bot builder and dialog closed when clicking start', () => {
+        mock_store.ui.is_desktop = true;
+        mock_DBot_store.dashboard.setTourDialogVisibility(true);
+        mock_DBot_store.dashboard.setActiveTab(DBOT_TABS.BOT_BUILDER);
+
+        render(<TourStartDialog />, { wrapper });
+
+        const start_button = screen.getByRole('button', { name: 'Start' });
+        userEvent.click(start_button);
+        expect(mock_DBot_store.dashboard.active_tour).toEqual('bot_builder');
+        expect(mock_DBot_store.dashboard.is_tour_dialog_visible).toBeFalsy();
+    });
+
+    it('render TourStartDialog component with show_mobile_tour_dialog as false when clicking start in mobile', () => {
+        mock_store.ui.is_desktop = false;
+        mock_DBot_store.dashboard.setTourDialogVisibility(true);
+        mock_DBot_store.dashboard.setActiveTab(DBOT_TABS.BOT_BUILDER);
+
+        render(<TourStartDialog />, { wrapper });
+
+        const start_button = screen.getByRole('button', { name: 'Start' });
+        userEvent.click(start_button);
+        expect(mock_DBot_store.dashboard.show_mobile_tour_dialog).toBeFalsy();
+    });
+
+    it('render TourStartDialog component with dialog closed when clicking skip', () => {
+        mock_store.ui.is_desktop = true;
+        mock_DBot_store.dashboard.setTourDialogVisibility(true);
+        mock_DBot_store.dashboard.setActiveTab(DBOT_TABS.BOT_BUILDER);
+
+        render(<TourStartDialog />, { wrapper });
+
+        const start_button = screen.getByRole('button', { name: 'Skip' });
+        userEvent.click(start_button);
+        expect(mock_DBot_store.dashboard.is_tour_dialog_visible).toBeFalsy();
+    });
+
+    it('render TourStartDialog component with show_mobile_tour_dialog as false when clicking skip in mobile', () => {
+        mock_store.ui.is_desktop = false;
+        mock_DBot_store.dashboard.setTourDialogVisibility(true);
+        mock_DBot_store.dashboard.setActiveTab(DBOT_TABS.BOT_BUILDER);
+
+        render(<TourStartDialog />, { wrapper });
+
+        const start_button = screen.getByRole('button', { name: 'Skip' });
+        userEvent.click(start_button);
+        expect(mock_DBot_store.dashboard.show_mobile_tour_dialog).toBeFalsy();
+    });
+});

--- a/packages/bot-web-ui/src/pages/tutorials/dbot-tours/common/__tests__/tour-steps.spec.tsx
+++ b/packages/bot-web-ui/src/pages/tutorials/dbot-tours/common/__tests__/tour-steps.spec.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { mockStore, StoreProvider } from '@deriv/stores';
+import { render, screen } from '@testing-library/react';
+import { mock_ws } from 'Utils/mock';
+import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
+import TourSteps from '../tour-steps';
+
+jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => jest.fn());
+jest.mock('@deriv/bot-skeleton/src/services/tradeEngine/utils/helpers', () => ({
+    getUUID: jest.fn(() => 'unique-id'),
+}));
+
+describe('Tour Steps', () => {
+    let wrapper: ({ children }: { children: JSX.Element }) => JSX.Element;
+    const mock_store = mockStore({});
+    const mock_DBot_store = mockDBotStore(mock_store, mock_ws);
+
+    beforeEach(() => {
+        wrapper = ({ children }: { children: JSX.Element }) => (
+            <StoreProvider store={mock_store}>
+                <DBotStoreProvider ws={mock_ws} mock={mock_DBot_store}>
+                    {children}
+                </DBotStoreProvider>
+            </StoreProvider>
+        );
+    });
+
+    it('render TourSteps component', () => {
+        render(<TourSteps content={[]} label={'Import or choose your bot'} step_index={1} />, { wrapper });
+        expect(screen.getByText('Import or choose your bot')).toBeInTheDocument();
+    });
+
+    it('render TourSteps with media files', () => {
+        render(<TourSteps content={[]} label='Import bot media' step_index={1} media='media.mp4' />);
+        const video_element = screen.getByText('Import bot media');
+        expect(video_element).toBeInTheDocument();
+    });
+
+    it('render with content if has_localize_component is true', () => {
+        const localize_component = <p key='localize-key'>Localized content</p>;
+        render(<TourSteps content={[localize_component]} label='Localized' step_index={1} has_localize_component />);
+        expect(screen.getByText('Localized content')).toBeInTheDocument();
+    });
+});

--- a/packages/bot-web-ui/src/pages/tutorials/dbot-tours/onboarding-tour/__tests__/onboarding-tour-desktop.spec.tsx
+++ b/packages/bot-web-ui/src/pages/tutorials/dbot-tours/onboarding-tour/__tests__/onboarding-tour-desktop.spec.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { mockStore, StoreProvider } from '@deriv/stores';
+import { render, screen } from '@testing-library/react';
+import { DBOT_TABS } from 'Constants/bot-contents';
+import { mock_ws } from 'Utils/mock';
+import { getSetting } from 'Utils/settings';
+import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
+import OnboardingTourDesktop from '../onboarding-tour-desktop';
+
+jest.mock('@deriv/bot-skeleton/src/scratch/blockly', () => jest.fn());
+jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => jest.fn());
+jest.mock('@deriv/bot-skeleton/src/scratch/hooks/block_svg', () => jest.fn());
+jest.mock('@deriv/deriv-charts', () => ({
+    setSmartChartsPublicPath: jest.fn(),
+}));
+jest.mock('Utils/settings', () => ({
+    getSetting: jest.fn(),
+}));
+
+describe('Onboarding Tour Desktop', () => {
+    let wrapper: ({ children }: { children: JSX.Element }) => JSX.Element;
+    const mock_store = mockStore({});
+    const mock_DBot_store = mockDBotStore(mock_store, mock_ws);
+
+    beforeEach(() => {
+        wrapper = ({ children }: { children: JSX.Element }) => (
+            <StoreProvider store={mock_store}>
+                <DBotStoreProvider ws={mock_ws} mock={mock_DBot_store}>
+                    {children}
+                </DBotStoreProvider>
+            </StoreProvider>
+        );
+    });
+
+    it('should render OnboardingTourDesktop component', () => {
+        render(<OnboardingTourDesktop />, {
+            wrapper,
+        });
+
+        expect(screen.getByText('Get started on Deriv Bot')).toBeInTheDocument();
+    });
+
+    it('should render Onboarding tour when no onboarding token and active tab is 0', () => {
+        (getSetting as jest.Mock).mockReturnValueOnce(null);
+        mock_DBot_store.dashboard.setActiveTab(DBOT_TABS.DASHBOARD);
+
+        render(<OnboardingTourDesktop />, {
+            wrapper,
+        });
+
+        expect(mock_DBot_store.dashboard.is_tour_dialog_visible).toBeTruthy();
+    });
+
+    it('should render ReactJoyrideWrapper when there is an active tour', () => {
+        render(<OnboardingTourDesktop />, {
+            wrapper,
+        });
+
+        mock_DBot_store.dashboard.setActiveTour('onboarding');
+        expect(screen.getByText('Get started on Deriv Bot')).toBeInTheDocument();
+    });
+
+    it('should not render Onboarding tour when token is set and active tab is not 0', () => {
+        (getSetting as jest.Mock).mockReturnValueOnce('onboarding_tour_token');
+        mock_DBot_store.dashboard.setActiveTab(DBOT_TABS.BOT_BUILDER);
+
+        render(<OnboardingTourDesktop />, {
+            wrapper,
+        });
+
+        expect(screen.queryByText('Get started on Deriv Bot')).not.toBeInTheDocument();
+    });
+});

--- a/packages/bot-web-ui/src/pages/tutorials/dbot-tours/onboarding-tour/__tests__/onboarding-tour-desktop.spec.tsx
+++ b/packages/bot-web-ui/src/pages/tutorials/dbot-tours/onboarding-tour/__tests__/onboarding-tour-desktop.spec.tsx
@@ -7,12 +7,8 @@ import { getSetting } from 'Utils/settings';
 import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
 import OnboardingTourDesktop from '../onboarding-tour-desktop';
 
-jest.mock('@deriv/bot-skeleton/src/scratch/blockly', () => jest.fn());
 jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => jest.fn());
-jest.mock('@deriv/bot-skeleton/src/scratch/hooks/block_svg', () => jest.fn());
-jest.mock('@deriv/deriv-charts', () => ({
-    setSmartChartsPublicPath: jest.fn(),
-}));
+
 jest.mock('Utils/settings', () => ({
     getSetting: jest.fn(),
 }));

--- a/packages/bot-web-ui/src/pages/tutorials/dbot-tours/onboarding-tour/__tests__/onboarding-tour-handler.spec.tsx
+++ b/packages/bot-web-ui/src/pages/tutorials/dbot-tours/onboarding-tour/__tests__/onboarding-tour-handler.spec.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { mockStore, StoreProvider } from '@deriv/stores';
+import { render, screen } from '@testing-library/react';
+import { mock_ws } from 'Utils/mock';
+import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
+import OnboardingTourHandler from '../index';
+
+jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => jest.fn());
+
+jest.mock('../onboarding-tour-desktop', () => jest.fn(() => <div>OnboardingTourDesktop</div>));
+jest.mock('../onboarding-tour-mobile', () => jest.fn(() => <div>OnboardingTourMobile</div>));
+
+describe('OnboardingTourHandler', () => {
+    let wrapper: ({ children }: { children: JSX.Element }) => JSX.Element;
+    const mock_store = mockStore({});
+    const mock_DBot_store = mockDBotStore(mock_store, mock_ws);
+
+    beforeEach(() => {
+        wrapper = ({ children }: { children: JSX.Element }) => (
+            <StoreProvider store={mock_store}>
+                <DBotStoreProvider ws={mock_ws} mock={mock_DBot_store}>
+                    {children}
+                </DBotStoreProvider>
+            </StoreProvider>
+        );
+    });
+
+    it('should render OnboardingTourDesktop when is_mobile is false', () => {
+        render(<OnboardingTourHandler is_mobile={false} />, {
+            wrapper,
+        });
+
+        expect(screen.getByText('OnboardingTourDesktop')).toBeInTheDocument();
+        expect(screen.queryByText('OnboardingTourMobile')).not.toBeInTheDocument();
+    });
+
+    it('should render OnboardingTourMobile when is_mobile is true', () => {
+        render(<OnboardingTourHandler is_mobile={true} />);
+
+        expect(screen.getByText('OnboardingTourMobile')).toBeInTheDocument();
+        expect(screen.queryByText('OnboardingTourDesktop')).not.toBeInTheDocument();
+    });
+});

--- a/packages/bot-web-ui/src/pages/tutorials/dbot-tours/onboarding-tour/__tests__/onboarding-tour-mobile.spec.tsx
+++ b/packages/bot-web-ui/src/pages/tutorials/dbot-tours/onboarding-tour/__tests__/onboarding-tour-mobile.spec.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { mockStore, StoreProvider } from '@deriv/stores';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { mock_ws } from 'Utils/mock';
+import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
+import OnboardingTourMobile from '../onboarding-tour-mobile';
+import { DBOT_ONBOARDING_MOBILE } from '../../tour-content';
+
+jest.mock('@deriv/bot-skeleton/src/scratch/blockly', () => jest.fn());
+jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => jest.fn());
+jest.mock('@deriv/bot-skeleton/src/scratch/hooks/block_svg', () => jest.fn());
+jest.mock('@deriv/deriv-charts', () => ({
+    setSmartChartsPublicPath: jest.fn(),
+}));
+
+describe('Onboarding Tour Mobile', () => {
+    let wrapper: ({ children }: { children: JSX.Element }) => JSX.Element;
+    const mock_store = mockStore({});
+    const mock_DBot_store = mockDBotStore(mock_store, mock_ws);
+
+    beforeEach(() => {
+        wrapper = ({ children }: { children: JSX.Element }) => (
+            <StoreProvider store={mock_store}>
+                <DBotStoreProvider ws={mock_ws} mock={mock_DBot_store}>
+                    {children}
+                </DBotStoreProvider>
+            </StoreProvider>
+        );
+    });
+    it('should render OnboardingTourMobile component', () => {
+        render(<OnboardingTourMobile />, {
+            wrapper,
+        });
+        expect(screen.getByText('Get started on Deriv Bot')).toBeInTheDocument();
+    });
+
+    it('should render OnboardingTourMobile steps when clicking start', () => {
+        render(<OnboardingTourMobile />, {
+            wrapper,
+        });
+
+        const start_button = screen.getByRole('button', { name: 'Start' });
+        userEvent.click(start_button);
+        expect(screen.getByRole('button', { name: 'Next' })).toBeInTheDocument();
+    });
+
+    it('should render OnboardingTourMobile steps with previous button from second step', () => {
+        render(<OnboardingTourMobile />, {
+            wrapper,
+        });
+
+        const start_button = screen.getByRole('button', { name: 'Start' });
+        userEvent.click(start_button);
+
+        const next_button = screen.getByRole('button', { name: 'Next' });
+        userEvent.click(next_button);
+        expect(screen.getByRole('button', { name: 'Previous' })).toBeInTheDocument();
+
+        const previous_button = screen.getByRole('button', { name: 'Previous' });
+        userEvent.click(previous_button);
+        expect(screen.getByRole('button', { name: 'Next' })).toBeInTheDocument();
+    });
+
+    it('should close OnboardingTourMobile when clicking on skip', () => {
+        render(<OnboardingTourMobile />, {
+            wrapper,
+        });
+
+        const skip_button = screen.getByRole('button', { name: 'Skip' });
+        userEvent.click(skip_button);
+        expect(mock_DBot_store.dashboard.active_tour).toBe('');
+    });
+});

--- a/packages/bot-web-ui/src/pages/tutorials/dbot-tours/onboarding-tour/__tests__/onboarding-tour-mobile.spec.tsx
+++ b/packages/bot-web-ui/src/pages/tutorials/dbot-tours/onboarding-tour/__tests__/onboarding-tour-mobile.spec.tsx
@@ -5,14 +5,8 @@ import userEvent from '@testing-library/user-event';
 import { mock_ws } from 'Utils/mock';
 import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
 import OnboardingTourMobile from '../onboarding-tour-mobile';
-import { DBOT_ONBOARDING_MOBILE } from '../../tour-content';
 
-jest.mock('@deriv/bot-skeleton/src/scratch/blockly', () => jest.fn());
 jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => jest.fn());
-jest.mock('@deriv/bot-skeleton/src/scratch/hooks/block_svg', () => jest.fn());
-jest.mock('@deriv/deriv-charts', () => ({
-    setSmartChartsPublicPath: jest.fn(),
-}));
 
 describe('Onboarding Tour Mobile', () => {
     let wrapper: ({ children }: { children: JSX.Element }) => JSX.Element;


### PR DESCRIPTION
## Changes:

- Added test coverage for all dbot tour files in tutorials folder including
- Onboarding Tour
- Bot Builder Tour
- Tour start and tour end dialog 
- Tour steps
- Tour content

## Screenshots:

<img width="1720" alt="Screenshot 2024-07-30 at 4 36 56 PM" src="https://github.com/user-attachments/assets/e3bda066-c089-4958-b123-480ef4fdbd20">

<img width="1720" alt="Screenshot 2024-07-30 at 4 37 35 PM" src="https://github.com/user-attachments/assets/f1d8e228-4471-4ad9-9229-9aa04d78e8e3">

