### PR TITLE
Update deriv-charts to 2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "@deriv-com/utils": "^0.0.25",
                 "@deriv/api-types": "1.0.172",
                 "@deriv/deriv-api": "^1.0.15",
-                "@deriv/deriv-charts": "^2.2.0",
+                "@deriv/deriv-charts": "^2.3.0",
                 "@deriv/js-interpreter": "^3.0.0",
                 "@deriv/quill-design": "^1.3.2",
                 "@deriv/quill-icons": "1.23.3",
@@ -3180,9 +3180,9 @@
             }
         },
         "node_modules/@deriv/deriv-charts": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.2.0.tgz",
-            "integrity": "sha512-q60cKdWrSHXeSbpY3WohMkmYn+mK4jlJJS+/ytmtOxPAUOdpIkplku8Jvq6+4kGuVAND1SqvwUJpMkK+767MQg==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.3.0.tgz",
+            "integrity": "sha512-+PRhXVeCgJmo+3feuyA68vhSZkJaj7u3saQlX4pFiwzDcDLPuAYBWQQA7jrYeoxH/BeKhpN+5qkJGxSRMQVfGA==",
             "dependencies": {
                 "@types/lodash.set": "^4.3.7",
                 "@welldone-software/why-did-you-render": "^3.3.8",

--- a/packages/bot-web-ui/package.json
+++ b/packages/bot-web-ui/package.json
@@ -77,7 +77,7 @@
         "@deriv/bot-skeleton": "^1.0.0",
         "@deriv/components": "^1.0.0",
         "@deriv/hooks": "^1.0.0",
-        "@deriv/deriv-charts": "^2.2.0",
+        "@deriv/deriv-charts": "^2.3.0",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",
         "@deriv/translations": "^1.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -111,7 +111,7 @@
         "@deriv/cfd": "^1.0.0",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv/deriv-charts": "^2.2.0",
+        "@deriv/deriv-charts": "^2.3.0",
         "@deriv/hooks": "^1.0.0",
         "@deriv/p2p": "^0.7.3",
         "@deriv/quill-design": "^1.3.2",

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -96,7 +96,7 @@
         "@deriv/api-types": "1.0.172",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv/deriv-charts": "^2.2.0",
+        "@deriv/deriv-charts": "^2.3.0",
         "@deriv/hooks": "^1.0.0",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",


### PR DESCRIPTION
This PR updates @deriv/deriv-charts to 2.3.0