### PR TITLE
[WALL] Lubega / WALL-4750 /Compare accounts components unit tests

### DIFF
--- a/packages/wallets/src/components/WalletListCardBalance/WalletListCardBalance.tsx
+++ b/packages/wallets/src/components/WalletListCardBalance/WalletListCardBalance.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { useActiveWalletAccount } from '@deriv/api-v2';
 import { displayMoney } from '@deriv/api-v2/src/utils';
-import { Text } from '@deriv-com/ui';
 import useAllBalanceSubscription from '../../hooks/useAllBalanceSubscription';
+import { WalletText } from '../Base';
 import './WalletListCardBalance.scss';
 
 const WalletListCardBalance = () => {
@@ -23,11 +23,11 @@ const WalletListCardBalance = () => {
                     data-testid='dt_wallet_list_card_balance_loader'
                 />
             ) : (
-                <Text align='right' data-testid='dt_wallets_list_card_balance' size='xl' weight='bold'>
+                <WalletText align='right' data-testid='dt_wallets_list_card_balance' size='xl' weight='bold'>
                     {displayMoney(balance, activeWallet?.currency, {
                         fractional_digits: activeWallet?.currency_config?.fractional_digits,
                     })}
-                </Text>
+                </WalletText>
             )}
         </div>
     );

--- a/packages/wallets/src/components/WalletListCardBalance/WalletListCardBalance.tsx
+++ b/packages/wallets/src/components/WalletListCardBalance/WalletListCardBalance.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { useActiveWalletAccount } from '@deriv/api-v2';
 import { displayMoney } from '@deriv/api-v2/src/utils';
+import { Text } from '@deriv-com/ui';
 import useAllBalanceSubscription from '../../hooks/useAllBalanceSubscription';
-import { WalletText } from '../Base';
 import './WalletListCardBalance.scss';
 
 const WalletListCardBalance = () => {
@@ -23,11 +23,11 @@ const WalletListCardBalance = () => {
                     data-testid='dt_wallet_list_card_balance_loader'
                 />
             ) : (
-                <WalletText align='right' size='xl' weight='bold'>
+                <Text align='right' data-testid='dt_wallets_list_card_balance' size='xl' weight='bold'>
                     {displayMoney(balance, activeWallet?.currency, {
                         fractional_digits: activeWallet?.currency_config?.fractional_digits,
                     })}
-                </WalletText>
+                </Text>
             )}
         </div>
     );

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/CompareAccountsHeader.tsx
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/CompareAccountsHeader.tsx
@@ -33,6 +33,7 @@ const CompareAccountsHeader = ({ isDemo, isEuRegion }: TCompareAccountsHeader) =
             </div>
             <CloseIcon
                 className='wallets-compare-accounts-header__close-icon'
+                data-testid='dt_wallets_compare_accounts_header_close_icon'
                 onClick={() => {
                     history.push('/');
                 }}

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/CompareAccountsPlatformLabel.tsx
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/CompareAccountsPlatformLabel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text } from '@deriv-com/ui';
+import { WalletText } from '../../../../components';
 import { TPlatforms } from '../../../../types';
 import { getPlatformType } from './compareAccountsConfig';
 import { headerColor, platformLabel } from './constants';
@@ -20,9 +20,9 @@ const CompareAccountsPlatformLabel = ({ platform }: TCompareAccountsPlatformLabe
             `}
             data-testid='dt_wallets_compare_accounts_platform_label'
         >
-            <Text align='center' as='p' color={headerColor[platformType]} size='xs' weight='bold'>
+            <WalletText align='center' as='p' color={headerColor[platformType]} size='xs' weight='bold'>
                 {platformLabel[platformType]}
-            </Text>
+            </WalletText>
         </div>
     );
 };

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/CompareAccountsPlatformLabel.tsx
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/CompareAccountsPlatformLabel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { WalletText } from '../../../../components';
+import { Text } from '@deriv-com/ui';
 import { TPlatforms } from '../../../../types';
 import { getPlatformType } from './compareAccountsConfig';
 import { headerColor, platformLabel } from './constants';
@@ -18,10 +18,11 @@ const CompareAccountsPlatformLabel = ({ platform }: TCompareAccountsPlatformLabe
             wallets-compare-accounts-platform-label
             wallets-compare-accounts-platform-label--${platformType.toLowerCase()}
             `}
+            data-testid='dt_wallets_compare_accounts_platform_label'
         >
-            <WalletText align='center' as='p' color={headerColor[platformType]} size='xs' weight='bold'>
+            <Text align='center' as='p' color={headerColor[platformType]} size='xs' weight='bold'>
                 {platformLabel[platformType]}
