### PR TITLE
Update deriv-charts to 2.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "@deriv-com/utils": "^0.0.25",
                 "@deriv/api-types": "1.0.172",
                 "@deriv/deriv-api": "^1.0.15",
-                "@deriv/deriv-charts": "^2.5.0",
+                "@deriv/deriv-charts": "^2.5.1",
                 "@deriv/js-interpreter": "^3.0.0",
                 "@deriv/quill-design": "^1.3.2",
                 "@deriv/quill-icons": "1.23.3",
@@ -3195,9 +3195,9 @@
             }
         },
         "node_modules/@deriv/deriv-charts": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.5.0.tgz",
-            "integrity": "sha512-zogotu034yYUF1k7SemD+BCoAY+atNSb6F7cDqy21TPWYqfZBGCbAQAtBiAhaetzea9z33e0SUEulgcTJ5cFwA==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.5.1.tgz",
+            "integrity": "sha512-CDyh1uQS2plp2EkGWOx0UYSWck8iqKgU1B9mFe0YrjHEqfz7WqwW4zyKqgojAMdEWzStbNMv5J811saB8Zmt8w==",
             "dependencies": {
                 "@types/lodash.set": "^4.3.7",
                 "@welldone-software/why-did-you-render": "^3.3.8",
@@ -3912,6 +3912,7 @@
         },
         "node_modules/@isaacs/string-locale-compare": {
             "version": "1.1.0",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/@istanbuljs/load-nyc-config": {
@@ -7363,6 +7364,7 @@
         },
         "node_modules/@npmcli/arborist": {
             "version": "5.3.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@isaacs/string-locale-compare": "^1.1.0",
@@ -7409,6 +7411,7 @@
         },
         "node_modules/@npmcli/arborist/node_modules/hosted-git-info": {
             "version": "5.2.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^7.5.1"
@@ -7419,6 +7422,7 @@
         },
         "node_modules/@npmcli/arborist/node_modules/npm-package-arg": {
             "version": "9.1.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "hosted-git-info": "^5.0.0",
@@ -7432,6 +7436,7 @@
         },
         "node_modules/@npmcli/arborist/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -7445,6 +7450,7 @@
         },
         "node_modules/@npmcli/arborist/node_modules/semver/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -7455,6 +7461,7 @@
         },
         "node_modules/@npmcli/fs": {
             "version": "2.1.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@gar/promisify": "^1.1.3",
@@ -7466,6 +7473,7 @@
         },
         "node_modules/@npmcli/fs/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -7476,6 +7484,7 @@
         },
         "node_modules/@npmcli/fs/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -7489,6 +7498,7 @@
         },
         "node_modules/@npmcli/git": {
             "version": "3.0.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/promise-spawn": "^3.0.0",
@@ -7507,6 +7517,7 @@
         },
         "node_modules/@npmcli/git/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -7520,6 +7531,7 @@
         },
         "node_modules/@npmcli/git/node_modules/semver/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -7530,6 +7542,7 @@
         },
         "node_modules/@npmcli/installed-package-contents": {
             "version": "1.0.7",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "npm-bundled": "^1.1.1",
@@ -7544,6 +7557,7 @@
         },
         "node_modules/@npmcli/map-workspaces": {
             "version": "2.0.4",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/name-from-folder": "^1.0.1",
@@ -7557,6 +7571,7 @@
         },
         "node_modules/@npmcli/map-workspaces/node_modules/brace-expansion": {
             "version": "2.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -7564,6 +7579,7 @@
         },
         "node_modules/@npmcli/map-workspaces/node_modules/glob": {
             "version": "8.0.3",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -7581,6 +7597,7 @@
         },
         "node_modules/@npmcli/map-workspaces/node_modules/minimatch": {
             "version": "5.1.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
@@ -7591,6 +7608,7 @@
         },
         "node_modules/@npmcli/metavuln-calculator": {
             "version": "3.1.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "cacache": "^16.0.0",
@@ -7604,6 +7622,7 @@
         },
         "node_modules/@npmcli/metavuln-calculator/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -7614,6 +7633,7 @@
         },
         "node_modules/@npmcli/metavuln-calculator/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -7627,6 +7647,7 @@
         },
         "node_modules/@npmcli/move-file": {
             "version": "2.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "mkdirp": "^1.0.4",
@@ -7638,10 +7659,12 @@
         },
         "node_modules/@npmcli/name-from-folder": {
             "version": "1.0.1",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/@npmcli/node-gyp": {
             "version": "2.0.0",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -7649,6 +7672,7 @@
         },
         "node_modules/@npmcli/package-json": {
             "version": "2.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "json-parse-even-better-errors": "^2.3.1"
@@ -7659,6 +7683,7 @@
         },
         "node_modules/@npmcli/promise-spawn": {
             "version": "3.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "infer-owner": "^1.0.4"
@@ -7669,6 +7694,7 @@
         },
         "node_modules/@npmcli/run-script": {
             "version": "4.2.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/node-gyp": "^2.0.0",
@@ -20583,6 +20609,7 @@
         },
         "node_modules/abbrev": {
             "version": "1.1.1",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/accepts": {
@@ -20703,6 +20730,7 @@
         },
         "node_modules/agentkeepalive": {
             "version": "4.2.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "debug": "^4.1.0",
@@ -20922,6 +20950,7 @@
         },
         "node_modules/are-we-there-yet": {
             "version": "3.0.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "delegates": "^1.0.0",
@@ -22291,6 +22320,7 @@
         },
         "node_modules/bin-links": {
             "version": "3.0.3",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "cmd-shim": "^5.0.0",
@@ -22306,6 +22336,7 @@
         },
         "node_modules/bin-links/node_modules/npm-normalize-package-bin": {
             "version": "2.0.0",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -22313,6 +22344,7 @@
         },
         "node_modules/bin-links/node_modules/write-file-atomic": {
             "version": "4.0.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "imurmurhash": "^0.1.4",
@@ -22909,6 +22941,7 @@
         },
         "node_modules/builtins": {
             "version": "5.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "semver": "^7.0.0"
@@ -22916,6 +22949,7 @@
         },
         "node_modules/builtins/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -22926,6 +22960,7 @@
         },
         "node_modules/builtins/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -23023,6 +23058,7 @@
         },
         "node_modules/cacache": {
             "version": "16.1.3",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/fs": "^2.1.0",
@@ -23050,6 +23086,7 @@
         },
         "node_modules/cacache/node_modules/brace-expansion": {
             "version": "2.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -23057,6 +23094,7 @@
         },
         "node_modules/cacache/node_modules/glob": {
             "version": "8.0.3",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -23074,6 +23112,7 @@
         },
         "node_modules/cacache/node_modules/minimatch": {
             "version": "5.1.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
@@ -23852,6 +23891,7 @@
         },
         "node_modules/cmd-shim": {
             "version": "5.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "mkdirp-infer-owner": "^2.0.0"
@@ -23972,6 +24012,7 @@
         },
         "node_modules/common-ancestor-path": {
             "version": "1.0.1",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/common-tags": {
@@ -26211,6 +26252,7 @@
         },
         "node_modules/debuglog": {
             "version": "1.0.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "*"
@@ -26971,6 +27013,7 @@
         },
         "node_modules/dezalgo": {
             "version": "1.0.4",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "asap": "^2.0.0",
@@ -27753,6 +27796,7 @@
         },
         "node_modules/err-code": {
             "version": "2.0.3",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/errno": {
@@ -31177,6 +31221,7 @@
         },
         "node_modules/gauge": {
             "version": "4.0.4",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "aproba": "^1.0.3 || ^2.0.0",
@@ -32362,6 +32407,7 @@
         },
         "node_modules/hosted-git-info": {
             "version": "4.1.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -32372,6 +32418,7 @@
         },
         "node_modules/hosted-git-info/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -32913,7 +32960,8 @@
         "node_modules/http-cache-semantics": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-            "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
