### PR TITLE
Akmal / feat: show only available trade types in guide

### DIFF
--- a/packages/trader/src/AppV2/Components/Guide/__tests__/guide-description-modal.spec.tsx
+++ b/packages/trader/src/AppV2/Components/Guide/__tests__/guide-description-modal.spec.tsx
@@ -5,9 +5,10 @@ import GuideDescriptionModal from '../guide-description-modal';
 import userEvent from '@testing-library/user-event';
 
 const mockProps = {
+    contract_list: AVAILABLE_CONTRACTS,
     is_open: true,
-    onClose: jest.fn(),
     onChipSelect: jest.fn(),
+    onClose: jest.fn(),
     onTermClick: jest.fn(),
     selected_contract_type: CONTRACT_LIST.ACCUMULATORS,
     show_guide_for_selected_contract: false,

--- a/packages/trader/src/AppV2/Components/Guide/__tests__/guide.spec.tsx
+++ b/packages/trader/src/AppV2/Components/Guide/__tests__/guide.spec.tsx
@@ -14,55 +14,55 @@ const trade_types = 'Trade types';
 const mock_contract_data = {
     contracts_for_company: [
         {
-            "value": "accumulator",
-            "text": "Accumulators",
-            "barrier_category": "american"
+            value: 'accumulator',
+            text: 'Accumulators',
+            barrier_category: 'american',
         },
         {
-            "value": "vanillalongcall",
-            "text": "Vanillas",
-            "barrier_category": "euro_atm"
+            value: 'vanillalongcall',
+            text: 'Vanillas',
+            barrier_category: 'euro_atm',
         },
         {
-            "value": "turboslong",
-            "text": "Turbos",
-            "barrier_category": "american"
+            value: 'turboslong',
+            text: 'Turbos',
+            barrier_category: 'american',
         },
         {
-            "value": "multiplier",
-            "text": "Multipliers",
-            "barrier_category": "american"
+            value: 'multiplier',
+            text: 'Multipliers',
+            barrier_category: 'american',
         },
         {
-            "value": "rise_fall",
-            "text": "Rise/Fall",
-            "barrier_category": "euro_atm"
+            value: 'rise_fall',
+            text: 'Rise/Fall',
+            barrier_category: 'euro_atm',
         },
         {
-            "value": "high_low",
-            "text": "Higher/Lower",
-            "barrier_category": "euro_atm"
+            value: 'high_low',
+            text: 'Higher/Lower',
+            barrier_category: 'euro_atm',
         },
         {
-            "value": "touch",
-            "text": "Touch/No Touch",
-            "barrier_category": "american"
+            value: 'touch',
+            text: 'Touch/No Touch',
+            barrier_category: 'american',
         },
         {
-            "value": "match_diff",
-            "text": "Matches/Differs",
-            "barrier_category": "non_financial"
+            value: 'match_diff',
+            text: 'Matches/Differs',
+            barrier_category: 'non_financial',
         },
         {
-            "value": "even_odd",
-            "text": "Even/Odd",
-            "barrier_category": "non_financial"
+            value: 'even_odd',
+            text: 'Even/Odd',
+            barrier_category: 'non_financial',
         },
         {
-            "value": "over_under",
-            "text": "Over/Under",
-            "barrier_category": "non_financial"
-        }
+            value: 'over_under',
+            text: 'Over/Under',
+            barrier_category: 'non_financial',
+        },
     ],
 };
 

--- a/packages/trader/src/AppV2/Components/Guide/__tests__/guide.spec.tsx
+++ b/packages/trader/src/AppV2/Components/Guide/__tests__/guide.spec.tsx
@@ -11,8 +11,72 @@ import Guide from '../guide';
 
 const trade_types = 'Trade types';
 
