### PR TITLE
Lubega / TRAH-3965 / Trader's hub link underline fix

### DIFF
--- a/packages/appstore/src/components/containers/listing-container.scss
+++ b/packages/appstore/src/components/containers/listing-container.scss
@@ -92,4 +92,8 @@
 
 .options {
     color: var(--text-red);
+
+    a {
+        text-decoration: underline;
+    }
 }

--- a/packages/appstore/src/components/containers/listing-container.scss
+++ b/packages/appstore/src/components/containers/listing-container.scss
@@ -92,8 +92,5 @@
 
 .options {
     color: var(--text-red);
-
-    a {
-        text-decoration: underline;
-    }
+    text-decoration: underline;
 }


### PR DESCRIPTION
## Changes:

- [x] Added underline to Trader's Hub `Learn more` link

### Before:

<img width="1335" alt="Screenshot 2024-08-16 at 11 14 17 AM" src="https://github.com/user-attachments/assets/864aa646-98c5-4a9b-8a38-e104cce5e8e3">
<img width="422" alt="Screenshot 2024-08-16 at 11 14 30 AM" src="https://github.com/user-attachments/assets/b46976c7-c7e6-4546-90e6-95a827abaf5c">

### After:
<img width="1338" alt="Screenshot 2024-08-16 at 11 33 20 AM" src="https://github.com/user-attachments/assets/bbb27346-d8bf-4c60-868c-d5f91a801f4f">
<img width="422" alt="Screenshot 2024-08-16 at 11 33 01 AM" src="https://github.com/user-attachments/assets/83f6b268-972d-4b29-8187-66588a35bfa8">

