### PR TITLE
[WALL] Lubega / WALL-4890 / Deposit clipboard rtl alignment

### DIFF
--- a/packages/cashier/src/modules/deposit-crypto/components/deposit-crypto-wallet-address/deposit-crypto-wallet-address.scss
+++ b/packages/cashier/src/modules/deposit-crypto/components/deposit-crypto-wallet-address/deposit-crypto-wallet-address.scss
@@ -13,14 +13,15 @@
     &__hash-container {
         padding: 0.8rem 1rem;
         border: 1px solid $color-grey-4;
-        border-radius: $BORDER_RADIUS 0 0 $BORDER_RADIUS;
+        border-start-start-radius: $BORDER_RADIUS;
+        border-end-start-radius: $BORDER_RADIUS;
     }
 
     &__action-container {
-        border-width: 1px 1px 1px 0px;
-        border-style: solid;
-        border-color: $color-grey-4;
-        border-radius: 0 $BORDER_RADIUS $BORDER_RADIUS 0;
+        border-block: 1px solid $color-grey-4;
+        border-inline-end: 1px solid $color-grey-4;
+        border-start-end-radius: $BORDER_RADIUS;
+        border-end-end-radius: $BORDER_RADIUS;
         padding: 1rem;
     }
 


### PR DESCRIPTION
## Changes:

- [x] Switched to css logical properties for deposit clipboard styling to support RTL languages

## Before:
<img width="662" alt="Screenshot 2024-09-20 at 4 55 20 PM" src="https://github.com/user-attachments/assets/caea9e50-a887-4b02-87f0-f0e895a64cf2">

## After:
<img width="662" alt="Screenshot 2024-09-20 at 4 51 00 PM" src="https://github.com/user-attachments/assets/1cbf6495-0687-476a-93f3-308f91002fcb">
