### PR TITLE
[BOT] Farabi/bot-1488/test-coverage-for-qs-selects

### DIFF
--- a/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/selects/__tests__/contract_type.spec.tsx
+++ b/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/selects/__tests__/contract_type.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Formik } from 'formik';
 import * as Yup from 'yup';
+import { ApiHelpers } from '@deriv/bot-skeleton';
 import { mockStore, StoreProvider } from '@deriv/stores';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -187,5 +188,25 @@ describe('<ContractType /> Desktop', () => {
             userEvent.click(option_element);
         });
         expect(autocomplete_element).toHaveDisplayValue('RISE');
+    });
+
+    it('should be empty list if value not found', async () => {
+        const mockAPI = ApiHelpers.instance as unknown as {
+            contracts_for: {
+                getContractTypes: jest.Mock<string, string[]>;
+            };
+        };
+        mockAPI.contracts_for.getContractTypes = jest.fn().mockReturnValue([]);
+
+        render(<ContractType name='type' />, {
+            wrapper,
+        });
+        const autocomplete_element = screen.getByTestId('dt_qs_contract_type');
+        userEvent.click(autocomplete_element);
+        await waitFor(() => {
+            const option_element = screen.getByText('No results found');
+            userEvent.click(option_element);
+        });
+        expect(autocomplete_element).toHaveDisplayValue('');
     });
 });

