### PR TITLE
[WALL] Lubega / WALL-4909 / Withdrawal crypto form text alignment

### DIFF
--- a/packages/cashier/src/components/crypto-fiat-converter/crypto-fiat-converter.scss
+++ b/packages/cashier/src/components/crypto-fiat-converter/crypto-fiat-converter.scss
@@ -35,7 +35,7 @@
         margin-bottom: unset;
 
         .dc-input__field {
-            text-align: left;
+            text-align: start;
         }
 
         .dc-field--error {

--- a/packages/cashier/src/pages/withdrawal/withdrawal-crypto-form/withdrawal-crypto-form.scss
+++ b/packages/cashier/src/pages/withdrawal/withdrawal-crypto-form/withdrawal-crypto-form.scss
@@ -6,6 +6,7 @@
 
     .dc-input__field {
         height: auto;
+        text-align: start;
     }
 
     .dc-field--error {


### PR DESCRIPTION
## Changes:

- [x] Added text align to input field

## Before:
<img width="677" alt="Screenshot 2024-09-20 at 5 15 36 PM" src="https://github.com/user-attachments/assets/b7a991fa-e25d-45c3-841f-c4113b1fcd67">

## After:

<img width="677" alt="Screenshot 2024-09-20 at 5 12 25 PM" src="https://github.com/user-attachments/assets/f87b5bc0-9537-42d4-815c-c8ec28bdefd8">
