### PR TITLE
Akmal / feat: swap payout per point and stake in trade params

### DIFF
--- a/packages/trader/src/AppV2/Components/TradeParameters/trade-parameters.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/trade-parameters.tsx
@@ -57,11 +57,11 @@ const TradeParameters = observer(({ is_minimized }: TTradeParametersProps) => {
                 {isVisible('last_digit') && <LastDigitPrediction is_minimized={is_minimized} />}
                 {isVisible('duration') && <Duration is_minimized={is_minimized} />}
                 {isVisible('strike') && <Strike is_minimized={is_minimized} />}
-                {isVisible('payout_per_point') && <PayoutPerPoint is_minimized={is_minimized} />}
                 {isVisible('barrier') && <Barrier is_minimized={is_minimized} />}
                 {isVisible('growth_rate') && <GrowthRate is_minimized={is_minimized} />}
                 {isVisible('multiplier') && <Multiplier is_minimized={is_minimized} />}
                 {isVisible('stake') && <Stake is_minimized={is_minimized} />}
+                {isVisible('payout_per_point') && <PayoutPerPoint is_minimized={is_minimized} />}
                 {isVisible('allow_equals') && !is_minimized && <AllowEquals />}
                 {isVisible('take_profit') && <TakeProfit is_minimized={is_minimized} />}
                 {isVisible('risk_management') && <RiskManagement is_minimized={is_minimized} />}


### PR DESCRIPTION
## Changes:

This feature modifies the trade parameters by swapping the positions of "Payout per Point" and "Stake" for improved clarity and user interaction.

- Parameter Swap: Switch the order of "Payout per Point" and "Stake" in the trade settings, making the layout more intuitive.
- User Interface Update: Adjust the user interface to reflect the new order, ensuring the change is seamlessly integrated.
- User Experience: Enhance the flow of selecting trade parameters, making it easier for users to configure their trades efficiently.

This update improves the usability of trade settings by presenting key parameters in a more logical and user-friendly order.
