### PR TITLE
[UPM-1375] Add tnc_acceptance field to account creation(real/malta) api req

### DIFF
--- a/packages/account/src/Components/terms-of-use/__tests__/terms-of-use.spec.tsx
+++ b/packages/account/src/Components/terms-of-use/__tests__/terms-of-use.spec.tsx
@@ -43,7 +43,7 @@ describe('<TermsOfUse/>', () => {
         onSubmit: jest.fn(),
         onSave: jest.fn(),
         real_account_signup_target: 'svg',
-        value: { agreed_tos: false, agreed_tnc: false },
+        value: { agreed_tos: false, tnc_acceptance: false },
         residence: 'id',
         is_multi_account: false,
     };

--- a/packages/account/src/Components/terms-of-use/terms-of-use.tsx
+++ b/packages/account/src/Components/terms-of-use/terms-of-use.tsx
@@ -21,7 +21,7 @@ import { useDevice } from '@deriv-com/ui';
 
 type TTermsOfUseFormProps = {
     agreed_tos: boolean;
-    agreed_tnc: boolean;
+    tnc_acceptance: boolean;
     fatca_declaration?: '0' | '1';
     resident_self_declaration?: boolean;
 };
@@ -132,8 +132,8 @@ const TermsOfUse = observer(
                                                 component={CheckboxField}
                                                 label_font_size={isDesktop ? 'xs' : 'xxs'}
                                                 className='terms-of-use__checkbox'
-                                                name='agreed_tnc'
-                                                id='agreed_tnc'
+                                                name='tnc_acceptance'
+                                                id='tnc_acceptance'
                                                 label={
                                                     <Localize
                                                         i18n_default_text='I agree to the <0>terms and conditions</0>.'
@@ -171,7 +171,7 @@ const TermsOfUse = observer(
                                         is_disabled={
                                             isSubmitting ||
                                             !values.agreed_tos ||
-                                            !values.agreed_tnc ||
+                                            !values.tnc_acceptance ||
                                             !values.fatca_declaration ||
                                             !(is_residence_self_declaration_required
                                                 ? values.resident_self_declaration

--- a/packages/account/src/Configs/terms-of-use-config.ts
+++ b/packages/account/src/Configs/terms-of-use-config.ts
@@ -10,7 +10,7 @@ const getTermsOfUseConfig = (account_settings: TTermsOfConfigSettings) => ({
         supported_in: ['svg', 'maltainvest'],
         default_value: false,
     },
-    agreed_tnc: {
+    tnc_acceptance: {
         supported_in: ['svg', 'maltainvest'],
         default_value: false,
     },

--- a/packages/core/src/App/Containers/RealAccountSignup/account-wizard.jsx
+++ b/packages/core/src/App/Containers/RealAccountSignup/account-wizard.jsx
@@ -298,7 +298,6 @@ const AccountWizard = observer(props => {
     const submitForm = (payload = undefined) => {
         let clone = { ...form_values() };
         delete clone?.tax_identification_confirm;
-        delete clone?.agreed_tnc;
         delete clone?.agreed_tos;
         delete clone?.confirmation_checkbox;
         delete clone?.crs_confirmation;
@@ -314,6 +313,9 @@ const AccountWizard = observer(props => {
             delete clone.tax_identification_number;
         }
 
+        if (clone?.tnc_acceptance[0] === 'on') {
+            clone.tnc_acceptance = 1;
+        }
         clone = processInputData(clone);
         modifiedProps.setRealAccountFormData(clone);
         if (payload) {


### PR DESCRIPTION
## Changes:

This PR implement's the T&C acceptance for the new account creation for real, Malta invest. The PR adds a new flag called `tnc_acceptance : 1` to `new_account_maltainvest` and `new_account_real` api request payload.


### Screenshots:
