### PR TITLE
[WALL] george / WALL-2951 / Unit test for CompareAccounts components

### DIFF
--- a/packages/wallets/src/features/cfd/__tests__/CFDPlatformsList.spec.tsx
+++ b/packages/wallets/src/features/cfd/__tests__/CFDPlatformsList.spec.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { useActiveWalletAccount } from '@deriv/api-v2';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import useDevice from '../../../hooks/useDevice';
+import CFDPlatformsList from '../CFDPlatformsList';
+
+jest.mock('@deriv/api-v2', () => ({
+    ...jest.requireActual('@deriv/api-v2'),
+    useActiveWalletAccount: jest.fn(() => ({
+        data: {
+            currency_config: {
+                is_crypto: false,
+            },
+        },
+    })),
+}));
+
+jest.mock('../../../hooks/useDevice', () => jest.fn(() => ({ isMobile: false })));
+
+const mockPush = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useHistory: jest.fn(() => ({ push: mockPush })),
+}));
+
+// eslint-disable-next-line react/display-name
+jest.mock('../CFDPlatformsListEmptyState', () => () => <div>CFDPlatformsListEmptyState</div>);
+
+jest.mock('../components', () => ({
+    ...jest.requireActual('../components'),
+    CFDPlatformsListAccounts: jest.fn(() => <div>CFDPlatformsListAccounts</div>),
+}));
+
+const mockUseActiveWalletAccount = useActiveWalletAccount as jest.MockedFunction<typeof useActiveWalletAccount>;
+const mockUseDevice = useDevice as jest.MockedFunction<typeof useDevice>;
+
+describe('CFDPlatformsList', () => {
+    describe('Mobile/Tablet view', () => {
+        it('renders proper content', () => {
+            //@ts-expect-error we only need partial action types
+            mockUseDevice.mockReturnValueOnce({ isMobile: true });
+            render(<CFDPlatformsList />);
+
+            expect(
+                screen.getByText('Trade bigger positions with less capital on a wide range of global markets.')
+            ).toBeInTheDocument();
+            expect(screen.getByText('Learn more')).toBeInTheDocument();
+            expect(screen.getByText('Compare accounts')).toBeInTheDocument();
+        });
+
+        it('opens proper link when the user is clicking on `Learn more` text', () => {
+            //@ts-expect-error we only need partial action types
+            mockUseDevice.mockReturnValueOnce({ isMobile: true });
+            render(<CFDPlatformsList />);
+
+            const learnMoreEl = screen.getByRole('link', { name: 'Learn more' });
+
+            expect(learnMoreEl).toHaveAttribute('href', 'https://deriv.com/trade-types/cfds/');
+        });
+
+        it('redirects to `/compare-accounts` route when the user is clicking on `Compare accounts` button', () => {
+            //@ts-expect-error we only need partial action types
+            mockUseDevice.mockReturnValueOnce({ isMobile: true });
+            render(<CFDPlatformsList />);
+
+            const compareAccountsBtn = screen.getByText('Compare accounts');
+            userEvent.click(compareAccountsBtn);
+
+            expect(mockPush).toHaveBeenCalledWith('/compare-accounts');
+        });
+    });
+
+    describe('Desktop view', () => {
+        it('renders proper content', () => {
+            render(<CFDPlatformsList />);
+
+            expect(screen.getByText('CFDs')).toBeInTheDocument();
+            expect(
+                screen.getByText('Trade bigger positions with less capital on a wide range of global markets.')
+            ).toBeInTheDocument();
+            expect(screen.getByText('Learn more')).toBeInTheDocument();
+            expect(screen.getByText('Compare accounts')).toBeInTheDocument();
+        });
+
+        it('opens proper link when the user is clicking on `Learn more` text', () => {
+            render(<CFDPlatformsList />);
+
+            const learnMoreEl = screen.getByRole('link', { name: 'Learn more' });
+
+            expect(learnMoreEl).toHaveAttribute('href', 'https://deriv.com/trade-types/cfds');
+        });
+
+        it('redirects to `/compare-accounts` route when the user is clicking on `Compare accounts` button', () => {
+            render(<CFDPlatformsList />);
+
+            const compareAccountsBtn = screen.getByText('Compare accounts');
+            userEvent.click(compareAccountsBtn);
+
+            expect(mockPush).toHaveBeenCalledWith('/compare-accounts');
+        });
+    });
+
+    it('renders proper content for fiat accounts', () => {
+        render(<CFDPlatformsList />);
+
+        expect(screen.getByText('CFDPlatformsListAccounts')).toBeInTheDocument();
+    });
+
+    it('renders proper content for crypto accounts', () => {
+        mockUseActiveWalletAccount.mockReturnValueOnce({
+            data: {
+                //@ts-expect-error we only need partial action types
+                currency_config: {
+                    is_crypto: true,
+                },
+            },
+        });
+        render(<CFDPlatformsList />);
+
+        expect(screen.getByText('CFDPlatformsListEmptyState')).toBeInTheDocument();
+    });
+});

