### PR TITLE
[WEBREL] aum/WEBREL-3083/wallet-poi-asked-again-after-creation-of-regulated-mt5-account

### DIFF
--- a/packages/wallets/src/features/cfd/flows/ClientVerification/ClientVerification.tsx
+++ b/packages/wallets/src/features/cfd/flows/ClientVerification/ClientVerification.tsx
@@ -57,10 +57,10 @@ const ClientVerification: React.FC<TClientVerificationProps> = ({
 
     const isPoiRequired = useMemo(
         () =>
-            poiData?.current.status && isSubmissionRequired[poiData?.current.status] && poiData?.previous?.status
-                ? // @ts-expect-error broken api-types for attempts/latest key in get_account_settings
-                  isSubmissionRequired[poiData.previous.status]
-                : true,
+            (poiData?.current.status && isSubmissionRequired[poiData?.current.status]) ||
+            (poiData?.previous?.status &&
+                // @ts-expect-error broken api-types for attempts/latest key in get_account_settings
+                isSubmissionRequired[poiData.previous.status]),
         [poiData]
     );
 


### PR DESCRIPTION
## Changes:

Fix issue when the client is going through POI/POA verification for MT5 account creation, if they drop the flow midway and then they come back to complete it, the flow restarts.

### Screenshots:

Please provide some screenshots of the change.
