### PR TITLE
[CFDS] shontzu/CFDS-4498/pound-sign-is-not-accepted-as-a-special-character

### DIFF
--- a/packages/account/src/Components/reset-trading-password-modal/reset-trading-password-modal.tsx
+++ b/packages/account/src/Components/reset-trading-password-modal/reset-trading-password-modal.tsx
@@ -68,7 +68,7 @@ const ResetTradingPassword = ({
             errors.password = getErrorMessages().password();
         } else if (platform === CFD_PLATFORMS.MT5 && !validMT5Password(values.password)) {
             errors.password = localize(
-                'Please include at least 1 special character such as ( _ @ ? ! / # ) in your password.'
+                'Password must have at least one of these special characters: !&‘’*-“%+.#&(),:;?=@<>\\[]^_{}|~'
             );
         }
 

--- a/packages/cfd/src/Containers/cfd-password-change.tsx
+++ b/packages/cfd/src/Containers/cfd-password-change.tsx
@@ -96,7 +96,7 @@ const CFDPasswordChange = observer(
                         'new_password',
                         // Localize is employed to convert the customized error message since the backend error lacks clarity.
                         localize(
-                            'Please include at least 1 special character such as ( _ @ ? ! / # ) in your password.'
+                            'Password must have at least one of these special characters: !&‘’*-“%+.#&(),:;?=@<>\\[]^_{}|~'
                         )
                     );
             }

--- a/packages/cfd/src/Containers/cfd-password-modal.tsx
+++ b/packages/cfd/src/Containers/cfd-password-modal.tsx
@@ -747,7 +747,7 @@ const CFDPasswordModal = observer(({ form_error, platform }: TCFDPasswordModalPr
             !validMT5Password(values.password)
         ) {
             errors.password = localize(
-                'Please include at least 1 special character such as ( _ @ ? ! / # ) in your password.'
+                'Password must have at least one of these special characters: !&‘’*-“%+.#&(),:;?=@<>\\[]^_{}|~'
             );
         }
         if (values.password?.toLowerCase() === email.toLowerCase()) {

--- a/packages/cfd/src/Containers/cfd-reset-password-modal.tsx
+++ b/packages/cfd/src/Containers/cfd-reset-password-modal.tsx
@@ -105,7 +105,7 @@ const CFDResetPasswordModal = observer(({ platform }: TCFDResetPasswordModal) =>
             errors.new_password = getErrorMessages().password();
         } else if (platform !== CFD_PLATFORMS.DXTRADE && !validMT5Password(values.new_password)) {
             errors.new_password = localize(
-                'Please include at least 1 special character such as ( _ @ ? ! / # ) in your password.'
+                'Password must have at least one of these special characters: !&‘’*-“%+.#&(),:;?=@<>\\[]^_{}|~'
             );
         }
         if (values.new_password.toLowerCase() === email.toLowerCase()) {
@@ -212,7 +212,8 @@ const CFDResetPasswordModal = observer(({ platform }: TCFDResetPasswordModal) =>
                                                         align='center'
                                                         className='cfd-reset-password__description2'
                                                     >
-                                                        <Localize i18n_default_text='Your password must contain between 8-16 characters that include uppercase and lowercase letters, and at least one number and special character ( _ @ ? ! / # ).' />
+                                                        \
+                                                        <Localize i18n_default_text='Password must have at least one of these special characters: !&amp;‘’*-“%+.#&amp;(),:;?=@&lt;&gt;\[\]^_{}|~' />{' '}
                                                     </Text>
                                                 </div>
                                             )}

--- a/packages/cfd/src/Helpers/constants.ts
+++ b/packages/cfd/src/Helpers/constants.ts
@@ -142,7 +142,9 @@ const validatePassword = (password: string): string | undefined => {
     } else if (!validPassword(password)) {
         return getErrorMessages().password();
     } else if (!validMT5Password(password)) {
-        return localize('Please include at least 1 special character such as ( _ @ ? ! / # ) in your password.');
+        return localize(
+            'Password must have at least one of these special characters: !&‘’*-“%+.#&(),:;?=@<>\\[]^_{}|~'
+        );
     }
 };
 

--- a/packages/wallets/src/constants/password.ts
+++ b/packages/wallets/src/constants/password.ts
@@ -42,7 +42,7 @@ export const getPasswordErrorMessage = () => ({
     }),
     missingCharacter: localize('Password should have lower and uppercase English letters with numbers.'),
     missingCharacterMT5: localize(
-        'Please include at least 1 special character such as ( _ @ ? ! / # ) in your password.'
+        'Password must have at least one of these special characters: !&‘’*-“%+.#&(),:;?=@<>\\[]^_{}|~'
     ),
     PasswordError: localize('That password is incorrect. Please try again.'),
 });


### PR DESCRIPTION
## Changes:

- [slack](https://deriv-group.slack.com/archives/C05H3QQ3FHA/p1723204990110039)
- [figma](https://www.figma.com/design/8jC3I58t0WCAyI6pGDAIVl/branch/j3FNRluNCrNwISYbsloia2/Release---Deriv-MT5-accounts?node-id=35790-326051&node-type=SECTION&m=dev)

### Screenshots:

Please provide some screenshots of the change.

<img height="300" alt="image" src="https://github.com/user-attachments/assets/03a9ce21-5723-4512-88c5-118ca1cc25dc"> <img height="300" alt="image" src="https://github.com/user-attachments/assets/8806ea8d-84a2-45ff-b336-d5e99f8f3a2c">