-            </WalletText>
+            </Text>
         </div>
     );
 };

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/CompareAccountsTitleIcon.tsx
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/CompareAccountsTitleIcon.tsx
@@ -77,6 +77,7 @@ const CompareAccountsTitleIcon = ({ isDemo, marketType, platform, shortCode }: T
                     {marketTypeShortCode === MARKET_TYPE_SHORTCODE.FINANCIAL_LABUAN && (
                         <Tooltip
                             as='div'
+                            data-testid='dt_wallets_compare_accounts_title__tooltip'
                             tooltipContainerClassName='wallets-compare-accounts-title__tooltip'
                             tooltipContent={labuanJurisdictionMessage}
                             tooltipPosition='bottom-start'

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/InstrumentsIconWithLabel.tsx
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/InstrumentsIconWithLabel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Text, useDevice } from '@deriv-com/ui';
+import { WalletText } from '../../../../components';
+import useDevice from '../../../../hooks/useDevice';
 import getInstrumentsIcons from '../../../../public/images/tradingInstruments';
 import './InstrumentsIconWithLabel.scss';
 
@@ -11,7 +12,7 @@ type TInstrumentsIcon = {
 };
 
 const InstrumentsIconWithLabel = ({ highlighted, icon, isAsterisk, text }: TInstrumentsIcon) => {
-    const { isDesktop } = useDevice();
+    const { isMobile } = useDevice();
 
     return (
         <div
@@ -21,11 +22,11 @@ const InstrumentsIconWithLabel = ({ highlighted, icon, isAsterisk, text }: TInst
                 opacity: highlighted ? '' : '0.2',
             }}
         >
-            {getInstrumentsIcons(isDesktop)[icon]}
+            {getInstrumentsIcons(isMobile)[icon]}
             <div className='wallets-compare-accounts-trading-instruments__text'>
-                <Text align='left' as='p' lineHeight='xs' size='xs' weight={isDesktop ? 'bold' : 'normal'}>
+                <WalletText align='left' as='p' lineHeight='xs' size='xs' weight={isMobile ? 'normal' : 'bold'}>
                     {text}
-                </Text>
+                </WalletText>
             </div>
             {isAsterisk && <span className='wallets-compare-accounts-trading-instruments__span'>*</span>}
         </div>

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/InstrumentsIconWithLabel.tsx
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/InstrumentsIconWithLabel.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import useDevice from '../../../../hooks/useDevice';
-import { WalletText } from '../../../../components';
+import { Text, useDevice } from '@deriv-com/ui';
 import getInstrumentsIcons from '../../../../public/images/tradingInstruments';
 import './InstrumentsIconWithLabel.scss';
 
@@ -24,9 +23,9 @@ const InstrumentsIconWithLabel = ({ highlighted, icon, isAsterisk, text }: TInst
         >
             {getInstrumentsIcons(isMobile)[icon]}
             <div className='wallets-compare-accounts-trading-instruments__text'>
-                <WalletText align='left' as='p' lineHeight='xs' size='xs' weight={isMobile ? 'normal' : 'bold'}>
+                <Text align='left' as='p' lineHeight='xs' size='xs' weight={isMobile ? 'normal' : 'bold'}>
                     {text}
-                </WalletText>
+                </Text>
             </div>
             {isAsterisk && <span className='wallets-compare-accounts-trading-instruments__span'>*</span>}
         </div>

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/InstrumentsIconWithLabel.tsx
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/InstrumentsIconWithLabel.tsx
@@ -11,7 +11,7 @@ type TInstrumentsIcon = {
 };
 
 const InstrumentsIconWithLabel = ({ highlighted, icon, isAsterisk, text }: TInstrumentsIcon) => {
-    const { isMobile } = useDevice();
+    const { isDesktop } = useDevice();
 
     return (
         <div
@@ -21,9 +21,9 @@ const InstrumentsIconWithLabel = ({ highlighted, icon, isAsterisk, text }: TInst
                 opacity: highlighted ? '' : '0.2',
             }}
         >
-            {getInstrumentsIcons(isMobile)[icon]}
+            {getInstrumentsIcons(isDesktop)[icon]}
             <div className='wallets-compare-accounts-trading-instruments__text'>
-                <Text align='left' as='p' lineHeight='xs' size='xs' weight={isMobile ? 'normal' : 'bold'}>
+                <Text align='left' as='p' lineHeight='xs' size='xs' weight={isDesktop ? 'bold' : 'normal'}>
                     {text}
                 </Text>
             </div>

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/__tests__/CompareAccountsCard.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/__tests__/CompareAccountsCard.spec.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { CFD_PLATFORMS } from '../../../constants';
+import CompareAccountsCard from '../CompareAccountsCard';
+
+describe('CompareAccountsCard', () => {
+    const defaultProps = {
+        isDemo: false,
+        isEuRegion: false,
+        isEuUser: false,
+        marketType: 'financial' as const,
+        platform: CFD_PLATFORMS.MT5,
+        shortCode: 'SVG',
+    };
+
+    it('renders the component with default props', () => {
+        render(<CompareAccountsCard {...defaultProps} />);
+
+        expect(screen.getByText('MT5 Platform')).toBeInTheDocument();
+        expect(screen.getByText('CFDs')).toBeInTheDocument();
+        expect(screen.getByText('Up to 1:1000')).toBeInTheDocument();
+        expect(screen.getByText('Maximum leverage')).toBeInTheDocument();
+        expect(screen.getByText('0.5 pips')).toBeInTheDocument();
+        expect(screen.getByText('Spreads from')).toBeInTheDocument();
+        expect(screen.getByText('Deriv (SVG) LLC')).toBeInTheDocument();
+    });
+
+    it('renders the new banner for cTrader platform', () => {
+        render(<CompareAccountsCard {...defaultProps} platform={CFD_PLATFORMS.CTRADER} />);
+
+        expect(screen.getByText('New!')).toBeInTheDocument();
+    });
+
+    it('does not render the new banner for non-cTrader platforms', () => {
+        render(<CompareAccountsCard {...defaultProps} />);
+
+        expect(screen.queryByText('New!')).not.toBeInTheDocument();
+    });
+
+    it('renders the EU clients disclaimer for EU users', () => {
+        render(<CompareAccountsCard {...defaultProps} isEuUser={true} />);
+
+        expect(screen.getByText('*Boom 300 and Crash 300 Index')).toBeInTheDocument();
+    });
+
+    it('does not render the EU clients disclaimer for non-EU users', () => {
+        render(<CompareAccountsCard {...defaultProps} />);
+
+        expect(screen.queryByText('*Boom 300 and Crash 300 Index')).not.toBeInTheDocument();
+    });
+});

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/__tests__/CompareAccountsDescription.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/__tests__/CompareAccountsDescription.spec.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { getJurisdictionDescription } from '../compareAccountsConfig';
+import CompareAccountsDescription from '../CompareAccountsDescription';
+
+jest.mock('../compareAccountsConfig', () => ({
+    getJurisdictionDescription: jest.fn(),
+}));
+
+describe('CompareAccountsDescription', () => {
+    const mockJurisdictionData = {
+        counterparty_company: 'Deriv (SVG) LLC',
+        counterparty_company_description: 'Counterparty company description',
+        jurisdiction: 'St. Vincent & Grenadines',
+        jurisdiction_description: 'Jurisdiction description',
+        leverage: '1:1000',
+        leverage_description: 'Leverage description',
+        regulator: 'Financial Commission',
+        regulator_description: 'Regulator description',
+        regulator_license: 'License number',
+        spread: '0.6 pips',
+        spread_description: 'Spread description',
+    };
+
+    beforeEach(() => {
+        (getJurisdictionDescription as jest.Mock).mockReturnValue(mockJurisdictionData);
+    });
+
+    const defaultProps = {
+        isDemo: false,
+        isEuRegion: false,
+        marketType: 'financial' as const,
+        shortCode: 'SVG',
+    };
+
+    it('renders correctly for non-demo, non-EU accounts', () => {
+        render(<CompareAccountsDescription {...defaultProps} />);
+
+        expect(screen.getByText('Up to 1:1000')).toBeInTheDocument();
+        expect(screen.getByText('Leverage description')).toBeInTheDocument();
+        expect(screen.getByText('0.6 pips')).toBeInTheDocument();
+        expect(screen.getByText('Spread description')).toBeInTheDocument();
+        expect(screen.getByText('Deriv (SVG) LLC')).toBeInTheDocument();
+        expect(screen.getByText('St. Vincent & Grenadines')).toBeInTheDocument();
+        expect(screen.getByText('Financial Commission')).toBeInTheDocument();
+        expect(screen.getByText('License number')).toBeInTheDocument();
+    });
+
+    it('renders correctly for demo accounts', () => {
+        render(<CompareAccountsDescription {...defaultProps} isDemo={true} />);
+
+        expect(screen.getByText('Up to 1:1000')).toBeInTheDocument();
+        expect(screen.getByText('Leverage description')).toBeInTheDocument();
+        expect(screen.getByText('0.6 pips')).toBeInTheDocument();
+        expect(screen.queryByText('Deriv (SVG) LLC')).not.toBeInTheDocument();
+        expect(screen.queryByText('St. Vincent & Grenadines')).not.toBeInTheDocument();
+    });
+
+    it('renders correctly for EU region accounts', () => {
+        render(<CompareAccountsDescription {...defaultProps} isEuRegion={true} />);
+
+        expect(screen.getByText('Up to 1:1000')).toBeInTheDocument();
+        expect(screen.getByText('Leverage')).toBeInTheDocument();
+        expect(screen.queryByText('0.6 pips')).not.toBeInTheDocument();
+        expect(screen.queryByText('Spread description')).not.toBeInTheDocument();
+    });
+
+    it('calls getJurisdictionDescription with correct marketTypeShortCode', () => {
+        render(<CompareAccountsDescription {...defaultProps} />);
+
+        expect(getJurisdictionDescription).toHaveBeenCalledWith('financial_SVG');
+    });
+});

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/__tests__/CompareAccountsDescription.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/__tests__/CompareAccountsDescription.spec.tsx
@@ -33,7 +33,7 @@ describe('CompareAccountsDescription', () => {
         shortCode: 'SVG',
     };
 
-    it('renders correctly for non-demo, non-EU accounts', () => {
+    it('renders correct compare accounts descriptions for non-demo, non-EU accounts', () => {
         render(<CompareAccountsDescription {...defaultProps} />);
 
         expect(screen.getByText('Up to 1:1000')).toBeInTheDocument();
@@ -46,7 +46,7 @@ describe('CompareAccountsDescription', () => {
         expect(screen.getByText('License number')).toBeInTheDocument();
     });
 
-    it('renders correctly for demo accounts', () => {
+    it('renders correct compare accounts descriptions for demo accounts', () => {
         render(<CompareAccountsDescription {...defaultProps} isDemo={true} />);
 
         expect(screen.getByText('Up to 1:1000')).toBeInTheDocument();
@@ -56,7 +56,7 @@ describe('CompareAccountsDescription', () => {
         expect(screen.queryByText('St. Vincent & Grenadines')).not.toBeInTheDocument();
     });
 
-    it('renders correctly for EU region accounts', () => {
+    it('renders correct compare accounts descriptions for EU region accounts', () => {
         render(<CompareAccountsDescription {...defaultProps} isEuRegion={true} />);
 
         expect(screen.getByText('Up to 1:1000')).toBeInTheDocument();

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/__tests__/CompareAccountsHeader.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/__tests__/CompareAccountsHeader.spec.tsx
@@ -14,25 +14,25 @@ describe('CompareAccountsHeader', () => {
         (useHistory as jest.Mock).mockReturnValue({ push: mockHistoryPush });
     });
 
-    it('renders correctly for non-demo, non-EU accounts', () => {
+    it('displays CFDs compare accounts header title for non-demo, non-EU accounts', () => {
         render(<CompareAccountsHeader isDemo={false} isEuRegion={false} />);
 
         expect(screen.getByText('Compare CFDs accounts')).toBeInTheDocument();
     });
 
-    it('renders correctly for demo, non-EU accounts', () => {
+    it('displays CFDs compare accounts header title for demo, non-EU accounts', () => {
         render(<CompareAccountsHeader isDemo={true} isEuRegion={false} />);
 
         expect(screen.getByText('Compare CFDs demo accounts')).toBeInTheDocument();
     });
 
-    it('renders correctly for non-demo, EU accounts', () => {
+    it('displays MT5 CFDs compare accounts header title for non-demo, EU accounts', () => {
         render(<CompareAccountsHeader isDemo={false} isEuRegion={true} />);
 
         expect(screen.getByText('Deriv MT5 CFDs real account')).toBeInTheDocument();
     });
 
-    it('renders correctly for demo, EU accounts', () => {
+    it('displays MT5 CFDs compare accounts header title for demo, EU accounts', () => {
         render(<CompareAccountsHeader isDemo={true} isEuRegion={true} />);
 
         expect(screen.getByText('Deriv MT5 CFDs Demo account')).toBeInTheDocument();

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/__tests__/CompareAccountsHeader.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/__tests__/CompareAccountsHeader.spec.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { useHistory } from 'react-router-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import CompareAccountsHeader from '../CompareAccountsHeader';
+
+jest.mock('react-router-dom', () => ({
+    useHistory: jest.fn(),
+}));
+
+describe('CompareAccountsHeader', () => {
+    const mockHistoryPush = jest.fn();
+
+    beforeEach(() => {
+        (useHistory as jest.Mock).mockReturnValue({ push: mockHistoryPush });
+    });
+
+    it('renders correctly for non-demo, non-EU accounts', () => {
+        render(<CompareAccountsHeader isDemo={false} isEuRegion={false} />);
+
+        expect(screen.getByText('Compare CFDs accounts')).toBeInTheDocument();
+    });
+
+    it('renders correctly for demo, non-EU accounts', () => {
+        render(<CompareAccountsHeader isDemo={true} isEuRegion={false} />);
+
+        expect(screen.getByText('Compare CFDs demo accounts')).toBeInTheDocument();
+    });
+
+    it('renders correctly for non-demo, EU accounts', () => {
+        render(<CompareAccountsHeader isDemo={false} isEuRegion={true} />);
+
+        expect(screen.getByText('Deriv MT5 CFDs real account')).toBeInTheDocument();
+    });
+
+    it('renders correctly for demo, EU accounts', () => {
+        render(<CompareAccountsHeader isDemo={true} isEuRegion={true} />);
+
+        expect(screen.getByText('Deriv MT5 CFDs Demo account')).toBeInTheDocument();
+    });
+
+    it('redirects back to root when close icon is clicked', () => {
+        render(<CompareAccountsHeader isDemo={false} isEuRegion={false} />);
+
+        const closeIcon = screen.getByTestId('dt_wallets_compare_accounts_header_close_icon');
+        fireEvent.click(closeIcon);
+        expect(mockHistoryPush).toHaveBeenCalledWith('/');
+    });
+});

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/__tests__/CompareAccountsPlatformLabel.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/__tests__/CompareAccountsPlatformLabel.spec.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { getPlatformType } from '../compareAccountsConfig';
+import CompareAccountsPlatformLabel from '../CompareAccountsPlatformLabel';
+import { platformLabel } from '../constants';
+
+jest.mock('../compareAccountsConfig', () => ({
+    getPlatformType: jest.fn(),
+}));
+
+describe('CompareAccountsPlatformLabel', () => {
+    const mockPlatform = 'mt5' as const;
+
+    beforeEach(() => {
+        (getPlatformType as jest.Mock).mockReturnValue('MT5');
+    });
+
+    it('renders correctly with the given platform', () => {
+        render(<CompareAccountsPlatformLabel platform={mockPlatform} />);
+
+        const labelElement = screen.getByTestId('dt_wallets_compare_accounts_platform_label');
+        expect(labelElement).toHaveTextContent(platformLabel.MT5);
+    });
+
+    it('calls getPlatformType with the correct platform', () => {
+        render(<CompareAccountsPlatformLabel platform={mockPlatform} />);
+
+        expect(getPlatformType).toHaveBeenCalledWith(mockPlatform);
+    });
+
+    it('handles different platform types correctly', () => {
+        (getPlatformType as jest.Mock).mockReturnValue('DerivX');
+
+        render(<CompareAccountsPlatformLabel platform={'dxtrade' as const} />);
+
+        const labelElement = screen.getByTestId('dt_wallets_compare_accounts_platform_label');
+        expect(labelElement).toHaveTextContent(platformLabel.DerivX);
+    });
+});

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/__tests__/CompareAccountsPlatformLabel.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/__tests__/CompareAccountsPlatformLabel.spec.tsx
@@ -15,7 +15,7 @@ describe('CompareAccountsPlatformLabel', () => {
         (getPlatformType as jest.Mock).mockReturnValue('MT5');
     });
 
-    it('renders correctly with the given platform', () => {
+    it('renders correct platform label according to the given platform', () => {
         render(<CompareAccountsPlatformLabel platform={mockPlatform} />);
 
         const labelElement = screen.getByTestId('dt_wallets_compare_accounts_platform_label');

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/__tests__/CompareAccountsScreen.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/__tests__/CompareAccountsScreen.spec.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import { useActiveWalletAccount, useCFDCompareAccounts } from '@deriv/api-v2';
+import { render, screen } from '@testing-library/react';
+import CompareAccountsScreen from '../CompareAccountsScreen';
+
+jest.mock('@deriv/api-v2', () => ({
+    useActiveWalletAccount: jest.fn(),
+    useCFDCompareAccounts: jest.fn(),
+}));
+
+jest.mock('../../../components', () => ({
+    CompareAccountsCarousel: ({ children }: React.PropsWithChildren) => <div data-testid='carousel'>{children}</div>,
+}));
+
+jest.mock('../CompareAccountsCard', () => ({
+    __esModule: true,
+    default: ({ marketType, platform, shortCode }: { marketType: string; platform: string; shortCode: string }) => (
+        <div data-testid={`card-${marketType}-${platform}-${shortCode}`} />
+    ),
+}));
+
+jest.mock('../CompareAccountsHeader', () => ({
+    __esModule: true,
+    default: () => <div data-testid='header' />,
+}));
+
+describe('CompareAccountsScreen', () => {
+    const mockMT5Accounts = [
+        { market_type: 'financial', platform: 'mt5', product: 'standard', shortcode: 'SVG' },
+        { market_type: 'synthetic', platform: 'mt5', product: 'standard', shortcode: 'BVI' },
+    ];
+
+    const mockCTraderAccount = { market_type: 'financial', platform: 'ctrader', shortcode: 'SVG' };
+    const mockDxtradeAccount = { market_type: 'financial', platform: 'dxtrade', shortcode: 'SVG' };
+
+    beforeEach(() => {
+        (useActiveWalletAccount as jest.Mock).mockReturnValue({
+            data: { is_malta_wallet: false, is_virtual: false },
+        });
+
+        (useCFDCompareAccounts as jest.Mock).mockReturnValue({
+            data: {
+                ctraderAccount: mockCTraderAccount,
+                dxtradeAccount: mockDxtradeAccount,
+                mt5Accounts: mockMT5Accounts,
+            },
+            hasCTraderAccountAvailable: true,
+            hasDxtradeAccountAvailable: true,
+        });
+    });
+
+    it('renders default components correctly', () => {
+        render(<CompareAccountsScreen />);
+
+        expect(screen.getByTestId('header')).toBeInTheDocument();
+        expect(screen.getByTestId('carousel')).toBeInTheDocument();
+    });
+
+    it('renders MT5 and other available account cards correctly', () => {
+        render(<CompareAccountsScreen />);
+
+        expect(screen.getByTestId('card-financial-mt5-SVG')).toBeInTheDocument();
+        expect(screen.getByTestId('card-synthetic-mt5-BVI')).toBeInTheDocument();
+        expect(screen.getByTestId('card-financial-ctrader-SVG')).toBeInTheDocument();
+        expect(screen.getByTestId('card-financial-dxtrade-SVG')).toBeInTheDocument();
+    });
+
+    it('does not render zero spread accounts', () => {
+        (useCFDCompareAccounts as jest.Mock).mockReturnValue({
+            data: {
+                ctraderAccount: mockCTraderAccount,
+                dxtradeAccount: mockDxtradeAccount,
+                mt5Accounts: [
+                    ...mockMT5Accounts,
+                    { market_type: 'financial', platform: 'mt5', product: 'zero_spread', shortcode: 'SVG' },
+                ],
+            },
+            hasCTraderAccountAvailable: true,
+            hasDxtradeAccountAvailable: true,
+        });
+
+        render(<CompareAccountsScreen />);
+
+        expect(screen.queryByTestId('card-financial-mt5-SVG-zero_spread')).not.toBeInTheDocument();
+    });
+
+    it('does not render MT5 cards when not available', () => {
+        (useCFDCompareAccounts as jest.Mock).mockReturnValue({
+            data: {
+                ctraderAccount: mockCTraderAccount,
+                dxtradeAccount: mockDxtradeAccount,
+                mt5Accounts: undefined,
+            },
+        });
+
+        render(<CompareAccountsScreen />);
+
+        expect(screen.queryByTestId('card-financial-mt5-SVG')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('card-synthetic-mt5-BVI')).not.toBeInTheDocument();
+    });
+
+    it('does not render cTrader card when not available', () => {
+        (useCFDCompareAccounts as jest.Mock).mockReturnValue({
+            data: {
+                ctraderAccount: null,
+                dxtradeAccount: mockDxtradeAccount,
+                mt5Accounts: mockMT5Accounts,
+            },
+            hasCTraderAccountAvailable: false,
+            hasDxtradeAccountAvailable: true,
+        });
+
+        render(<CompareAccountsScreen />);
+
+        expect(screen.queryByTestId('card-financial-ctrader-SVG')).not.toBeInTheDocument();
+    });
+
+    it('does not render Deriv X card when not available', () => {
+        (useCFDCompareAccounts as jest.Mock).mockReturnValue({
+            data: {
+                ctraderAccount: mockCTraderAccount,
+                dxtradeAccount: null,
+                mt5Accounts: mockMT5Accounts,
+            },
+            hasCTraderAccountAvailable: true,
+            hasDxtradeAccountAvailable: false,
+        });
+
+        render(<CompareAccountsScreen />);
+
+        expect(screen.queryByTestId('card-financial-dxtrade-SVG')).not.toBeInTheDocument();
+    });
+
+    it('handles case when activeWallet is undefined', () => {
+        (useActiveWalletAccount as jest.Mock).mockReturnValue({
+            data: undefined,
+        });
+
+        render(<CompareAccountsScreen />);
+
+        expect(screen.getByTestId('header')).toBeInTheDocument();
+        expect(screen.getByTestId('carousel')).toBeInTheDocument();
+    });
+});

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/__tests__/CompareAccountsTitleIcon.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/__tests__/CompareAccountsTitleIcon.spec.tsx
@@ -11,13 +11,13 @@ describe('CompareAccountsTitleIcon', () => {
         shortCode: 'SVG',
     };
 
-    it('renders correctly with default props', () => {
+    it('renders default real account title when isDemo is false', () => {
         render(<CompareAccountsTitleIcon {...defaultProps} />);
 
         expect(screen.getByText('CFDs')).toBeInTheDocument();
     });
 
-    it('renders demo account title when isDemo is true', () => {
+    it('renders default demo account title when isDemo is true', () => {
         render(<CompareAccountsTitleIcon {...defaultProps} isDemo={true} />);
 
         expect(screen.getByText('CFDs Demo')).toBeInTheDocument();

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/__tests__/CompareAccountsTitleIcon.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/__tests__/CompareAccountsTitleIcon.spec.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { CFD_PLATFORMS } from '../../../constants';
+import CompareAccountsTitleIcon from '../CompareAccountsTitleIcon';
+
+describe('CompareAccountsTitleIcon', () => {
+    const defaultProps = {
+        isDemo: false,
+        marketType: 'financial' as const,
+        platform: 'mt5' as const,
+        shortCode: 'SVG',
+    };
+
+    it('renders correctly with default props', () => {
+        render(<CompareAccountsTitleIcon {...defaultProps} />);
+
+        expect(screen.getByText('CFDs')).toBeInTheDocument();
+    });
+
+    it('renders demo account title when isDemo is true', () => {
+        render(<CompareAccountsTitleIcon {...defaultProps} isDemo={true} />);
+
+        expect(screen.getByText('CFDs Demo')).toBeInTheDocument();
+    });
+
+    it('renders correct title for Deriv X platform', () => {
+        render(<CompareAccountsTitleIcon {...defaultProps} platform={CFD_PLATFORMS.DXTRADE} />);
+
+        expect(screen.getByText('Deriv X')).toBeInTheDocument();
+    });
+
+    it('renders correct title for demo Deriv X', () => {
+        render(<CompareAccountsTitleIcon {...defaultProps} isDemo={true} platform={CFD_PLATFORMS.DXTRADE} />);
+
+        expect(screen.getByText('Deriv X Demo')).toBeInTheDocument();
+    });
+
+    it('renders correct title for Deriv cTrader platform', () => {
+        render(<CompareAccountsTitleIcon {...defaultProps} platform={CFD_PLATFORMS.CTRADER} />);
+
+        expect(screen.getByText('Deriv cTrader')).toBeInTheDocument();
+    });
+
+    it('renders correct title for Deriv cTrader platform', () => {
+        render(<CompareAccountsTitleIcon {...defaultProps} isDemo={true} platform={CFD_PLATFORMS.CTRADER} />);
+
+        expect(screen.getByText('Deriv cTrader Demo')).toBeInTheDocument();
+    });
+
+    it('renders tooltip for Labuan jurisdiction', () => {
+        render(<CompareAccountsTitleIcon {...defaultProps} marketType='financial' shortCode='labuan' />);
+
+        expect(screen.getByText('Financial - Labuan')).toBeInTheDocument();
+        const tooltip = screen.getByTestId('dt_wallets_compare_accounts_title__tooltip');
+        expect(tooltip).toBeInTheDocument();
+    });
+
+    it('does not render tooltip for non-Labuan jurisdictions', () => {
+        render(<CompareAccountsTitleIcon {...defaultProps} />);
+
+        expect(screen.queryByTestId('dt_wallets_compare_accounts_title__tooltip')).not.toBeInTheDocument();
+    });
+
+    it('renders correct title for swap-free accounts', () => {
+        render(<CompareAccountsTitleIcon {...defaultProps} marketType='all' shortCode='svg' />);
+
+        expect(screen.getByText('Swap-Free - SVG')).toBeInTheDocument();
+    });
+
+    it('renders correct title for demo swap-free accounts', () => {
+        render(<CompareAccountsTitleIcon {...defaultProps} isDemo={true} marketType='all' shortCode='svg' />);
+
+        expect(screen.getByText('Swap-Free Demo')).toBeInTheDocument();
+    });
+
+    it('renders correct title for synthetic SVG accounts', () => {
+        render(<CompareAccountsTitleIcon {...defaultProps} marketType='synthetic' shortCode='svg' />);
+
+        expect(screen.getByText('Standard - SVG')).toBeInTheDocument();
+    });
+
+    it('renders correct title for demo SVG accounts', () => {
+        render(<CompareAccountsTitleIcon {...defaultProps} isDemo={true} marketType='synthetic' shortCode='svg' />);
+
+        expect(screen.getByText('Standard Demo')).toBeInTheDocument();
+    });
+
+    it('renders correct title for synthetic BVI accounts', () => {
+        render(<CompareAccountsTitleIcon {...defaultProps} marketType='synthetic' shortCode='bvi' />);
+
+        expect(screen.getByText('Standard - BVI')).toBeInTheDocument();
+    });
+
+    it('renders correct title for synthetic Vanuatu accounts', () => {
+        render(<CompareAccountsTitleIcon {...defaultProps} marketType='synthetic' shortCode='vanuatu' />);
+
+        expect(screen.getByText('Standard - Vanuatu')).toBeInTheDocument();
+    });
+
+    it('renders correct title for financial SVG accounts', () => {
+        render(<CompareAccountsTitleIcon {...defaultProps} marketType='financial' shortCode='svg' />);
+
+        expect(screen.getByText('Financial - SVG')).toBeInTheDocument();
+    });
+
+    it('renders correct title for demo financial SVG accounts', () => {
+        render(<CompareAccountsTitleIcon {...defaultProps} isDemo={true} marketType='financial' shortCode='svg' />);
+
+        expect(screen.getByText('Financial Demo')).toBeInTheDocument();
+    });
+
+    it('renders correct title for financial BVI accounts', () => {
+        render(<CompareAccountsTitleIcon {...defaultProps} marketType='financial' shortCode='bvi' />);
+
+        expect(screen.getByText('Financial - BVI')).toBeInTheDocument();
+    });
+
+    it('renders correct title for financial Vanuatu accounts', () => {
+        render(<CompareAccountsTitleIcon {...defaultProps} marketType='financial' shortCode='vanuatu' />);
+
+        expect(screen.getByText('Financial - Vanuatu')).toBeInTheDocument();
+    });
+});

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/__tests__/InstrumentsIconWithLabel.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/__tests__/InstrumentsIconWithLabel.spec.tsx
@@ -23,7 +23,7 @@ describe('InstrumentsIconWithLabel', () => {
         text: 'Forex',
     };
 
-    it('renders correctly with default props', () => {
+    it('renders default icon with label for given trading instrument', () => {
         render(<InstrumentsIconWithLabel {...defaultProps} />);
 
         expect(screen.getByTestId('dt_instruments_icon_container')).toBeInTheDocument();

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/__tests__/InstrumentsIconWithLabel.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/__tests__/InstrumentsIconWithLabel.spec.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import InstrumentsIconWithLabel from '../InstrumentsIconWithLabel';
+
+jest.mock('../../../../../public/images/tradingInstruments', () => ({
+    __esModule: true,
+    default: jest.fn().mockReturnValue({
+        Forex: <svg data-testid='forex-icon' />,
+    }),
+}));
+
+jest.mock('@deriv-com/ui', () => ({
+    ...jest.requireActual('@deriv-com/ui'),
+    useDevice: jest.fn(() => ({
+        isMobile: false,
+    })),
+}));
+
+describe('InstrumentsIconWithLabel', () => {
+    const defaultProps = {
+        highlighted: true,
+        icon: 'Forex' as const,
+        text: 'Forex',
+    };
+
+    it('renders correctly with default props', () => {
+        render(<InstrumentsIconWithLabel {...defaultProps} />);
+
+        expect(screen.getByTestId('dt_instruments_icon_container')).toBeInTheDocument();
+        expect(screen.getByTestId('forex-icon')).toBeInTheDocument();
+        expect(screen.getByText('Forex')).toBeInTheDocument();
+    });
+
+    it('renders asterisk when isAsterisk is true', () => {
+        render(<InstrumentsIconWithLabel {...defaultProps} isAsterisk={true} />);
+
+        expect(screen.getByText('*')).toBeInTheDocument();
+    });
+});

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/__tests__/InstrumentsLabelHighlighted.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/__tests__/InstrumentsLabelHighlighted.spec.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { getHighlightedIconLabel } from '../compareAccountsConfig';
+import InstrumentsLabelHighlighted from '../InstrumentsLabelHighlighted';
+
+jest.mock('../compareAccountsConfig', () => ({
+    getHighlightedIconLabel: jest.fn(),
+}));
+
+jest.mock('../InstrumentsIconWithLabel', () => ({
+    __esModule: true,
+    default: ({ text }: { text: string }) => <div data-testid='instrument-icon'>{text}</div>,
+}));
+
+describe('InstrumentsLabelHighlighted', () => {
+    const defaultProps = {
+        isDemo: false,
+        isEuRegion: false,
+        marketType: 'financial' as const,
+        platform: 'mt5' as const,
+        shortCode: 'SVG' as const,
+    };
+
+    const mockIconData = [{ text: 'Forex' }, { text: 'Stocks' }, { text: 'Indices' }];
+
+    beforeEach(() => {
+        (getHighlightedIconLabel as jest.Mock).mockReturnValue(mockIconData);
+    });
+
+    it('renders correctly with default props', () => {
+        render(<InstrumentsLabelHighlighted {...defaultProps} />);
+
+        const container = screen.getByTestId('dt_compare_cfd_account_outline__container');
+        expect(container).toBeInTheDocument();
+
+        mockIconData.forEach(item => {
+            expect(screen.getByText(item.text)).toBeInTheDocument();
+        });
+    });
+
+    it('renders InstrumentsIconWithLabel for each item in iconData', () => {
+        render(<InstrumentsLabelHighlighted {...defaultProps} />);
+
+        const instrumentIcons = screen.getAllByTestId('instrument-icon');
+        expect(instrumentIcons).toHaveLength(mockIconData.length);
+        instrumentIcons.forEach((icon, index) => {
+            expect(icon).toHaveTextContent(mockIconData[index].text);
+        });
+    });
+
+    it('handles empty iconData', () => {
+        (getHighlightedIconLabel as jest.Mock).mockReturnValue([]);
+        render(<InstrumentsLabelHighlighted {...defaultProps} />);
+
+        const container = screen.getByTestId('dt_compare_cfd_account_outline__container');
+        expect(container).toBeInTheDocument();
+        expect(container).toBeEmptyDOMElement();
+    });
+});

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/__tests__/InstrumentsLabelHighlighted.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/__tests__/InstrumentsLabelHighlighted.spec.tsx
@@ -27,7 +27,7 @@ describe('InstrumentsLabelHighlighted', () => {
         (getHighlightedIconLabel as jest.Mock).mockReturnValue(mockIconData);
     });
 
-    it('renders correctly with default props', () => {
+    it('renders default content and label for given trading instrument', () => {
         render(<InstrumentsLabelHighlighted {...defaultProps} />);
 
         const container = screen.getByTestId('dt_compare_cfd_account_outline__container');

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/__tests__/compareAccountsConfig.spec.ts
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/__tests__/compareAccountsConfig.spec.ts
@@ -1,0 +1,307 @@
+import { CFD_PLATFORMS, MARKET_TYPE } from '../../../constants';
+import {
+    getAccountVerificationStatus,
+    getHighlightedIconLabel,
+    getJurisdictionDescription,
+    getPlatformType,
+    isCTraderAccountAdded,
+    isDxtradeAccountAdded,
+    isMt5AccountAdded,
+    shouldRestrictBviAccountCreation,
+    shouldRestrictVanuatuAccountCreation,
+} from '../compareAccountsConfig';
+import { JURISDICTION, MARKET_TYPE_SHORTCODE } from '../constants';
+
+jest.mock('@deriv-com/translations', () => ({
+    localize: jest.fn(str => str),
+}));
+
+describe('compareAccountsConfig', () => {
+    describe('getHighlightedIconLabel', () => {
+        it('returns correct labels for synthetic market type', () => {
+            const result = getHighlightedIconLabel(CFD_PLATFORMS.MT5, false, MARKET_TYPE.SYNTHETIC, 'SVG');
+            expect(result).toHaveLength(9);
+            expect(result[0].text).toBe('Forex: standard');
+        });
+
+        it('returns correct labels for EU region', () => {
+            const result = getHighlightedIconLabel(CFD_PLATFORMS.MT5, true, MARKET_TYPE.SYNTHETIC, 'SVG');
+            expect(result).toHaveLength(9);
+            expect(result[0].text).toBe('Forex');
+        });
+
+        it('returns correct labels for financial market type with LABUAN jurisdiction', () => {
+            const result = getHighlightedIconLabel(
+                CFD_PLATFORMS.MT5,
+                false,
+                MARKET_TYPE.FINANCIAL,
+                JURISDICTION.LABUAN
+            );
+            expect(result).toHaveLength(9);
+            expect(result[0].text).toBe('Forex: standard/exotic');
+        });
+
+        it('returns correct labels for financial market type with MALTAINVEST jurisdiction', () => {
+            const result = getHighlightedIconLabel(
+                CFD_PLATFORMS.MT5,
+                false,
+                MARKET_TYPE.FINANCIAL,
+                JURISDICTION.MALTAINVEST
+            );
+            expect(result).toHaveLength(6);
+            expect(result[5].isAsterisk).toBe(true);
+        });
+
+        it('returns correct labels for ALL market type with MT5 platform', () => {
+            const result = getHighlightedIconLabel(CFD_PLATFORMS.MT5, false, MARKET_TYPE.ALL, 'SVG');
+            expect(result).toHaveLength(9);
+            expect(result[6].text).toBe('Synthetics indices');
+        });
+
+        it('returns correct labels for ALL market type with non-MT5 platform', () => {
+            const result = getHighlightedIconLabel(CFD_PLATFORMS.CTRADER, false, MARKET_TYPE.ALL, 'SVG');
+            expect(result).toHaveLength(9);
+            expect(result[6].text).toBe('Synthetic indices');
+        });
+    });
+
+    describe('getPlatformType', () => {
+        it('returns correct platform type', () => {
+            expect(getPlatformType(CFD_PLATFORMS.MT5)).toBe('MT5');
+            expect(getPlatformType(CFD_PLATFORMS.CTRADER)).toBe('CTrader');
+            expect(getPlatformType(CFD_PLATFORMS.DXTRADE)).toBe('DerivX');
+            // @ts-expect-error - mock unknown value to test output of default case
+            expect(getPlatformType('unknown')).toBe('OtherCFDs');
+        });
+    });
+
+    describe('getJurisdictionDescription', () => {
+        it('returns correct description for synthetic BVI', () => {
+            const result = getJurisdictionDescription(MARKET_TYPE_SHORTCODE.SYNTHETIC_BVI);
+            expect(result.jurisdiction).toBe('British Virgin Islands');
+        });
+
+        it('returns correct description for financial BVI', () => {
+            const result = getJurisdictionDescription(MARKET_TYPE_SHORTCODE.FINANCIAL_BVI);
+            expect(result.jurisdiction).toBe('British Virgin Islands');
+        });
+
+        it('returns correct description for synthetic Vanuatu', () => {
+            const result = getJurisdictionDescription(MARKET_TYPE_SHORTCODE.SYNTHETIC_VANUATU);
+            expect(result.jurisdiction).toBe('Vanuatu');
+        });
+
+        it('returns correct description for financial Vanuatu', () => {
+            const result = getJurisdictionDescription(MARKET_TYPE_SHORTCODE.FINANCIAL_VANUATU);
+            expect(result.jurisdiction).toBe('Vanuatu');
+        });
+
+        it('returns correct description for financial Labuan', () => {
+            const result = getJurisdictionDescription(MARKET_TYPE_SHORTCODE.FINANCIAL_LABUAN);
+            expect(result.jurisdiction).toBe('Labuan');
+        });
+
+        it('returns correct description for financial Maltainvest', () => {
+            const result = getJurisdictionDescription(MARKET_TYPE_SHORTCODE.FINANCIAL_MALTAINVEST);
+            expect(result.jurisdiction).toBe('Malta');
+        });
+
+        it('returns default description for DerivX', () => {
+            const result = getJurisdictionDescription(MARKET_TYPE_SHORTCODE.ALL_DXTRADE);
+            expect(result).toEqual(
+                expect.objectContaining({
+                    jurisdiction: 'St. Vincent & Grenadines',
+                })
+            );
+        });
+
+        it('returns default description for all SVG', () => {
+            const result = getJurisdictionDescription(MARKET_TYPE_SHORTCODE.ALL_SVG);
+            expect(result).toEqual(
+                expect.objectContaining({
+                    jurisdiction: 'St. Vincent & Grenadines',
+                })
+            );
+        });
+
+        it('returns default description for synthetic SVG', () => {
+            const result = getJurisdictionDescription(MARKET_TYPE_SHORTCODE.SYNTHETIC_SVG);
+            expect(result).toEqual(
+                expect.objectContaining({
+                    jurisdiction: 'St. Vincent & Grenadines',
+                })
+            );
+        });
+
+        it('returns default description for financial SVG', () => {
+            const result = getJurisdictionDescription(MARKET_TYPE_SHORTCODE.FINANCIAL_SVG);
+            expect(result).toEqual(
+                expect.objectContaining({
+                    jurisdiction: 'St. Vincent & Grenadines',
+                })
+            );
+        });
+
+        it('returns default description for unknown shortcode', () => {
+            const result = getJurisdictionDescription('unknown');
+            expect(result).toEqual(
+                expect.objectContaining({
+                    jurisdiction: 'St. Vincent & Grenadines',
+                })
+            );
+        });
+    });
+
+    describe('getAccountVerificationStatus', () => {
+        it('returns correct status for SVG jurisdiction', () => {
+            expect(getAccountVerificationStatus(JURISDICTION.SVG, false, false, true)).toBe(true);
+        });
+
+        it('returns correct status for BVI jurisdiction', () => {
+            const authInfo = {
+                has_poa_been_attempted: true,
+                has_poi_been_attempted: true,
+                identity: { services: { manual: { status: 'verified' } } },
+                poa_status: 'verified',
+                risk_classification: 'low',
+            };
+            // @ts-expect-error - since this is a mock, we only need partial properties of authInfo
+            expect(getAccountVerificationStatus(JURISDICTION.BVI, false, false, true, authInfo)).toBe(true);
+        });
+
+        it('returns correct status for high risk classification', () => {
+            const authInfo = {
+                has_poa_been_attempted: true,
+                has_poi_been_attempted: true,
+                identity: { services: { manual: { status: 'verified' } } },
+                poa_status: 'verified',
+                risk_classification: 'high',
+            };
+            // @ts-expect-error - since this is a mock, we only need partial properties of authInfo
+            expect(getAccountVerificationStatus(JURISDICTION.BVI, false, false, true, authInfo)).toBe(false);
+        });
+
+        it('returns correct status for Vanuatu jurisdiction', () => {
+            const authInfo = {
+                has_poa_been_attempted: true,
+                has_poi_been_attempted: true,
+                identity: { services: { manual: { status: 'verified' } } },
+                poa_status: 'verified',
+                risk_classification: 'low',
+            };
+            // @ts-expect-error - since this is a mock, we only need partial properties of authInfo
+            expect(getAccountVerificationStatus(JURISDICTION.VANUATU, false, false, true, authInfo)).toBe(true);
+        });
+
+        it('returns correct status for Labuan jurisdiction', () => {
+            const authInfo = {
+                has_poa_been_attempted: true,
+                has_poi_been_attempted: true,
+                identity: { services: { manual: { status: 'verified' } } },
+                poa_status: 'verified',
+                risk_classification: 'low',
+            };
+            // @ts-expect-error - since this is a mock, we only need partial properties of authInfo
+            expect(getAccountVerificationStatus(JURISDICTION.LABUAN, false, false, true, authInfo)).toBe(true);
+        });
+
+        it('returns correct status for Maltainvest jurisdiction', () => {
+            const authInfo = {
+                has_poa_been_attempted: true,
+                has_poi_been_attempted: true,
+                identity: { services: { manual: { status: 'verified' } } },
+                poa_status: 'verified',
+            };
+            // @ts-expect-error - since this is a mock, we only need partial properties of authInfo
+            expect(getAccountVerificationStatus(JURISDICTION.MALTAINVEST, false, false, true, authInfo)).toBe(true);
+            // @ts-expect-error - since this is a mock, we only need partial properties of authInfo
+            expect(getAccountVerificationStatus(JURISDICTION.MALTAINVEST, false, false, true, authInfo, true)).toBe(
+                true
+            );
+        });
+    });
+
+    describe('isMt5AccountAdded', () => {
+        it('returns true if account is added', () => {
+            const list = [
+                {
+                    account_type: 'real',
+                    landing_company_short: 'svg',
+                    market_type: MARKET_TYPE.FINANCIAL,
+                    platform: CFD_PLATFORMS.MT5,
+                },
+            ];
+            // @ts-expect-error - since this is a mock, we only need partial properties of the list
+            expect(isMt5AccountAdded(list, MARKET_TYPE.FINANCIAL, 'svg')).toBe(true);
+        });
+
+        it('returns false if account is not added', () => {
+            const list = [
+                {
+                    account_type: 'real',
+                    landing_company_short: 'svg',
+                    market_type: MARKET_TYPE.FINANCIAL,
+                    platform: CFD_PLATFORMS.MT5,
+                },
+            ];
+            // @ts-expect-error - since this is a mock, we only need partial properties of the list
+            expect(isMt5AccountAdded(list, MARKET_TYPE.FINANCIAL, 'svg', true)).toBe(false);
+        });
+    });
+
+    describe('isDxtradeAccountAdded', () => {
+        it('returns true if account is added', () => {
+            const list = [{ account_type: 'real', platform: CFD_PLATFORMS.DXTRADE }];
+            // @ts-expect-error - since this is a mock, we only need partial properties of the list
+            expect(isDxtradeAccountAdded(list)).toBe(true);
+        });
+
+        it('returns false if account is not added', () => {
+            const list = [{ account_type: 'real', platform: CFD_PLATFORMS.DXTRADE }];
+            // @ts-expect-error - since this is a mock, we only need partial properties of the list
+            expect(isDxtradeAccountAdded(list, true)).toBe(false);
+        });
+    });
+
+    describe('isCTraderAccountAdded', () => {
+        it('returns true if account is added', () => {
+            const list = [{ account_type: 'real', platform: CFD_PLATFORMS.CTRADER }];
+            // @ts-expect-error - since this is a mock, we only need partial properties of the list
+            expect(isCTraderAccountAdded(list)).toBe(true);
+        });
+
+        it('returns false if account is not added', () => {
+            const list = [{ account_type: 'real', platform: CFD_PLATFORMS.CTRADER }];
+            // @ts-expect-error - since this is a mock, we only need partial properties of the list
+            expect(isCTraderAccountAdded(list, true)).toBe(false);
+        });
+    });
+
+    describe('shouldRestrictBviAccountCreation', () => {
+        it('returns true if BVI account creation should be restricted', () => {
+            const accounts = [{ landing_company_short: 'bvi', status: 'poa_failed' }];
+            // @ts-expect-error - since this is a mock, we only need partial properties of the accounts
+            expect(shouldRestrictBviAccountCreation(accounts)).toBe(true);
+        });
+
+        it('returns false if BVI account creation should not be restricted', () => {
+            const accounts = [{ landing_company_short: 'bvi', status: 'active' }];
+            // @ts-expect-error - since this is a mock, we only need partial properties of the accounts
+            expect(shouldRestrictBviAccountCreation(accounts)).toBe(false);
+        });
+    });
+
+    describe('shouldRestrictVanuatuAccountCreation', () => {
+        it('returns true if Vanuatu account creation should be restricted', () => {
+            const accounts = [{ landing_company_short: 'vanuatu', status: 'poa_failed' }];
+            // @ts-expect-error - since this is a mock, we only need partial properties of the accounts
+            expect(shouldRestrictVanuatuAccountCreation(accounts)).toBe(true);
+        });
+
+        it('returns false if Vanuatu account creation should not be restricted', () => {
+            const accounts = [{ landing_company_short: 'vanuatu', status: 'active' }];
+            // @ts-expect-error - since this is a mock, we only need partial properties of the accounts
+            expect(shouldRestrictVanuatuAccountCreation(accounts)).toBe(false);
+        });
+    });
+});

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/constants.tsx
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/constants.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import {
     AccountsDerivXIcon,
     AccountsDmt5CfdsIcon,
-    AccountsDmt5StandardIcon,
     AccountsDmt5FinancialIcon,
+    AccountsDmt5StandardIcon,
     AccountsDmt5SwfIcon,
     PartnersProductDerivCtraderBrandLightLogoHorizontalIcon,
 } from '@deriv/quill-icons';

--- a/packages/wallets/src/public/images/tradingInstruments.tsx
+++ b/packages/wallets/src/public/images/tradingInstruments.tsx
@@ -11,8 +11,8 @@ import {
     IllustrativeSyntheticIndicesIcon,
 } from '@deriv/quill-icons';
 
-const getInstrumentsIcons = (isMobile: boolean) => {
-    const size = isMobile ? { height: 16, width: 16 } : { height: 24, width: 24 };
+const getInstrumentsIcons = (isDesktop: boolean) => {
+    const size = isDesktop ? { height: 24, width: 24 } : { height: 16, width: 16 };
 
     return {
         Baskets: <IllustrativeBasketIndicesIcon {...size} />,

--- a/packages/wallets/src/public/images/tradingInstruments.tsx
+++ b/packages/wallets/src/public/images/tradingInstruments.tsx
@@ -11,8 +11,8 @@ import {
     IllustrativeSyntheticIndicesIcon,
 } from '@deriv/quill-icons';
 
-const getInstrumentsIcons = (isDesktop: boolean) => {
-    const size = isDesktop ? { height: 24, width: 24 } : { height: 16, width: 16 };
+const getInstrumentsIcons = (isMobile: boolean) => {
+    const size = isMobile ? { height: 16, width: 16 } : { height: 24, width: 24 };
 
     return {
         Baskets: <IllustrativeBasketIndicesIcon {...size} />,


### PR DESCRIPTION
## Changes:

- [x] Added unit test for compare accounts components
- [x] Converted WalletText to deriv-com/ui Text for compare accounts components
- [x] Added data-testid to WalletListCardBalance for automation

### Screenshots:

<img width="1727" alt="Screenshot 2024-08-19 at 1 59 23 PM" src="https://github.com/user-attachments/assets/1be54d61-8219-4e8e-8877-4df2bd0fcbc4">

<img width="1727" alt="image" src="https://github.com/user-attachments/assets/eb5e080c-c613-450f-b3f7-49db02f76828">
