### PR TITLE
DTRA / Kate / DTRA-1722 / Show error message on purchase button if index was turned off from BO

### DIFF
--- a/packages/trader/src/AppV2/Components/PurchaseButton/__tests__/purchase-button-content.spec.tsx
+++ b/packages/trader/src/AppV2/Components/PurchaseButton/__tests__/purchase-button-content.spec.tsx
@@ -7,24 +7,16 @@ type TInfo = React.ComponentProps<typeof PurchaseButtonContent>['info'];
 
 const mock_props = {
     currency: 'USD',
-    current_stake: 12,
     has_open_accu_contract: false,
     info: {
-        has_error: false,
-        has_error_details: false,
         obj_contract_basis: {
             text: 'Payout',
             value: 19.23,
         },
-        payout: 19.23,
-        profit: '9.23',
     } as TInfo,
-    is_accumulator: false,
     is_multiplier: false,
-    is_touch: false,
     is_turbos: false,
     is_vanilla: false,
-    is_vanilla_fx: false,
     is_reverse: false,
 };
 const wrapper_data_test_id = 'dt_purchase_button_wrapper';
@@ -74,73 +66,21 @@ describe('PurchaseButtonContent', () => {
         expect(screen.getByText(/USD/i)).toBeInTheDocument();
     });
 
