### PR TITLE
[WALL] [WEBREL] aum / WEBREL-3055 / wallet-password-validation-error-DerivX-MT5

### DIFF
--- a/packages/wallets/src/constants/password.ts
+++ b/packages/wallets/src/constants/password.ts
@@ -32,11 +32,11 @@ export const passwordValues = {
 };
 
 export const getPasswordErrorMessage = () => ({
-    invalidLength: localize('You should enter{{minLength}}-{{maxLength}} characters.', {
+    invalidLength: localize('You should enter {{minLength}}-{{maxLength}} characters.', {
         maxLength: passwordValues.maxLength,
         minLength: passwordValues.minLength,
     }),
-    invalidLengthMT5: localize('You should enter {{minLength}}-{{maxLengthMT5}} characters.', {
+    invalidLengthMT5: localize('You should enter {{minLength}}-{{maxLength}} characters.', {
         maxLength: passwordValues.maxLengthMT5,
         minLength: passwordValues.minLength,
     }),


### PR DESCRIPTION
## Changes:

Fix error message shown during password field validation for MT5 and DerivX accounts.

### Screenshots:

Please provide some screenshots of the change.
