### PR TITLE
[WALL] aum / WALL-2957 / unit-test-wallets-VerificationFailed

### DIFF
--- a/packages/wallets/src/features/cfd/screens/VerificationFailed/__tests__/VerificationFailed.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/VerificationFailed/__tests__/VerificationFailed.spec.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { usePOA, usePOI } from '@deriv/api-v2';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import VerificationFailed from '../VerificationFailed';
+
+const mockHideModal = jest.fn();
+const mockShowModal = jest.fn();
+
+jest.mock('../../../flows/ClientVerification/ClientVerification', () => ({
+    ...jest.requireActual('../../../flows/ClientVerification/ClientVerification'),
+    ClientVerification: jest.fn(() => <div>ClientVerification</div>),
+}));
+
+jest.mock('@deriv/api-v2', () => ({
+    ...jest.requireActual('@deriv/api-v2'),
+    usePOA: jest.fn(),
+    usePOI: jest.fn(),
+}));
+
+jest.mock('../../../../../components/ModalProvider', () => ({
+    ...jest.requireActual('../../../../../components/ModalProvider'),
+    useModal: jest.fn(() => ({
+        hide: mockHideModal,
+        show: mockShowModal,
+    })),
+}));
+
+describe('<VerificationFailed />', () => {
+    it('renders failed verification modal for POI failure', () => {
+        (usePOI as jest.Mock).mockReturnValue({
+            data: { is_expired: true, is_rejected: true, is_suspected: true },
+        });
+        (usePOA as jest.Mock).mockReturnValue({
+            data: { is_expired: false, is_rejected: false, is_suspected: false },
+        });
+        render(<VerificationFailed selectedJurisdiction='bvi' />);
+
+        expect(screen.getByText('Why did my verification fail?')).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                'Your proof of identity document did not pass our verification checks. This could be due to reasons such as:'
+            )
+        ).toBeInTheDocument();
+        expect(screen.getByText('Maybe later')).toBeInTheDocument();
+        expect(screen.getAllByText('Resubmit documents')[1]).toBeInTheDocument();
+    });
+
+    it('renders failed verification modal for POA failure', () => {
+        (usePOI as jest.Mock).mockReturnValue({
+            data: { is_expired: false, is_rejected: false, is_suspected: false },
+        });
+        (usePOA as jest.Mock).mockReturnValue({
+            data: { is_expired: true, is_rejected: true, is_suspected: true },
+        });
+        render(<VerificationFailed selectedJurisdiction='bvi' />);
+
+        expect(screen.getByText('Why did my verification fail?')).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                'Your proof of address document did not pass our verification checks. This could be due to reasons such as:'
+            )
+        ).toBeInTheDocument();
+        expect(screen.getByText('Maybe later')).toBeInTheDocument();
+        expect(screen.getAllByText('Resubmit documents')[1]).toBeInTheDocument();
+    });
+
+    it('renders failed verification modal for both POI and POA failure', () => {
+        (usePOI as jest.Mock).mockReturnValue({
+            data: { is_expired: true, is_rejected: false, is_suspected: false },
+        });
+        (usePOA as jest.Mock).mockReturnValue({
+            data: { is_expired: true, is_rejected: false, is_suspected: false },
+        });
+        render(<VerificationFailed selectedJurisdiction='bvi' />);
+
+        expect(screen.getByText('Why did my verification fail?')).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                'Your proof of identity and proof of address documents did not pass our verification checks. This could be due to reasons such as:'
+            )
+        ).toBeInTheDocument();
+        expect(screen.getByText('Maybe later')).toBeInTheDocument();
+        expect(screen.getAllByText('Resubmit documents')[1]).toBeInTheDocument();
+    });
+
+    it('closes the failed verification popup upon clicking `Maybe later`', async () => {
+        (usePOI as jest.Mock).mockReturnValue({
+            data: { is_expired: true, is_rejected: false, is_suspected: false },
+        });
+        (usePOA as jest.Mock).mockReturnValue({
+            data: { is_expired: true, is_rejected: false, is_suspected: false },
+        });
+        render(<VerificationFailed selectedJurisdiction='bvi' />);
+
+        expect(screen.getByText('Why did my verification fail?')).toBeInTheDocument();
+
+        userEvent.click(screen.getByText('Maybe later'));
+
+        await waitFor(() => {
+            expect(mockHideModal).toBeCalled();
+        });
+    });
+
+    it('shows the failed verification popup upon clicking `Resubmit documents`', async () => {
+        (usePOI as jest.Mock).mockReturnValue({
+            data: { is_expired: true, is_rejected: false, is_suspected: false },
+        });
+        (usePOA as jest.Mock).mockReturnValue({
+            data: { is_expired: true, is_rejected: false, is_suspected: false },
+        });
+        render(<VerificationFailed selectedJurisdiction='bvi' />);
+
+        expect(screen.getByText('Why did my verification fail?')).toBeInTheDocument();
+
+        userEvent.click(screen.getAllByText('Resubmit documents')[1]);
+
+        await waitFor(() => {
+            expect(mockShowModal).toBeCalled();
+        });
+    });
+});

--- a/packages/wallets/src/features/cfd/screens/VerificationFailed/__tests__/VerificationFailed.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/VerificationFailed/__tests__/VerificationFailed.spec.tsx
@@ -102,7 +102,7 @@ describe('<VerificationFailed />', () => {
         });
     });
 
-    it('shows the failed verification popup upon clicking `Resubmit documents`', async () => {
+    it('triggers show function which mounts ClientVerification component on clicking `Resubmit documents`', async () => {
         (usePOI as jest.Mock).mockReturnValue({
             data: { is_expired: true, is_rejected: false, is_suspected: false },
         });


### PR DESCRIPTION
## Changes:

This PR is for adding unit tests to the VerificationFailed modal shown when the client tries to add MT5 accounts and their POI/POA fails. The modal pops-up when they click on `Verification failed. Why?` .

<img width="1705" alt="Screenshot 2024-09-03 at 12 04 31 PM" src="https://github.com/user-attachments/assets/a352f77e-d2ae-430b-b4fc-b8646dde9245">

### Screenshots:

<img width="360" alt="Screenshot 2024-09-03 at 10 00 56 AM" src="https://github.com/user-attachments/assets/bb1fd6b2-9956-471c-a657-3a17a586f61b">

<img width="360" alt="Screenshot 2024-09-03 at 10 01 03 AM" src="https://github.com/user-attachments/assets/8691ee79-cc22-4696-970b-6e622ce446d1">
