### PR TITLE
DTRA-1891 / Kate / [DTrader-V2]: Bug - Plus stepper on risk management showing NaN

### DIFF
--- a/packages/trader/src/AppV2/Components/TradeParameters/RiskManagement/take-profit-and-stop-loss-input.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/RiskManagement/take-profit-and-stop-loss-input.tsx
@@ -282,7 +282,7 @@ const TakeProfitAndStopLossInput = ({
                     textAlignment='center'
                     unitLeft={currency_display_code}
                     variant='fill'
-                    value={new_input_value}
+                    value={new_input_value ?? ''}
                 />
                 {!is_enabled && (
                     <button


### PR DESCRIPTION
## Changes:

- Added a fallback value. If there are no TP or SL , the value in the trade store  for `take_profit` & `stop_loss` is `undefined` (expected). When user was clicking on 'plus' button, math operation (+1) was performed with `undefined` and the error was thrown.

### Screenshots:

https://github.com/user-attachments/assets/606169d6-ba35-4c00-8fbd-a45ff3e10d51
