### PR TITLE
[BOT]TrackJS/Rupato/BOT-1320/Fix-Cannot-Read-Properties-undefined-set

### DIFF
--- a/packages/bot-skeleton/src/scratch/hooks/workspace_svg.js
+++ b/packages/bot-skeleton/src/scratch/hooks/workspace_svg.js
@@ -65,7 +65,7 @@ Blockly.WorkspaceSvg.prototype.centerOnBlock = function (id, hideChaff = true) {
         Blockly.hideChaff();
     }
 
-    this.scrollbar.set(scrollToCenterX, scrollToCenterY);
+    this?.scrollbar?.set(scrollToCenterX, scrollToCenterY);
 };
 
 /**

--- a/packages/bot-skeleton/src/scratch/utils/index.js
+++ b/packages/bot-skeleton/src/scratch/utils/index.js
@@ -458,16 +458,16 @@ export const scrollWorkspace = (workspace, scroll_amount, is_horizontal, is_chro
         */
 
         if (window.innerWidth < 768) {
-            workspace.scrollbar.set(0, scroll_y);
+            workspace?.scrollbar?.set(0, scroll_y);
             const calc_scroll =
                 workspace.svgBlockCanvas_?.getBoundingClientRect().width -
                 workspace.svgBlockCanvas_?.getBoundingClientRect().left +
                 60;
-            workspace.scrollbar.set(calc_scroll, scroll_y);
+            workspace?.scrollbar?.set(calc_scroll, scroll_y);
             return;
         }
     }
-    workspace.scrollbar.set(scroll_x, scroll_y);
+    workspace?.scrollbar?.set(scroll_x, scroll_y);
 };
 
 /**

--- a/packages/bot-web-ui/src/stores/app-store.ts
+++ b/packages/bot-web-ui/src/stores/app-store.ts
@@ -292,7 +292,7 @@ export default class AppStore {
                                 .filter(block => block.type === 'trade_definition_market')
                                 .forEach(block => {
                                     runIrreversibleEvents(() => {
-                                        const fake_create_event = new window.Blockly.Events.BlockCreate(this);
+                                        const fake_create_event = new window.Blockly.Events.BlockCreate(block);
                                         window.Blockly.Events.fire(fake_create_event);
                                     });
                                 });

--- a/packages/bot-web-ui/src/stores/toolbox-store.ts
+++ b/packages/bot-web-ui/src/stores/toolbox-store.ts
@@ -136,7 +136,7 @@ export default class ToolboxStore {
                 const workspace_metrics = workspace.getMetrics();
                 const block_canvas_space =
                     workspace_metrics.scrollWidth + workspace_metrics.viewLeft - workspace_metrics.viewWidth;
-                workspace.scrollbar.set(block_canvas_space, scroll_y);
+                workspace?.scrollbar?.set(block_canvas_space, scroll_y);
             }
         }
     }


### PR DESCRIPTION
- This PR addresses issues with the track JS that emerged after we changed the Blockly reference according to the import loader. As a result, registerOnAccountSwitch was executed on a switcher change, leading to an error where id was undefined. This occurred because we were not sending the correct block reference.
- Additionally, when resizing the workspace, the scrollbar was set to null, which caused an "undefined" error in the scrollbar set method.

