### PR TITLE
[BOT] sandeep/feat: :fire: server bot subscribe on load - and refetch on focus

### DIFF
--- a/packages/bot-web-ui/src/pages/server-side-bot/bot-list/bot-list.tsx
+++ b/packages/bot-web-ui/src/pages/server-side-bot/bot-list/bot-list.tsx
@@ -43,6 +43,16 @@ const BotList: React.FC<TBotList> = observer(({ setFormVisibility }) => {
     useEffect(() => {
         if (should_subscribe) getBotList();
         // eslint-disable-next-line react-hooks/exhaustive-deps
+
+        window.addEventListener('focus', () => {
+            getBotList();
+        });
+        return () => {
+            window.removeEventListener('focus', () => {
+                getBotList();
+            });
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     useEffect(() => {


### PR DESCRIPTION
## Changes:
1. If the server bot is open in multiple tabs or multiple browsers, then the bot should run/stop if done in one browser or tab
2. If a bot is created/deleted it should reflect on the other browser tab -- it will happen on focus of the tab

Dev Note:
1. If a bot is deleted then remove the subscription
2. If a new bot is created immediately subscribe to it
