### PR TITLE
DTRA / Kate / DTRA-1561 / Update layout for Even / Odd

### DIFF
--- a/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/__tests__/last-digit-prediction.spec.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/__tests__/last-digit-prediction.spec.tsx
@@ -56,16 +56,6 @@ describe('LastDigitPrediction', () => {
             expect(button).toBeEnabled();
         });
     });
-    it('should render 10 disabled buttons for each digit in stats mode if digit_stats are available', () => {
-        default_mock_store.modules.trade.digit_stats = digit_stats;
-        render(mockLastDigitPrediction({ is_stats_mode: true }));
-
-        const buttons = screen.getAllByRole('button');
-        expect(buttons).toHaveLength(10);
-        buttons.forEach((button: HTMLElement) => {
-            expect(button).toBeDisabled();
-        });
-    });
     it('should render component with correct last digit value when minimized', () => {
         render(mockLastDigitPrediction({ is_minimized: true }));
 

--- a/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/last-digit-prediction.scss
+++ b/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/last-digit-prediction.scss
@@ -60,14 +60,4 @@
             margin: var(--core-spacing-1600) 0;
         }
     }
-    &--stats-mode {
-        border-radius: var(--core-borderRadius-400);
-        background-color: var(--core-color-solid-slate-50);
-        padding: var(--core-spacing-400) var(--core-spacing-800) var(--core-spacing-800);
-
-        .digit button {
-            background-color: unset;
-            border: unset;
-        }
-    }
 }

--- a/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/last-digit-prediction.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/last-digit-prediction.tsx
@@ -9,12 +9,11 @@ import LastDigitSelector from './last-digit-selector';
 
 type TLastDigitSelectorProps = {
     is_minimized?: boolean;
-    is_stats_mode?: boolean;
 };
 
 const displayed_digits = [...Array(10).keys()]; // digits array [0 - 9]
 
-const LastDigitPrediction = observer(({ is_minimized, is_stats_mode }: TLastDigitSelectorProps) => {
+const LastDigitPrediction = observer(({ is_minimized }: TLastDigitSelectorProps) => {
     const { digit_stats = [], last_digit, onChange } = useTraderStore();
     const [is_open, setIsOpen] = React.useState(false);
     const [selected_digit, setSelectedDigit] = React.useState(last_digit);
@@ -59,7 +58,6 @@ const LastDigitPrediction = observer(({ is_minimized, is_stats_mode }: TLastDigi
                                 digit_stats={digit_stats}
                                 onDigitSelect={setSelectedDigit}
                                 selected_digit={selected_digit}
-                                is_stats_mode={is_stats_mode}
                             />
                         </ActionSheet.Content>
                         <ActionSheet.Footer
@@ -75,18 +73,15 @@ const LastDigitPrediction = observer(({ is_minimized, is_stats_mode }: TLastDigi
         );
     if (!digit_stats.length) return <Skeleton height={182} />;
     return (
-        <div className={clsx('last-digit-prediction', is_stats_mode && 'last-digit-prediction--stats-mode')}>
-            {!is_stats_mode && (
-                <CaptionText size='sm' className='last-digit-prediction__title'>
-                    <Localize i18n_default_text='Last digit prediction' />
-                </CaptionText>
-            )}
+        <div className='last-digit-prediction'>
+            <CaptionText size='sm' className='last-digit-prediction__title'>
+                <Localize i18n_default_text='Last digit prediction' />
+            </CaptionText>
             <LastDigitSelector
                 digits={displayed_digits}
                 digit_stats={digit_stats}
                 onDigitSelect={handleLastDigitChange}
                 selected_digit={last_digit}
-                is_stats_mode={is_stats_mode}
             />
         </div>
     );

--- a/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/last-digit-selector.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/last-digit-selector.tsx
@@ -4,18 +4,11 @@ import Digit from './digit';
 type TLastDigitSelectorProps = {
     digits: number[];
     digit_stats: number[];
-    is_stats_mode?: boolean;
     onDigitSelect?: (digit: number) => void;
     selected_digit?: number;
 };
 
-const LastDigitSelector = ({
-    digits = [],
-    digit_stats,
-    is_stats_mode,
-    onDigitSelect,
-    selected_digit,
-}: TLastDigitSelectorProps) => (
+const LastDigitSelector = ({ digits = [], digit_stats, onDigitSelect, selected_digit }: TLastDigitSelectorProps) => (
     <div className='last-digit-prediction__selector'>
         {[...Array(2).keys()].map(row_key => (
             <div key={row_key} className='last-digit-prediction__selector-row'>
@@ -24,8 +17,7 @@ const LastDigitSelector = ({
                         key={digit}
                         digit={digit}
                         digit_stats={digit_stats}
-                        is_active={!is_stats_mode && selected_digit === digit}
-                        is_disabled={is_stats_mode}
+                        is_active={selected_digit === digit}
                         is_max={digit_stats[digit] === Math.max(...digit_stats)}
                         is_min={digit_stats[digit] === Math.min(...digit_stats)}
                         onClick={onDigitSelect}

--- a/packages/trader/src/AppV2/Components/TradeParameters/trade-parameters.scss
+++ b/packages/trader/src/AppV2/Components/TradeParameters/trade-parameters.scss
@@ -32,6 +32,13 @@
             padding: 0px;
             transition: transform 0.5s, opacity 0.5s, max-height 0.5s, padding 0.1s;
 
+            // if container has 2 children, then apply style to children
+            &:has(> :last-child:nth-child(2)) {
+                .trade-params__option--minimized {
+                    width: unset;
+                }
+            }
+
             &::-webkit-scrollbar {
                 display: none;
             }

--- a/packages/trader/src/AppV2/Containers/Trade/trade.tsx
+++ b/packages/trader/src/AppV2/Containers/Trade/trade.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { observer } from 'mobx-react';
 import { Loading } from '@deriv/components';
 import ClosedMarketMessage from 'AppV2/Components/ClosedMarketMessage';
-import { TRADE_TYPES } from '@deriv/shared';
 import { useTraderStore } from 'Stores/useTraderStores';
 import BottomNav from 'AppV2/Components/BottomNav';
 import PurchaseButton from 'AppV2/Components/PurchaseButton';
@@ -13,7 +12,6 @@ import CurrentSpot from 'AppV2/Components/CurrentSpot';
 import { TradeChart } from '../Chart';
 import { isDigitTradeType } from 'Modules/Trading/Helpers/digits';
 import TemporaryTradeTypes from './trade-types';
-import LastDigitPrediction from 'AppV2/Components/TradeParameters/LastDigitPrediction';
 import MarketSelector from 'AppV2/Components/MarketSelector';
 
 const Trade = observer(() => {
@@ -75,7 +73,6 @@ const Trade = observer(() => {
                         />
                         <MarketSelector />
                         {isDigitTradeType(contract_type) && <CurrentSpot />}
-                        {contract_type === TRADE_TYPES.EVEN_ODD && <LastDigitPrediction is_stats_mode />}
                         <TradeParametersContainer>
                             <TradeParameters />
                         </TradeParametersContainer>


### PR DESCRIPTION
## Changes:

- Removed Last digit prediction Stats from Even/Odd trade type according to the latest design;
- Aligned Parameters minimized buttons for stake and duration based on the design for Even/Odd;

### Screenshots:

![Screenshot 2024-08-01 at 5 17 09 PM](https://github.com/user-attachments/assets/313a22e2-2d01-4741-903e-dac829b070ad)
![Screenshot 2024-08-01 at 5 17 15 PM](https://github.com/user-attachments/assets/34775353-8480-4a36-a0c8-eb8aefdc700a)

