### PR TITLE
[WALL] aum / WALL-4617 / idv-fix-double-click-issue-of-next-button

### DIFF
--- a/packages/wallets/src/components/Base/ModalStepWrapper/ModalStepWrapper.tsx
+++ b/packages/wallets/src/components/Base/ModalStepWrapper/ModalStepWrapper.tsx
@@ -18,6 +18,18 @@ type TModalStepWrapperProps = {
     title?: string;
 };
 
+type TFooterProps = {
+    hasRenderFooter: boolean;
+    renderFooter: TModalStepWrapperProps['renderFooter'];
+};
+
+const Footer: FC<TFooterProps> = ({ hasRenderFooter, renderFooter }) =>
+    hasRenderFooter && renderFooter ? (
+        <div className='wallets-modal-step-wrapper__footer' data-testid='dt_modal_step_wrapper_footer'>
+            {renderFooter()}
+        </div>
+    ) : null;
+
 const ModalStepWrapper: FC<PropsWithChildren<TModalStepWrapperProps>> = ({
     children,
     disableAnimation = false,
@@ -47,13 +59,6 @@ const ModalStepWrapper: FC<PropsWithChildren<TModalStepWrapperProps>> = ({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [shouldHideDerivAppHeader]);
 
-    const Footer = () =>
-        hasRenderFooter ? (
-            <div className='wallets-modal-step-wrapper__footer' data-testid='dt_modal_step_wrapper_footer'>
-                {renderFooter()}
-            </div>
-        ) : null;
-
     return (
         <div
             className={classNames('wallets-modal-step-wrapper', {
@@ -80,9 +85,9 @@ const ModalStepWrapper: FC<PropsWithChildren<TModalStepWrapperProps>> = ({
             )}
             <div className='wallets-modal-step-wrapper__body' data-testid='dt_modal_step_wrapper_body'>
                 {children}
-                {!shouldFixedFooter && <Footer />}
+                {!shouldFixedFooter && <Footer hasRenderFooter={hasRenderFooter} renderFooter={renderFooter} />}
             </div>
-            {shouldFixedFooter && <Footer />}
+            {shouldFixedFooter && <Footer hasRenderFooter={hasRenderFooter} renderFooter={renderFooter} />}
         </div>
     );
 };


### PR DESCRIPTION
## Changes:

Fix the issue of double clicking `next` for triggering IDV submission. This problem happened because of `Footer` component created inside of the the `ModalStepWrapper` which would unpredictably break the state of footer upon re-renders.

### Screenshots:

<img width="1331" alt="Screenshot 2024-08-06 at 2 14 51 PM" src="https://github.com/user-attachments/assets/1200ba06-7996-48a9-bcae-998f1a880913">
