### PR TITLE
aum / WALL-4881 / remove-deposit-pop-up-for-mf-clients-real-account-creation

### DIFF
--- a/packages/core/src/App/Containers/Modals/deposit-now-or-later-modal/__test__/deposit-now-or-later-modal.spec.tsx
+++ b/packages/core/src/App/Containers/Modals/deposit-now-or-later-modal/__test__/deposit-now-or-later-modal.spec.tsx
@@ -15,17 +15,12 @@ describe('<DepositNowOrLaterModal />', () => {
 
     const setShouldShowDepositNowOrLaterModal = jest.fn();
     const setShouldShowOneTimeDepositModal = jest.fn();
-    const toggleAccountSuccessModal = jest.fn();
 
     const mockDefault = mockStore({
-        client: {
-            is_mf_account: true,
-        },
         ui: {
             should_show_deposit_now_or_later_modal: true,
             setShouldShowDepositNowOrLaterModal,
             setShouldShowOneTimeDepositModal,
-            toggleAccountSuccessModal,
         },
     });
 
@@ -84,7 +79,7 @@ describe('<DepositNowOrLaterModal />', () => {
         expect(setShouldShowDepositNowOrLaterModal).toHaveBeenCalledWith(false);
     });
 
-    it('should call setShouldShowDepositNowOrLaterModal, setShouldShowOneTimeDepositModal and toggleAccountSuccessModal for MF account when try to click cancel or close button', () => {
+    it('should call setShouldShowDepositNowOrLaterModal, setShouldShowOneTimeDepositModal and toggleAccountSuccessModal for ROW account when try to click cancel or close button', () => {
         render(<DepositNowOrLaterModal />, {
             wrapper: wrapper(),
         });
@@ -96,33 +91,5 @@ describe('<DepositNowOrLaterModal />', () => {
 
         expect(setShouldShowDepositNowOrLaterModal).toHaveBeenCalledWith(false);
         expect(setShouldShowOneTimeDepositModal).toHaveBeenCalledWith(false);
-        expect(toggleAccountSuccessModal).toHaveBeenCalledTimes(1);
-    });
-
-    it('should call setShouldShowDepositNowOrLaterModal, setShouldShowOneTimeDepositModal and toggleAccountSuccessModal for not MF account when try to click cancel or close button', () => {
-        const mock = mockStore({
-            client: {
-                is_mf_account: false,
-            },
-            ui: {
-                should_show_deposit_now_or_later_modal: true,
-                setShouldShowDepositNowOrLaterModal,
-                setShouldShowOneTimeDepositModal,
-                toggleAccountSuccessModal,
-            },
-        });
-
-        render(<DepositNowOrLaterModal />, {
-            wrapper: wrapper(mock),
-        });
-
-        const close_button = screen.getByRole('button', {
-            name: /Deposit later/,
-        });
-        userEvent.click(close_button);
-
-        expect(setShouldShowDepositNowOrLaterModal).toHaveBeenCalledWith(false);
-        expect(setShouldShowOneTimeDepositModal).toHaveBeenCalledWith(false);
-        expect(toggleAccountSuccessModal).toHaveBeenCalledTimes(0);
     });
 });

--- a/packages/core/src/App/Containers/Modals/deposit-now-or-later-modal/__test__/deposit-now-or-later-modal.spec.tsx
+++ b/packages/core/src/App/Containers/Modals/deposit-now-or-later-modal/__test__/deposit-now-or-later-modal.spec.tsx
@@ -79,7 +79,7 @@ describe('<DepositNowOrLaterModal />', () => {
         expect(setShouldShowDepositNowOrLaterModal).toHaveBeenCalledWith(false);
     });
 
-    it('should call setShouldShowDepositNowOrLaterModal, setShouldShowOneTimeDepositModal and toggleAccountSuccessModal for ROW account when try to click cancel or close button', () => {
+    it('should call setShouldShowDepositNowOrLaterModal and setShouldShowOneTimeDepositModal for ROW account when try to click cancel or close button', () => {
         render(<DepositNowOrLaterModal />, {
             wrapper: wrapper(),
         });

--- a/packages/core/src/App/Containers/Modals/deposit-now-or-later-modal/deposit-now-or-later-modal.tsx
+++ b/packages/core/src/App/Containers/Modals/deposit-now-or-later-modal/deposit-now-or-later-modal.tsx
@@ -57,8 +57,6 @@ const DepositNowOrLaterModal = observer(() => {
 
         if (is_click_on_cancel_button) {
             setShouldShowOneTimeDepositModal(false);
-            // for MF accounts we need to show success modal
-            if (is_mf_account) toggleAccountSuccessModal();
         }
     };
 

--- a/packages/core/src/App/Containers/Modals/deposit-now-or-later-modal/deposit-now-or-later-modal.tsx
+++ b/packages/core/src/App/Containers/Modals/deposit-now-or-later-modal/deposit-now-or-later-modal.tsx
@@ -8,13 +8,11 @@ import './deposit-now-or-later-modal.scss';
 
 const DepositNowOrLaterModal = observer(() => {
     const { isMobile } = useDevice();
-    const { client, ui } = useStore();
-    const { is_mf_account } = client;
+    const { ui } = useStore();
     const {
         should_show_deposit_now_or_later_modal,
         setShouldShowDepositNowOrLaterModal,
         setShouldShowOneTimeDepositModal,
-        toggleAccountSuccessModal,
     } = ui;
 
     const onConfirmModal = () => {

--- a/packages/core/src/App/Containers/RealAccountSignup/real-account-signup.jsx
+++ b/packages/core/src/App/Containers/RealAccountSignup/real-account-signup.jsx
@@ -86,6 +86,7 @@ const RealAccountSignup = observer(({ history, state_index, is_trading_experienc
         should_show_appropriateness_warning_modal,
         should_show_risk_warning_modal,
         setShouldShowOneTimeDepositModal,
+        toggleAccountSuccessModal,
         real_account_signup: state_value,
         is_trading_assessment_for_new_user_enabled,
     } = ui;
@@ -327,7 +328,11 @@ const RealAccountSignup = observer(({ history, state_index, is_trading_experienc
 
     const closeModalthenOpenDepositModal = () => {
         closeRealAccountSignup();
-        setShouldShowOneTimeDepositModal(true);
+        if (!client.is_mf_account) {
+            setShouldShowOneTimeDepositModal(true);
+        } else {
+            toggleAccountSuccessModal();
+        }
     };
 
     const showStatusDialog = curr => {


### PR DESCRIPTION
## Changes:

This PR is to hide the one-time deposit flow for MF clients.

### Screenshots:

<img width="1243" alt="Screenshot 2024-09-11 at 6 13 42 PM" src="https://github.com/user-attachments/assets/15fe372b-328b-48be-9ac4-abcf1ba8a30e">