+            "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
+            "dev": true
         },
         "node_modules/http-deceiver": {
             "version": "1.2.7",
@@ -33139,6 +33187,7 @@
         },
         "node_modules/humanize-ms": {
             "version": "1.2.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.0.0"
@@ -33304,6 +33353,7 @@
         },
         "node_modules/ignore-walk": {
             "version": "5.0.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "minimatch": "^5.0.1"
@@ -33314,6 +33364,7 @@
         },
         "node_modules/ignore-walk/node_modules/brace-expansion": {
             "version": "2.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -33321,6 +33372,7 @@
         },
         "node_modules/ignore-walk/node_modules/minimatch": {
             "version": "5.1.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
@@ -33467,6 +33519,7 @@
         },
         "node_modules/init-package-json": {
             "version": "3.0.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "npm-package-arg": "^9.0.1",
@@ -33483,6 +33536,7 @@
         },
         "node_modules/init-package-json/node_modules/hosted-git-info": {
             "version": "5.2.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^7.5.1"
@@ -33493,6 +33547,7 @@
         },
         "node_modules/init-package-json/node_modules/npm-package-arg": {
             "version": "9.1.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "hosted-git-info": "^5.0.0",
@@ -33506,6 +33561,7 @@
         },
         "node_modules/init-package-json/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -33519,6 +33575,7 @@
         },
         "node_modules/init-package-json/node_modules/semver/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -34025,6 +34082,7 @@
         },
         "node_modules/is-lambda": {
             "version": "1.0.1",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/is-lite": {
@@ -38107,6 +38165,7 @@
         },
         "node_modules/json-stringify-nice": {
             "version": "1.1.4",
+            "dev": true,
             "license": "ISC",
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -38174,6 +38233,7 @@
         },
         "node_modules/jsonparse": {
             "version": "1.3.1",
+            "dev": true,
             "engines": [
                 "node >= 0.2.0"
             ],
@@ -38223,10 +38283,12 @@
         },
         "node_modules/just-diff": {
             "version": "5.1.1",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/just-diff-apply": {
             "version": "5.4.1",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/just-extend": {
@@ -38398,6 +38460,7 @@
         },
         "node_modules/libnpmaccess": {
             "version": "6.0.4",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "aproba": "^2.0.0",
@@ -38411,6 +38474,7 @@
         },
         "node_modules/libnpmaccess/node_modules/hosted-git-info": {
             "version": "5.2.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^7.5.1"
@@ -38421,6 +38485,7 @@
         },
         "node_modules/libnpmaccess/node_modules/npm-package-arg": {
             "version": "9.1.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "hosted-git-info": "^5.0.0",
@@ -38434,6 +38499,7 @@
         },
         "node_modules/libnpmaccess/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -38447,6 +38513,7 @@
         },
         "node_modules/libnpmaccess/node_modules/semver/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -38457,6 +38524,7 @@
         },
         "node_modules/libnpmpublish": {
             "version": "6.0.5",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "normalize-package-data": "^4.0.0",
@@ -38471,6 +38539,7 @@
         },
         "node_modules/libnpmpublish/node_modules/hosted-git-info": {
             "version": "5.2.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^7.5.1"
@@ -38481,6 +38550,7 @@
         },
         "node_modules/libnpmpublish/node_modules/normalize-package-data": {
             "version": "4.0.1",
+            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "hosted-git-info": "^5.0.0",
@@ -38494,6 +38564,7 @@
         },
         "node_modules/libnpmpublish/node_modules/npm-package-arg": {
             "version": "9.1.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "hosted-git-info": "^5.0.0",
@@ -38507,6 +38578,7 @@
         },
         "node_modules/libnpmpublish/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -38520,6 +38592,7 @@
         },
         "node_modules/libnpmpublish/node_modules/semver/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -39157,6 +39230,7 @@
         },
         "node_modules/lru-cache": {
             "version": "7.14.1",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">=12"
@@ -39197,6 +39271,7 @@
         },
         "node_modules/make-fetch-happen": {
             "version": "10.2.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "agentkeepalive": "^4.2.1",
@@ -39796,6 +39871,7 @@
         },
         "node_modules/minipass-fetch": {
             "version": "2.1.2",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "minipass": "^3.1.6",
@@ -39821,6 +39897,7 @@
         },
         "node_modules/minipass-json-stream": {
             "version": "1.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "jsonparse": "^1.3.1",
@@ -39839,6 +39916,7 @@
         },
         "node_modules/minipass-sized": {
             "version": "1.0.3",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "minipass": "^3.0.0"
@@ -39961,6 +40039,7 @@
         },
         "node_modules/mkdirp-infer-owner": {
             "version": "2.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "chownr": "^2.0.0",
@@ -40175,6 +40254,7 @@
         },
         "node_modules/mute-stream": {
             "version": "0.0.8",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/mz": {
@@ -40401,6 +40481,7 @@
         },
         "node_modules/node-gyp": {
             "version": "9.3.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "env-paths": "^2.2.0",
@@ -40433,6 +40514,7 @@
         },
         "node_modules/node-gyp/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -40443,6 +40525,7 @@
         },
         "node_modules/node-gyp/node_modules/nopt": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "abbrev": "^1.0.0"
