### PR TITLE
[WEBREL] george / WEBREL-3155 / Reports link on Dtrader page not appearing for wallet accounts

### DIFF
--- a/packages/core/src/App/Containers/Layout/header/dtrader-header-wallets.tsx
+++ b/packages/core/src/App/Containers/Layout/header/dtrader-header-wallets.tsx
@@ -56,9 +56,9 @@ const MenuLeft = observer(() => {
                     {header_extension && is_logged_in && (
                         <div className='header__menu-left-extensions'>{header_extension}</div>
                     )}
-                    <MenuLinks />
                 </React.Fragment>
             )}
+            <MenuLinks />
         </div>
     );
 });


### PR DESCRIPTION
## Changes:

- fix `MenuLinks` visibility

### Screenshots:

Please provide some screenshots of the change.
