### PR TITLE
[CFDS] shontzu/CFDS-4266/new-password-input-field-is-misaligned-in-MT5-new-password-policy-modal

### DIFF
--- a/packages/appstore/src/components/cfds-listing/cfds-listing.scss
+++ b/packages/appstore/src/components/cfds-listing/cfds-listing.scss
@@ -47,6 +47,7 @@
             }
         }
         @include mobile-or-tablet-screen {
+            padding: 1rem;
             bottom: 0;
             position: sticky;
             justify-content: center;
@@ -2457,6 +2458,11 @@
         &__container {
             padding: 0 1.3rem;
             border-bottom: 1px solid var(--general-hover);
+        }
+    }
+    @include mobile-or-tablet-screen {
+        &__footer-button {
+            padding: 1rem;
         }
     }
 }

--- a/packages/appstore/src/components/cfds-listing/cfds-listing.scss
+++ b/packages/appstore/src/components/cfds-listing/cfds-listing.scss
@@ -36,6 +36,8 @@
         }
     }
     &__footer-button {
+        width: 100%;
+        display: flex;
         background-color: var(--general-main-1);
         button {
             height: 4rem;
@@ -2021,15 +2023,6 @@
     .cfd-password-reset {
         @include mobile-or-tablet-screen {
             flex: 1;
-        }
-    }
-    & .dc-password-meter__container {
-        flex-grow: 1;
-        margin: auto;
-
-        @include mobile-or-tablet-screen {
-            width: calc(100vw - 4.8rem);
-            max-width: 30rem;
         }
     }
     & .mt5-password-field {

--- a/packages/cfd/src/sass/cfd.scss
+++ b/packages/cfd/src/sass/cfd.scss
@@ -66,8 +66,7 @@
         margin: auto;
 
         @include mobile-or-tablet-screen {
-            width: calc(100vw - 4.8rem);
-            max-width: 30rem;
+            max-width: 100%;
         }
     }
     & .mt5-password-field {


### PR DESCRIPTION
## Changes:

- fix input width (tablet and mobile)
- fix footer button width and position (tablet)
- remove duplicated css

### Before: 

<img width="1332" alt="image" src="https://github.com/user-attachments/assets/cb26a580-9260-4fd6-94c8-4dff46534913" />
<img height="400" alt="image" src="https://github.com/user-attachments/assets/d2195db0-9a73-4923-bcef-6d1ea70ca7bb" /> <img height="400" alt="image" src="https://github.com/user-attachments/assets/f9021912-4c02-4dc0-b979-78cf9f720407" />


### After:

<img width="1332" alt="image" src="https://github.com/user-attachments/assets/bbfb934f-fcc4-46bf-872b-7ca4fa3331ac">

<img height="400" src="https://github.com/user-attachments/assets/c07a5ca2-0d2a-473f-9b70-144d9fa99dd9" /> <img height="400" alt="image" src="https://github.com/user-attachments/assets/99fcbb40-aeb8-4438-9085-4ca640f47f93">


