### PR TITLE
Rupato/bot 2098/fix delete and zoom after blockly update

### DIFF
--- a/packages/bot-skeleton/src/scratch/dbot.js
+++ b/packages/bot-skeleton/src/scratch/dbot.js
@@ -133,10 +133,7 @@ class DBot {
                 this.workspace.addChangeListener(event => updateDisabledBlocks(this.workspace, event));
                 this.workspace.addChangeListener(event => this.workspace.dispatchBlockEventEffects(event));
                 this.workspace.addChangeListener(event => {
-                    if (event.type === 'drag' && !event.isStart && !is_mobile) {
-                        this.workspace.cancelCurrentGesture();
-                        validateErrorOnBlockDelete();
-                    }
+                    if (event.type === 'drag' && !event.isStart && !is_mobile) validateErrorOnBlockDelete();
                     if (event.type == Blockly.Events.BLOCK_CHANGE) {
                         const block = this.workspace.getBlockById(event.blockId);
                         if (is_mobile && block && event.element == 'collapsed') {

--- a/packages/bot-skeleton/src/scratch/dbot.js
+++ b/packages/bot-skeleton/src/scratch/dbot.js
@@ -133,7 +133,10 @@ class DBot {
                 this.workspace.addChangeListener(event => updateDisabledBlocks(this.workspace, event));
                 this.workspace.addChangeListener(event => this.workspace.dispatchBlockEventEffects(event));
                 this.workspace.addChangeListener(event => {
-                    if (event.type === 'drag' && !event.isStart && !is_mobile) validateErrorOnBlockDelete();
+                    if (event.type === 'drag' && !event.isStart && !is_mobile) {
+                        this.workspace.cancelCurrentGesture();
+                        validateErrorOnBlockDelete();
+                    }
                     if (event.type == Blockly.Events.BLOCK_CHANGE) {
                         const block = this.workspace.getBlockById(event.blockId);
                         if (is_mobile && block && event.element == 'collapsed') {

--- a/packages/bot-skeleton/src/scratch/hooks/gesture.js
+++ b/packages/bot-skeleton/src/scratch/hooks/gesture.js
@@ -27,6 +27,9 @@ Blockly.Gesture.prototype.updateIsDraggingFromFlyout = function () {
         this.startBlock = null;
         this.targetBlock = this.flyout.createBlock(this.mostRecentEvent, this.targetBlock);
         this.targetBlock.select();
+
+        // retuning true since block is being dragged from flyout
+        Blockly.Gesture.inProgress = () => false;
         return true;
     }
     return false;

--- a/packages/bot-skeleton/src/scratch/hooks/gesture.js
+++ b/packages/bot-skeleton/src/scratch/hooks/gesture.js
@@ -24,10 +24,10 @@ Blockly.Gesture.prototype.updateIsDraggingFromFlyout = function () {
         }
 
         // The start block is no longer relevant, because this is a drag.
+        this.startBlock.workspace.clearGesture();
         this.startBlock = null;
         this.targetBlock = this.flyout.createBlock(this.mostRecentEvent, this.targetBlock);
         this.targetBlock.select();
-        this.startBlock.workspace.clearGesture();
         return true;
     }
     return false;

--- a/packages/bot-skeleton/src/scratch/hooks/gesture.js
+++ b/packages/bot-skeleton/src/scratch/hooks/gesture.js
@@ -27,6 +27,7 @@ Blockly.Gesture.prototype.updateIsDraggingFromFlyout = function () {
         this.startBlock = null;
         this.targetBlock = this.flyout.createBlock(this.mostRecentEvent, this.targetBlock);
         this.targetBlock.select();
+        this.startBlock.workspace.clearGesture();
         return true;
     }
     return false;

--- a/packages/bot-skeleton/src/scratch/hooks/gesture.js
+++ b/packages/bot-skeleton/src/scratch/hooks/gesture.js
@@ -27,9 +27,6 @@ Blockly.Gesture.prototype.updateIsDraggingFromFlyout = function () {
         this.startBlock = null;
         this.targetBlock = this.flyout.createBlock(this.mostRecentEvent, this.targetBlock);
         this.targetBlock.select();
-
-        // retuning false since block has been dragged from flyout
-        Blockly.Gesture.inProgress = () => false;
         return true;
     }
     return false;

--- a/packages/bot-skeleton/src/scratch/hooks/gesture.js
+++ b/packages/bot-skeleton/src/scratch/hooks/gesture.js
@@ -28,7 +28,7 @@ Blockly.Gesture.prototype.updateIsDraggingFromFlyout = function () {
         this.targetBlock = this.flyout.createBlock(this.mostRecentEvent, this.targetBlock);
         this.targetBlock.select();
 
-        // retuning true since block is being dragged from flyout
+        // retuning true since block has been dragged from flyout
         Blockly.Gesture.inProgress = () => false;
         return true;
     }

--- a/packages/bot-skeleton/src/scratch/hooks/gesture.js
+++ b/packages/bot-skeleton/src/scratch/hooks/gesture.js
@@ -28,7 +28,7 @@ Blockly.Gesture.prototype.updateIsDraggingFromFlyout = function () {
         this.targetBlock = this.flyout.createBlock(this.mostRecentEvent, this.targetBlock);
         this.targetBlock.select();
 
-        // retuning true since block has been dragged from flyout
+        // retuning false since block has been dragged from flyout
         Blockly.Gesture.inProgress = () => false;
         return true;
     }


### PR DESCRIPTION
Changed the return type of the method to false after the block is dragged from the flyout. Because other events do not trigger unless this is set to false. The method returns true while the block is being dragged from the flyout.