### PR TITLE
[WALL] Lubega / WEBREL-3157 / MT5 enter password button size

### DIFF
--- a/packages/wallets/src/features/cfd/screens/EnterPassword/EnterPassword.tsx
+++ b/packages/wallets/src/features/cfd/screens/EnterPassword/EnterPassword.tsx
@@ -105,6 +105,7 @@ const EnterPassword: React.FC<TProps> = ({
                         isLoading={isForgotPasswordLoading}
                         onClick={onSecondaryClick}
                         size='lg'
+                        textSize='sm'
                         variant='outlined'
                     >
                         <Localize i18n_default_text='Forgot password?' />
@@ -114,6 +115,7 @@ const EnterPassword: React.FC<TProps> = ({
                         isLoading={isLoading}
                         onClick={onPrimaryClick}
                         size='lg'
+                        textSize='sm'
                     >
                         <Localize i18n_default_text='Add account' />
                     </Button>


### PR DESCRIPTION
## Changes:

- [x] Fix button text size for MT5 enter password modal

### Screenshots:

<img width="1315" alt="Screenshot 2024-09-12 at 11 20 09 AM" src="https://github.com/user-attachments/assets/87b2671a-0f5c-4cdc-9fe7-b97ecc392fde">
<img width="403" alt="Screenshot 2024-09-12 at 11 20 34 AM" src="https://github.com/user-attachments/assets/3ae06be9-f101-4798-8fa5-3eed39489155">