-    it('should not render text basis and amount for Accumulators (when there is no open contract and with it)', () => {
-        const accumulators_info = {
-            has_error: false,
-            has_error_details: false,
-            obj_contract_basis: {
-                text: '',
-                value: '',
-            },
-            maximum_payout: 4000,
-        };
-        const { rerender } = render(
-            <PurchaseButtonContent {...mock_props} is_accumulator info={accumulators_info as TInfo} />
-        );
+    it('should not render button content if has_no_button_content === true and there is no error', () => {
+        const { container } = render(<PurchaseButtonContent {...mock_props} has_no_button_content />);
 
-        expect(screen.queryByText(localized_basis.max_payout)).not.toBeInTheDocument();
-        expect(screen.queryByText(/4,000.00/)).not.toBeInTheDocument();
-        expect(screen.queryByText(/USD/i)).not.toBeInTheDocument();
-
-        rerender(
-            <PurchaseButtonContent
-                {...mock_props}
-                is_accumulator
-                info={accumulators_info as TInfo}
-                has_open_accu_contract
-            />
-        );
-
-        expect(screen.getByText(localized_basis.current_stake)).toBeInTheDocument();
-        expect(screen.getByText(/12/)).toBeInTheDocument();
-        expect(screen.getByText(/USD/i)).toBeInTheDocument();
+        expect(container).toBeEmptyDOMElement();
     });
 
-    it('should not render text basis and amount for Turbos', () => {
-        const turbos_info = {
-            has_error: false,
-            has_error_details: false,
-            obj_contract_basis: {
-                text: 'Payout per point',
-                value: '8.250455',
-            },
-        };
-        render(<PurchaseButtonContent {...mock_props} is_turbos info={turbos_info as TInfo} />);
+    it('should render error text as button content if error is not falsy', () => {
+        render(<PurchaseButtonContent {...mock_props} error='Mock error text' />);
 
-        expect(screen.queryByText(localized_basis.payout_per_point)).not.toBeInTheDocument();
-        expect(screen.queryByText(/8.250455/)).not.toBeInTheDocument();
-        expect(screen.queryByText(/USD/i)).not.toBeInTheDocument();
+        expect(screen.getByText('Mock error text')).toBeInTheDocument();
     });
 
-    it('should not render text basis and amount for Vanilla (not fx and fx)', () => {
-        const vanilla_info = {
-            has_error: false,
-            has_error_details: false,
-            obj_contract_basis: {
-                text: 'Payout per point',
-                value: '12.77095',
-            },
-        };
-        const { rerender } = render(<PurchaseButtonContent {...mock_props} is_vanilla info={vanilla_info as TInfo} />);
+    it('should render error text as button content even if error is not falsy, but has_no_button_content === true', () => {
+        render(<PurchaseButtonContent {...mock_props} error='Mock error text' has_no_button_content />);
 
-        expect(screen.queryByText(localized_basis.payout_per_point)).not.toBeInTheDocument();
-        expect(screen.queryByText(/12.77095/)).not.toBeInTheDocument();
-        expect(screen.queryByText(/USD/i)).not.toBeInTheDocument();
-
-        rerender(<PurchaseButtonContent {...mock_props} is_vanilla is_vanilla_fx info={vanilla_info as TInfo} />);
-
-        expect(screen.queryByText(localized_basis.payout_per_pip)).not.toBeInTheDocument();
-        expect(screen.queryByText(/12.77095/)).not.toBeInTheDocument();
-        expect(screen.queryByText(/USD/i)).not.toBeInTheDocument();
+        expect(screen.getByText('Mock error text')).toBeInTheDocument();
     });
 });

--- a/packages/trader/src/AppV2/Components/PurchaseButton/__tests__/purchase-button.spec.tsx
+++ b/packages/trader/src/AppV2/Components/PurchaseButton/__tests__/purchase-button.spec.tsx
@@ -187,6 +187,16 @@ describe('PositionsContent', () => {
         expect(default_mock_store.modules.trade.onPurchase).not.toBeCalled();
     });
 
+    it('should call onPurchaseV2 function if user clicks on purchase button and it is not disabled', () => {
+        mockPurchaseButton();
+        const purchase_button = screen.getAllByRole('button')[0];
+
+        expect(default_mock_store.modules.trade.onPurchaseV2).not.toBeCalled();
+        userEvent.click(purchase_button);
+
+        expect(default_mock_store.modules.trade.onPurchaseV2).toBeCalled();
+    });
+
     it('should render only one button if trade_types have only one field and there are no trade type tabs', () => {
         default_mock_store.modules.trade.contract_type = TRADE_TYPES.ACCUMULATOR;
         default_mock_store.modules.trade.trade_types = {

--- a/packages/trader/src/AppV2/Components/PurchaseButton/purchase-button-content.tsx
+++ b/packages/trader/src/AppV2/Components/PurchaseButton/purchase-button-content.tsx
@@ -6,24 +6,21 @@ import { getLocalizedBasis } from '@deriv/shared';
 import { Money } from '@deriv/components';
 
 type TPurchaseButtonContent = {
-    current_stake?: number | null;
     error?: React.ReactNode;
     has_no_button_content?: boolean;
     info: ReturnType<typeof useTraderStore>['proposal_info'][0] | Record<string, never>;
     is_reverse?: boolean;
 } & Pick<
     ReturnType<typeof useTraderStore>,
-    'currency' | 'has_open_accu_contract' | 'is_accumulator' | 'is_multiplier' | 'is_vanilla' | 'is_turbos'
+    'currency' | 'has_open_accu_contract' | 'is_multiplier' | 'is_vanilla' | 'is_turbos'
 >;
 
 const PurchaseButtonContent = ({
     currency,
-    current_stake,
     error,
     has_open_accu_contract,
     has_no_button_content,
     info,
-    is_accumulator,
     is_multiplier,
     is_turbos,
     is_vanilla,
@@ -31,20 +28,13 @@ const PurchaseButtonContent = ({
 }: TPurchaseButtonContent) => {
     if (has_no_button_content && !error) return null;
 
-    const { current_stake: localized_current_stake, payout, stake } = getLocalizedBasis();
+    const { payout, stake } = getLocalizedBasis();
 
     const getAmount = () => {
         const { stake, obj_contract_basis } = info;
-
-        if (is_multiplier) return stake;
-        if (is_accumulator) return Number(current_stake);
-        return obj_contract_basis?.value;
+        return is_multiplier ? stake : obj_contract_basis?.value;
     };
-    const getTextBasis = () => {
-        if (is_multiplier) return stake;
-        if (is_accumulator) return localized_current_stake;
-        return payout;
-    };
+    const getTextBasis = () => (is_multiplier ? stake : payout);
 
     const text_basis = getTextBasis();
     const amount = getAmount();

--- a/packages/trader/src/AppV2/Components/PurchaseButton/purchase-button-content.tsx
+++ b/packages/trader/src/AppV2/Components/PurchaseButton/purchase-button-content.tsx
@@ -8,19 +8,12 @@ import { Money } from '@deriv/components';
 type TPurchaseButtonContent = {
     current_stake?: number | null;
     error?: React.ReactNode;
+    has_no_button_content?: boolean;
     info: ReturnType<typeof useTraderStore>['proposal_info'][0] | Record<string, never>;
     is_reverse?: boolean;
-    is_high_low?: boolean;
 } & Pick<
     ReturnType<typeof useTraderStore>,
-    | 'currency'
-    | 'has_open_accu_contract'
-    | 'is_accumulator'
-    | 'is_multiplier'
-    | 'is_vanilla_fx'
-    | 'is_vanilla'
-    | 'is_turbos'
-    | 'is_touch'
+    'currency' | 'has_open_accu_contract' | 'is_accumulator' | 'is_multiplier' | 'is_vanilla' | 'is_turbos'
 >;
 
 const PurchaseButtonContent = ({
@@ -28,16 +21,16 @@ const PurchaseButtonContent = ({
     current_stake,
     error,
     has_open_accu_contract,
+    has_no_button_content,
     info,
     is_accumulator,
-    is_high_low,
     is_multiplier,
     is_turbos,
     is_vanilla,
-    is_vanilla_fx,
     is_reverse,
-    is_touch,
 }: TPurchaseButtonContent) => {
+    if (has_no_button_content && !error) return null;
+
     const { current_stake: localized_current_stake, payout, stake } = getLocalizedBasis();
 
     const getAmount = () => {
@@ -52,9 +45,6 @@ const PurchaseButtonContent = ({
         if (is_accumulator) return localized_current_stake;
         return payout;
     };
-
-    if (is_vanilla || is_vanilla_fx || is_turbos || is_high_low || is_touch) return null;
-    if (is_accumulator && !has_open_accu_contract) return null;
 
     const text_basis = getTextBasis();
     const amount = getAmount();

--- a/packages/trader/src/AppV2/Components/PurchaseButton/purchase-button.tsx
+++ b/packages/trader/src/AppV2/Components/PurchaseButton/purchase-button.tsx
@@ -59,7 +59,6 @@ const PurchaseButton = observer(() => {
     const purchase_button_content_props = {
         currency,
         has_open_accu_contract,
-        is_accumulator,
         is_multiplier,
         is_turbos,
         is_vanilla,

--- a/packages/trader/src/AppV2/Components/PurchaseButton/purchase-button.tsx
+++ b/packages/trader/src/AppV2/Components/PurchaseButton/purchase-button.tsx
@@ -141,7 +141,7 @@ const PurchaseButton = observer(() => {
                         const error_message = is_max_payout_exceeded ? (
                             <Localize i18n_default_text='Exceeds max payout' />
                         ) : (
-                            ''
+                            api_error
                         );
 
                         return (
@@ -149,14 +149,10 @@ const PurchaseButton = observer(() => {
                                 <Button
                                     color={getButtonType(index, trade_type)}
                                     size='lg'
-                                    label={
-                                        has_no_button_content && !!api_error
-                                            ? api_error
-                                            : getContractTypeDisplay(trade_type, {
-                                                  isHighLow: is_high_low,
-                                                  showButtonName: true,
-                                              })
-                                    }
+                                    label={getContractTypeDisplay(trade_type, {
+                                        isHighLow: is_high_low,
+                                        showButtonName: true,
+                                    })}
                                     fullWidth
                                     className={clsx(
                                         'purchase-button',

--- a/packages/trader/src/AppV2/Components/TradeParameters/AccumulatorsInformation/__tests__/accumulators-information.spec.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/AccumulatorsInformation/__tests__/accumulators-information.spec.tsx
@@ -35,6 +35,26 @@ describe('AccumulatorsInformation', () => {
         expect(container).toBeEmptyDOMElement();
     });
 
+    it('should not render if there is API error ', () => {
+        default_mock_store.modules.trade.proposal_info = {
+            ACCU: {
+                has_error: true,
+            },
+        };
+        const { container } = mockAccumulatorsInformation();
+
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('should render loader if maximum_payout is falsy but there is no API error', () => {
+        default_mock_store.modules.trade.maximum_payout = 0;
+        mockAccumulatorsInformation();
+
+        expect(screen.getByText('Max. payout')).toBeInTheDocument();
+        expect(screen.getByTestId('dt_skeleton')).toBeInTheDocument();
+        expect(screen.queryByText('4,000.00 USD')).not.toBeInTheDocument();
+    });
+
     it('should render description that is provided', () => {
         mockAccumulatorsInformation();
 

--- a/packages/trader/src/AppV2/Components/TradeParameters/AccumulatorsInformation/accumulators-information.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/AccumulatorsInformation/accumulators-information.tsx
@@ -1,26 +1,33 @@
 import React from 'react';
 import { observer } from 'mobx-react';
 import { Localize } from '@deriv/translations';
-import { Money } from '@deriv/components';
+import { Money, Skeleton } from '@deriv/components';
 import { Text } from '@deriv-com/quill-ui';
 import { useTraderStore } from 'Stores/useTraderStores';
+import { CONTRACT_TYPES } from '@deriv/shared';
 
 type TAccumulatorsInformationProps = {
     is_minimized?: boolean;
 };
 
 const AccumulatorsInformation = observer(({ is_minimized }: TAccumulatorsInformationProps) => {
-    const { currency, maximum_payout } = useTraderStore();
+    const { currency, maximum_payout, proposal_info } = useTraderStore();
+    const has_error = proposal_info[CONTRACT_TYPES.ACCUMULATOR]?.has_error;
 
-    if (is_minimized) return null;
+    if (is_minimized || has_error) return null;
+
     return (
         <div className='accumulators-info__wrapper'>
             <Text size='sm' className='accumulators-info__title'>
                 <Localize i18n_default_text='Max. payout' />
             </Text>
-            <Text size='sm' bold>
-                <Money amount={maximum_payout} show_currency currency={currency} />
-            </Text>
+            {maximum_payout ? (
+                <Text size='sm' bold>
+                    <Money amount={maximum_payout} show_currency currency={currency} />
+                </Text>
+            ) : (
+                <Skeleton width={100} height={14} />
+            )}
         </div>
     );
 });

--- a/packages/trader/src/AppV2/Components/TradeParameters/BarrierInfo/__tests__/barrier-info.spec.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/BarrierInfo/__tests__/barrier-info.spec.tsx
@@ -2,28 +2,55 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import BarrierInfo from '../barrier-info';
 import TraderProviders from '../../../../../trader-providers';
-import { TCoreStores } from '@deriv/stores/types';
 import { mockStore } from '@deriv/stores';
+import { CONTRACT_TYPES } from '@deriv/shared';
 
 describe('<BarrierInfo />', () => {
-    const mock_store = {
-        modules: {
-            trade: {
-                barrier_1: '1.2345',
-            },
-        },
-    };
+    let default_mock_store: ReturnType<typeof mockStore>;
 
-    const MockedBarrierInfo = (mocked_store: TCoreStores) => {
-        return (
-            <TraderProviders store={mocked_store}>
+    beforeEach(
+        () =>
+            (default_mock_store = mockStore({
+                modules: {
+                    trade: {
+                        ...mockStore({}),
+                        barrier_1: '1.2345',
+                        contract_type: 'turboslong',
+                    },
+                },
+            }))
+    );
+
+    const mockedBarrierInfo = () =>
+        render(
+            <TraderProviders store={default_mock_store}>
                 <BarrierInfo />
             </TraderProviders>
         );
-    };
 
-    it('displays the correct barrier value', () => {
-        render(MockedBarrierInfo(mockStore(mock_store)));
+    it('should not render if there is API error ', () => {
+        default_mock_store.modules.trade.proposal_info = {
+            [CONTRACT_TYPES.TURBOS.LONG]: {
+                has_error: true,
+            },
+        };
+        const { container } = mockedBarrierInfo();
+
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('should render loader if barrier_1 is falsy but there is no API error', () => {
+        default_mock_store.modules.trade.barrier_1 = '';
+        mockedBarrierInfo();
+
+        expect(screen.getByText('Barrier')).toBeInTheDocument();
+        expect(screen.getByTestId('dt_skeleton')).toBeInTheDocument();
+        expect(screen.queryByText('1.2345')).not.toBeInTheDocument();
+    });
+
+    it('should render correct barrier value', () => {
+        mockedBarrierInfo();
+
         expect(screen.getByText('Barrier')).toBeInTheDocument();
         expect(screen.getByText('1.2345')).toBeInTheDocument();
     });

--- a/packages/trader/src/AppV2/Components/TradeParameters/BarrierInfo/barrier-info.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/BarrierInfo/barrier-info.tsx
@@ -1,20 +1,28 @@
 import React from 'react';
 import { observer } from '@deriv/stores';
+import { Skeleton } from '@deriv/components';
 import { useTraderStore } from 'Stores/useTraderStores';
 import { Text } from '@deriv-com/quill-ui';
 import { Localize } from '@deriv/translations';
 
 const BarrierInfo = observer(() => {
-    const { barrier_1 } = useTraderStore();
+    const { barrier_1, contract_type, proposal_info } = useTraderStore();
+    const contract_key = contract_type.toUpperCase();
+    const has_error = proposal_info[contract_key]?.has_error;
 
+    if (has_error) return null;
     return (
         <div className='barrier-info__container'>
             <Text size='sm'>
                 <Localize i18n_default_text='Barrier' />
             </Text>
-            <Text size='sm' bold>
-                {barrier_1}
-            </Text>
+            {barrier_1 ? (
+                <Text size='sm' bold>
+                    {barrier_1}
+                </Text>
+            ) : (
+                <Skeleton width={50} height={14} />
+            )}
         </div>
     );
 });

--- a/packages/trader/src/AppV2/Components/TradeParameters/PayoutPerPointInfo/payout-per-point-info.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/PayoutPerPointInfo/payout-per-point-info.tsx
@@ -3,20 +3,28 @@ import { observer } from '@deriv/stores';
 import { useTraderStore } from 'Stores/useTraderStores';
 import { Text } from '@deriv-com/quill-ui';
 import { Localize } from '@deriv/translations';
+import { Skeleton } from '@deriv/components';
 
 const PayoutPerPointInfo = observer(() => {
     const { contract_type, currency, proposal_info } = useTraderStore();
     const contract_key = contract_type.toUpperCase();
     const { value: payout_per_point } = proposal_info[contract_key]?.obj_contract_basis || {};
+    const has_error = proposal_info[contract_key]?.has_error;
+
+    if (has_error) return null;
 
     return (
         <div className='payout-per-point-info__container'>
             <Text size='sm'>
                 <Localize i18n_default_text='Payout per point' />
             </Text>
-            <Text size='sm' bold>
-                {payout_per_point} {currency}
-            </Text>
+            {payout_per_point ? (
+                <Text size='sm' bold>
+                    {payout_per_point} {currency}
+                </Text>
+            ) : (
+                <Skeleton width={100} height={14} />
+            )}
         </div>
     );
 });


### PR DESCRIPTION
## Changes:

- Added disabling logic  for purchase button if index was turned off from BO + added text with error under the label.
 - Added conditional rendering for PPP (Vanillas), Barrier (Turbos), Max payout (Acc): ff there is an error, we won't render them. In case if values haven't not loaded yet we would show Skeleton Loader.
 - Refactored tests

### Screenshots:


![Screenshot 2024-09-02 at 4 27 53 PM](https://github.com/user-attachments/assets/74a168f2-ef62-4142-8539-4f0f5673c4db)
![Screenshot 2024-09-02 at 3 14 53 PM](https://github.com/user-attachments/assets/a7cf303f-aa76-4a69-a3b4-534d96e7daff)
![Screenshot 2024-09-02 at 3 14 45 PM](https://github.com/user-attachments/assets/b486d748-708e-4b2f-919c-1ae95317b43c)
