### PR TITLE
Hirad/TRAH-3854/Adding a new empty div for clever tap

### DIFF
--- a/packages/appstore/src/modules/traders-hub/index.tsx
+++ b/packages/appstore/src/modules/traders-hub/index.tsx
@@ -59,7 +59,7 @@ const TradersHub = observer(() => {
     } = client;
 
     const { is_eu_demo, is_eu_real } = useContentFlag();
-    const { selected_platform_type, setTogglePlatformType, is_eu_user } = traders_hub;
+    const { selected_platform_type, setTogglePlatformType, is_eu_user, is_real } = traders_hub;
     const traders_hub_ref = React.useRef<HTMLDivElement>(null);
 
     const can_show_notify =
@@ -162,6 +162,7 @@ const TradersHub = observer(() => {
                     })}
                     ref={traders_hub_ref}
                 >
+                    {has_any_real_account && is_real && <div className='get-started-trading-banner-ct' />}
                     {should_show_banner && !has_any_real_account && !is_eu && is_landing_company_loaded && (
                         <Suspense fallback={<div />}>
                             <RealAccountCreationBanner />


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
To show Clevertap banner, we'll need an empty DIV with a class name specified below. Please follow the screenshot to follow the placement of the DIV. Make sure it's also available after the real account is just created.

### Screenshots:

Please provide some screenshots of the change.

![image](https://github.com/user-attachments/assets/df29d5a3-fe23-4a97-b0d4-6f48b4e78436)

