### PR TITLE
[DTRA] Maryia/DTRA-1410/fix: show all chart tools for minimized screen on a desktop device

### DIFF
--- a/packages/trader/src/Modules/SmartChart/Components/__tests__/toolbar-widgets.spec.tsx
+++ b/packages/trader/src/Modules/SmartChart/Components/__tests__/toolbar-widgets.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import ToolbarWidgets from '../toolbar-widgets';
 import { useDevice } from '@deriv-com/ui';
+import { isDesktopOs } from '@deriv/shared';
 
 jest.mock('Modules/SmartChart', () => ({
     ...jest.requireActual('Modules/SmartChart'),
@@ -15,7 +16,12 @@ jest.mock('Modules/SmartChart', () => ({
 
 jest.mock('@deriv-com/ui', () => ({
     ...jest.requireActual('@deriv-com/ui'),
-    useDevice: jest.fn(() => ({ isMobile: true, isDesktop: false })),
+    useDevice: jest.fn(() => ({ isMobile: true })),
+}));
+
+jest.mock('@deriv/shared', () => ({
+    ...jest.requireActual('@deriv/shared'),
+    isDesktopOs: jest.fn(() => false),
 }));
 
 describe('<ToolBarWidgets />', () => {
@@ -36,7 +42,8 @@ describe('<ToolBarWidgets />', () => {
         expect(screen.queryByText(/mockedviews/i)).not.toBeInTheDocument();
     });
     it('Should render all mocked widgets when isDesktop is true', () => {
-        (useDevice as jest.Mock).mockReturnValueOnce({ isDesktop: true, isMobile: false });
+        (isDesktopOs as jest.Mock).mockReturnValue(true);
+        (useDevice as jest.Mock).mockReturnValueOnce({ isMobile: false });
         render(<ToolbarWidgets {...mocked_props} />);
         expect(screen.getByText(/mockedchartmode/i)).toBeInTheDocument();
         expect(screen.getByText(/mockeddrawtools/i)).toBeInTheDocument();

--- a/packages/trader/src/Modules/SmartChart/Components/toolbar-widgets.tsx
+++ b/packages/trader/src/Modules/SmartChart/Components/toolbar-widgets.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ChartMode, DrawTools, Share, StudyLegend, Views, ToolbarWidget } from 'Modules/SmartChart';
 import { useDevice } from '@deriv-com/ui';
-import { isTabletOs } from '@deriv/shared';
+import { isDesktopOs } from '@deriv/shared';
 
 type TToolbarWidgetsProps = {
     position?: string;
@@ -10,12 +10,12 @@ type TToolbarWidgetsProps = {
 };
 
 const ToolbarWidgets = ({ position, updateChartType, updateGranularity }: TToolbarWidgetsProps) => {
-    const { isDesktop, isMobile } = useDevice();
+    const { isMobile } = useDevice();
 
     return (
         <ToolbarWidget position={position || (isMobile ? 'bottom' : null)}>
             <ChartMode portalNodeId='modal_root' onChartType={updateChartType} onGranularity={updateGranularity} />
-            {isDesktop && !isTabletOs && (
+            {isDesktopOs() && !isMobile && (
                 <StudyLegend portalNodeId='modal_root' searchInputClassName='data-hj-whitelist' />
             )}
             {!isMobile && (
@@ -26,8 +26,8 @@ const ToolbarWidgets = ({ position, updateChartType, updateGranularity }: TToolb
                     onGranularity={updateGranularity}
                 />
             )}
-            {isDesktop && !isTabletOs && <DrawTools portalNodeId='modal_root' />}
-            {isDesktop && !isTabletOs && <Share portalNodeId='modal_root' />}
+            {isDesktopOs() && !isMobile && <DrawTools portalNodeId='modal_root' />}
+            {isDesktopOs() && !isMobile && <Share portalNodeId='modal_root' />}
         </ToolbarWidget>
     );
 };

--- a/packages/trader/src/Modules/SmartChart/Components/toolbar-widgets.tsx
+++ b/packages/trader/src/Modules/SmartChart/Components/toolbar-widgets.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ChartMode, DrawTools, Share, StudyLegend, Views, ToolbarWidget } from 'Modules/SmartChart';
 import { useDevice } from '@deriv-com/ui';
-import { isDesktopOs } from '@deriv/shared';
+import { isDesktopOs, isTabletOs } from '@deriv/shared';
 
 type TToolbarWidgetsProps = {
     position?: string;
@@ -11,11 +11,12 @@ type TToolbarWidgetsProps = {
 
 const ToolbarWidgets = ({ position, updateChartType, updateGranularity }: TToolbarWidgetsProps) => {
     const { isMobile } = useDevice();
+    const is_real_desktop_device = isDesktopOs() && !isTabletOs; // in a tablet simulator on desktop, isDesktopOs returns true
 
     return (
         <ToolbarWidget position={position || (isMobile ? 'bottom' : null)}>
             <ChartMode portalNodeId='modal_root' onChartType={updateChartType} onGranularity={updateGranularity} />
-            {isDesktopOs() && !isMobile && (
+            {is_real_desktop_device && !isMobile && (
                 <StudyLegend portalNodeId='modal_root' searchInputClassName='data-hj-whitelist' />
             )}
             {!isMobile && (
@@ -26,8 +27,8 @@ const ToolbarWidgets = ({ position, updateChartType, updateGranularity }: TToolb
                     onGranularity={updateGranularity}
                 />
             )}
-            {isDesktopOs() && !isMobile && <DrawTools portalNodeId='modal_root' />}
-            {isDesktopOs() && !isMobile && <Share portalNodeId='modal_root' />}
+            {is_real_desktop_device && !isMobile && <DrawTools portalNodeId='modal_root' />}
+            {is_real_desktop_device && !isMobile && <Share portalNodeId='modal_root' />}
         </ToolbarWidget>
     );
 };


### PR DESCRIPTION
## Changes:

- to show all 5 chart tools for minimized screen on a desktop device (unless minimized to responsive screen size) instead of hiding 3 of them like for a tablet device:

### Screenshot:
<img width="1094" alt="360888261-9c3621ee-0f18-4416-994f-e26407b19924" src="https://github.com/user-attachments/assets/5450482d-72d0-40e9-bf10-810ee10ec021">
