### PR TITLE
DTRA-1810 / Kate / [DTrader-V2]: Risk Management bug fixes

### DIFF
--- a/packages/trader/src/AppV2/Components/TradeParameters/RiskManagement/__tests__/risk_management-picker.spec.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/RiskManagement/__tests__/risk_management-picker.spec.tsx
@@ -24,4 +24,14 @@ describe('RiskManagementPicker', () => {
 
         expect(screen.getByText('Page content 2')).toBeInTheDocument();
     });
+
+    it('should open initial tab corresponding to passed initial_tab_index prop', () => {
+        render(<RiskManagementPicker {...mock_props} initial_tab_index={1} />);
+
+        const first_tab = screen.getAllByRole('button')[0];
+        const second_tab = screen.getAllByRole('button')[1];
+
+        expect(first_tab).not.toHaveClass('item selected');
+        expect(second_tab).toHaveClass('item selected');
+    });
 });

--- a/packages/trader/src/AppV2/Components/TradeParameters/RiskManagement/risk-management-picker.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/RiskManagement/risk-management-picker.tsx
@@ -6,11 +6,16 @@ import TakeProfitAndStopLossContainer from './take-profit-and-stop-loss-containe
 
 type TRiskManagementPickerProps = {
     closeActionSheet: () => void;
+    initial_tab_index?: number;
     should_show_deal_cancellation?: boolean;
 };
 
-const RiskManagementPicker = ({ closeActionSheet, should_show_deal_cancellation }: TRiskManagementPickerProps) => {
-    const [tab_index, setTabIndex] = React.useState(0);
+const RiskManagementPicker = ({
+    closeActionSheet,
+    initial_tab_index = 0,
+    should_show_deal_cancellation,
+}: TRiskManagementPickerProps) => {
+    const [tab_index, setTabIndex] = React.useState(initial_tab_index);
 
     return (
         <ActionSheet.Content className='risk-management__picker'>

--- a/packages/trader/src/AppV2/Components/TradeParameters/RiskManagement/risk-management.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/RiskManagement/risk-management.tsx
@@ -50,6 +50,7 @@ const RiskManagement = observer(({ is_minimized }: TRiskManagementProps) => {
             component: (
                 <RiskManagementPicker
                     closeActionSheet={closeActionSheet}
+                    initial_tab_index={Number(has_cancellation)}
                     should_show_deal_cancellation={should_show_deal_cancellation}
                 />
             ),

--- a/packages/trader/src/AppV2/Components/TradeParameters/RiskManagement/take-profit-and-stop-loss-input.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/RiskManagement/take-profit-and-stop-loss-input.tsx
@@ -77,7 +77,8 @@ const TakeProfitAndStopLossInput = ({
     const decimals = getDecimalPlaces(currency);
     const currency_display_code = getCurrencyDisplayCode(currency);
     const Component = has_actionsheet_wrapper ? ActionSheet.Content : 'div';
-    const should_set_validation_params = is_multiplier && is_enabled && new_input_value === '';
+    const should_set_validation_params =
+        is_multiplier && is_enabled && (new_input_value === '' || typeof new_input_value === 'undefined');
 
     const min_value = validation_params[contract_types[0]]?.[type]?.min;
     const max_value = validation_params[contract_types[0]]?.[type]?.max;
@@ -174,6 +175,7 @@ const TakeProfitAndStopLossInput = ({
                 onProposalResponse,
                 {
                     ...(is_take_profit_input ? { has_take_profit: is_enabled } : { has_stop_loss: is_enabled }),
+                    has_cancellation: false,
                     ...(is_take_profit_input
                         ? { take_profit: is_enabled ? input_value : '' }
                         : { stop_loss: is_enabled ? input_value : '' }),


### PR DESCRIPTION
## Changes:

- Added prop (initial_tab_index), for controlling opened by default tab in Risk Management. If DC is active, then selected tab in the ActionSheet will be DC, not TP&SL and vise versa. 
- Fixed case when DC is active and user is trying to add TP, but we are showing a BE error below the input, preventing user from saving. 
- Add test cases 

### Screenshots:

https://github.com/user-attachments/assets/e5bcb155-e1ae-484c-a618-8021196310a3

