### PR TITLE
[CFDS][TRAH] shontzu/CFDS-3959/Financial-Assessment-hyperlink-is-not-working-from-transfer-page

### DIFF
--- a/packages/appstore/src/components/account-transfer-modal/__tests__/account-transfer-modal.spec.tsx
+++ b/packages/appstore/src/components/account-transfer-modal/__tests__/account-transfer-modal.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import AccountTransferModal from '../account-transfer-modal';
 import { render, screen } from '@testing-library/react';
 import { StoreProvider, mockStore } from '@deriv/stores';
+import { MemoryRouter } from 'react-router-dom';
 
 jest.mock('@deriv/cashier/src/pages/account-transfer', () => jest.fn(() => <div>AccountTransfer</div>));
 
@@ -24,6 +25,7 @@ describe('AccountTransferModal', () => {
                     account_transfer: {
                         is_transfer_confirm: false,
                         should_switch_account: false,
+                        error: '',
                     },
                     general_store: { setActiveTab: jest.fn() },
                 },
@@ -50,6 +52,7 @@ describe('AccountTransferModal', () => {
                     account_transfer: {
                         is_transfer_confirm: false,
                         should_switch_account: false,
+                        error: '',
                     },
                     general_store: { setActiveTab: jest.fn() },
                 },
@@ -77,6 +80,7 @@ describe('AccountTransferModal', () => {
                     account_transfer: {
                         is_transfer_confirm: false,
                         should_switch_account: true,
+                        error: '',
                     },
                     general_store: { setActiveTab: jest.fn() },
                 },
@@ -98,5 +102,39 @@ describe('AccountTransferModal', () => {
         expect(screen.getByText('Transfer funds to your accounts')).toHaveClass(
             'dc-modal-header__title--account-transfer-modal'
         );
+    });
+
+    it('should open error dialog when financial assessment error is present', async () => {
+        const mock = mockStore({
+            modules: {
+                cashier: {
+                    account_transfer: {
+                        is_transfer_confirm: false,
+                        should_switch_account: true,
+                        error: {
+                            code: 'FinancialAssessmentRequired',
+                            message: 'Please complete your financial assessment.',
+                        },
+                    },
+                    general_store: { setActiveTab: jest.fn() },
+                },
+            },
+        });
+
+        const wrapper = ({ children }: { children: JSX.Element }) => (
+            <StoreProvider store={mock}>
+                <MemoryRouter>{children}</MemoryRouter>
+            </StoreProvider>
+        );
+
+        render(
+            <AccountTransferModal is_modal_open={true} toggleModal={mock.traders_hub.toggleAccountTransferModal} />,
+            {
+                wrapper,
+            }
+        );
+
+        expect(screen.getByText('Cashier Error')).toBeInTheDocument();
+        expect(screen.getByText(/financial assessment/i)).toBeInTheDocument();
     });
 });

--- a/packages/appstore/src/components/account-transfer-modal/account-transfer-modal.tsx
+++ b/packages/appstore/src/components/account-transfer-modal/account-transfer-modal.tsx
@@ -54,16 +54,18 @@ const AccountTransferModal = observer(({ is_modal_open, toggleModal }: TAccountT
         history.push(routes.cashier_acc_transfer);
     };
 
+    const dismissError = () => {
+        toggleModal();
+        setIsErrorDialogOpen(false);
+        error.setErrorMessage({ code: '', message: '' }, null, false);
+    };
+
     if (is_error_dialog_open) {
         return (
             <Dialog
                 title={localize('Cashier Error')}
                 confirm_button_text={localize('OK')}
-                onConfirm={() => {
-                    toggleModal();
-                    setIsErrorDialogOpen(false);
-                    error.setErrorMessage({ code: '', message: '' }, null, false);
-                }}
+                onConfirm={dismissError}
                 is_visible={is_error_dialog_open}
                 has_close_icon={false}
                 dismissable={false}
@@ -71,16 +73,7 @@ const AccountTransferModal = observer(({ is_modal_open, toggleModal }: TAccountT
                 <Localize
                     i18n_default_text='Please complete your <0>financial assessment</0>.'
                     components={[
-                        <Link
-                            to={routes.financial_assessment}
-                            key={0}
-                            className='link'
-                            onClick={() => {
-                                toggleModal();
-                                setIsErrorDialogOpen(false);
-                                error.setErrorMessage({ code: '', message: '' }, null, false);
-                            }}
-                        />,
+                        <Link to={routes.financial_assessment} key={0} className='link' onClick={dismissError} />,
                     ]}
                 />
             </Dialog>

--- a/packages/appstore/src/components/account-transfer-modal/account-transfer-modal.tsx
+++ b/packages/appstore/src/components/account-transfer-modal/account-transfer-modal.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { useHistory } from 'react-router-dom';
-import { Modal } from '@deriv/components';
+import { Link, useHistory } from 'react-router-dom';
+import { Modal, Dialog } from '@deriv/components';
 import { routes } from '@deriv/shared';
 import { useStore, observer } from '@deriv/stores';
-import { Localize } from '@deriv/translations';
+import { Localize, localize } from '@deriv/translations';
 import AccountTransfer from '@deriv/cashier/src/pages/account-transfer';
 import './account-transfer-modal.scss';
 
@@ -16,17 +16,19 @@ const AccountTransferModal = observer(({ is_modal_open, toggleModal }: TAccountT
     const {
         modules: {
             cashier: {
-                account_transfer: { is_transfer_confirm, should_switch_account, setShouldSwitchAccount },
+                account_transfer: { is_transfer_confirm, should_switch_account, setShouldSwitchAccount, error },
                 general_store: { setActiveTab },
             },
         },
         traders_hub: { closeModal, setSelectedAccount },
     } = useStore();
+    const [is_error_dialog_open, setIsErrorDialogOpen] = React.useState(false);
 
     const history = useHistory();
 
     React.useEffect(() => {
         if (is_modal_open) setActiveTab('account_transfer');
+        if (error.code === 'FinancialAssessmentRequired') setIsErrorDialogOpen(true);
 
         return () => {
             if (is_modal_open) {
@@ -35,9 +37,10 @@ const AccountTransferModal = observer(({ is_modal_open, toggleModal }: TAccountT
                 setActiveTab('deposit');
                 closeModal();
             }
+            if (error.code === 'FinancialAssessmentRequired') setIsErrorDialogOpen(false);
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [is_modal_open]);
+    }, [is_modal_open, error.code]);
 
     const modal_title = !is_transfer_confirm && <Localize i18n_default_text={'Transfer funds to your accounts'} />;
 
@@ -50,6 +53,39 @@ const AccountTransferModal = observer(({ is_modal_open, toggleModal }: TAccountT
         toggleModal();
         history.push(routes.cashier_acc_transfer);
     };
+
+    if (is_error_dialog_open) {
+        return (
+            <Dialog
+                title={localize('Cashier Error')}
+                confirm_button_text={localize('OK')}
+                onConfirm={() => {
+                    toggleModal();
+                    setIsErrorDialogOpen(false);
+                    error.setErrorMessage({ code: '', message: '' }, null, false);
+                }}
+                is_visible={is_error_dialog_open}
+                has_close_icon={false}
+                dismissable={false}
+            >
+                <Localize
+                    i18n_default_text='Please complete your <0>financial assessment</0>.'
+                    components={[
+                        <Link
+                            to={routes.financial_assessment}
+                            key={0}
+                            className='link'
+                            onClick={() => {
+                                toggleModal();
+                                setIsErrorDialogOpen(false);
+                                error.setErrorMessage({ code: '', message: '' }, null, false);
+                            }}
+                        />,
+                    ]}
+                />
+            </Dialog>
+        );
+    }
 
     return (
         <Modal

--- a/packages/cashier/src/pages/account-transfer/account-transfer-form/__tests__/account-transfer-form.spec.tsx
+++ b/packages/cashier/src/pages/account-transfer/account-transfer-form/__tests__/account-transfer-form.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MT5_ACCOUNT_STATUS, isMobile } from '@deriv/shared';
+import { MT5_ACCOUNT_STATUS, isMobile, routes } from '@deriv/shared';
 import { fireEvent, render, screen } from '@testing-library/react';
 import CashierProviders from '../../../../cashier-providers';
 import { mockStore } from '@deriv/stores';
@@ -129,6 +129,11 @@ describe('<AccountTransferForm />', () => {
     };
 
     const renderAccountTransferForm = () => {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: { pathname: routes.cashier },
+        });
+
         render(<AccountTransferForm {...props} />, {
             wrapper: ({ children }) => <CashierProviders store={mockRootStore}>{children}</CashierProviders>,
         });

--- a/packages/cashier/src/pages/account-transfer/account-transfer-form/account-transfer-form.tsx
+++ b/packages/cashier/src/pages/account-transfer/account-transfer-form/account-transfer-form.tsx
@@ -779,7 +779,7 @@ const AccountTransferForm = observer(
                                                 />
                                             </SideNote>
                                         )}
-                                        <ErrorDialog error={error} />
+                                        {!is_from_outside_cashier && <ErrorDialog error={error} />}
                                     </Form>
                                 </>
                             )}

--- a/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts.scss
+++ b/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts.scss
@@ -35,7 +35,7 @@
             justify-content: center;
             margin-left: 13rem;
             &--mobile {
-                margin-left: 10.5rem;
+                margin-left: 0;
             }
         }
     }

--- a/packages/components/src/components/cfd-compare-accounts-carousel/cfd-compare-accounts-carousel.scss
+++ b/packages/components/src/components/cfd-compare-accounts-carousel/cfd-compare-accounts-carousel.scss
@@ -8,7 +8,7 @@
         overflow: hidden;
         width: 100%;
         height: 100%;
-        @include mobile {
+        @include mobile-or-tablet-screen {
             padding-bottom: 6rem;
         }
     }
@@ -20,6 +20,9 @@
         max-height: auto;
         margin-left: calc(var(--slide-spacing) * -1);
         transition: transform 0s ease-in-out;
+        @include mobile-or-tablet-screen {
+            justify-content: safe center;
+        }
     }
     &__slide {
         flex: 0 0 var(--slide-size);


### PR DESCRIPTION
## Changes:

- financial assessment link redirection is handled in `cashier` but not handled in `appstore`
- "Financial Assessment" redirection link on `tradershub` and `cashier` properly redirects to `accounts/financial-assessment`
- "OK" button dismisses the error
- navigating between `/cashier/transfer` and `/tradershub` does not cause modal or dialog popup issue
- added unit test for the dialog
- included a small css fix in cfd-compare-accounts

### Screenshots:

https://github.com/user-attachments/assets/ccf6e0dc-34d9-4add-99e8-023611ca95b4



