### PR TITLE
[WEBREL] [WALL] shontzu/WEBREL-3106/The-text-for-the-Verification-failed-is-yellow-in-staging

### DIFF
--- a/packages/wallets/src/features/cfd/flows/MT5/AddedMT5AccountsList/AddedMT5AccountsList.scss
+++ b/packages/wallets/src/features/cfd/flows/MT5/AddedMT5AccountsList/AddedMT5AccountsList.scss
@@ -47,9 +47,6 @@
 
         &-badge {
             width: fit-content;
-            span {
-                color: var(--status-warning, #ffad3a);
-            }
             & a {
                 cursor: pointer;
                 text-decoration: underline;


### PR DESCRIPTION
## Changes:

remove overriding css since PlatformStatusBadge is warning in default:
<img width="433" alt="image" src="https://github.com/user-attachments/assets/cec6792c-6065-4c78-b440-28722d142f61">

### Screenshots:

![image](https://github.com/user-attachments/assets/c6c09e52-2deb-44d0-8ccb-929af73848dc)

![image](https://github.com/user-attachments/assets/c16cec26-625a-445d-9361-27b63590b121)
![image](https://github.com/user-attachments/assets/627fbf79-2619-4629-9dc6-640bff6584a8)
