### PR TITLE
DTRA-1855 / Kate / [DTrader-V2]: Change chart height calculations based on the latest design

### DIFF
--- a/packages/trader/src/AppV2/Components/TradeParameters/trade-parameters.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/trade-parameters.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { getTradeParams } from 'AppV2/Utils/trade-params-utils';
 import clsx from 'clsx';
 import { observer } from 'mobx-react';
 import { useTraderStore } from 'Stores/useTraderStores';
+import { isTradeParamVisible } from 'AppV2/Utils/layout-utils';
 import AllowEquals from './AllowEquals';
 import Duration from './Duration';
 import Stake from './Stake';
@@ -28,10 +28,8 @@ type TTradeParametersProps = {
 
 const TradeParameters = observer(({ is_minimized }: TTradeParametersProps) => {
     const { contract_type, has_cancellation, symbol } = useTraderStore();
-    const isVisible = (component_key: string) => {
-        const params = getTradeParams(symbol, has_cancellation)?.[contract_type] ?? {};
-        return component_key in params;
-    };
+    const isVisible = (component_key: string) =>
+        isTradeParamVisible({ component_key, contract_type, has_cancellation, symbol });
 
     return (
         <div

--- a/packages/trader/src/AppV2/Containers/Trade/__tests__/trade.spec.tsx
+++ b/packages/trader/src/AppV2/Containers/Trade/__tests__/trade.spec.tsx
@@ -20,6 +20,7 @@ jest.mock('AppV2/Components/BottomNav', () =>
         </div>
     ))
 );
+jest.mock('AppV2/Components/AccumulatorStats', () => jest.fn(() => <div>AccumulatorStats</div>));
 jest.mock('AppV2/Components/ClosedMarketMessage', () => jest.fn(() => <div>ClosedMarketMessage</div>));
 jest.mock('AppV2/Components/CurrentSpot', () => jest.fn(() => <div>Current Spot</div>));
 jest.mock('AppV2/Components/PurchaseButton', () => jest.fn(() => <div>Purchase Button</div>));
@@ -116,11 +117,12 @@ describe('Trade', () => {
         expect(screen.getByTestId('dt_trade_loader')).toBeInTheDocument();
     });
 
-    it('should render trading page with all components', () => {
+    it('should render trading page with all necessary components', () => {
         render(mockTrade());
 
         expect(screen.queryByTestId('dt_trade_loader')).not.toBeInTheDocument();
         expect(screen.queryByText('Current Spot')).not.toBeInTheDocument();
+        expect(screen.queryByText('AccumulatorStats')).not.toBeInTheDocument();
 
         expect(screen.getByText('Trade Types Selection')).toBeInTheDocument();
         expect(screen.getByText('MarketSelector')).toBeInTheDocument();
@@ -135,6 +137,13 @@ describe('Trade', () => {
         render(mockTrade());
 
         expect(screen.getByText('Current Spot')).toBeInTheDocument();
+    });
+
+    it('should render AccumulatorStats if is_accumulator === true', () => {
+        default_mock_store.modules.trade.is_accumulator = true;
+        render(mockTrade());
+
+        expect(screen.getByText('AccumulatorStats')).toBeInTheDocument();
     });
 
     it('should call state setter when user scrolls BottomNav', () => {

--- a/packages/trader/src/AppV2/Containers/Trade/trade.tsx
+++ b/packages/trader/src/AppV2/Containers/Trade/trade.tsx
@@ -2,13 +2,12 @@ import React from 'react';
 import { observer } from 'mobx-react';
 import { useStore } from '@deriv/stores';
 import { Loading } from '@deriv/components';
-import { isAccumulatorContract } from '@deriv/shared';
 import { useLocalStorageData } from '@deriv/hooks';
 import ClosedMarketMessage from 'AppV2/Components/ClosedMarketMessage';
 import { useTraderStore } from 'Stores/useTraderStores';
 import BottomNav from 'AppV2/Components/BottomNav';
 import PurchaseButton from 'AppV2/Components/PurchaseButton';
-import { HEIGHT } from 'AppV2/Utils/layout-utils';
+import { getChartHeight, HEIGHT } from 'AppV2/Utils/layout-utils';
 import { getTradeTypesList } from 'AppV2/Utils/trade-types-utils';
 import { TradeParametersContainer, TradeParameters } from 'AppV2/Components/TradeParameters';
 import CurrentSpot from 'AppV2/Components/CurrentSpot';
@@ -26,7 +25,8 @@ const Trade = observer(() => {
     const {
         client: { is_logged_in },
     } = useStore();
-    const { active_symbols, contract_type, onMount, onChange, onUnmount } = useTraderStore();
+    const { active_symbols, contract_type, has_cancellation, symbol, is_accumulator, onMount, onChange, onUnmount } =
+        useTraderStore();
     const { contract_types_list } = useContractsForCompany();
     const [guide_dtrader_v2] = useLocalStorageData<boolean>('guide_dtrader_v2_trade_page', false);
 
@@ -44,9 +44,6 @@ const Trade = observer(() => {
             })),
         [active_symbols]
     );
-
-    const dynamic_chart_height =
-        window.innerHeight - HEIGHT.HEADER - HEIGHT.BOTTOM_NAV - HEIGHT.ADVANCED_FOOTER - HEIGHT.PADDING;
 
     const onTradeTypeSelect = React.useCallback(
         (e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
@@ -92,11 +89,17 @@ const Trade = observer(() => {
                             <TradeParameters />
                         </TradeParametersContainer>
                         <div className='trade__chart-tooltip'>
-                            <section className='trade__chart' style={{ height: dynamic_chart_height }} ref={chart_ref}>
+                            <section
+                                className='trade__chart'
+                                style={{
+                                    height: getChartHeight({ is_accumulator, symbol, has_cancellation, contract_type }),
+                                }}
+                                ref={chart_ref}
+                            >
                                 <TradeChart />
                             </section>
                         </div>
-                        {isAccumulatorContract(contract_type) && <AccumulatorStats />}
+                        {is_accumulator && <AccumulatorStats />}
                     </div>
                     <div className='trade__parameter'>
                         <TradeParametersContainer is_minimized_visible={is_minimized_params_visible} is_minimized>

--- a/packages/trader/src/AppV2/Utils/__tests__/layout-utils.spec.ts
+++ b/packages/trader/src/AppV2/Utils/__tests__/layout-utils.spec.ts
@@ -1,0 +1,134 @@
+import { TRADE_TYPES } from '@deriv/shared';
+import { isTradeParamVisible, getChartHeight } from '../layout-utils';
+
+describe('isTradeParamVisible', () => {
+    it('should return correct value for expiration component key', () => {
+        const common_args = {
+            component_key: 'expiration',
+            contract_type: TRADE_TYPES.MULTIPLIER,
+            has_cancellation: false,
+            symbol: 'cryBTCUSD',
+        };
+        expect(
+            isTradeParamVisible({
+                ...common_args,
+            })
+        ).toEqual(true);
+        expect(
+            isTradeParamVisible({
+                ...common_args,
+                symbol: '1HZ100V',
+            })
+        ).toEqual(false);
+        expect(
+            isTradeParamVisible({
+                ...common_args,
+                contract_type: TRADE_TYPES.ACCUMULATOR,
+            })
+        ).toEqual(false);
+    });
+
+    it('should return correct value for mult_info_display component key', () => {
+        const common_args = {
+            component_key: 'mult_info_display',
+            contract_type: TRADE_TYPES.MULTIPLIER,
+            has_cancellation: true,
+            symbol: '1HZ100V',
+        };
+        expect(
+            isTradeParamVisible({
+                ...common_args,
+            })
+        ).toEqual(true);
+        expect(
+            isTradeParamVisible({
+                ...common_args,
+                has_cancellation: false,
+            })
+        ).toEqual(false);
+    });
+    it('should return false if there is no such contract type or component_key', () => {
+        const common_args = {
+            component_key: 'barrier',
+            contract_type: TRADE_TYPES.HIGH_LOW,
+            has_cancellation: false,
+            symbol: '1HZ150V',
+        };
+        expect(
+            isTradeParamVisible({
+                ...common_args,
+                component_key: 'mock_component_key',
+            })
+        ).toEqual(false);
+        expect(
+            isTradeParamVisible({
+                ...common_args,
+                contract_type: 'mock_contract_type',
+            })
+        ).toEqual(false);
+    });
+});
+
+describe('getChartHeight', () => {
+    const original_height = window.innerHeight;
+
+    beforeAll(() => (window.innerHeight = 740));
+    afterAll(() => (window.innerHeight = original_height));
+
+    it('should return correct chart height', () => {
+        const common_args = {
+            contract_type: TRADE_TYPES.MATCH_DIFF,
+            has_cancellation: false,
+            is_accumulator: false,
+            symbol: '1HZ100V',
+        };
+        const default_chart_height = 484;
+        const accumulators_chart_height = 428;
+        const chart_height_with_additional_info = 454;
+
+        expect(
+            getChartHeight({
+                ...common_args,
+            })
+        ).toEqual(default_chart_height);
+        expect(
+            getChartHeight({
+                ...common_args,
+                contract_type: TRADE_TYPES.ACCUMULATOR,
+                is_accumulator: true,
+            })
+        ).toEqual(accumulators_chart_height);
+        expect(
+            getChartHeight({
+                ...common_args,
+                contract_type: TRADE_TYPES.MULTIPLIER,
+                has_cancellation: true,
+            })
+        ).toEqual(chart_height_with_additional_info);
+        expect(
+            getChartHeight({
+                ...common_args,
+                contract_type: TRADE_TYPES.MULTIPLIER,
+                symbol: 'cryBTCUSD',
+            })
+        ).toEqual(chart_height_with_additional_info);
+        expect(
+            getChartHeight({
+                ...common_args,
+                contract_type: TRADE_TYPES.VANILLA.CALL,
+            })
+        ).toEqual(chart_height_with_additional_info);
+        expect(
+            getChartHeight({
+                ...common_args,
+                contract_type: TRADE_TYPES.RISE_FALL,
+            })
+        ).toEqual(chart_height_with_additional_info);
+        expect(
+            getChartHeight({
+                ...common_args,
+                contract_type: TRADE_TYPES.HIGH_LOW,
+            })
+        ).toEqual(chart_height_with_additional_info);
+    });
+});

--- a/packages/trader/src/AppV2/Utils/layout-utils.tsx
+++ b/packages/trader/src/AppV2/Utils/layout-utils.tsx
@@ -1,6 +1,52 @@
+import { getTradeParams } from './trade-params-utils';
+
 export const HEIGHT = {
     ADVANCED_FOOTER: 136,
+    ADDITIONAL_INFO: 30,
     BOTTOM_NAV: 56,
+    CHART_STATS: 56,
     HEADER: 40,
     PADDING: 24,
+};
+
+export const isTradeParamVisible = ({
+    component_key,
+    contract_type,
+    has_cancellation,
+    symbol,
+}: {
+    component_key: string;
+    contract_type: string;
+    has_cancellation: boolean;
+    symbol: string;
+}) => {
+    const params = getTradeParams(symbol, has_cancellation)?.[contract_type] ?? {};
+    return component_key in params;
+};
+
+export const getChartHeight = ({
+    contract_type,
+    has_cancellation,
+    is_accumulator,
+    symbol,
+}: {
+    contract_type: string;
+    has_cancellation: boolean;
+    is_accumulator: boolean;
+    symbol: string;
+}) => {
+    const height = window.innerHeight - HEIGHT.HEADER - HEIGHT.BOTTOM_NAV - HEIGHT.ADVANCED_FOOTER - HEIGHT.PADDING;
+    const isVisible = (component_key: string) =>
+        isTradeParamVisible({ component_key, symbol, has_cancellation, contract_type });
+
+    if (is_accumulator) return height - HEIGHT.CHART_STATS;
+    if (
+        isVisible('expiration') ||
+        isVisible('mult_info_display') ||
+        isVisible('payout_per_point_info') ||
+        isVisible('allow_equals') ||
+        isVisible('payout')
+    )
+        return height - HEIGHT.ADDITIONAL_INFO;
+    return height;
 };


### PR DESCRIPTION
## Changes:

- Removed all chart height calculations. Created getChartHeight function, which take into consider 'stats' section for Accumulators trade type and additional information for expiration, deal cancellation, payout per point, allow equals and payout, based on passed arguments.
- Moved function for checking if trade_param is visible or not to layout-utils. Previously it was in trade-parameters.tsx, but I need to reuse it in another place too.
- Covered changes with tests.

### Screenshots:
![Screenshot 2024-09-09 at 4 44 59 PM](https://github.com/user-attachments/assets/44ad3040-1f06-4a39-acba-07312cae6f4b)
![Screenshot 2024-09-09 at 5 01 38 PM](https://github.com/user-attachments/assets/3ec4c964-2f93-445e-bc05-ba91b9215fce)
![Screenshot 2024-09-09 at 5 01 27 PM](https://github.com/user-attachments/assets/0b5bb68d-9e7a-4ca5-a6eb-2924bd897cd2)
![Screenshot 2024-09-09 at 5 00 52 PM](https://github.com/user-attachments/assets/b0b0b4ac-25cf-4152-98c1-383e4d3377c6)
![Screenshot 2024-09-09 at 5 00 42 PM](https://github.com/user-attachments/assets/f20f532f-0f4b-43dd-8187-998b16dbdda9)
![Screenshot 2024-09-09 at 5 00 31 PM](https://github.com/user-attachments/assets/7fe1c897-f603-4524-8fae-3b9bb73c05a9)
![Screenshot 2024-09-09 at 5 00 21 PM](https://github.com/user-attachments/assets/98df7357-7663-4c3e-93d8-fd866fad7cb8)
![Screenshot 2024-09-09 at 5 00 09 PM](https://github.com/user-attachments/assets/713a35b7-6637-4a5e-8000-0e6646326c24)
