### PR TITLE
[DTRA] Maryia/DTRA-1557/feat: [V2] make 1 active_symbols API call for each pair of Vanillas and Turbos contract types

### DIFF
--- a/packages/trader/src/AppV2/Hooks/useActiveSymbols.ts
+++ b/packages/trader/src/AppV2/Hooks/useActiveSymbols.ts
@@ -1,5 +1,13 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { TRADE_TYPES, WS, getContractTypesConfig, pickDefaultSymbol } from '@deriv/shared';
+import {
+    CONTRACT_TYPES,
+    TRADE_TYPES,
+    WS,
+    getContractTypesConfig,
+    isTurbosContract,
+    isVanillaContract,
+    pickDefaultSymbol,
+} from '@deriv/shared';
 import { useStore } from '@deriv/stores';
 import { localize } from '@deriv/translations';
 import { ActiveSymbols } from '@deriv/api-types';
@@ -16,6 +24,8 @@ const useActiveSymbols = () => {
         active_symbols: symbols_from_store,
         contract_type,
         has_symbols_for_v2,
+        is_vanilla,
+        is_turbos,
         onChange,
         setActiveSymbolsV2,
         symbol,
@@ -25,8 +35,14 @@ const useActiveSymbols = () => {
     const previous_logged_in = usePrevious(is_logged_in);
     const previous_contract_type = usePrevious(contract_type);
 
+    const getContractTypesList = () => {
+        if (is_turbos) return [CONTRACT_TYPES.TURBOS.LONG, CONTRACT_TYPES.TURBOS.SHORT];
+        if (is_vanilla) return [CONTRACT_TYPES.VANILLA.CALL, CONTRACT_TYPES.VANILLA.PUT];
+        return getContractTypesConfig()[contract_type]?.trade_types ?? [];
+    };
+
     const fetchActiveSymbols = useCallback(
-        async (trade_type = '') => {
+        async () => {
             let response;
 
             const trade_types_with_barrier_category = [
@@ -34,16 +50,22 @@ const useActiveSymbols = () => {
                 TRADE_TYPES.RISE_FALL_EQUAL,
                 TRADE_TYPES.HIGH_LOW,
             ] as string[];
-            const barrier_category = ContractType.getBarrierCategory(trade_type).barrier_category;
+            const barrier_category = ContractType.getBarrierCategory(contract_type).barrier_category;
 
             const request = {
                 active_symbols: 'brief',
-                contract_type: getContractTypesConfig()[trade_type]?.trade_types ?? [],
-                ...(trade_types_with_barrier_category.includes(trade_type) && barrier_category
+                contract_type: getContractTypesList(),
+                ...(trade_types_with_barrier_category.includes(contract_type) && barrier_category
                     ? { barrier_category: [barrier_category] }
                     : {}),
             };
 
+            if (
+                (isVanillaContract(previous_contract_type) && is_vanilla) ||
+                (isTurbosContract(previous_contract_type) && is_turbos)
+            ) {
+                return;
+            }
             if (is_logged_in) {
                 response = await WS.authorized.activeSymbols(request);
             } else {
@@ -63,14 +85,14 @@ const useActiveSymbols = () => {
             }
         },
         // eslint-disable-next-line react-hooks/exhaustive-deps
-        [is_logged_in, symbol]
+        [contract_type, is_logged_in, is_turbos, is_vanilla, previous_contract_type, symbol]
     );
     useEffect(() => {
         const is_logged_in_changed = previous_logged_in !== undefined && previous_logged_in !== is_logged_in;
         const has_contract_type_changed =
             previous_contract_type && contract_type && previous_contract_type !== contract_type;
         if (!symbols_from_store.length || !has_symbols_for_v2 || is_logged_in_changed || has_contract_type_changed) {
-            fetchActiveSymbols(contract_type);
+            fetchActiveSymbols();
         } else {
             setActiveSymbols(symbols_from_store);
         }


### PR DESCRIPTION
## Changes:

- to make 1 `active_symbols` API call for both of the **Vanillas** contract types (`VANILLALONGCALL`, `VANILLALONGPUT`) only once when `Vanillas` trade type is selected, instead of separate calls for each of them when we switch between `Call`/`Put` tabs:
```
{
       active_symbols: 'brief',
       contract_type: ['VANILLALONGCALL', 'VANILLALONGPUT'],
}
```

- to make 1 `active_symbols` API call for both of the **Turbos** contract types (`TURBOSLONG`, `TURBOSSHORT`) only once when `Turbos` trade type is selected, instead of separate calls for each of them when we switch between `Up`/`Down` tabs:
```
{
       active_symbols: 'brief',
       contract_type: ['TURBOSLONG', 'TURBOSSHORT'],
}

```

