### PR TITLE
Akmal / feat: change default chart style from ticks to candles

### DIFF
--- a/packages/core/src/Stores/contract-trade-store.js
+++ b/packages/core/src/Stores/contract-trade-store.js
@@ -32,7 +32,7 @@ export default class ContractTradeStore extends BaseStore {
 
     // Chart specific observables
     granularity = +LocalStore.get('contract_trade.granularity') || 0;
-    chart_type = LocalStore.get('contract_trade.chart_style') || 'line';
+    chart_type = LocalStore.get('contract_trade.chart_style') || 'candles';
     prev_chart_type = '';
     prev_granularity = null;
 

--- a/packages/shared/src/utils/contract/contract.tsx
+++ b/packages/shared/src/utils/contract/contract.tsx
@@ -172,6 +172,8 @@ export const isResetContract = (contract_type = '') => /RESET/i.test(contract_ty
 
 export const isCryptoContract = (underlying = '') => underlying.startsWith('cry');
 
+export const isUpDownContract = (contract_type = '') => /rise_fall|high_low/i.test(contract_type);
+
 export const getAccuBarriersDefaultTimeout = (symbol: string) => {
     return symbols_2s.includes(symbol) ? DELAY_TIME_1S_SYMBOL * 2 : DELAY_TIME_1S_SYMBOL;
 };

--- a/packages/shared/src/utils/contract/trade-url-params-config.ts
+++ b/packages/shared/src/utils/contract/trade-url-params-config.ts
@@ -61,7 +61,7 @@ export const getTradeURLParams = ({ active_symbols = [], contract_types_list = {
         }>((acc, [key, value]) => ({ ...acc, [key]: value }), {});
         const validInterval = tradeURLParamsConfig.interval.find(item => item.text === interval);
         const validChartType = tradeURLParamsConfig.chartType.find(item => item.text === chart_type);
-        const chartTypeParam = Number(validInterval?.value) === 0 ? 'line' : validChartType?.value;
+        const chartTypeParam = Number(validInterval?.value) === 0 ? 'candles' : validChartType?.value;
         const isSymbolValid = active_symbols.some(item => item.symbol === symbol);
         const contractList = Object.keys(contract_types_list).reduce<string[]>((acc, key) => {
             const categories: TTradeTypesCategories['Ups & Downs']['categories'] =


### PR DESCRIPTION
## Changes:

This feature updates the default chart style in the platform, switching it from ticks to candles to enhance data visualization.

- Default Chart Style: Change the default setting for charts to display candlestick patterns instead of ticks, providing a more detailed and informative view of market data.
- User Interface: Update the user interface to reflect the new default chart style, ensuring users experience the change seamlessly.
- User Preferences: Ensure that user preferences are respected, allowing users to switch back to ticks if desired.

This change enhances the default data visualization experience by offering a more comprehensive view of price movements through candlestick charts.
