### PR TITLE
[DTRA] Maryia/DTRA-1559/feat: [V2] disable vertical scroll on the chart outside Y-axis

### DIFF
--- a/packages/trader/src/AppV2/Containers/Chart/trade-chart.tsx
+++ b/packages/trader/src/AppV2/Containers/Chart/trade-chart.tsx
@@ -148,6 +148,7 @@ const TradeChart = observer(() => {
             enabledChartFooter={false}
             id='trade'
             isMobile={isMobile}
+            isVerticalScrollEnabled={false}
             maxTick={isMobile ? max_ticks : undefined}
             granularity={show_digits_stats || is_accumulator ? 0 : granularity}
             requestAPI={wsSendRequest}


### PR DESCRIPTION
## Changes:

- to disable vertical scroll on the chart outside Y-axis using the new `isVerticalScrollEnabled` SmartCharts prop added in this PR: https://github.com/deriv-com/SmartCharts/pull/1625.
The reason: We need the entire Trade page to be scrolled instead of the chart when users are scrolling vertically on it.