+const mock_contract_data = {
+    contracts_for_company: [
+        {
+            "value": "accumulator",
+            "text": "Accumulators",
+            "barrier_category": "american"
+        },
+        {
+            "value": "vanillalongcall",
+            "text": "Vanillas",
+            "barrier_category": "euro_atm"
+        },
+        {
+            "value": "turboslong",
+            "text": "Turbos",
+            "barrier_category": "american"
+        },
+        {
+            "value": "multiplier",
+            "text": "Multipliers",
+            "barrier_category": "american"
+        },
+        {
+            "value": "rise_fall",
+            "text": "Rise/Fall",
+            "barrier_category": "euro_atm"
+        },
+        {
+            "value": "high_low",
+            "text": "Higher/Lower",
+            "barrier_category": "euro_atm"
+        },
+        {
+            "value": "touch",
+            "text": "Touch/No Touch",
+            "barrier_category": "american"
+        },
+        {
+            "value": "match_diff",
+            "text": "Matches/Differs",
+            "barrier_category": "non_financial"
+        },
+        {
+            "value": "even_odd",
+            "text": "Even/Odd",
+            "barrier_category": "non_financial"
+        },
+        {
+            "value": "over_under",
+            "text": "Over/Under",
+            "barrier_category": "non_financial"
+        }
+    ],
+};
+
 jest.mock('@lottiefiles/dotlottie-react', () => ({
     DotLottieReact: jest.fn(() => <div>DotLottieReact</div>),
+}));
+
+jest.mock('AppV2/Hooks/useContractsForCompany', () => ({
+    __esModule: true,
+    default: jest.fn(() => ({
+        contracts_for_company: mock_contract_data,
+        is_fetching_ref: { current: false },
+        trade_types: mock_contract_data.contracts_for_company,
+    })),
 }));
 
 Loadable.preloadAll();

--- a/packages/trader/src/AppV2/Components/Guide/guide-description-modal.tsx
+++ b/packages/trader/src/AppV2/Components/Guide/guide-description-modal.tsx
@@ -3,26 +3,27 @@ import { ActionSheet, Heading, Chip, Text } from '@deriv-com/quill-ui';
 import { VideoPlayer } from '@deriv/components';
 import { Localize } from '@deriv/translations';
 import { clickAndKeyEventHandler } from '@deriv/shared';
