### PR TITLE
[BOT] Farabi/bot-1493/test coverage analytics folder

### DIFF
--- a/packages/bot-web-ui/src/analytics/__tests__/utils.spec.ts
+++ b/packages/bot-web-ui/src/analytics/__tests__/utils.spec.ts
@@ -1,8 +1,25 @@
-import { DBOT_TABS } from 'Constants/bot-contents';
-import { TFormStrategy } from '../constants';
-import { getRsDropdownTextFromLocalStorage, getTradeParameterData, rudderstack_text_error } from '../utils';
+import { Analytics } from '@deriv-com/analytics';
+import { ACTION, TFormStrategy } from '../constants';
+import { rudderStackSendSwitchLoadStrategyTabEvent } from '../rudderstack-bot-builder';
+import {
+    rudderStackSendGoogleDriveConnectEvent,
+    rudderStackSendGoogleDriveDisconnectEvent,
+    rudderStackSendUploadStrategyCompletedEvent,
+} from '../rudderstack-common-events';
+import {
+    getRsDropdownTextFromLocalStorage,
+    getStrategyType,
+    getTradeParameterData,
+    rudderstack_text_error,
+} from '../utils';
 
 jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => jest.fn());
+
+jest.mock('@deriv-com/analytics', () => ({
+    Analytics: {
+        trackEvent: jest.fn(),
+    },
+}));
 
 describe('utils', () => {
     const form_strategy = {
@@ -68,6 +85,114 @@ describe('utils', () => {
             trade_type: 'CALL',
             purchase_condition: 'MULT',
             initial_stake: '100',
+        });
+    });
+
+    it('should return "new" if the XML has is_dbot="true"', () => {
+        const xml = `
+            <xml is_dbot="true">
+                <block></block>
+            </xml>`;
+
+        const result = getStrategyType(xml);
+        expect(result).toBe('new');
+    });
+
+    it('should return "old" if the XML has is_dbot="false"', () => {
+        const xml = `
+            <xml is_dbot="false">
+                <someElement></someElement>
+            </xml>`;
+
+        const result = getStrategyType(xml);
+        expect(result).toBe('old');
+    });
+
+    it('should return "old" if the XML does not contain the is_dbot attribute', () => {
+        const xml = `
+            <xml>
+                <block></block>
+            </xml>`;
+        const result = getStrategyType(xml);
+        expect(result).toBe('old');
+    });
+
+    it('should return "old" for invalid XML', () => {
+        const xml = `
+            <xml>
+                <block>
+            </xml>`;
+
+        const result = getStrategyType(xml);
+        expect(result).toBe('old');
+    });
+
+    it('should return "old" if an unexpected error occurs during parsing', () => {
+        global.DOMParser = jest.fn().mockImplementation(() => {
+            return {
+                parseFromString: () => {
+                    throw new Error('Parsing error');
+                },
+            };
+        });
+
+        const xml = '<xml></xml>';
+        const result = getStrategyType(xml);
+
+        expect(result).toBe('old');
+    });
+
+    it('should call Analytics.trackEvent with the correct parameters', () => {
+        const load_strategy = { load_strategy_tab: 'local' };
+
+        rudderStackSendSwitchLoadStrategyTabEvent(load_strategy);
+
+        expect(Analytics.trackEvent).toHaveBeenCalledWith('ce_bot_form', {
+            action: ACTION.SWITCH_LOAD_STRATEGY_TAB,
+            form_name: 'ce_bot_form',
+            load_strategy_tab: load_strategy.load_strategy_tab,
+            subform_name: 'load_strategy',
+            subpage_name: 'bot_builder',
+        });
+    });
+
+    it('should call Analytics.trackEvent with correct parameters for upload strategy completed event', () => {
+        const upload_parameters = {
+            upload_provider: 'my_computer',
+            upload_id: '12345',
+            upload_type: 'new',
+        };
+
+        rudderStackSendUploadStrategyCompletedEvent(upload_parameters);
+
+        expect(Analytics.trackEvent).toHaveBeenCalledWith('ce_bot_form', {
+            action: ACTION.UPLOAD_STRATEGY_COMPLETED,
+            form_name: 'ce_bot_form',
+            subform_name: 'load_strategy',
+            subpage_name: 'bot_builder',
+            upload_provider: upload_parameters.upload_provider,
+            upload_id: upload_parameters.upload_id,
+            upload_type: upload_parameters.upload_type,
+        });
+    });
+
+    it('should call Analytics.trackEvent with correct parameters for Google Drive connect event', () => {
+        rudderStackSendGoogleDriveConnectEvent();
+
+        expect(Analytics.trackEvent).toHaveBeenCalledWith('ce_bot_form', {
+            action: ACTION.GOOGLE_DRIVE_CONNECT,
+            form_name: 'ce_bot_form',
+            subpage_name: 'bot_builder',
+        });
+    });
+
+    it('should call Analytics.trackEvent with correct parameters for Google Drive disconnect event', () => {
+        rudderStackSendGoogleDriveDisconnectEvent();
+
+        expect(Analytics.trackEvent).toHaveBeenCalledWith('ce_bot_form', {
+            action: ACTION.GOOGLE_DRIVE_DISCONNECT,
+            form_name: 'ce_bot_form',
+            subpage_name: 'bot_builder',
         });
     });
 });


### PR DESCRIPTION
## Changes:

- Test coverage for rudderstack files under analytics folder:


### Screenshots:

<img width="1717" alt="Screenshot 2024-08-13 at 7 03 18 PM" src="https://github.com/user-attachments/assets/46077a0c-8a76-4f40-b77a-684b9b1a732d">
