### PR TITLE
DTRA-2003 / Kate / [DTrader-V2] Blinking of 'Close' market

### DIFF
--- a/packages/trader/src/AppV2/Components/MarketSelector/__tests__/market-selector.spec.tsx
+++ b/packages/trader/src/AppV2/Components/MarketSelector/__tests__/market-selector.spec.tsx
@@ -56,6 +56,6 @@ describe('MarketSelector', () => {
         mock_store.modules.trade.symbol = 'USDJPY';
         render(MockedMarketSelector(mockStore(mock_store)));
 
-        expect(screen.getByTestId('dt_skeleton')).toBeInTheDocument();
+        expect(screen.getByTestId('square-skeleton')).toBeInTheDocument();
     });
 });

--- a/packages/trader/src/AppV2/Components/MarketSelector/__tests__/market-selector.spec.tsx
+++ b/packages/trader/src/AppV2/Components/MarketSelector/__tests__/market-selector.spec.tsx
@@ -52,4 +52,10 @@ describe('MarketSelector', () => {
         expect(screen.getByText(mock_store.modules.trade.tick_data.quote)).toBeInTheDocument();
         expect(screen.getByText('CLOSED')).toBeInTheDocument();
     });
+    it('should render loader when current symbol exchange_is_open is not defined (is not among active symbols list)', () => {
+        mock_store.modules.trade.symbol = 'USDJPY';
+        render(MockedMarketSelector(mockStore(mock_store)));
+
+        expect(screen.getByTestId('dt_skeleton')).toBeInTheDocument();
+    });
 });

--- a/packages/trader/src/AppV2/Components/MarketSelector/market-selector.tsx
+++ b/packages/trader/src/AppV2/Components/MarketSelector/market-selector.tsx
@@ -2,12 +2,11 @@ import React, { useState } from 'react';
 import ActiveSymbolsList from '../ActiveSymbolsList';
 import useActiveSymbols from 'AppV2/Hooks/useActiveSymbols';
 import SymbolIconsMapper from '../SymbolIconsMapper/symbol-icons-mapper';
-import { CaptionText, Tag, Text } from '@deriv-com/quill-ui';
+import { CaptionText, Skeleton, Tag, Text } from '@deriv-com/quill-ui';
 import { Localize } from '@deriv/translations';
 import { LabelPairedChevronDownMdRegularIcon } from '@deriv/quill-icons';
 import { observer } from '@deriv/stores';
 import { useTraderStore } from 'Stores/useTraderStores';
-import { Skeleton } from '@deriv/components';
 
 const MarketSelector = observer(() => {
     const [isOpen, setIsOpen] = useState(false);
@@ -18,7 +17,8 @@ const MarketSelector = observer(() => {
     const { pip_size, quote } = tick_data ?? {};
     const current_spot = quote?.toFixed(pip_size);
     // For closed markets exchange_is_open === 0
-    if (typeof currentSymbol?.exchange_is_open === 'undefined') return <Skeleton height={42} width={240} />;
+    if (typeof currentSymbol?.exchange_is_open === 'undefined')
+        return <Skeleton.Square height={42} width={240} rounded />;
 
     return (
         <React.Fragment>
@@ -42,7 +42,7 @@ const MarketSelector = observer(() => {
                         {current_spot ? (
                             <CaptionText className='market-selector-info__price'>{current_spot}</CaptionText>
                         ) : (
-                            <Skeleton height={18} width={64} />
+                            <Skeleton.Square height={18} width={64} rounded />
                         )}
                     </div>
                 </div>

--- a/packages/trader/src/AppV2/Components/MarketSelector/market-selector.tsx
+++ b/packages/trader/src/AppV2/Components/MarketSelector/market-selector.tsx
@@ -17,6 +17,8 @@ const MarketSelector = observer(() => {
 
     const { pip_size, quote } = tick_data ?? {};
     const current_spot = quote?.toFixed(pip_size);
+    // For closed markets exchange_is_open === 0
+    if (typeof currentSymbol?.exchange_is_open === 'undefined') return <Skeleton height={42} width={240} />;
 
     return (
         <React.Fragment>


### PR DESCRIPTION
## Changes:

- Added loader for market selector for cases when symbol is not available for current trade type and it's changing it to the default one
- Replaced old skeleton with the new one from Quill
- Refactored tests

### Screenshots:


https://github.com/user-attachments/assets/c6abcee1-1f14-42d8-bff2-46f8feabc198
