### PR TITLE
DTRA-1913 / Kate / [DTrader-V2] Stake field header and the amount is not aligned properly

### DIFF
--- a/packages/trader/src/AppV2/Components/RiskManagementItem/risk-management-item.tsx
+++ b/packages/trader/src/AppV2/Components/RiskManagementItem/risk-management-item.tsx
@@ -160,6 +160,7 @@ const RiskManagementItem = observer(
                                 <TextFieldWithSteppers
                                     allowDecimals
                                     allowSign={false}
+                                    className='text-field--custom'
                                     customType='commaRemoval'
                                     decimals={getDecimalPlaces(currency)}
                                     message={errorMessage}

--- a/packages/trader/src/AppV2/Components/TradeParameters/RiskManagement/take-profit-and-stop-loss-input.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/RiskManagement/take-profit-and-stop-loss-input.tsx
@@ -266,6 +266,7 @@ const TakeProfitAndStopLossInput = ({
                 <TextFieldWithSteppers
                     allowDecimals
                     customType='commaRemoval'
+                    className='text-field--custom'
                     disabled={!is_enabled}
                     decimals={decimals}
                     data-testid={is_take_profit_input ? 'dt_tp_input' : 'dt_sl_input'}

--- a/packages/trader/src/AppV2/Components/TradeParameters/Stake/stake.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Stake/stake.tsx
@@ -181,6 +181,7 @@ const Stake = observer(({ is_minimized }: TStakeProps) => {
                             allowDecimals
                             allowSign={false}
                             customType='commaRemoval'
+                            className='text-field--custom'
                             decimals={getDecimalPlaces(currency)}
                             data-testid='dt_input_with_steppers'
                             message={getInputMessage()}

--- a/packages/trader/src/AppV2/Components/TradeParameters/trade-parameters.scss
+++ b/packages/trader/src/AppV2/Components/TradeParameters/trade-parameters.scss
@@ -67,3 +67,21 @@
         width: 100%;
     }
 }
+
+.text-field--custom {
+    .quill-input {
+        &-no-label__wrapper {
+            position: relative;
+            .input {
+                padding-inline: var(--core-spacing-1700);
+            }
+        }
+        &-label__label {
+            position: absolute;
+            top: 50%;
+            transform: translateY(-50%);
+            inset-inline-start: 0;
+            z-index: 2;
+        }
+    }
+}

--- a/packages/trader/src/AppV2/Containers/Positions/positions.scss
+++ b/packages/trader/src/AppV2/Containers/Positions/positions.scss
@@ -81,3 +81,21 @@ $TABS_HEIGHT: var(--core-size-2400);
         height: 100%;
     }
 }
+
+.text-field--custom {
+    .quill-input {
+        &-no-label__wrapper {
+            position: relative;
+            .input {
+                padding-inline: var(--core-spacing-1700);
+            }
+        }
+        &-label__label {
+            position: absolute;
+            top: 50%;
+            transform: translateY(-50%);
+            inset-inline-start: 0;
+            z-index: 2;
+        }
+    }
+}


### PR DESCRIPTION
## Changes:

- Via css class  alignement in Quill components was changed the same way as it was done in production. The Issue was fixed for all InputFields with Steppers in V-2: Stake, TP&SL (trade page + contract details). The issue was fixed in our repp, not in quill, because the component contains a lot of additional elements inside, like left/right icons, left/right text and etc.

### Screenshots:

![Screenshot 2024-09-19 at 4 44 57 PM](https://github.com/user-attachments/assets/a9255d26-4697-412c-95bb-faa280acb061)
![Screenshot 2024-09-19 at 4 44 15 PM](https://github.com/user-attachments/assets/dac09a7c-ebc2-4e23-8b09-56df71bc5e0e)
![Screenshot 2024-09-19 at 4 42 18 PM](https://github.com/user-attachments/assets/b4463fa4-cf17-4314-be25-ef3cdc77aa07)
![Screenshot 2024-09-19 at 4 37 00 PM](https://github.com/user-attachments/assets/dffbd5c6-29c0-427a-a1a3-b6f2f42e053e)
