### PR TITLE
[P2PS] / Ameerul / P2PS-3224 P2P page is stuck on loading when switching accounts

### DIFF
--- a/packages/p2p/src/stores/general-store.js
+++ b/packages/p2p/src/stores/general-store.js
@@ -519,6 +519,8 @@ export default class GeneralStore extends BaseStore {
                 ),
             };
         });
+
+        this.setIsLoading(false);
     }
 
     onUnmount() {


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- Added setIsLoading(false) at the end of onMount function in general store as it sets it to true even after it was set to false due to how p2p renders when switching from BTC to USD.

### Screenshots:

Please provide some screenshots of the change.

https://github.com/user-attachments/assets/828e4f4d-dbda-4004-b766-2457340ea6f0



https://github.com/user-attachments/assets/54a18fa8-f4f2-40be-8e8d-623d84de5e06