-import { AVAILABLE_CONTRACTS, CONTRACT_LIST } from 'AppV2/Utils/trade-types-utils';
 import { getDescriptionVideoIds } from 'AppV2/Utils/contract-description-utils';
 import TradeDescription from './Description/trade-description';
 import VideoPreview from './Description/video-preview';
 
 type TGuideDescriptionModal = {
-    is_open?: boolean;
+    contract_list: { tradeType: React.ReactNode; id: string }[];
     is_dark_mode_on?: boolean;
-    onClose: () => void;
+    is_open?: boolean;
     onChipSelect: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+    onClose: () => void;
     onTermClick: (term: string) => void;
     selected_contract_type: string;
     show_guide_for_selected_contract?: boolean;
 };
 
 const GuideDescriptionModal = ({
-    is_open,
+    contract_list,
     is_dark_mode_on,
-    onClose,
+    is_open,
     onChipSelect,
+    onClose,
     onTermClick,
     selected_contract_type,
     show_guide_for_selected_contract,
@@ -31,27 +32,10 @@ const GuideDescriptionModal = ({
     const modal_ref = React.useRef<HTMLDialogElement>(null);
 
     const video_src = getDescriptionVideoIds(selected_contract_type, is_dark_mode_on);
-    //TODO: temporary, until we'll have ordered list, coming from contract type selection
-    const order = [
-        CONTRACT_LIST.RISE_FALL,
-        CONTRACT_LIST.ACCUMULATORS,
-        CONTRACT_LIST.MULTIPLIERS,
-        CONTRACT_LIST.VANILLAS,
-        CONTRACT_LIST.TURBOS,
-        CONTRACT_LIST.HIGHER_LOWER,
-        CONTRACT_LIST.TOUCH_NO_TOUCH,
-        CONTRACT_LIST.MATCHES_DIFFERS,
-        CONTRACT_LIST.EVEN_ODD,
-        CONTRACT_LIST.OVER_UNDER,
-    ];
 
     const toggleVideoPlayer = (e?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
         clickAndKeyEventHandler(() => setIsVideoPlayerOpened(!is_video_player_opened), e);
     };
-
-    const ordered_contract_list = [...AVAILABLE_CONTRACTS].sort(
-        (a, b) => order.findIndex(item => item === a.id) - order.findIndex(item => item === b.id)
-    );
 
     React.useEffect(() => {
         if (modal_ref.current) is_video_player_opened ? modal_ref.current.showModal() : modal_ref.current.close();
@@ -71,7 +55,7 @@ const GuideDescriptionModal = ({
                         </Heading.H4>
                         {!show_guide_for_selected_contract && (
                             <div className='guide__menu'>
-                                {ordered_contract_list.map(({ tradeType, id }) => (
+                                {contract_list.map(({ tradeType, id }: { tradeType: React.ReactNode; id: string }) => (
                                     <Chip.Selectable
                                         key={id}
                                         onChipSelect={onChipSelect}

--- a/packages/trader/src/AppV2/Components/Guide/guide.tsx
+++ b/packages/trader/src/AppV2/Components/Guide/guide.tsx
@@ -4,10 +4,11 @@ import { LabelPairedPresentationScreenSmRegularIcon } from '@deriv/quill-icons';
 import { Localize } from '@deriv/translations';
 import { observer, useStore } from '@deriv/stores';
 import { useTraderStore } from 'Stores/useTraderStores';
-import { CONTRACT_LIST } from 'AppV2/Utils/trade-types-utils';
+import { AVAILABLE_CONTRACTS, CONTRACT_LIST } from 'AppV2/Utils/trade-types-utils';
 import GuideDefinitionModal from './guide-definition-modal';
 import GuideDescriptionModal from './guide-description-modal';
 import { getContractTypesConfig } from '@deriv/shared';
+import useContractsForCompany from 'AppV2/Hooks/useContractsForCompany';
 
 type TGuide = {
     has_label?: boolean;
@@ -20,11 +21,30 @@ const Guide = observer(({ has_label, show_guide_for_selected_contract }: TGuide)
     } = useStore();
     const { contract_type, is_vanilla } = useTraderStore();
     const contract_type_title = is_vanilla ? CONTRACT_LIST.VANILLAS : getContractTypesConfig()[contract_type]?.title;
+    const { trade_types } = useContractsForCompany();
+    const order = [
+        CONTRACT_LIST.RISE_FALL,
+        CONTRACT_LIST.ACCUMULATORS,
+        CONTRACT_LIST.MULTIPLIERS,
+        CONTRACT_LIST.VANILLAS,
+        CONTRACT_LIST.TURBOS,
+        CONTRACT_LIST.HIGHER_LOWER,
+        CONTRACT_LIST.TOUCH_NO_TOUCH,
+        CONTRACT_LIST.MATCHES_DIFFERS,
+        CONTRACT_LIST.EVEN_ODD,
+        CONTRACT_LIST.OVER_UNDER,
+    ];
+
+    const filtered_contract_list = AVAILABLE_CONTRACTS.filter(contract =>
+        trade_types.some((trade: { text?: string }) => trade.text === contract.id)
+    );
+
+    const ordered_contract_list = [...filtered_contract_list].sort(
+        (a, b) => order.findIndex(item => item === a.id) - order.findIndex(item => item === b.id)
+    );
 
     const [is_description_opened, setIsDescriptionOpened] = React.useState(false);
-    const [selected_contract_type, setSelectedContractType] = React.useState(
-        show_guide_for_selected_contract ? contract_type_title : CONTRACT_LIST.RISE_FALL
-    );
+    const [selected_contract_type, setSelectedContractType] = React.useState(contract_type_title);
     const [selected_term, setSelectedTerm] = React.useState<string>('');
 
     const onChipSelect = React.useCallback((e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
@@ -52,10 +72,11 @@ const Guide = observer(({ has_label, show_guide_for_selected_contract }: TGuide)
                 )}
             </Button>
             <GuideDescriptionModal
-                is_open={is_description_opened}
+                contract_list={ordered_contract_list}
                 is_dark_mode_on={is_dark_mode_on}
-                onClose={onClose}
+                is_open={is_description_opened}
                 onChipSelect={onChipSelect}
+                onClose={onClose}
                 onTermClick={setSelectedTerm}
                 selected_contract_type={selected_contract_type}
                 show_guide_for_selected_contract={show_guide_for_selected_contract}


### PR DESCRIPTION
## Changes:

This feature ensures that only available trade types are displayed in the guide, improving the relevance and accuracy of the information provided.

1. Filter Trade Types: Implement logic to filter out unavailable trade types and display only those currently supported in the guide.
2. User Interface Update: Adjust the guide interface to reflect the updated list of available trade types, ensuring users see only valid options.
3. Enhanced User Experience: Provide a clearer and more focused guide by removing irrelevant trade types, improving usability and reducing confusion.

This feature improves the user experience by ensuring the guide displays only relevant trade types based on availability.

