### PR TITLE
[CFDS] CFDS-4278/shontzu/Overlapping-in-reset-investor-password-modal

### DIFF
--- a/packages/appstore/src/components/modals/modal-manager.tsx
+++ b/packages/appstore/src/components/modals/modal-manager.tsx
@@ -226,6 +226,7 @@ const ModalManager = () => {
         enableApp,
         disableApp,
         is_reset_trading_password_modal_visible,
+        setResetTradingPasswordModalOpen,
         setCFDPasswordResetModal,
         is_top_up_virtual_open,
         is_top_up_virtual_success,
@@ -345,7 +346,10 @@ const ModalManager = () => {
                     platform={trading_platform_dxtrade_password_reset ? 'dxtrade' : 'mt5'}
                     enableApp={enableApp}
                     disableApp={disableApp}
-                    toggleResetTradingPasswordModal={setCFDPasswordResetModal}
+                    toggleResetTradingPasswordModal={() => {
+                        setResetTradingPasswordModalOpen(false);
+                        setCFDPasswordResetModal(false);
+                    }}
                     is_visible={is_reset_trading_password_modal_visible}
                     is_loading={is_populating_mt5_account_list}
                     verification_code={trading_platform_dxtrade_password_reset || trading_platform_mt5_password_reset}

--- a/packages/core/src/App/Containers/Redirect/redirect.jsx
+++ b/packages/core/src/App/Containers/Redirect/redirect.jsx
@@ -16,7 +16,6 @@ const Redirect = observer(() => {
 
     const {
         openRealAccountSignup,
-        setCFDPasswordResetModal,
         setResetTradingPasswordModalOpen,
         toggleAccountSignupModal,
         toggleResetPasswordModal,
@@ -125,8 +124,7 @@ const Redirect = observer(() => {
                         hash = 'demo';
                         break;
                     case '3':
-                        pathname = routes.passwords;
-                        setCFDPasswordResetModal(true);
+                        pathname = routes.traders_hub;
                         break;
                     default:
                         break;

--- a/packages/core/src/Stores/ui-store.js
+++ b/packages/core/src/Stores/ui-store.js
@@ -924,7 +924,6 @@ export default class UIStore extends BaseStore {
 
     setCFDPasswordResetModal(val) {
         this.is_cfd_reset_password_modal_enabled = !!val;
-        this.is_reset_trading_password_modal_visible = !!val;
     }
 
     setSubSectionIndex(index) {


### PR DESCRIPTION
## Changes:

- Reset `MT5 Password` should not open `Investor Password` modal
- Reset `Investor Password` should not open `MT5 Password `modal
- Reset `MT5 Password` and `Investor Password` should be smooth in both appstore and account/password
- Navigating between `tradershub` and `account/passwords` should not cause modal issue (i.e. reopening the modal)

## Screenshots:
### Before:

<img src='https://github.com/user-attachments/assets/7ad4439b-b19a-4454-87e1-10d5727e151a' width="50%" />

https://github.com/user-attachments/assets/9e14aa36-dcac-4359-9fef-9318ef9eb2e5



### After:

https://github.com/user-attachments/assets/727114be-820b-4c53-9712-110d18b3b372




