### PR TITLE
Aizad/WALL-2948/Unit test for CreatePassword

### DIFF
--- a/packages/wallets/src/features/cfd/screens/CreatePassword/CreatePassword.tsx
+++ b/packages/wallets/src/features/cfd/screens/CreatePassword/CreatePassword.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { DerivLightDmt5PasswordIcon, DerivLightIcDxtradePasswordIcon } from '@deriv/quill-icons';
 import { Localize, useTranslations } from '@deriv-com/translations';
-import { Text } from '@deriv-com/ui';
+import { Text, useDevice } from '@deriv-com/ui';
 import { WalletButton, WalletPasswordFieldLazy } from '../../../../components/Base';
-import useDevice from '../../../../hooks/useDevice';
 import { TPlatforms } from '../../../../types';
 import { validPassword, validPasswordMT5 } from '../../../../utils/password-validation';
 import { CFD_PLATFORMS, PlatformDetails } from '../../constants';

--- a/packages/wallets/src/features/cfd/screens/CreatePassword/__test__/CreatePassword.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/CreatePassword/__test__/CreatePassword.spec.tsx
@@ -43,14 +43,16 @@ describe('CreatePassword', () => {
     });
 
     it('calls onPrimaryClick when the button is clicked', async () => {
-        renderComponent({ password: 'ValidPassword123' });
+        const validPassword = 'Abcd1234';
+        renderComponent({ password: validPassword });
         const button = screen.getByRole('button', { name: `Create ${DxtradeTitle} password` });
         await userEvent.click(button);
         expect(mockOnPrimaryClick).toHaveBeenCalled();
     });
 
     it('disables the button when the password is invalid or loading', () => {
-        renderComponent({ password: 'short' });
+        const shortPassword = 'Abcd';
+        renderComponent({ password: shortPassword });
         const button = screen.getByRole('button', { name: `Create ${DxtradeTitle} password` });
         expect(button).toBeDisabled();
 

--- a/packages/wallets/src/features/cfd/screens/CreatePassword/__test__/CreatePassword.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/CreatePassword/__test__/CreatePassword.spec.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CFD_PLATFORMS, PlatformDetails } from '../../../constants';
+import CreatePassword from '../CreatePassword';
+
+describe('CreatePassword', () => {
+    const mockOnPasswordChange = jest.fn();
+    const mockOnPrimaryClick = jest.fn();
+
+    const { title: DxtradeTitle } = PlatformDetails.dxtrade;
+    const { title: MT5Title } = PlatformDetails.mt5;
+
+    const renderComponent = (props = {}) => {
+        return render(
+            <CreatePassword
+                isLoading={false}
+                onPasswordChange={mockOnPasswordChange}
+                onPrimaryClick={mockOnPrimaryClick}
+                password=''
+                platform={CFD_PLATFORMS.DXTRADE}
+                {...props}
+            />
+        );
+    };
+
+    it('renders the component correctly', () => {
+        renderComponent();
+        expect(screen.getByText(`Create a ${DxtradeTitle} password`)).toBeInTheDocument();
+        expect(
+            screen.getByText(`You can use this password for all your ${DxtradeTitle} accounts.`)
+        ).toBeInTheDocument();
+        const button = screen.getByRole('button', { name: `Create ${DxtradeTitle} password` });
+        expect(button).toBeInTheDocument();
+        expect(button).toBeDisabled();
+    });
+
+    it('calls onPasswordChange when typing in the password field', async () => {
+        renderComponent();
+        const passwordField = screen.getByLabelText(`${DxtradeTitle} password`);
+        await userEvent.type(passwordField, 'testpassword');
+        expect(mockOnPasswordChange).toHaveBeenCalledTimes(12); // 'testpassword' has 12 characters
+    });
+
+    it('calls onPrimaryClick when the button is clicked', async () => {
+        renderComponent({ password: 'ValidPassword123' });
+        const button = screen.getByRole('button', { name: `Create ${DxtradeTitle} password` });
+        await userEvent.click(button);
+        expect(mockOnPrimaryClick).toHaveBeenCalled();
+    });
+
+    it('disables the button when the password is invalid or loading', () => {
+        renderComponent({ password: 'short' });
+        const button = screen.getByRole('button', { name: `Create ${DxtradeTitle} password` });
+        expect(button).toBeDisabled();
+
+        renderComponent({ isLoading: true });
+        expect(button).toBeDisabled();
+    });
+
+    it('renders correctly for MT5 platform', () => {
+        renderComponent({ platform: CFD_PLATFORMS.MT5 });
+        expect(screen.getByText(`Create a ${MT5Title} password`)).toBeInTheDocument();
+        expect(screen.getByText(`You can use this password for all your ${MT5Title} accounts.`)).toBeInTheDocument();
+        expect(screen.getByLabelText(`${MT5Title} password`)).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Changes:
- Create test case for `CreatePassword` component
- Change import `useDevice` from internal package to `deriv-com/ui`

### Screenshots:

![image](https://github.com/user-attachments/assets/cd5749b4-517a-469b-9ddd-107cf1b85a32)