@@ -40456,6 +40539,7 @@
         },
         "node_modules/node-gyp/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -40616,6 +40700,7 @@
         },
         "node_modules/nopt": {
             "version": "5.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "abbrev": "1"
@@ -40629,6 +40714,7 @@
         },
         "node_modules/normalize-package-data": {
             "version": "3.0.3",
+            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "hosted-git-info": "^4.0.1",
@@ -40642,6 +40728,7 @@
         },
         "node_modules/normalize-package-data/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -40652,6 +40739,7 @@
         },
         "node_modules/normalize-package-data/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -40847,6 +40935,7 @@
         },
         "node_modules/npm-bundled": {
             "version": "1.1.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "npm-normalize-package-bin": "^1.0.1"
@@ -40854,6 +40943,7 @@
         },
         "node_modules/npm-install-checks": {
             "version": "5.0.0",
+            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "semver": "^7.1.1"
@@ -40864,6 +40954,7 @@
         },
         "node_modules/npm-install-checks/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -40874,6 +40965,7 @@
         },
         "node_modules/npm-install-checks/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -40887,10 +40979,12 @@
         },
         "node_modules/npm-normalize-package-bin": {
             "version": "1.0.1",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/npm-package-arg": {
             "version": "8.1.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "hosted-git-info": "^3.0.6",
@@ -40903,10 +40997,12 @@
         },
         "node_modules/npm-package-arg/node_modules/builtins": {
             "version": "1.0.3",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/npm-package-arg/node_modules/hosted-git-info": {
             "version": "3.0.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -40917,6 +41013,7 @@
         },
         "node_modules/npm-package-arg/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -40927,6 +41024,7 @@
         },
         "node_modules/npm-package-arg/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -40940,6 +41038,7 @@
         },
         "node_modules/npm-package-arg/node_modules/validate-npm-package-name": {
             "version": "3.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "builtins": "^1.0.3"
@@ -40947,6 +41046,7 @@
         },
         "node_modules/npm-packlist": {
             "version": "5.1.3",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "glob": "^8.0.1",
@@ -40963,6 +41063,7 @@
         },
         "node_modules/npm-packlist/node_modules/brace-expansion": {
             "version": "2.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -40970,6 +41071,7 @@
         },
         "node_modules/npm-packlist/node_modules/glob": {
             "version": "8.0.3",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -40987,6 +41089,7 @@
         },
         "node_modules/npm-packlist/node_modules/minimatch": {
             "version": "5.1.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
@@ -40997,6 +41100,7 @@
         },
         "node_modules/npm-packlist/node_modules/npm-bundled": {
             "version": "2.0.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "npm-normalize-package-bin": "^2.0.0"
@@ -41007,6 +41111,7 @@
         },
         "node_modules/npm-packlist/node_modules/npm-normalize-package-bin": {
             "version": "2.0.0",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -41014,6 +41119,7 @@
         },
         "node_modules/npm-pick-manifest": {
             "version": "7.0.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "npm-install-checks": "^5.0.0",
@@ -41027,6 +41133,7 @@
         },
         "node_modules/npm-pick-manifest/node_modules/hosted-git-info": {
             "version": "5.2.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^7.5.1"
@@ -41037,6 +41144,7 @@
         },
         "node_modules/npm-pick-manifest/node_modules/npm-normalize-package-bin": {
             "version": "2.0.0",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -41044,6 +41152,7 @@
         },
         "node_modules/npm-pick-manifest/node_modules/npm-package-arg": {
             "version": "9.1.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "hosted-git-info": "^5.0.0",
@@ -41057,6 +41166,7 @@
         },
         "node_modules/npm-pick-manifest/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -41070,6 +41180,7 @@
         },
         "node_modules/npm-pick-manifest/node_modules/semver/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -41080,6 +41191,7 @@
         },
         "node_modules/npm-registry-fetch": {
             "version": "13.3.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "make-fetch-happen": "^10.0.6",
@@ -41096,6 +41208,7 @@
         },
         "node_modules/npm-registry-fetch/node_modules/hosted-git-info": {
             "version": "5.2.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^7.5.1"
@@ -41106,6 +41219,7 @@
         },
         "node_modules/npm-registry-fetch/node_modules/npm-package-arg": {
             "version": "9.1.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "hosted-git-info": "^5.0.0",
@@ -41119,6 +41233,7 @@
         },
         "node_modules/npm-registry-fetch/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -41132,6 +41247,7 @@
         },
         "node_modules/npm-registry-fetch/node_modules/semver/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -43333,6 +43449,7 @@
         },
         "node_modules/npmlog": {
             "version": "6.0.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "are-we-there-yet": "^3.0.0",
@@ -44320,6 +44437,7 @@
         },
         "node_modules/pacote": {
             "version": "13.6.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/git": "^3.0.0",
@@ -44353,6 +44471,7 @@
         },
         "node_modules/pacote/node_modules/hosted-git-info": {
             "version": "5.2.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^7.5.1"
@@ -44363,6 +44482,7 @@
         },
         "node_modules/pacote/node_modules/npm-package-arg": {
             "version": "9.1.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "hosted-git-info": "^5.0.0",
@@ -44376,6 +44496,7 @@
         },
         "node_modules/pacote/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -44389,6 +44510,7 @@
         },
         "node_modules/pacote/node_modules/semver/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -44481,6 +44603,7 @@
         },
         "node_modules/parse-conflict-json": {
             "version": "2.0.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "json-parse-even-better-errors": "^2.3.1",
@@ -46601,6 +46724,7 @@
         },
         "node_modules/proc-log": {
             "version": "2.0.1",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -46636,6 +46760,7 @@
         },
         "node_modules/promise-all-reject-late": {
             "version": "1.0.1",
+            "dev": true,
             "license": "ISC",
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -46643,6 +46768,7 @@
         },
         "node_modules/promise-call-limit": {
             "version": "1.0.1",
+            "dev": true,
             "license": "ISC",
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -46659,6 +46785,7 @@
         },
         "node_modules/promise-retry": {
             "version": "2.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "err-code": "^2.0.2",
@@ -46718,6 +46845,7 @@
         },
         "node_modules/promzard": {
             "version": "0.3.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "read": "1"
@@ -48135,6 +48263,7 @@
         },
         "node_modules/read": {
             "version": "1.0.7",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "mute-stream": "~0.0.4"
@@ -48145,6 +48274,7 @@
         },
         "node_modules/read-cmd-shim": {
             "version": "3.0.1",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -48152,6 +48282,7 @@
         },
         "node_modules/read-package-json": {
             "version": "5.0.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "glob": "^8.0.1",
@@ -48165,6 +48296,7 @@
         },
         "node_modules/read-package-json-fast": {
             "version": "2.0.3",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "json-parse-even-better-errors": "^2.3.0",
@@ -48176,6 +48308,7 @@
         },
         "node_modules/read-package-json/node_modules/brace-expansion": {
             "version": "2.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -48183,6 +48316,7 @@
         },
         "node_modules/read-package-json/node_modules/glob": {
             "version": "8.0.3",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -48200,6 +48334,7 @@
         },
         "node_modules/read-package-json/node_modules/hosted-git-info": {
             "version": "5.2.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^7.5.1"
@@ -48210,6 +48345,7 @@
         },
         "node_modules/read-package-json/node_modules/minimatch": {
             "version": "5.1.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
@@ -48220,6 +48356,7 @@
         },
         "node_modules/read-package-json/node_modules/normalize-package-data": {
             "version": "4.0.1",
+            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "hosted-git-info": "^5.0.0",
@@ -48233,6 +48370,7 @@
         },
         "node_modules/read-package-json/node_modules/npm-normalize-package-bin": {
             "version": "2.0.0",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -48240,6 +48378,7 @@
         },
         "node_modules/read-package-json/node_modules/semver": {
             "version": "7.3.8",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -48253,6 +48392,7 @@
         },
         "node_modules/read-package-json/node_modules/semver/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -48573,6 +48713,7 @@
         },
         "node_modules/readdir-scoped-modules": {
             "version": "1.1.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "debuglog": "^1.0.1",
@@ -51204,6 +51345,7 @@
         },
         "node_modules/smart-buffer": {
             "version": "4.2.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 6.0.0",
@@ -51427,6 +51569,7 @@
         },
         "node_modules/socks": {
             "version": "2.7.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ip": "^2.0.0",
@@ -51439,6 +51582,7 @@
         },
         "node_modules/socks-proxy-agent": {
             "version": "7.0.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "agent-base": "^6.0.2",
@@ -51687,6 +51831,7 @@
         },
         "node_modules/ssri": {
             "version": "9.0.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "minipass": "^3.1.1"
@@ -53622,7 +53767,8 @@
         },
         "node_modules/text-table": {
             "version": "0.2.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/thenify": {
             "version": "3.3.1",
@@ -53871,6 +54017,7 @@
         },
         "node_modules/treeverse": {
             "version": "2.0.0",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -54448,6 +54595,7 @@
         },
         "node_modules/unique-filename": {
             "version": "2.0.1",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "unique-slug": "^3.0.0"
@@ -54458,6 +54606,7 @@
         },
         "node_modules/unique-slug": {
             "version": "3.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "imurmurhash": "^0.1.4"
@@ -54987,6 +55136,7 @@
         },
         "node_modules/validate-npm-package-name": {
             "version": "4.0.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "builtins": "^5.0.0"
@@ -55095,6 +55245,7 @@
         },
         "node_modules/walk-up-path": {
             "version": "1.0.0",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/walker": {

--- a/packages/bot-web-ui/package.json
+++ b/packages/bot-web-ui/package.json
@@ -77,7 +77,7 @@
         "@deriv/bot-skeleton": "^1.0.0",
         "@deriv/components": "^1.0.0",
         "@deriv/hooks": "^1.0.0",
-        "@deriv/deriv-charts": "^2.5.0",
+        "@deriv/deriv-charts": "^2.5.1",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",
         "@deriv/translations": "^1.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -110,7 +110,7 @@
         "@deriv/cfd": "^1.0.0",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv/deriv-charts": "^2.5.0",
+        "@deriv/deriv-charts": "^2.5.1",
         "@deriv/hooks": "^1.0.0",
         "@deriv/p2p": "^0.7.3",
         "@deriv/quill-design": "^1.3.2",

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -96,7 +96,7 @@
         "@deriv/api-types": "1.0.172",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv/deriv-charts": "^2.5.0",
+        "@deriv/deriv-charts": "^2.5.1",
         "@deriv/hooks": "^1.0.0",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",


### PR DESCRIPTION
This PR updates @deriv/deriv-charts to 2.5.1