### PR TITLE
[WALL] Lubega / WALL-4410 / Remove fiat text from transfer messages

### DIFF
--- a/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/utils/__tests__/lifetimeAccountLimitsBetweenWalletsMessageFn.spec.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/utils/__tests__/lifetimeAccountLimitsBetweenWalletsMessageFn.spec.tsx
@@ -63,7 +63,7 @@ describe('lifetimeAccountLimitsBetweenWalletsMessageFn', () => {
             },
             message: (
                 <Localize
-                    i18n_default_text="You've reached the lifetime transfer limit from your {{sourceAccountName}} to any fiat Wallet. Verify your account to upgrade the limit."
+                    i18n_default_text="You've reached the lifetime transfer limit from your {{sourceAccountName}} to any Wallet. Verify your account to upgrade the limit."
                     values={{ sourceAccountName: cryptoAccount.accountName }}
                 />
             ),
@@ -200,7 +200,7 @@ describe('lifetimeAccountLimitsBetweenWalletsMessageFn', () => {
             },
             message: (
                 <Localize
-                    i18n_default_text='Your remaining lifetime transfer limit from {{sourceAccountName}} to any fiat Wallets is {{formattedSourceCurrencyRemainder}}. Verify your account to upgrade the limit.'
+                    i18n_default_text='Your remaining lifetime transfer limit from {{sourceAccountName}} to any Wallet is {{formattedSourceCurrencyRemainder}}. Verify your account to upgrade the limit.'
                     values={{
                         formattedSourceCurrencyRemainder: '5.00000000 BTC',
                         sourceAccountName: cryptoAccount.accountName,
@@ -233,7 +233,7 @@ describe('lifetimeAccountLimitsBetweenWalletsMessageFn', () => {
         expect(result).toEqual({
             message: (
                 <Localize
-                    i18n_default_text='The lifetime transfer limit from {{sourceAccountName}} to any fiat Wallets is up to {{formattedSourceCurrencyLimit}}.'
+                    i18n_default_text='The lifetime transfer limit from {{sourceAccountName}} to any Wallet is up to {{formattedSourceCurrencyLimit}}.'
                     values={{
                         formattedSourceCurrencyLimit: '10.00000000 BTC',
                         sourceAccountName: cryptoAccount.accountName,

--- a/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/utils/lifetimeAccountLimitsBetweenWalletsMessageFn.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/utils/lifetimeAccountLimitsBetweenWalletsMessageFn.tsx
@@ -80,7 +80,7 @@ const lifetimeAccountLimitsBetweenWalletsMessageFn = ({
                 />
             ) : (
                 <Localize
-                    i18n_default_text="You've reached the lifetime transfer limit from your {{sourceAccountName}} to any fiat Wallet. Verify your account to upgrade the limit."
+                    i18n_default_text="You've reached the lifetime transfer limit from your {{sourceAccountName}} to any Wallet. Verify your account to upgrade the limit."
                     values={{ sourceAccountName: sourceAccount.accountName }}
                 />
             );
@@ -104,7 +104,7 @@ const lifetimeAccountLimitsBetweenWalletsMessageFn = ({
                         />
                     ) : (
                         <Localize
-                            i18n_default_text='The lifetime transfer limit from {{sourceAccountName}} to any fiat Wallets is up to {{formattedSourceCurrencyLimit}}.'
+                            i18n_default_text='The lifetime transfer limit from {{sourceAccountName}} to any Wallet is up to {{formattedSourceCurrencyLimit}}.'
                             values={{ formattedSourceCurrencyLimit, sourceAccountName: sourceAccount.accountName }}
                         />
                     );
@@ -140,7 +140,7 @@ const lifetimeAccountLimitsBetweenWalletsMessageFn = ({
                     />
                 ) : (
                     <Localize
-                        i18n_default_text='Your remaining lifetime transfer limit from {{sourceAccountName}} to any fiat Wallets is {{formattedSourceCurrencyRemainder}}. Verify your account to upgrade the limit.'
+                        i18n_default_text='Your remaining lifetime transfer limit from {{sourceAccountName}} to any Wallet is {{formattedSourceCurrencyRemainder}}. Verify your account to upgrade the limit.'
                         values={{ formattedSourceCurrencyRemainder, sourceAccountName: sourceAccount.accountName }}
                     />
                 );


### PR DESCRIPTION
## Changes:

- [x] Remove 'fiat' text from crypto to fiat transfer messages


### Screenshots:

Please provide some screenshots of the change.
<img width="1235" alt="Screenshot 2024-08-20 at 3 33 04 PM" src="https://github.com/user-attachments/assets/2a7bb5b6-c1e6-492a-b8c0-f978d23a2e94">
<img width="1235" alt="Screenshot 2024-08-20 at 3 41 05 PM" src="https://github.com/user-attachments/assets/15b334f6-d10d-4aad-9f8f-bfe7bf8ef717">

