### PR TITLE
[BOT] Sandeep/bot-2072/ssb-fix-already-subscribed

### DIFF
--- a/packages/bot-web-ui/src/pages/server-side-bot/bot-list/bot-list.tsx
+++ b/packages/bot-web-ui/src/pages/server-side-bot/bot-list/bot-list.tsx
@@ -31,6 +31,7 @@ const BotList: React.FC<TBotList> = observer(({ setFormVisibility }) => {
         deleteBot,
         active_bot,
         setActiveBotId,
+        should_subscribe,
     } = server_bot;
 
     const [menu_open, setMenuOpen] = React.useState({ visible: false, y: 0, bot_id: '' });
@@ -40,7 +41,7 @@ const BotList: React.FC<TBotList> = observer(({ setFormVisibility }) => {
     const { is_logged_in } = client;
 
     useEffect(() => {
-        getBotList(true);
+        if (should_subscribe) getBotList();
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 

--- a/packages/bot-web-ui/src/stores/server-side-bot-store.ts
+++ b/packages/bot-web-ui/src/stores/server-side-bot-store.ts
@@ -370,7 +370,6 @@ export default class ServerBotStore {
 
     getBotList = async () => {
         try {
-            this.setShouldSubscribe(false);
             this.setListLoading(true);
             await getAPI();
             // eslint-disable-next-line no-console
@@ -404,6 +403,8 @@ export default class ServerBotStore {
                     msg: localize('Bots loaded successfully'),
                 });
             }
+
+            this.setShouldSubscribe(false);
         } catch (error) {
             // eslint-disable-next-line no-console
             console.dir(error);

--- a/packages/bot-web-ui/src/stores/server-side-bot-store.ts
+++ b/packages/bot-web-ui/src/stores/server-side-bot-store.ts
@@ -106,6 +106,7 @@ export default class ServerBotStore {
     subscriptions: { [key: string]: any } = {};
 
     pocs: { [key: string]: ProposalOpenContract } = {};
+    should_subscribe = true;
 
     constructor(root_store: RootStore) {
         this.root_store = root_store;
@@ -117,6 +118,8 @@ export default class ServerBotStore {
             active_bot: observable,
             pocs: observable,
             journal: observable,
+            should_subscribe: observable,
+            setShouldSubscribe: action,
             performance: computed,
             setListLoading: action,
             getBotList: action,
@@ -361,8 +364,13 @@ export default class ServerBotStore {
         this.transactions = {};
     };
 
-    getBotList = async (should_subscribe?: boolean) => {
+    setShouldSubscribe = (should_subscribe: boolean) => {
+        this.should_subscribe = should_subscribe;
+    };
+
+    getBotList = async () => {
         try {
+            this.setShouldSubscribe(false);
             this.setListLoading(true);
             await getAPI();
             // eslint-disable-next-line no-console
@@ -371,7 +379,7 @@ export default class ServerBotStore {
             // eslint-disable-next-line no-console
             console.info('%cAUTHORIZATION SUCCESSFUL', 'color:green;');
 
-            if (should_subscribe) api_base.api?.onMessage()?.subscribe(this.onMessage);
+            if (this.should_subscribe) api_base.api?.onMessage()?.subscribe(this.onMessage);
 
             const { bot_list, error } = await api_base.api.send({ bot_list: 1 });
             if (error) {
@@ -391,7 +399,7 @@ export default class ServerBotStore {
                 this.subscribeToBotNotification(running_bot?.bot_id);
             }
 
-            if (should_subscribe && !!list.length) {
+            if (this.should_subscribe && !!list.length) {
                 this.onJournalMessage(JOURNAL_TYPE.INFO, {
                     msg: localize('Bots loaded successfully'),
                 });
@@ -461,7 +469,7 @@ export default class ServerBotStore {
                 bot_id: bot_create.bot_id,
                 msg: bot_create.message,
             });
-            this.getBotList(false);
+            this.getBotList();
         } catch (error) {
             // eslint-disable-next-line no-console
             console.dir(error);
@@ -480,7 +488,7 @@ export default class ServerBotStore {
                 return;
             }
 
-            this.getBotList(false);
+            this.getBotList();
             botNotification(bot_remove.message);
             this.onJournalMessage(JOURNAL_TYPE.INFO, {
                 msg: bot_remove.message || localize('Bot deleted successfully'),


### PR DESCRIPTION
## Changes:
We have noticed during the demo that whenever the server bot is running and user jumps from server bot tab to another tab and goes back to server tab, user is encountered with and error `Already Subscribed`.

To fix the error we have added a flag which will make sure that even after switching the tabs the bot do not try to subscribe again since the subscriptions are being handled at store leave.