--- a/packages/wallets/src/features/cfd/__tests__/CFDPlatformsListEmptyState.spec.tsx
+++ b/packages/wallets/src/features/cfd/__tests__/CFDPlatformsListEmptyState.spec.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CFDPlatformsListEmptyState from '../CFDPlatformsListEmptyState';
+
+const cryptoCurrency = 'BTC';
+const fiatCurrency = 'USD';
+
+jest.mock('@deriv/api-v2', () => ({
+    ...jest.requireActual('@deriv/api-v2'),
+    useActiveWalletAccount: jest.fn(() => ({
+        data: {
+            currency: 'BTC',
+        },
+    })),
+    useWalletAccountsList: jest.fn(() => ({
+        data: [
+            { account_type: 'doughflow', wallet_currency_type: fiatCurrency },
+            { account_type: 'crypto', wallet_currency_type: cryptoCurrency },
+        ],
+    })),
+}));
+
+const mockPush = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useHistory: jest.fn(() => ({ push: mockPush })),
+}));
+
+describe('CFDPlatformsListEmptyState', () => {
+    it('renders proper content', () => {
+        render(<CFDPlatformsListEmptyState />);
+
+        expect(
+            screen.getByText(
+                `To trade CFDs, you'll need to use your ${fiatCurrency} Wallet. Click Transfer to move your ${cryptoCurrency} to your ${fiatCurrency} Wallet.`
+            )
+        ).toBeInTheDocument();
+    });
+
+    it('redirects to `wallet/account-transfer` route if the user is clicking on `Transfer` button', () => {
+        render(<CFDPlatformsListEmptyState />);
+
+        const transferBtn = screen.getByRole('button', { name: 'Transfer' });
+        userEvent.click(transferBtn);
+
+        expect(mockPush).toHaveBeenCalledWith('/wallet/account-transfer', { shouldSelectDefaultWallet: true });
+    });
+});

--- a/packages/wallets/src/features/cfd/__tests__/ResetMT5PasswordHandler.spec.tsx
+++ b/packages/wallets/src/features/cfd/__tests__/ResetMT5PasswordHandler.spec.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { WalletsResetMT5Password } from '../../../components';
+import { getActionFromUrl } from '../../../helpers/urls';
+import ResetMT5PasswordHandler from '../ResetMT5PasswordHandler';
+
+jest.mock('../../../helpers/urls', () => ({
+    getActionFromUrl: jest.fn(() => 'trading_platform_dxtrade_password_reset'),
+}));
+
+const mockShow = jest.fn();
+
+jest.mock('../../../components/ModalProvider', () => ({
+    useModal: jest.fn(() => ({ show: mockShow })),
+}));
+
+const mockGetActionFromUrl = getActionFromUrl as jest.MockedFunction<typeof getActionFromUrl>;
+
+describe('ResetMT5PasswordHandler', () => {
+    beforeAll(() => {
+        localStorage.setItem('verification_code.trading_platform_dxtrade_password_reset', 'Abcd123');
+        localStorage.setItem('verification_code.trading_platform_investor_password_reset', 'Abcd456');
+        localStorage.setItem('verification_code.trading_platform_mt5_password_reset', 'Abcd789');
+    });
+
+    afterAll(() => {
+        localStorage.clear();
+    });
+
+    it('calls show function with proper parameters for for dxtrade platform', () => {
+        render(<ResetMT5PasswordHandler />);
+
+        expect(mockShow).toHaveBeenCalledWith(
+            <WalletsResetMT5Password
+                actionParams='trading_platform_dxtrade_password_reset'
+                isInvestorPassword={false}
+                platform='dxtrade'
+                verificationCode='Abcd123'
+            />,
+            { defaultRootId: 'wallets_modal_root' }
+        );
+    });
+
+    it('calls show function with proper parameters for mt5 platform (investor password)', () => {
+        mockGetActionFromUrl.mockReturnValueOnce('trading_platform_investor_password_reset');
+        render(<ResetMT5PasswordHandler />);
+
+        expect(mockShow).toHaveBeenCalledWith(
+            <WalletsResetMT5Password
+                actionParams='trading_platform_investor_password_reset'
+                isInvestorPassword={true}
+                platform='mt5'
+                verificationCode='Abcd456'
+            />,
+            { defaultRootId: 'wallets_modal_root' }
+        );
+    });
+
+    it('calls show function with proper parameters for mt5 platform', () => {
+        mockGetActionFromUrl.mockReturnValueOnce('trading_platform_mt5_password_reset');
+        render(<ResetMT5PasswordHandler />);
+
+        expect(mockShow).toHaveBeenCalledWith(
+            <WalletsResetMT5Password
+                actionParams='trading_platform_mt5_password_reset'
+                isInvestorPassword={false}
+                platform='mt5'
+                verificationCode='Abcd789'
+            />,
+            { defaultRootId: 'wallets_modal_root' }
+        );
+    });
+});


### PR DESCRIPTION
## Changes:

Implement unit test for `CFDPlatformsList`, `CFDPlatformsListEmptyState` and `ResetMT5PasswordHandler` components.

### Screenshots:

![Screenshot 2024-08-30 at 17 24 32](https://github.com/user-attachments/assets/ea3532d8-80d3-4dff-8326-7aec53a1ac36)