--- a/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/selects/__tests__/duration_type.spec.tsx
+++ b/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/selects/__tests__/duration_type.spec.tsx
@@ -56,9 +56,10 @@ describe('<DurationUnit />', () => {
         mock_DBot_store = mockDBotStore(mock_store, mock_ws);
         const mock_onSubmit = jest.fn();
         const initial_value = {
-            durationtype: 1,
+            durationtype: 's',
             symbol: 'R_100',
             tradetype: 'callput',
+            duration: 15,
         };
 
         wrapper = ({ children }: { children: JSX.Element }) => (

--- a/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/selects/__tests__/duration_type.spec.tsx
+++ b/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/selects/__tests__/duration_type.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Formik } from 'formik';
 import * as Yup from 'yup';
+import { ApiHelpers } from '@deriv/bot-skeleton';
 import { mockStore, StoreProvider } from '@deriv/stores';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -49,13 +50,9 @@ window.Blockly = {
 
 describe('<DurationUnit />', () => {
     let wrapper: ({ children }: { children: JSX.Element }) => JSX.Element, mock_DBot_store: RootStore | undefined;
+    const mock_store = mockStore({});
 
     beforeEach(() => {
-        const mock_store = mockStore({
-            ui: {
-                is_mobile: true,
-            },
-        });
         mock_DBot_store = mockDBotStore(mock_store, mock_ws);
         const mock_onSubmit = jest.fn();
         const initial_value = {
@@ -101,5 +98,27 @@ describe('<DurationUnit />', () => {
             userEvent.click(option_element);
         });
         expect(autocomplete_element).toHaveDisplayValue('sample');
+    });
+
+    it('should be empty list if value not found', async () => {
+        mock_store.ui.is_desktop = true;
+        const mockAPI = ApiHelpers.instance as unknown as {
+            contracts_for: {
+                getDurations: jest.Mock<string, string[]>;
+            };
+        };
+        mockAPI.contracts_for.getDurations = jest.fn().mockReturnValue([]);
+
+        render(<DurationUnit />, {
+            wrapper,
+        });
+        const autocomplete_element = screen.getByTestId('dt_qs_durationtype');
+        userEvent.click(autocomplete_element);
+        await waitFor(() => {
+            const option_element = screen.getByText('No results found');
+            userEvent.click(option_element);
+        });
+
+        expect(autocomplete_element).toHaveDisplayValue('');
     });
 });

--- a/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/selects/__tests__/symbol.spec.tsx
+++ b/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/selects/__tests__/symbol.spec.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Formik } from 'formik';
+import { ApiHelpers } from '@deriv/bot-skeleton';
 import { mockStore, StoreProvider } from '@deriv/stores';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -11,7 +12,6 @@ import SymbolSelect from '../symbol';
 jest.mock('@deriv/bot-skeleton/src/scratch/blockly', () => jest.fn());
 jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => jest.fn());
 jest.mock('@deriv/bot-skeleton/src/scratch/hooks/block_svg', () => jest.fn());
-
 jest.mock('@deriv/bot-skeleton', () => ({
     ...jest.requireActual('@deriv/bot-skeleton'),
     ApiHelpers: {
@@ -62,14 +62,9 @@ window.Blockly = {
 
 describe('<SymbolSelect />', () => {
     let wrapper: ({ children }: { children: JSX.Element }) => JSX.Element, mock_DBot_store: RootStore | undefined;
+    const mock_store = mockStore({});
 
     beforeEach(() => {
-        const mock_store = mockStore({
-            ui: {
-                is_mobile: true,
-            },
-        });
-
         mock_DBot_store = mockDBotStore(mock_store, mock_ws);
         const mock_onSubmit = jest.fn();
         const initial_value = {
@@ -96,7 +91,7 @@ describe('<SymbolSelect />', () => {
     });
 
     it('should select item from the list', async () => {
-        render(<SymbolSelect key='RDBULL' />, {
+        render(<SymbolSelect />, {
             wrapper,
         });
 
@@ -106,18 +101,52 @@ describe('<SymbolSelect />', () => {
         const option_element = screen.getByText(/Bear Market Index/i);
         userEvent.click(option_element);
 
-        expect(autocomplete_element).toHaveDisplayValue([/Bear Market Index/i]);
+        expect(autocomplete_element).toHaveValue('Bear Market Index');
     });
 
-    it('should input to be empty when the user clicks to type something', () => {
-        mockStore({ ui: { is_mobile: false } });
+    it('should select item from the list if item is not found', async () => {
+        mock_store.ui.is_desktop = true;
         render(<SymbolSelect />, {
             wrapper,
         });
 
         const autocomplete_element = screen.getByTestId('dt_qs_symbol');
-        userEvent.hover(autocomplete_element);
+        userEvent.click(autocomplete_element);
 
-        expect((autocomplete_element as HTMLInputElement).value).toBe('AUD Basket');
+        expect(autocomplete_element).not.toHaveValue('Bear Market Index');
+    });
+
+    it('should handle hide dropdown list', async () => {
+        mock_store.ui.is_desktop = true;
+        render(<SymbolSelect />, { wrapper });
+
+        const autocomplete_element = screen.getByTestId('dt_qs_symbol');
+        userEvent.click(autocomplete_element);
+        userEvent.type(autocomplete_element, 'Invalid');
+        userEvent.tab();
+
+        expect(autocomplete_element).toHaveValue('AUD Basket');
+    });
+
+    it('should handle hide dropdown list if symbol is not found', async () => {
+        mock_store.ui.is_desktop = true;
+        const mockAPI = ApiHelpers.instance as unknown as {
+            active_symbols: {
+                getSymbolsForBot: jest.Mock<string, string[]>;
+            };
+        };
+        if (mockAPI) {
+            mockAPI.active_symbols.getSymbolsForBot = jest.fn().mockReturnValue([]);
+        }
+        render(<SymbolSelect />, {
+            wrapper,
+        });
+
+        const autocomplete_element = screen.getByTestId('dt_qs_symbol');
+        userEvent.click(autocomplete_element);
+        userEvent.type(autocomplete_element, 'Invalid');
+        userEvent.tab();
+
+        expect(autocomplete_element).not.toHaveValue('Bear Market Index');
     });
 });

--- a/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/selects/__tests__/symbol.spec.tsx
+++ b/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/selects/__tests__/symbol.spec.tsx
@@ -135,9 +135,8 @@ describe('<SymbolSelect />', () => {
                 getSymbolsForBot: jest.Mock<string, string[]>;
             };
         };
-        if (mockAPI) {
-            mockAPI.active_symbols.getSymbolsForBot = jest.fn().mockReturnValue([]);
-        }
+        mockAPI.active_symbols.getSymbolsForBot = jest.fn().mockReturnValue([]);
+
         render(<SymbolSelect />, {
             wrapper,
         });

--- a/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/selects/__tests__/symbol.spec.tsx
+++ b/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/selects/__tests__/symbol.spec.tsx
@@ -121,7 +121,6 @@ describe('<SymbolSelect />', () => {
         render(<SymbolSelect />, { wrapper });
 
         const autocomplete_element = screen.getByTestId('dt_qs_symbol');
-        userEvent.click(autocomplete_element);
         userEvent.type(autocomplete_element, 'Invalid');
         userEvent.tab();
 
@@ -142,7 +141,6 @@ describe('<SymbolSelect />', () => {
         });
 
         const autocomplete_element = screen.getByTestId('dt_qs_symbol');
-        userEvent.click(autocomplete_element);
         userEvent.type(autocomplete_element, 'Invalid');
         userEvent.tab();
 

--- a/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/selects/__tests__/trade-type.spec.tsx
+++ b/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/selects/__tests__/trade-type.spec.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Formik } from 'formik';
-import { ApiHelpers } from '@deriv/bot-skeleton';
 import { mockStore, StoreProvider } from '@deriv/stores';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -49,22 +48,19 @@ window.Blockly = {
     },
 };
 
+let initial_value = {
+    durationtype: 1,
+    symbol: 'R_100',
+    tradetype: 'callput',
+};
+
 describe('<TradeType />', () => {
     let wrapper: ({ children }: { children: JSX.Element }) => JSX.Element, mock_DBot_store: RootStore | undefined;
 
     beforeEach(() => {
-        const mock_store = mockStore({
-            ui: {
-                is_mobile: true,
-            },
-        });
+        const mock_store = mockStore({});
         mock_DBot_store = mockDBotStore(mock_store, mock_ws);
         const mock_onSubmit = jest.fn();
-        const initial_value = {
-            durationtype: 1,
-            symbol: 'R_100',
-            tradetype: 'callput',
-        };
 
         wrapper = ({ children }: { children: JSX.Element }) => (
             <StoreProvider store={mock_store}>
@@ -97,16 +93,28 @@ describe('<TradeType />', () => {
         expect(autocomplete_element).toHaveDisplayValue([/Rise\/Fall/i]);
     });
 
-    it('should be empty list if value not found on the first time the browser is used', async () => {
-        const mockAPI = ApiHelpers.instance as unknown as {
-            contracts_for: {
-                getTradeTypesForQuickStrategy: jest.Mock<string, string[]>;
-            };
+    it('should be empty list if tradetype not found on the first time the browser is used', async () => {
+        initial_value = {
+            durationtype: 1,
+            symbol: 'R_100',
+            tradetype: '',
         };
-        if (mockAPI) {
-            mockAPI.contracts_for.getTradeTypesForQuickStrategy = jest.fn().mockReturnValue([]);
-        }
+        render(<TradeType />, {
+            wrapper,
+        });
 
+        const autocomplete_element = screen.getByTestId('dt_qs_tradetype');
+        userEvent.click(autocomplete_element);
+
+        expect(autocomplete_element).toHaveDisplayValue('');
+    });
+
+    it('should be empty list if symbol not found on the first time the browser is used', async () => {
+        initial_value = {
+            durationtype: 1,
+            symbol: '',
+            tradetype: '',
+        };
         render(<TradeType />, {
             wrapper,
         });
@@ -117,6 +125,7 @@ describe('<TradeType />', () => {
             const option_element = screen.getByText('No results found');
             userEvent.click(option_element);
         });
+
         expect(autocomplete_element).toHaveDisplayValue('');
     });
 });

--- a/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/selects/__tests__/trade-type.spec.tsx
+++ b/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/selects/__tests__/trade-type.spec.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Formik } from 'formik';
+import { ApiHelpers } from '@deriv/bot-skeleton';
 import { mockStore, StoreProvider } from '@deriv/stores';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -94,5 +95,28 @@ describe('<TradeType />', () => {
             userEvent.click(option_element);
         });
         expect(autocomplete_element).toHaveDisplayValue([/Rise\/Fall/i]);
+    });
+
+    it('should be empty list if value not found on the first time the browser is used', async () => {
+        const mockAPI = ApiHelpers.instance as unknown as {
+            contracts_for: {
+                getTradeTypesForQuickStrategy: jest.Mock<string, string[]>;
+            };
+        };
+        if (mockAPI) {
+            mockAPI.contracts_for.getTradeTypesForQuickStrategy = jest.fn().mockReturnValue([]);
+        }
+
+        render(<TradeType />, {
+            wrapper,
+        });
+
+        const autocomplete_element = screen.getByTestId('dt_qs_tradetype');
+        userEvent.click(autocomplete_element);
+        await waitFor(() => {
+            const option_element = screen.getByText('No results found');
+            userEvent.click(option_element);
+        });
+        expect(autocomplete_element).toHaveDisplayValue('');
     });
 });

--- a/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/selects/trade-type.tsx
+++ b/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/selects/trade-type.tsx
@@ -41,8 +41,8 @@ const TradeTypeSelect: React.FC = () => {
                 setTradeTypes(trade_types);
                 const has_selected = trade_types?.some(trade_type => trade_type.value === selected);
                 if (!has_selected && trade_types?.[0]?.value !== selected) {
-                    setFieldValue?.('tradetype', trade_types?.[0]?.value || '');
-                    setValue('tradetype', trade_types?.[0]?.value);
+                    setFieldValue?.('tradetype', trade_types?.[0].value || '');
+                    setValue('tradetype', trade_types?.[0].value);
                 }
             };
             getTradeTypes();

--- a/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/selects/trade-type.tsx
+++ b/packages/bot-web-ui/src/pages/bot-builder/quick-strategy/selects/trade-type.tsx
@@ -41,8 +41,8 @@ const TradeTypeSelect: React.FC = () => {
                 setTradeTypes(trade_types);
                 const has_selected = trade_types?.some(trade_type => trade_type.value === selected);
                 if (!has_selected && trade_types?.[0]?.value !== selected) {
-                    setFieldValue?.('tradetype', trade_types?.[0].value || '');
-                    setValue('tradetype', trade_types?.[0].value);
+                    setFieldValue?.('tradetype', trade_types?.[0]?.value || '');
+                    setValue('tradetype', trade_types?.[0]?.value);
                 }
             };
             getTradeTypes();


### PR DESCRIPTION
## Changes:

-  Test coverage increased for symbol.tsx, contract_type.tsx, trade_type.tsx and duration_type.tsx

### Screenshots:

<img width="1717" alt="Screenshot 2024-09-11 at 2 11 46 PM" src="https://github.com/user-attachments/assets/4b0a5078-4c9f-4401-9d5a-1266ddd0923c">

