### PR TITLE
Jim/wall 2947/unit tests for change password

### DIFF
--- a/packages/wallets/src/features/cfd/screens/ChangePassword/InvestorPassword/__tests__/MT5ChangeInvestorPasswordInputsScreen.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/ChangePassword/InvestorPassword/__tests__/MT5ChangeInvestorPasswordInputsScreen.spec.tsx
@@ -2,7 +2,7 @@ import React, { PropsWithChildren } from 'react';
 import { useTradingPlatformInvestorPasswordChange } from '@deriv/api-v2';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { WalletButton } from '../../../../../../components';
+import { WalletButton } from '../../../../../../components/Base';
 import { useModal } from '../../../../../../components/ModalProvider';
 import useDevice from '../../../../../../hooks/useDevice';
 import { validPasswordMT5 } from '../../../../../../utils/password-validation';
@@ -15,6 +15,16 @@ jest.mock('@deriv/api-v2', () => ({
 
 jest.mock('../../../../../../components', () => ({
     ...jest.requireActual('../../../../../../components'),
+    WalletsActionScreen: jest.fn(({ description, renderButtons }) => (
+        <div>
+            {description}
+            {renderButtons()}
+        </div>
+    )),
+}));
+
+jest.mock('../../../../../../components/Base', () => ({
+    ...jest.requireActual('../../../../../../components/Base'),
     WalletButton: jest.fn(
         ({
             children,
@@ -37,12 +47,6 @@ jest.mock('../../../../../../components', () => ({
             );
         }
     ),
-    WalletsActionScreen: jest.fn(({ description, renderButtons }) => (
-        <div>
-            {description}
-            {renderButtons()}
-        </div>
-    )),
 }));
 
 jest.mock('../../../../../../components/ModalProvider', () => ({
@@ -65,6 +69,7 @@ jest.mock('../../../../../../utils/password-validation', () => ({
 
 describe('MT5ChangeInvestorPasswordInputsScreen', () => {
     beforeEach(() => {
+        jest.clearAllMocks();
         (useTradingPlatformInvestorPasswordChange as jest.Mock).mockReturnValue({
             mutateAsync: jest.fn(),
             status: 'idle',
@@ -147,5 +152,10 @@ describe('MT5ChangeInvestorPasswordInputsScreen', () => {
         expect(currentPasswordInput).toHaveAttribute('type', 'password');
         userEvent.click(screen.getAllByRole('button', { name: 'PasswordViewerIcon' })[0]);
         expect(currentPasswordInput).toHaveAttribute('type', 'text');
+    });
+    it('renders button with correct text size', () => {
+        (useDevice as jest.Mock).mockReturnValue({ isMobile: true });
+        render(<MT5ChangeInvestorPasswordInputsScreen />);
+        expect(WalletButton).toHaveBeenCalledWith(expect.objectContaining({ textSize: 'md' }), {});
     });
 });

--- a/packages/wallets/src/features/cfd/screens/ChangePassword/InvestorPassword/__tests__/MT5ChangeInvestorPasswordInputsScreen.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/ChangePassword/InvestorPassword/__tests__/MT5ChangeInvestorPasswordInputsScreen.spec.tsx
@@ -143,13 +143,9 @@ describe('MT5ChangeInvestorPasswordInputsScreen', () => {
     });
     it('displays the password when the viewer icon is clicked', () => {
         render(<MT5ChangeInvestorPasswordInputsScreen />);
-        expect(screen.getByPlaceholderText('Current investor password')).toHaveAttribute('type', 'password');
-        userEvent.click(screen.getByText('PasswordViewerIcon'));
-        expect(screen.getByPlaceholderText('Current investor password')).toHaveAttribute('type', 'text');
-    });
-    it('renders button with correct text size', () => {
-        (useDevice as jest.Mock).mockReturnValue({ isMobile: true });
-        render(<MT5ChangeInvestorPasswordInputsScreen />);
-        expect(WalletButton).toHaveBeenCalledWith(expect.objectContaining({ textSize: 'md' }), {});
+        const currentPasswordInput = screen.getByPlaceholderText('Current investor password');
+        expect(currentPasswordInput).toHaveAttribute('type', 'password');
+        userEvent.click(screen.getAllByRole('button', { name: 'PasswordViewerIcon' })[0]);
+        expect(currentPasswordInput).toHaveAttribute('type', 'text');
     });
 });

--- a/packages/wallets/src/features/cfd/screens/ChangePassword/InvestorPassword/__tests__/MT5ChangeInvestorPasswordInputsScreen.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/ChangePassword/InvestorPassword/__tests__/MT5ChangeInvestorPasswordInputsScreen.spec.tsx
@@ -1,0 +1,155 @@
+import React, { PropsWithChildren } from 'react';
+import { useTradingPlatformInvestorPasswordChange } from '@deriv/api-v2';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { WalletButton } from '../../../../../../components';
+import { useModal } from '../../../../../../components/ModalProvider';
+import useDevice from '../../../../../../hooks/useDevice';
+import { validPasswordMT5 } from '../../../../../../utils/password-validation';
+import MT5ChangeInvestorPasswordInputsScreen from '../MT5ChangeInvestorPasswordInputsScreen'; // Adjust the import path accordingly
+import '@testing-library/jest-dom/extend-expect';
+
+jest.mock('@deriv/api-v2', () => ({
+    useTradingPlatformInvestorPasswordChange: jest.fn(),
+}));
+
+jest.mock('../../../../../../components', () => ({
+    ...jest.requireActual('../../../../../../components'),
+    WalletButton: jest.fn(
+        ({
+            children,
+            disabled,
+            isLoading,
+            onClick,
+            type,
+        }: PropsWithChildren<{
+            disabled: boolean;
+            isLoading: boolean;
+            onClick: () => void;
+            textSize: string;
+            type?: 'button' | 'reset' | 'submit';
+        }>) => {
+            return (
+                <button disabled={disabled} onClick={onClick} type={type}>
+                    {isLoading && <>Loading...</>}
+                    {!isLoading ? children : null}
+                </button>
+            );
+        }
+    ),
+    WalletsActionScreen: jest.fn(({ description, renderButtons }) => (
+        <div>
+            {description}
+            {renderButtons()}
+        </div>
+    )),
+}));
+
+jest.mock('../../../../../../components/ModalProvider', () => ({
+    ...jest.requireActual('../../../../../../components/ModalProvider'),
+    useModal: jest.fn(),
+}));
+
+jest.mock('../../../../../../components/Base/WalletPasswordField/PasswordViewerIcon', () =>
+    jest.fn(({ setViewPassword, viewPassword }) => (
+        <button onClick={() => setViewPassword(!viewPassword)}>PasswordViewerIcon</button>
+    ))
+);
+
+jest.mock('../../../../../../hooks/useDevice', () => jest.fn());
+
+jest.mock('../../../../../../utils/password-validation', () => ({
+    ...jest.requireActual('../../../../../../utils/password-validation'),
+    validPasswordMT5: jest.fn(),
+}));
+
+describe('MT5ChangeInvestorPasswordInputsScreen', () => {
+    beforeEach(() => {
+        (useTradingPlatformInvestorPasswordChange as jest.Mock).mockReturnValue({
+            mutateAsync: jest.fn(),
+            status: 'idle',
+        });
+        (useModal as jest.Mock).mockReturnValue({
+            getModalState: jest.fn().mockReturnValue('test-account-id'),
+        });
+        (useDevice as jest.Mock).mockReturnValue({
+            isMobile: false,
+        });
+        (validPasswordMT5 as jest.Mock).mockReturnValue(true);
+    });
+
+    it('renders the component correctly', async () => {
+        render(<MT5ChangeInvestorPasswordInputsScreen />);
+        expect(screen.getByText(/Use this password to grant viewing access to another user/)).toBeInTheDocument();
+        expect(screen.getByText(/Change investor password/)).toBeInTheDocument();
+        expect(screen.getByText(/Create or reset investor password/)).toBeInTheDocument();
+    });
+
+    it('validates current password field', async () => {
+        render(<MT5ChangeInvestorPasswordInputsScreen />);
+        userEvent.click(screen.getByText('Current investor password'));
+        userEvent.tab();
+        userEvent.click(screen.getByText(/Change investor password/));
+
+        await waitFor(() => {
+            expect(screen.getByText('The field is required')).toBeInTheDocument();
+        });
+    });
+
+    it('submits the form with valid data', async () => {
+        const mockChangePassword = jest.fn().mockResolvedValue({});
+        (useTradingPlatformInvestorPasswordChange as jest.Mock).mockReturnValue({
+            mutateAsync: mockChangePassword,
+        });
+
+        render(<MT5ChangeInvestorPasswordInputsScreen setNextScreen={jest.fn()} />);
+
+        userEvent.type(screen.getByLabelText(/Current investor password/), 'currentPassword123');
+        const newInvestorPasswordInput = await screen.findByText('New investor password');
+        userEvent.type(newInvestorPasswordInput, 'newPassword123');
+
+        userEvent.click(screen.getByText(/Change investor password/));
+
+        await waitFor(() => {
+            expect(mockChangePassword).toHaveBeenCalledWith({
+                account_id: 'test-account-id',
+                new_password: 'newPassword123',
+                old_password: 'currentPassword123',
+                platform: 'mt5',
+            });
+        });
+    });
+
+    it('displays error message if change password fails', () => {
+        (useTradingPlatformInvestorPasswordChange as jest.Mock).mockReturnValue({
+            error: { error: { message: 'Error changing password' } },
+            mutateAsync: jest.fn(),
+        });
+
+        render(<MT5ChangeInvestorPasswordInputsScreen />);
+        expect(screen.getByText('Error changing password')).toBeInTheDocument();
+    });
+    it('shows the loader when the change investor password mutation is loading', () => {
+        (useTradingPlatformInvestorPasswordChange as jest.Mock).mockReturnValue({
+            status: 'loading',
+        });
+
+        render(<MT5ChangeInvestorPasswordInputsScreen />);
+        expect(
+            screen.getByRole('button', {
+                name: 'Loading...',
+            })
+        ).toBeInTheDocument();
+    });
+    it('displays the password when the viewer icon is clicked', () => {
+        render(<MT5ChangeInvestorPasswordInputsScreen />);
+        expect(screen.getByPlaceholderText('Current investor password')).toHaveAttribute('type', 'password');
+        userEvent.click(screen.getByText('PasswordViewerIcon'));
+        expect(screen.getByPlaceholderText('Current investor password')).toHaveAttribute('type', 'text');
+    });
+    it('renders button with correct text size', () => {
+        (useDevice as jest.Mock).mockReturnValue({ isMobile: true });
+        render(<MT5ChangeInvestorPasswordInputsScreen />);
+        expect(WalletButton).toHaveBeenCalledWith(expect.objectContaining({ textSize: 'md' }), {});
+    });
+});

--- a/packages/wallets/src/features/cfd/screens/ChangePassword/InvestorPassword/__tests__/MT5ChangeInvestorPasswordInputsScreen.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/ChangePassword/InvestorPassword/__tests__/MT5ChangeInvestorPasswordInputsScreen.spec.tsx
@@ -102,6 +102,8 @@ describe('MT5ChangeInvestorPasswordInputsScreen', () => {
     });
 
     it('submits the form with valid data', async () => {
+        const newPassword = 'newPassword123';
+        const oldPassword = 'oldPassword123';
         const mockChangePassword = jest.fn().mockResolvedValue({});
         (useTradingPlatformInvestorPasswordChange as jest.Mock).mockReturnValue({
             mutateAsync: mockChangePassword,
@@ -109,17 +111,17 @@ describe('MT5ChangeInvestorPasswordInputsScreen', () => {
 
         render(<MT5ChangeInvestorPasswordInputsScreen setNextScreen={jest.fn()} />);
 
-        userEvent.type(screen.getByLabelText(/Current investor password/), 'currentPassword123');
+        userEvent.type(screen.getByLabelText(/Current investor password/), oldPassword);
         const newInvestorPasswordInput = await screen.findByText('New investor password');
-        userEvent.type(newInvestorPasswordInput, 'newPassword123');
+        userEvent.type(newInvestorPasswordInput, newPassword);
 
         userEvent.click(screen.getByText(/Change investor password/));
 
         await waitFor(() => {
             expect(mockChangePassword).toHaveBeenCalledWith({
                 account_id: 'test-account-id',
-                new_password: 'newPassword123',
-                old_password: 'currentPassword123',
+                new_password: newPassword,
+                old_password: oldPassword,
                 platform: 'mt5',
             });
         });

--- a/packages/wallets/src/features/cfd/screens/ChangePassword/InvestorPassword/__tests__/MT5ChangeInvestorPasswordInputsScreen.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/ChangePassword/InvestorPassword/__tests__/MT5ChangeInvestorPasswordInputsScreen.spec.tsx
@@ -6,8 +6,7 @@ import { WalletButton } from '../../../../../../components/Base';
 import { useModal } from '../../../../../../components/ModalProvider';
 import useDevice from '../../../../../../hooks/useDevice';
 import { validPasswordMT5 } from '../../../../../../utils/password-validation';
-import MT5ChangeInvestorPasswordInputsScreen from '../MT5ChangeInvestorPasswordInputsScreen'; // Adjust the import path accordingly
-import '@testing-library/jest-dom/extend-expect';
+import MT5ChangeInvestorPasswordInputsScreen from '../MT5ChangeInvestorPasswordInputsScreen';
 
 jest.mock('@deriv/api-v2', () => ({
     useTradingPlatformInvestorPasswordChange: jest.fn(),
@@ -69,7 +68,6 @@ jest.mock('../../../../../../utils/password-validation', () => ({
 
 describe('MT5ChangeInvestorPasswordInputsScreen', () => {
     beforeEach(() => {
-        jest.clearAllMocks();
         (useTradingPlatformInvestorPasswordChange as jest.Mock).mockReturnValue({
             mutateAsync: jest.fn(),
             status: 'idle',
@@ -83,8 +81,9 @@ describe('MT5ChangeInvestorPasswordInputsScreen', () => {
         (validPasswordMT5 as jest.Mock).mockReturnValue(true);
     });
 
-    it('renders the component correctly', async () => {
+    it('renders the component correctly', () => {
         render(<MT5ChangeInvestorPasswordInputsScreen />);
+
         expect(screen.getByText(/Use this password to grant viewing access to another user/)).toBeInTheDocument();
         expect(screen.getByText(/Change investor password/)).toBeInTheDocument();
         expect(screen.getByText(/Create or reset investor password/)).toBeInTheDocument();
@@ -92,6 +91,7 @@ describe('MT5ChangeInvestorPasswordInputsScreen', () => {
 
     it('validates current password field', async () => {
         render(<MT5ChangeInvestorPasswordInputsScreen />);
+
         userEvent.click(screen.getByText('Current investor password'));
         userEvent.tab();
         userEvent.click(screen.getByText(/Change investor password/));
@@ -132,30 +132,40 @@ describe('MT5ChangeInvestorPasswordInputsScreen', () => {
         });
 
         render(<MT5ChangeInvestorPasswordInputsScreen />);
+
         expect(screen.getByText('Error changing password')).toBeInTheDocument();
     });
+
     it('shows the loader when the change investor password mutation is loading', () => {
         (useTradingPlatformInvestorPasswordChange as jest.Mock).mockReturnValue({
             status: 'loading',
         });
 
         render(<MT5ChangeInvestorPasswordInputsScreen />);
+
         expect(
             screen.getByRole('button', {
                 name: 'Loading...',
             })
         ).toBeInTheDocument();
     });
+
     it('displays the password when the viewer icon is clicked', () => {
         render(<MT5ChangeInvestorPasswordInputsScreen />);
+
         const currentPasswordInput = screen.getByPlaceholderText('Current investor password');
         expect(currentPasswordInput).toHaveAttribute('type', 'password');
+
         userEvent.click(screen.getAllByRole('button', { name: 'PasswordViewerIcon' })[0]);
+
         expect(currentPasswordInput).toHaveAttribute('type', 'text');
     });
-    it('renders button with correct text size', () => {
+
+    it('renders button with correct text size for mobile', () => {
         (useDevice as jest.Mock).mockReturnValue({ isMobile: true });
+
         render(<MT5ChangeInvestorPasswordInputsScreen />);
+
         expect(WalletButton).toHaveBeenCalledWith(expect.objectContaining({ textSize: 'md' }), {});
     });
 });

--- a/packages/wallets/src/features/cfd/screens/ChangePassword/InvestorPassword/__tests__/MT5ChangeInvestorPasswordSavedScreen.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/ChangePassword/InvestorPassword/__tests__/MT5ChangeInvestorPasswordSavedScreen.spec.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import MT5ChangeInvestorPasswordSavedScreen from '../MT5ChangeInvestorPasswordSavedScreen';
-import '@testing-library/jest-dom'; // for the custom matchers
 
 describe('MT5ChangeInvestorPasswordSavedScreen', () => {
     it('renders without crashing', () => {
@@ -15,10 +14,11 @@ describe('MT5ChangeInvestorPasswordSavedScreen', () => {
 
     it('calls setNextScreen when OK button is clicked', () => {
         const setNextScreenMock = jest.fn();
+
         render(<MT5ChangeInvestorPasswordSavedScreen setNextScreen={setNextScreenMock} />);
 
         userEvent.click(screen.getByRole('button', { name: /OK/i }));
 
-        expect(setNextScreenMock).toHaveBeenCalledTimes(1);
+        expect(setNextScreenMock).toHaveBeenCalled();
     });
 });

--- a/packages/wallets/src/features/cfd/screens/ChangePassword/InvestorPassword/__tests__/MT5ChangeInvestorPasswordSavedScreen.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/ChangePassword/InvestorPassword/__tests__/MT5ChangeInvestorPasswordSavedScreen.spec.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MT5ChangeInvestorPasswordSavedScreen from '../MT5ChangeInvestorPasswordSavedScreen';
+import '@testing-library/jest-dom'; // for the custom matchers
+
+describe('MT5ChangeInvestorPasswordSavedScreen', () => {
+    it('renders without crashing', () => {
+        render(<MT5ChangeInvestorPasswordSavedScreen />);
+
+        expect(screen.getByText('Your investor password has been changed.')).toBeInTheDocument();
+        expect(screen.getByText('Password saved')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /OK/i })).toBeInTheDocument();
+    });
+
+    it('calls setNextScreen when OK button is clicked', () => {
+        const setNextScreenMock = jest.fn();
+        render(<MT5ChangeInvestorPasswordSavedScreen setNextScreen={setNextScreenMock} />);
+
+        userEvent.click(screen.getByRole('button', { name: /OK/i }));
+
+        expect(setNextScreenMock).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/wallets/src/features/cfd/screens/ChangePassword/InvestorPassword/__tests__/MT5ChangeInvestorPasswordScreens.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/ChangePassword/InvestorPassword/__tests__/MT5ChangeInvestorPasswordScreens.spec.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { useActiveWalletAccount, useSettings, useVerifyEmail } from '@deriv/api-v2';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useModal } from '../../../../../../components/ModalProvider';
+import MT5ChangeInvestorPasswordScreens from '../MT5ChangeInvestorPasswordScreens';
+import '@testing-library/jest-dom/extend-expect';
+
+jest.mock('@deriv/api-v2', () => ({
+    ...jest.requireActual('@deriv/api-v2'),
+    useActiveWalletAccount: jest.fn(),
+    useSettings: jest.fn(),
+    useVerifyEmail: jest.fn(),
+}));
+jest.mock('../../../../../../components/ModalProvider', () => ({
+    ...jest.requireActual('../../../../../../components/ModalProvider'),
+    useModal: jest.fn(),
+}));
+jest.mock('../MT5ChangeInvestorPasswordInputsScreen', () =>
+    jest.fn(({ sendEmail, setNextScreen }) => (
+        <div>
+            <button onClick={sendEmail}>Send Email</button>
+            <button onClick={setNextScreen}>Next Screen</button>
+        </div>
+    ))
+);
+jest.mock('../MT5ChangeInvestorPasswordSavedScreen', () =>
+    jest.fn(({ setNextScreen }) => (
+        <div>
+            <button onClick={setNextScreen}>Close</button>
+        </div>
+    ))
+);
+
+describe('MT5ChangeInvestorPasswordScreens', () => {
+    beforeEach(() => {
+        (useModal as jest.Mock).mockReturnValue({
+            getModalState: jest.fn().mockReturnValue('account-id'),
+            hide: jest.fn(),
+        });
+        (useSettings as jest.Mock).mockReturnValue({ data: { email: 'user@example.com' } });
+        (useVerifyEmail as jest.Mock).mockReturnValue({ mutate: jest.fn() });
+        (useActiveWalletAccount as jest.Mock).mockReturnValue({ data: { is_virtual: false } });
+    });
+
+    it('renders intro screen by default', () => {
+        render(<MT5ChangeInvestorPasswordScreens />);
+        expect(screen.getByText('Send Email')).toBeInTheDocument();
+        expect(screen.getByText('Next Screen')).toBeInTheDocument();
+    });
+
+    it('handles send email button click', async () => {
+        const setShowEmailSentScreen = jest.fn();
+        const { mutate } = useVerifyEmail();
+
+        render(<MT5ChangeInvestorPasswordScreens setShowEmailSentScreen={setShowEmailSentScreen} />);
+
+        userEvent.click(screen.getByText('Send Email'));
+
+        await waitFor(() => {
+            expect(mutate).toHaveBeenCalled();
+            expect(setShowEmailSentScreen).toHaveBeenCalledWith(true);
+            expect(localStorage.getItem('trading_platform_investor_password_reset_account_id')).toBe('account-id');
+        });
+    });
+
+    it('switches to saved screen on next screen button click', () => {
+        render(<MT5ChangeInvestorPasswordScreens />);
+
+        userEvent.click(screen.getByText('Next Screen'));
+
+        expect(screen.getByText('Close')).toBeInTheDocument();
+    });
+
+    it('calls hide modal on close button click in saved screen', () => {
+        const { hide } = useModal();
+
+        render(<MT5ChangeInvestorPasswordScreens />);
+
+        userEvent.click(screen.getByText('Next Screen'));
+        userEvent.click(screen.getByText('Close'));
+
+        expect(hide).toHaveBeenCalled();
+    });
+});

--- a/packages/wallets/src/features/cfd/screens/ChangePassword/InvestorPassword/__tests__/MT5ChangeInvestorPasswordScreens.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/ChangePassword/InvestorPassword/__tests__/MT5ChangeInvestorPasswordScreens.spec.tsx
@@ -4,7 +4,6 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useModal } from '../../../../../../components/ModalProvider';
 import MT5ChangeInvestorPasswordScreens from '../MT5ChangeInvestorPasswordScreens';
-import '@testing-library/jest-dom/extend-expect';
 
 jest.mock('@deriv/api-v2', () => ({
     ...jest.requireActual('@deriv/api-v2'),
@@ -12,10 +11,12 @@ jest.mock('@deriv/api-v2', () => ({
     useSettings: jest.fn(),
     useVerifyEmail: jest.fn(),
 }));
+
 jest.mock('../../../../../../components/ModalProvider', () => ({
     ...jest.requireActual('../../../../../../components/ModalProvider'),
     useModal: jest.fn(),
 }));
+
 jest.mock('../MT5ChangeInvestorPasswordInputsScreen', () =>
     jest.fn(({ sendEmail, setNextScreen }) => (
         <div>
@@ -24,6 +25,7 @@ jest.mock('../MT5ChangeInvestorPasswordInputsScreen', () =>
         </div>
     ))
 );
+
 jest.mock('../MT5ChangeInvestorPasswordSavedScreen', () =>
     jest.fn(({ setNextScreen }) => (
         <div>
@@ -45,8 +47,9 @@ describe('MT5ChangeInvestorPasswordScreens', () => {
 
     it('renders intro screen by default', () => {
         render(<MT5ChangeInvestorPasswordScreens />);
-        expect(screen.getByText('Send Email')).toBeInTheDocument();
-        expect(screen.getByText('Next Screen')).toBeInTheDocument();
+
+        expect(screen.getByRole('button', { name: 'Send Email' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Next Screen' })).toBeInTheDocument();
     });
 
     it('handles send email button click', async () => {
@@ -55,7 +58,7 @@ describe('MT5ChangeInvestorPasswordScreens', () => {
 
         render(<MT5ChangeInvestorPasswordScreens setShowEmailSentScreen={setShowEmailSentScreen} />);
 
-        userEvent.click(screen.getByText('Send Email'));
+        userEvent.click(screen.getByRole('button', { name: 'Send Email' }));
 
         await waitFor(() => {
             expect(mutate).toHaveBeenCalled();
@@ -67,9 +70,9 @@ describe('MT5ChangeInvestorPasswordScreens', () => {
     it('switches to saved screen on next screen button click', () => {
         render(<MT5ChangeInvestorPasswordScreens />);
 
-        userEvent.click(screen.getByText('Next Screen'));
+        userEvent.click(screen.getByRole('button', { name: 'Next Screen' }));
 
-        expect(screen.getByText('Close')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
     });
 
     it('calls hide modal on close button click in saved screen', () => {
@@ -77,8 +80,8 @@ describe('MT5ChangeInvestorPasswordScreens', () => {
 
         render(<MT5ChangeInvestorPasswordScreens />);
 
-        userEvent.click(screen.getByText('Next Screen'));
-        userEvent.click(screen.getByText('Close'));
+        userEvent.click(screen.getByRole('button', { name: 'Next Screen' }));
+        userEvent.click(screen.getByRole('button', { name: 'Close' }));
 
         expect(hide).toHaveBeenCalled();
     });

--- a/packages/wallets/src/features/cfd/screens/ChangePassword/MT5ChangePasswordScreens.tsx
+++ b/packages/wallets/src/features/cfd/screens/ChangePassword/MT5ChangePasswordScreens.tsx
@@ -16,7 +16,10 @@ const MT5ChangePasswordScreens = () => {
     const { title } = PlatformDetails[platform];
 
     return showSentEmailContentWithoutTabs ? (
-        <div className='wallets-change-password__sent-email-content-wrapper--mt5-investor'>
+        <div
+            className='wallets-change-password__sent-email-content-wrapper--mt5-investor'
+            data-testid='dt_change_password_sent_email_content_wrapper'
+        >
             <SentEmailContent
                 description={localize('Please click on the link in the email to reset your password.')}
                 isInvestorPassword

--- a/packages/wallets/src/features/cfd/screens/ChangePassword/__tests__/ChangePassword.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/ChangePassword/__tests__/ChangePassword.spec.tsx
@@ -44,6 +44,7 @@ jest.mock('../../../../../components/ModalProvider', () => ({
 }));
 
 jest.mock('../MT5ChangePasswordScreens', () => jest.fn(() => <div>MT5 Change Password</div>));
+
 jest.mock('../TradingPlatformChangePasswordScreens', () =>
     jest.fn(({ platform }) => <div>Trading Platform Change Password: {platform}</div>)
 );
@@ -54,7 +55,8 @@ describe('ChangePassword', () => {
 
         expect(screen.getByText('MT5 Change Password')).toBeInTheDocument();
     });
-    it('renders the MT5ChangePasswordScreens component when the paltform is mt5', () => {
+
+    it('renders the MT5ChangePasswordScreens component when the platform is mt5', () => {
         (useModal as jest.Mock).mockReturnValue({
             getModalState: jest.fn(() => 'mt5'),
             setModalOptions: jest.fn(),

--- a/packages/wallets/src/features/cfd/screens/ChangePassword/__tests__/ChangePassword.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/ChangePassword/__tests__/ChangePassword.spec.tsx
@@ -48,7 +48,7 @@ jest.mock('../TradingPlatformChangePasswordScreens', () =>
     jest.fn(({ platform }) => <div>Trading Platform Change Password: {platform}</div>)
 );
 
-describe('ChangePassword Component', () => {
+describe('ChangePassword', () => {
     it('renders the MT5ChangePasswordScreens component by default', () => {
         render(<ChangePassword />, { wrapper });
 

--- a/packages/wallets/src/features/cfd/screens/ChangePassword/__tests__/ChangePassword.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/ChangePassword/__tests__/ChangePassword.spec.tsx
@@ -1,0 +1,100 @@
+import React, { PropsWithChildren } from 'react';
+import { APIProvider } from '@deriv/api-v2';
+import { render, screen } from '@testing-library/react';
+import WalletsAuthProvider from '../../../../../AuthProvider';
+import { ModalProvider, useModal } from '../../../../../components/ModalProvider';
+import ChangePassword from '../ChangePassword';
+
+const wrapper = ({ children }: PropsWithChildren) => (
+    <APIProvider>
+        <WalletsAuthProvider>
+            <ModalProvider>{children}</ModalProvider>
+        </WalletsAuthProvider>
+    </APIProvider>
+);
+
+jest.mock('../../../constants', () => ({
+    ...jest.requireActual('../../../constants'),
+    PlatformDetails: {
+        ctrader: {
+            platform: 'ctrader',
+            title: 'Deriv cTrader',
+        },
+        dxtrade: {
+            platform: 'dxtrade',
+            title: 'Deriv X',
+        },
+        mt5: {
+            platform: 'mt5',
+            title: 'Deriv MT5',
+        },
+        mt5Investor: {
+            platform: 'mt5',
+            title: 'Deriv MT5 investor',
+        },
+    },
+}));
+
+jest.mock('../../../../../components/ModalProvider', () => ({
+    ...jest.requireActual('../../../../../components/ModalProvider'),
+    useModal: jest.fn(() => ({
+        ...jest.requireActual('../../../../../components/ModalProvider').useModal(),
+        getModalState: jest.fn(),
+    })),
+}));
+
+jest.mock('../MT5ChangePasswordScreens', () => jest.fn(() => <div>MT5 Change Password</div>));
+jest.mock('../TradingPlatformChangePasswordScreens', () =>
+    jest.fn(({ platform }) => <div>Trading Platform Change Password: {platform}</div>)
+);
+
+describe('ChangePassword Component', () => {
+    it('renders the MT5ChangePasswordScreens component by default', () => {
+        render(<ChangePassword />, { wrapper });
+
+        expect(screen.getByText('MT5 Change Password')).toBeInTheDocument();
+    });
+    it('renders the MT5ChangePasswordScreens component when the paltform is mt5', () => {
+        (useModal as jest.Mock).mockReturnValue({
+            getModalState: jest.fn(() => 'mt5'),
+            setModalOptions: jest.fn(),
+        });
+
+        render(<ChangePassword />, { wrapper });
+
+        expect(screen.getByText('MT5 Change Password')).toBeInTheDocument();
+    });
+
+    it('renders the TradingPlatformChangePasswordScreens component when platform is dxtrade', () => {
+        (useModal as jest.Mock).mockReturnValue({
+            getModalState: jest.fn(() => 'dxtrade'),
+            setModalOptions: jest.fn(),
+        });
+
+        render(<ChangePassword />, { wrapper });
+
+        expect(screen.getByText('Trading Platform Change Password: dxtrade')).toBeInTheDocument();
+    });
+
+    it('displays the correct title in ModalStepWrapper', () => {
+        (useModal as jest.Mock).mockReturnValue({
+            getModalState: jest.fn(() => 'mt5'),
+            setModalOptions: jest.fn(),
+        });
+
+        render(<ChangePassword />, { wrapper });
+
+        expect(screen.getByText('Manage Deriv MT5 password')).toBeInTheDocument();
+    });
+
+    it('passes the correct platform prop to the TradingPlatformChangePasswordScreens component', () => {
+        (useModal as jest.Mock).mockReturnValue({
+            getModalState: jest.fn(() => 'dxtrade'),
+            setModalOptions: jest.fn(),
+        });
+
+        render(<ChangePassword />, { wrapper });
+
+        expect(screen.getByText('Trading Platform Change Password: dxtrade')).toBeInTheDocument();
+    });
+});

--- a/packages/wallets/src/features/cfd/screens/ChangePassword/__tests__/MT5ChangePasswordScreens.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/ChangePassword/__tests__/MT5ChangePasswordScreens.spec.tsx
@@ -1,0 +1,101 @@
+import React, { PropsWithChildren } from 'react';
+import { useTranslations } from '@deriv-com/translations';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Tabs } from '../../../../../components/Base';
+import useDevice from '../../../../../hooks/useDevice';
+import MT5ChangePasswordScreens from '../MT5ChangePasswordScreens';
+
+jest.mock('@deriv-com/translations', () => ({
+    useTranslations: jest.fn(),
+}));
+jest.mock('../../../../../hooks/useDevice', () => jest.fn(() => ({ isMobile: false })));
+jest.mock('../../../../../components', () => ({
+    SentEmailContent: () => <div>Sent Email Content</div>,
+}));
+
+jest.mock('../../../../../components/Base', () => ({
+    ...jest.requireActual('../../../../../components/Base'),
+    Tab: jest.fn(({ children, title }: PropsWithChildren<{ title: string }>) => (
+        <>
+            <span>{title}</span>
+            <div>{children}</div>
+        </>
+    )),
+    Tabs: jest.fn(({ children }: PropsWithChildren) => <div>{children}</div>),
+}));
+
+jest.mock('../InvestorPassword/MT5ChangeInvestorPasswordScreens', () =>
+    jest.fn(({ setShowEmailSentScreen }) => (
+        <div>
+            MT5 Change Investor Password
+            <button onClick={setShowEmailSentScreen}>Create or reset investor password</button>
+        </div>
+    ))
+);
+jest.mock('../TradingPlatformChangePasswordScreens', () =>
+    jest.fn(({ platform }) => <div>Trading Platform Change Password: {platform}</div>)
+);
+
+jest.mock('../../../constants', () => ({
+    ...jest.requireActual('../../../constants'),
+    PlatformDetails: {
+        ctrader: {
+            platform: 'ctrader',
+            title: 'Deriv cTrader',
+        },
+        dxtrade: {
+            platform: 'dxtrade',
+            title: 'Deriv X',
+        },
+        mt5: {
+            platform: 'mt5',
+            title: 'Deriv MT5',
+        },
+        mt5Investor: {
+            platform: 'mt5',
+            title: 'Deriv MT5 investor',
+        },
+    },
+}));
+
+describe('MT5ChangePasswordScreens', () => {
+    const mockLocalize = jest.fn((text, params) => {
+        const { title = '' } = params || {};
+        return text.replace('{{title}}', title);
+    });
+
+    beforeAll(() => {
+        (useTranslations as jest.Mock).mockReturnValue({ localize: mockLocalize });
+    });
+
+    it('renders Tabs by default', () => {
+        render(<MT5ChangePasswordScreens />);
+        expect(screen.getByText('Deriv MT5 Password')).toBeInTheDocument();
+        expect(screen.getByText('Investor Password')).toBeInTheDocument();
+    });
+
+    it('renders SentEmailContent when create or reset investor password button is clicked', () => {
+        render(<MT5ChangePasswordScreens />);
+        userEvent.click(screen.getByText('Investor Password'));
+        const createOrResetInvestorPasswordButton = screen.getByText('Create or reset investor password');
+        expect(createOrResetInvestorPasswordButton).toBeInTheDocument();
+        userEvent.click(createOrResetInvestorPasswordButton);
+        expect(screen.getByText('Sent Email Content')).toBeInTheDocument();
+        expect(screen.getByTestId('dt_change_password_sent_email_content_wrapper')).toBeInTheDocument();
+    });
+
+    it('calls localize when rendering tab titles', () => {
+        render(<MT5ChangePasswordScreens />);
+        expect(mockLocalize).toHaveBeenCalledWith('{{title}} Password', { title: 'Deriv MT5' });
+        expect(mockLocalize).toHaveBeenCalledWith('Investor Password');
+        expect(screen.getByText('Deriv MT5 Password')).toBeInTheDocument();
+        expect(screen.getByText('Investor Password')).toBeInTheDocument();
+    });
+
+    it('renders tabs with fontSize of sm for non-mobile', () => {
+        render(<MT5ChangePasswordScreens />);
+        expect(Tabs).toHaveBeenCalledWith(expect.objectContaining({ fontSize: 'sm' }), {});
+        expect(screen.getByText('MT5 Change Investor Password')).toBeInTheDocument();
+    });
+});

--- a/packages/wallets/src/features/cfd/screens/ChangePassword/__tests__/MT5ChangePasswordScreens.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/ChangePassword/__tests__/MT5ChangePasswordScreens.spec.tsx
@@ -3,7 +3,6 @@ import { useTranslations } from '@deriv-com/translations';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Tabs } from '../../../../../components/Base';
-import useDevice from '../../../../../hooks/useDevice';
 import MT5ChangePasswordScreens from '../MT5ChangePasswordScreens';
 
 jest.mock('@deriv-com/translations', () => ({

--- a/packages/wallets/src/features/cfd/screens/ChangePassword/__tests__/MT5ChangePasswordScreens.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/ChangePassword/__tests__/MT5ChangePasswordScreens.spec.tsx
@@ -8,7 +8,9 @@ import MT5ChangePasswordScreens from '../MT5ChangePasswordScreens';
 jest.mock('@deriv-com/translations', () => ({
     useTranslations: jest.fn(),
 }));
+
 jest.mock('../../../../../hooks/useDevice', () => jest.fn(() => ({ isMobile: false })));
+
 jest.mock('../../../../../components', () => ({
     SentEmailContent: () => <div>Sent Email Content</div>,
 }));
@@ -32,6 +34,7 @@ jest.mock('../InvestorPassword/MT5ChangeInvestorPasswordScreens', () =>
         </div>
     ))
 );
+
 jest.mock('../TradingPlatformChangePasswordScreens', () =>
     jest.fn(({ platform }) => <div>Trading Platform Change Password: {platform}</div>)
 );
@@ -70,22 +73,31 @@ describe('MT5ChangePasswordScreens', () => {
 
     it('renders Tabs by default', () => {
         render(<MT5ChangePasswordScreens />);
+
         expect(screen.getByText('Deriv MT5 Password')).toBeInTheDocument();
         expect(screen.getByText('Investor Password')).toBeInTheDocument();
     });
 
     it('renders SentEmailContent when create or reset investor password button is clicked', () => {
         render(<MT5ChangePasswordScreens />);
+
         userEvent.click(screen.getByText('Investor Password'));
-        const createOrResetInvestorPasswordButton = screen.getByText('Create or reset investor password');
+
+        const createOrResetInvestorPasswordButton = screen.getByRole('button', {
+            name: 'Create or reset investor password',
+        });
+
         expect(createOrResetInvestorPasswordButton).toBeInTheDocument();
+
         userEvent.click(createOrResetInvestorPasswordButton);
+
         expect(screen.getByText('Sent Email Content')).toBeInTheDocument();
         expect(screen.getByTestId('dt_change_password_sent_email_content_wrapper')).toBeInTheDocument();
     });
 
     it('calls localize when rendering tab titles', () => {
         render(<MT5ChangePasswordScreens />);
+
         expect(mockLocalize).toHaveBeenCalledWith('{{title}} Password', { title: 'Deriv MT5' });
         expect(mockLocalize).toHaveBeenCalledWith('Investor Password');
         expect(screen.getByText('Deriv MT5 Password')).toBeInTheDocument();
@@ -94,6 +106,7 @@ describe('MT5ChangePasswordScreens', () => {
 
     it('renders tabs with fontSize of sm for non-mobile', () => {
         render(<MT5ChangePasswordScreens />);
+
         expect(Tabs).toHaveBeenCalledWith(expect.objectContaining({ fontSize: 'sm' }), {});
         expect(screen.getByText('MT5 Change Investor Password')).toBeInTheDocument();
     });

--- a/packages/wallets/src/features/cfd/screens/ChangePassword/__tests__/TradingPlatformChangePasswordScreens.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/ChangePassword/__tests__/TradingPlatformChangePasswordScreens.spec.tsx
@@ -3,7 +3,7 @@ import { useActiveWalletAccount, useSettings, useVerifyEmail } from '@deriv/api-
 import { useTranslations } from '@deriv-com/translations';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { WalletButton } from '../../../../../components';
+import { WalletButton } from '../../../../../components/Base';
 import { useModal } from '../../../../../components/ModalProvider';
 import useDevice from '../../../../../hooks/useDevice';
 import TradingPlatformChangePasswordScreens from '../TradingPlatformChangePasswordScreens';
@@ -27,7 +27,6 @@ jest.mock('../../../../../hooks/useDevice', () => jest.fn(() => ({ isMobile: fal
 jest.mock('../../../../../components', () => ({
     ...jest.requireActual('../../../../../components'),
     SentEmailContent: jest.fn().mockImplementation(() => <div>SentEmailContent</div>),
-    WalletButton: jest.fn(({ children, onClick }) => <button onClick={onClick}>{children}</button>),
     WalletsActionScreen: jest.fn(({ description, renderButtons, title }) => (
         <div>
             <h1>{title}</h1>
@@ -35,6 +34,11 @@ jest.mock('../../../../../components', () => ({
             {renderButtons()}
         </div>
     )),
+}));
+
+jest.mock('../../../../../components/Base', () => ({
+    ...jest.requireActual('../../../../../components/Base'),
+    WalletButton: jest.fn(({ children, onClick }) => <button onClick={onClick}>{children}</button>),
 }));
 
 describe('TradingPlatformChangePasswordScreens', () => {
@@ -111,6 +115,7 @@ describe('TradingPlatformChangePasswordScreens', () => {
             },
             verify_email: 'test@mail.com',
         });
+        expect(WalletButton).toHaveBeenCalledWith(expect.objectContaining({ textSize: 'md' }), {});
     });
     it('calls handleSendEmail when Confirm is clicked and the platform is dxtrade', () => {
         render(<TradingPlatformChangePasswordScreens platform='dxtrade' />);

--- a/packages/wallets/src/features/cfd/screens/ChangePassword/__tests__/TradingPlatformChangePasswordScreens.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/ChangePassword/__tests__/TradingPlatformChangePasswordScreens.spec.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { useActiveWalletAccount, useSettings, useVerifyEmail } from '@deriv/api-v2';
+import { useTranslations } from '@deriv-com/translations';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { WalletButton } from '../../../../../components';
+import { useModal } from '../../../../../components/ModalProvider';
+import useDevice from '../../../../../hooks/useDevice';
+import TradingPlatformChangePasswordScreens from '../TradingPlatformChangePasswordScreens';
+import '@testing-library/jest-dom/extend-expect';
+
+jest.mock('@deriv/api-v2', () => ({
+    ...jest.requireActual('@deriv/api-v2'),
+    useActiveWalletAccount: jest.fn(),
+    useSettings: jest.fn(),
+    useVerifyEmail: jest.fn(),
+}));
+jest.mock('@deriv-com/translations', () => ({
+    ...jest.requireActual('@deriv-com/translations'),
+    useTranslations: jest.fn(),
+}));
+jest.mock('../../../../../components/ModalProvider', () => ({
+    ...jest.requireActual('../../../../../components/ModalProvider'),
+    useModal: jest.fn(),
+}));
+jest.mock('../../../../../hooks/useDevice', () => jest.fn(() => ({ isMobile: false })));
+jest.mock('../../../../../components', () => ({
+    ...jest.requireActual('../../../../../components'),
+    SentEmailContent: jest.fn().mockImplementation(() => <div>SentEmailContent</div>),
+    WalletButton: jest
+        .fn()
+        .mockImplementation(({ children, onClick }) => <button onClick={onClick}>{children}</button>),
+    WalletsActionScreen: jest.fn().mockImplementation(({ description, renderButtons, title }) => (
+        <div>
+            <h1>{title}</h1>
+            <p>{description}</p>
+            {renderButtons()}
+        </div>
+    )),
+}));
+
+describe('TradingPlatformChangePasswordScreens', () => {
+    const mockUseVerifyEmail = jest.fn();
+    beforeEach(() => {
+        (useVerifyEmail as jest.Mock).mockReturnValue({
+            mutate: mockUseVerifyEmail,
+        });
+
+        (useModal as jest.Mock).mockReturnValue({
+            hide: jest.fn(),
+        });
+
+        (useDevice as jest.Mock).mockReturnValue({
+            isMobile: false,
+        });
+
+        (useSettings as jest.Mock).mockReturnValue({
+            data: { email: 'test@mail.com' },
+        });
+
+        (useActiveWalletAccount as jest.Mock).mockReturnValue({
+            data: { is_virtual: false },
+        });
+        (useTranslations as jest.Mock).mockReturnValue({
+            localize: jest.fn().mockImplementation((str, { title }) => str.replace('{{title}}', title)),
+        });
+    });
+    it('renders intro screen by default', () => {
+        render(<TradingPlatformChangePasswordScreens platform='mt5' />);
+
+        expect(screen.getByText('Deriv MT5 password')).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                'Use this password to log in to your Deriv MT5 accounts on the desktop, web, and mobile apps.'
+            )
+        ).toBeInTheDocument();
+        expect(screen.getByText('Change password')).toBeInTheDocument();
+    });
+
+    it('renders confirmation screen when Change password is clicked', () => {
+        render(<TradingPlatformChangePasswordScreens platform='mt5' />);
+
+        userEvent.click(screen.getByText('Change password'));
+
+        expect(screen.getByText('Confirm to change your Deriv MT5 password')).toBeInTheDocument();
+        expect(
+            screen.getByText('This will change the password to all of your Deriv MT5 accounts.')
+        ).toBeInTheDocument();
+        expect(screen.getByText('Cancel')).toBeInTheDocument();
+        expect(screen.getByText('Confirm')).toBeInTheDocument();
+    });
+
+    it('renders email verification screen when Confirm is clicked', async () => {
+        render(<TradingPlatformChangePasswordScreens platform='mt5' />);
+
+        userEvent.click(screen.getByText('Change password'));
+        userEvent.click(screen.getByText('Confirm'));
+
+        expect(screen.getByText('SentEmailContent')).toBeInTheDocument();
+    });
+
+    it('calls handleSendEmail when Confirm is clicked and the platform is mt5', () => {
+        (useDevice as jest.Mock).mockReturnValue({ isMobile: true });
+        render(<TradingPlatformChangePasswordScreens platform='mt5' />);
+
+        userEvent.click(screen.getByText('Change password'));
+        userEvent.click(screen.getByText('Confirm'));
+
+        expect(mockUseVerifyEmail).toHaveBeenCalledWith({
+            type: 'trading_platform_mt5_password_reset',
+            url_parameters: {
+                redirect_to: expect.anything(),
+            },
+            verify_email: 'test@mail.com',
+        });
+        expect(WalletButton).toHaveBeenCalledWith(expect.objectContaining({ textSize: 'md' }), {});
+    });
+    it('calls handleSendEmail when Confirm is clicked and the platform is dxtrade', () => {
+        render(<TradingPlatformChangePasswordScreens platform='dxtrade' />);
+
+        userEvent.click(screen.getByText('Change password'));
+        userEvent.click(screen.getByText('Confirm'));
+
+        expect(mockUseVerifyEmail).toHaveBeenCalledWith({
+            type: 'trading_platform_dxtrade_password_reset',
+            url_parameters: {
+                redirect_to: expect.anything(),
+            },
+            verify_email: 'test@mail.com',
+        });
+    });
+
+    it('hides modal when Cancel is clicked', () => {
+        const { hide } = useModal();
+
+        render(<TradingPlatformChangePasswordScreens platform='mt5' />);
+
+        userEvent.click(screen.getByText('Change password'));
+        userEvent.click(screen.getByText('Cancel'));
+
+        expect(hide).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/wallets/src/features/cfd/screens/ChangePassword/__tests__/TradingPlatformChangePasswordScreens.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/ChangePassword/__tests__/TradingPlatformChangePasswordScreens.spec.tsx
@@ -7,7 +7,6 @@ import { WalletButton } from '../../../../../components/Base';
 import { useModal } from '../../../../../components/ModalProvider';
 import useDevice from '../../../../../hooks/useDevice';
 import TradingPlatformChangePasswordScreens from '../TradingPlatformChangePasswordScreens';
-import '@testing-library/jest-dom/extend-expect';
 
 jest.mock('@deriv/api-v2', () => ({
     ...jest.requireActual('@deriv/api-v2'),
@@ -15,15 +14,19 @@ jest.mock('@deriv/api-v2', () => ({
     useSettings: jest.fn(),
     useVerifyEmail: jest.fn(),
 }));
+
 jest.mock('@deriv-com/translations', () => ({
     ...jest.requireActual('@deriv-com/translations'),
     useTranslations: jest.fn(),
 }));
+
 jest.mock('../../../../../components/ModalProvider', () => ({
     ...jest.requireActual('../../../../../components/ModalProvider'),
     useModal: jest.fn(),
 }));
+
 jest.mock('../../../../../hooks/useDevice', () => jest.fn(() => ({ isMobile: false })));
+
 jest.mock('../../../../../components', () => ({
     ...jest.requireActual('../../../../../components'),
     SentEmailContent: jest.fn().mockImplementation(() => <div>SentEmailContent</div>),
@@ -43,6 +46,7 @@ jest.mock('../../../../../components/Base', () => ({
 
 describe('TradingPlatformChangePasswordScreens', () => {
     const mockUseVerifyEmail = jest.fn();
+
     beforeEach(() => {
         (useVerifyEmail as jest.Mock).mockReturnValue({
             mutate: mockUseVerifyEmail,
@@ -63,10 +67,12 @@ describe('TradingPlatformChangePasswordScreens', () => {
         (useActiveWalletAccount as jest.Mock).mockReturnValue({
             data: { is_virtual: false },
         });
+
         (useTranslations as jest.Mock).mockReturnValue({
             localize: jest.fn().mockImplementation((str, { title }) => str.replace('{{title}}', title)),
         });
     });
+
     it('renders intro screen by default', () => {
         render(<TradingPlatformChangePasswordScreens platform='mt5' />);
 
@@ -82,31 +88,32 @@ describe('TradingPlatformChangePasswordScreens', () => {
     it('renders confirmation screen when Change password is clicked', () => {
         render(<TradingPlatformChangePasswordScreens platform='mt5' />);
 
-        userEvent.click(screen.getByText('Change password'));
+        userEvent.click(screen.getByRole('button', { name: 'Change password' }));
 
         expect(screen.getByText('Confirm to change your Deriv MT5 password')).toBeInTheDocument();
         expect(
             screen.getByText('This will change the password to all of your Deriv MT5 accounts.')
         ).toBeInTheDocument();
-        expect(screen.getByText('Cancel')).toBeInTheDocument();
-        expect(screen.getByText('Confirm')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument();
     });
 
     it('renders email verification screen when Confirm is clicked', async () => {
         render(<TradingPlatformChangePasswordScreens platform='mt5' />);
 
-        userEvent.click(screen.getByText('Change password'));
-        userEvent.click(screen.getByText('Confirm'));
+        userEvent.click(screen.getByRole('button', { name: 'Change password' }));
+        userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
 
         expect(screen.getByText('SentEmailContent')).toBeInTheDocument();
     });
 
     it('calls handleSendEmail when Confirm is clicked and the platform is mt5', () => {
         (useDevice as jest.Mock).mockReturnValue({ isMobile: true });
+
         render(<TradingPlatformChangePasswordScreens platform='mt5' />);
 
-        userEvent.click(screen.getByText('Change password'));
-        userEvent.click(screen.getByText('Confirm'));
+        userEvent.click(screen.getByRole('button', { name: 'Change password' }));
+        userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
 
         expect(mockUseVerifyEmail).toHaveBeenCalledWith({
             type: 'trading_platform_mt5_password_reset',
@@ -117,11 +124,12 @@ describe('TradingPlatformChangePasswordScreens', () => {
         });
         expect(WalletButton).toHaveBeenCalledWith(expect.objectContaining({ textSize: 'md' }), {});
     });
+
     it('calls handleSendEmail when Confirm is clicked and the platform is dxtrade', () => {
         render(<TradingPlatformChangePasswordScreens platform='dxtrade' />);
 
-        userEvent.click(screen.getByText('Change password'));
-        userEvent.click(screen.getByText('Confirm'));
+        userEvent.click(screen.getByRole('button', { name: 'Change password' }));
+        userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
 
         expect(mockUseVerifyEmail).toHaveBeenCalledWith({
             type: 'trading_platform_dxtrade_password_reset',
@@ -137,9 +145,9 @@ describe('TradingPlatformChangePasswordScreens', () => {
 
         render(<TradingPlatformChangePasswordScreens platform='mt5' />);
 
-        userEvent.click(screen.getByText('Change password'));
-        userEvent.click(screen.getByText('Cancel'));
+        userEvent.click(screen.getByRole('button', { name: 'Change password' }));
+        userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
-        expect(hide).toHaveBeenCalledTimes(1);
+        expect(hide).toHaveBeenCalled();
     });
 });

--- a/packages/wallets/src/features/cfd/screens/ChangePassword/__tests__/TradingPlatformChangePasswordScreens.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/ChangePassword/__tests__/TradingPlatformChangePasswordScreens.spec.tsx
@@ -27,10 +27,8 @@ jest.mock('../../../../../hooks/useDevice', () => jest.fn(() => ({ isMobile: fal
 jest.mock('../../../../../components', () => ({
     ...jest.requireActual('../../../../../components'),
     SentEmailContent: jest.fn().mockImplementation(() => <div>SentEmailContent</div>),
-    WalletButton: jest
-        .fn()
-        .mockImplementation(({ children, onClick }) => <button onClick={onClick}>{children}</button>),
-    WalletsActionScreen: jest.fn().mockImplementation(({ description, renderButtons, title }) => (
+    WalletButton: jest.fn(({ children, onClick }) => <button onClick={onClick}>{children}</button>),
+    WalletsActionScreen: jest.fn(({ description, renderButtons, title }) => (
         <div>
             <h1>{title}</h1>
             <p>{description}</p>
@@ -113,7 +111,6 @@ describe('TradingPlatformChangePasswordScreens', () => {
             },
             verify_email: 'test@mail.com',
         });
-        expect(WalletButton).toHaveBeenCalledWith(expect.objectContaining({ textSize: 'md' }), {});
     });
     it('calls handleSendEmail when Confirm is clicked and the platform is dxtrade', () => {
         render(<TradingPlatformChangePasswordScreens platform='dxtrade' />);


### PR DESCRIPTION
## Changes:

- Added unit tests for:
    `MT5ChangeInvestorPasswordInputsScreen`
    `MT5ChangeInvestorPasswordSavedScreen`
    `MT5ChangeInvestorPasswordScreens`
    `ChangePassword`
    `MT5ChangePasswordScreens`
    `TradingPlatformChangePasswordScreens`

### Screenshots:

![image](https://github.com/user-attachments/assets/ebbca90d-50f3-4e34-9cd0-254cb889157e)

![image](https://github.com/user-attachments/assets/6c98c558-2248-4170-8859-c7db0057405f)

