### PR TITLE
Update deriv-charts to 2.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "@deriv-com/utils": "^0.0.25",
                 "@deriv/api-types": "1.0.172",
                 "@deriv/deriv-api": "^1.0.15",
-                "@deriv/deriv-charts": "^2.4.0",
+                "@deriv/deriv-charts": "^2.5.0",
                 "@deriv/js-interpreter": "^3.0.0",
                 "@deriv/quill-design": "^1.3.2",
                 "@deriv/quill-icons": "1.23.3",
@@ -3180,9 +3180,9 @@
             }
         },
         "node_modules/@deriv/deriv-charts": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.4.0.tgz",
-            "integrity": "sha512-r8C6Zw+kDCFEQDytPmIdONttQvAlQAW9HjRxg4+YjYa3K1Dn7vOz+dQ9rVS4VBPZZ/iVJKTR4lzDOaDG8xyiXg==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.5.0.tgz",
+            "integrity": "sha512-zogotu034yYUF1k7SemD+BCoAY+atNSb6F7cDqy21TPWYqfZBGCbAQAtBiAhaetzea9z33e0SUEulgcTJ5cFwA==",
             "dependencies": {
                 "@types/lodash.set": "^4.3.7",
                 "@welldone-software/why-did-you-render": "^3.3.8",
@@ -54584,91 +54584,6 @@
             },
             "engines": {
                 "node": ">=4.2.0"
-            }
-        },
-        "node_modules/typescript-plugin-css-modules": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/typescript-plugin-css-modules/-/typescript-plugin-css-modules-5.1.0.tgz",
-            "integrity": "sha512-6h+sLBa4l+XYSTn/31vZHd/1c3SvAbLpobY6FxDiUOHJQG1eD9Gh3eCs12+Eqc+TCOAdxcO+zAPvUq0jBfdciw==",
-            "dependencies": {
-                "@types/postcss-modules-local-by-default": "^4.0.2",
-                "@types/postcss-modules-scope": "^3.0.4",
-                "dotenv": "^16.4.2",
-                "icss-utils": "^5.1.0",
-                "less": "^4.2.0",
-                "lodash.camelcase": "^4.3.0",
-                "postcss": "^8.4.35",
-                "postcss-load-config": "^3.1.4",
-                "postcss-modules-extract-imports": "^3.0.0",
-                "postcss-modules-local-by-default": "^4.0.4",
-                "postcss-modules-scope": "^3.1.1",
-                "reserved-words": "^0.1.2",
-                "sass": "^1.70.0",
-                "source-map-js": "^1.0.2",
-                "stylus": "^0.62.0",
-                "tsconfig-paths": "^4.2.0"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.0.0"
-            }
-        },
-        "node_modules/typescript-plugin-css-modules/node_modules/dotenv": {
-            "version": "16.4.5",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-            "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://dotenvx.com"
-            }
-        },
-        "node_modules/typescript-plugin-css-modules/node_modules/postcss": {
-            "version": "8.4.41",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.41.tgz",
-            "integrity": "sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==",
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/postcss"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "dependencies": {
-                "nanoid": "^3.3.7",
-                "picocolors": "^1.0.1",
-                "source-map-js": "^1.2.0"
-            },
-            "engines": {
-                "node": "^10 || ^12 || >=14"
-            }
-        },
-        "node_modules/typescript-plugin-css-modules/node_modules/strip-bom": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-            "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/typescript-plugin-css-modules/node_modules/tsconfig-paths": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
-            "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
-            "dependencies": {
-                "json5": "^2.2.2",
-                "minimist": "^1.2.6",
-                "strip-bom": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/ua-parser-js": {

--- a/packages/bot-web-ui/package.json
+++ b/packages/bot-web-ui/package.json
@@ -77,7 +77,7 @@
         "@deriv/bot-skeleton": "^1.0.0",
         "@deriv/components": "^1.0.0",
         "@deriv/hooks": "^1.0.0",
-        "@deriv/deriv-charts": "^2.4.0",
+        "@deriv/deriv-charts": "^2.5.0",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",
         "@deriv/translations": "^1.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -110,7 +110,7 @@
         "@deriv/cfd": "^1.0.0",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv/deriv-charts": "^2.4.0",
+        "@deriv/deriv-charts": "^2.5.0",
         "@deriv/hooks": "^1.0.0",
         "@deriv/p2p": "^0.7.3",
         "@deriv/quill-design": "^1.3.2",

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -95,7 +95,7 @@
         "@deriv/api-types": "1.0.172",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv/deriv-charts": "^2.4.0",
+        "@deriv/deriv-charts": "^2.5.0",
         "@deriv/hooks": "^1.0.0",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",


### PR DESCRIPTION
This PR updates @deriv/deriv-charts to 2.5.0